### PR TITLE
Fix module path and add cmd/argus entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binaries
-argus
+/argus
 /cmd/argus/argus
 *.exe
 *.dll

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Manage multiple Claude Code / Codex sessions with task tracking, git worktree is
 ## Install
 
 ```bash
-go install github.com/darrencheng/argus/cmd/argus@latest
+go install github.com/drn/argus/cmd/argus@latest
 ```
 
 ## Usage

--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/store"
+	"github.com/drn/argus/internal/ui"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error loading config: %v\n", err)
+		os.Exit(1)
+	}
+
+	s := store.New()
+	if err := s.Load(); err != nil {
+		fmt.Fprintf(os.Stderr, "error loading tasks: %v\n", err)
+		os.Exit(1)
+	}
+
+	m := ui.NewModel(cfg, s)
+	p := tea.NewProgram(m, tea.WithAltScreen())
+	if _, err := p.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/darrencheng/argus
+module github.com/drn/argus
 
 go 1.24.10
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/darrencheng/argus/internal/config"
-	"github.com/darrencheng/argus/internal/model"
+	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/model"
 )
 
 // Store manages task persistence to a JSON file.

--- a/internal/ui/newtask.go
+++ b/internal/ui/newtask.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/darrencheng/argus/internal/config"
-	"github.com/darrencheng/argus/internal/model"
+	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/model"
 )
 
 // NewTaskForm handles the new task creation UI.

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -6,9 +6,9 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/darrencheng/argus/internal/config"
-	"github.com/darrencheng/argus/internal/model"
-	"github.com/darrencheng/argus/internal/store"
+	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/model"
+	"github.com/drn/argus/internal/store"
 )
 
 type view int

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/darrencheng/argus/internal/model"
+	"github.com/drn/argus/internal/model"
 )
 
 // StatusBar renders the bottom status bar.

--- a/internal/ui/tasklist.go
+++ b/internal/ui/tasklist.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/darrencheng/argus/internal/model"
+	"github.com/drn/argus/internal/model"
 )
 
 // TaskList renders the task list view.


### PR DESCRIPTION
Update module path from github.com/darrencheng/argus to github.com/drn/argus to match the GitHub remote. Create cmd/argus/main.go entry point so `go install` works. Fix .gitignore pattern that was blocking the cmd/argus directory.

Co-Authored-By: Claude <noreply@anthropic.com>