### PR TITLE
Implement agent runner with PTY management

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,0 +1,76 @@
+package agent
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/model"
+)
+
+// ResolveBackend returns the backend config for a task.
+// Priority: task.Backend > project.Backend > cfg.Defaults.Backend.
+func ResolveBackend(task *model.Task, cfg config.Config) (config.Backend, error) {
+	name := cfg.Defaults.Backend
+
+	if task.Project != "" {
+		if proj, ok := cfg.Projects[task.Project]; ok && proj.Backend != "" {
+			name = proj.Backend
+		}
+	}
+
+	if task.Backend != "" {
+		name = task.Backend
+	}
+
+	if name == "" {
+		return config.Backend{}, fmt.Errorf("no backend configured")
+	}
+
+	backend, ok := cfg.Backends[name]
+	if !ok {
+		return config.Backend{}, fmt.Errorf("backend %q not found in config", name)
+	}
+
+	return backend, nil
+}
+
+// ResolveDir returns the working directory for a task.
+// Returns the project path if configured, otherwise empty string.
+func ResolveDir(task *model.Task, cfg config.Config) string {
+	if task.Project == "" {
+		return ""
+	}
+	if proj, ok := cfg.Projects[task.Project]; ok {
+		return proj.Path
+	}
+	return ""
+}
+
+// BuildCmd constructs the exec.Cmd for running an agent on a task.
+func BuildCmd(task *model.Task, cfg config.Config) (*exec.Cmd, error) {
+	backend, err := ResolveBackend(task, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	cmdStr := backend.Command
+	if backend.PromptFlag != "" && task.Prompt != "" {
+		cmdStr += " " + backend.PromptFlag + " " + shellQuote(task.Prompt)
+	}
+
+	cmd := exec.Command("sh", "-c", cmdStr)
+
+	if dir := ResolveDir(task, cfg); dir != "" {
+		cmd.Dir = dir
+	}
+
+	return cmd, nil
+}
+
+// shellQuote wraps a string in single quotes with proper escaping.
+// Single quotes within the string are replaced with '\'' (end quote, escaped quote, start quote).
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,184 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/model"
+)
+
+func testConfig() config.Config {
+	return config.Config{
+		Defaults: config.Defaults{Backend: "claude"},
+		Backends: map[string]config.Backend{
+			"claude": {Command: "claude --dangerously-skip-permissions", PromptFlag: "-p"},
+			"codex":  {Command: "codex", PromptFlag: "--prompt"},
+			"bare":   {Command: "my-agent", PromptFlag: ""},
+		},
+		Projects: map[string]config.Project{
+			"myapp": {Path: "/home/user/myapp", Backend: "codex"},
+			"other": {Path: "/home/user/other"},
+		},
+	}
+}
+
+func TestResolveBackend_DefaultFallback(t *testing.T) {
+	cfg := testConfig()
+	task := &model.Task{}
+
+	b, err := ResolveBackend(task, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Command != "claude --dangerously-skip-permissions" {
+		t.Errorf("expected claude command, got %q", b.Command)
+	}
+}
+
+func TestResolveBackend_ProjectOverride(t *testing.T) {
+	cfg := testConfig()
+	task := &model.Task{Project: "myapp"}
+
+	b, err := ResolveBackend(task, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Command != "codex" {
+		t.Errorf("expected codex command, got %q", b.Command)
+	}
+}
+
+func TestResolveBackend_TaskOverride(t *testing.T) {
+	cfg := testConfig()
+	task := &model.Task{Project: "myapp", Backend: "claude"}
+
+	b, err := ResolveBackend(task, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Command != "claude --dangerously-skip-permissions" {
+		t.Errorf("expected claude command, got %q", b.Command)
+	}
+}
+
+func TestResolveBackend_ProjectWithoutBackend(t *testing.T) {
+	cfg := testConfig()
+	task := &model.Task{Project: "other"}
+
+	b, err := ResolveBackend(task, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Falls back to default since project "other" has no backend
+	if b.Command != "claude --dangerously-skip-permissions" {
+		t.Errorf("expected claude command, got %q", b.Command)
+	}
+}
+
+func TestResolveBackend_NotFound(t *testing.T) {
+	cfg := testConfig()
+	task := &model.Task{Backend: "nonexistent"}
+
+	_, err := ResolveBackend(task, cfg)
+	if err == nil {
+		t.Fatal("expected error for missing backend")
+	}
+}
+
+func TestResolveBackend_NoDefault(t *testing.T) {
+	cfg := testConfig()
+	cfg.Defaults.Backend = ""
+	task := &model.Task{}
+
+	_, err := ResolveBackend(task, cfg)
+	if err == nil {
+		t.Fatal("expected error for no backend")
+	}
+}
+
+func TestResolveDir(t *testing.T) {
+	cfg := testConfig()
+
+	if dir := ResolveDir(&model.Task{}, cfg); dir != "" {
+		t.Errorf("expected empty dir, got %q", dir)
+	}
+	if dir := ResolveDir(&model.Task{Project: "myapp"}, cfg); dir != "/home/user/myapp" {
+		t.Errorf("expected /home/user/myapp, got %q", dir)
+	}
+	if dir := ResolveDir(&model.Task{Project: "unknown"}, cfg); dir != "" {
+		t.Errorf("expected empty dir for unknown project, got %q", dir)
+	}
+}
+
+func TestBuildCmd(t *testing.T) {
+	cfg := testConfig()
+	task := &model.Task{Prompt: "fix the bug"}
+
+	cmd, err := BuildCmd(task, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// sh -c '<command> <flag> <quoted prompt>'
+	args := cmd.Args
+	if args[0] != "sh" || args[1] != "-c" {
+		t.Errorf("expected sh -c, got %v", args[:2])
+	}
+	expected := "claude --dangerously-skip-permissions -p 'fix the bug'"
+	if args[2] != expected {
+		t.Errorf("expected %q, got %q", expected, args[2])
+	}
+}
+
+func TestBuildCmd_WithProject(t *testing.T) {
+	cfg := testConfig()
+	task := &model.Task{Project: "myapp", Prompt: "test"}
+
+	cmd, err := BuildCmd(task, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cmd.Dir != "/home/user/myapp" {
+		t.Errorf("expected dir /home/user/myapp, got %q", cmd.Dir)
+	}
+	// Should use codex backend from project
+	if cmd.Args[2] != "codex --prompt 'test'" {
+		t.Errorf("unexpected command: %q", cmd.Args[2])
+	}
+}
+
+func TestBuildCmd_EmptyPromptFlag(t *testing.T) {
+	cfg := testConfig()
+	task := &model.Task{Backend: "bare", Prompt: "do stuff"}
+
+	cmd, err := BuildCmd(task, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cmd.Args[2] != "my-agent" {
+		t.Errorf("expected bare command without prompt, got %q", cmd.Args[2])
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"hello", "'hello'"},
+		{"it's a test", `'it'\''s a test'`},
+		{"", "''"},
+		{"foo'bar'baz", `'foo'\''bar'\''baz'`},
+		{`no "problem" here`, `'no "problem" here'`},
+		{"line\nnewline", "'line\nnewline'"},
+	}
+
+	for _, tt := range tests {
+		got := shellQuote(tt.input)
+		if got != tt.expected {
+			t.Errorf("shellQuote(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/drn/argus/internal/agent"
 	"github.com/drn/argus/internal/config"
 	"github.com/drn/argus/internal/model"
 	"github.com/drn/argus/internal/store"
@@ -23,6 +24,12 @@ const (
 
 // TickMsg is sent periodically to update elapsed times.
 type TickMsg struct{}
+
+// AgentFinishedMsg is sent when an agent process exits.
+type AgentFinishedMsg struct {
+	TaskID string
+	Err    error
+}
 
 // Model is the top-level Bubble Tea model.
 type Model struct {
@@ -83,7 +90,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return TickMsg{}
 		})
 
+	case AgentFinishedMsg:
+		return m.handleAgentFinished(msg)
+
 	case tea.KeyMsg:
+		m.statusbar.ClearError()
 		return m.handleKey(msg)
 	}
 
@@ -152,6 +163,9 @@ func (m Model) handleTaskListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.current = viewHelp
 		return m, nil
 
+	case key.Matches(msg, m.keys.Attach):
+		return m.attachAgent()
+
 	case key.Matches(msg, m.keys.Prompt):
 		if m.tasklist.Selected() != nil {
 			m.current = viewPrompt
@@ -159,6 +173,56 @@ func (m Model) handleTaskListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	return m, nil
+}
+
+func (m Model) attachAgent() (tea.Model, tea.Cmd) {
+	t := m.tasklist.Selected()
+	if t == nil {
+		return m, nil
+	}
+
+	if t.Prompt == "" {
+		m.statusbar.SetError("no prompt set — press [p] to view/set prompt")
+		return m, nil
+	}
+
+	if t.AgentPID != 0 {
+		m.statusbar.SetError("agent already running")
+		return m, nil
+	}
+
+	cmd, err := agent.BuildCmd(t, m.cfg)
+	if err != nil {
+		m.statusbar.SetError(err.Error())
+		return m, nil
+	}
+
+	t.SetStatus(model.StatusInProgress)
+	_ = m.store.Update(t)
+	m.refreshTasks()
+
+	taskID := t.ID
+	return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return AgentFinishedMsg{TaskID: taskID, Err: err}
+	})
+}
+
+func (m Model) handleAgentFinished(msg AgentFinishedMsg) (tea.Model, tea.Cmd) {
+	t, err := m.store.Get(msg.TaskID)
+	if err != nil {
+		// Task was deleted while agent was running — silently ignore
+		return m, nil
+	}
+
+	if msg.Err != nil {
+		m.statusbar.SetError("agent error: " + msg.Err.Error())
+	} else {
+		t.SetStatus(model.StatusInReview)
+		_ = m.store.Update(t)
+	}
+
+	m.refreshTasks()
 	return m, nil
 }
 

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -12,6 +12,7 @@ type StatusBar struct {
 	theme  Theme
 	width  int
 	tasks  []*model.Task
+	errMsg string
 }
 
 func NewStatusBar(theme Theme) StatusBar {
@@ -24,6 +25,14 @@ func (sb *StatusBar) SetWidth(w int) {
 
 func (sb *StatusBar) SetTasks(tasks []*model.Task) {
 	sb.tasks = tasks
+}
+
+func (sb *StatusBar) SetError(msg string) {
+	sb.errMsg = msg
+}
+
+func (sb *StatusBar) ClearError() {
+	sb.errMsg = ""
 }
 
 func (sb StatusBar) View() string {
@@ -41,7 +50,12 @@ func (sb StatusBar) View() string {
 		}
 	}
 
-	left := fmt.Sprintf(" %d active  %d pending  %d done", active, pending, complete)
+	var left string
+	if sb.errMsg != "" {
+		left = " ⚠ " + sb.errMsg
+	} else {
+		left = fmt.Sprintf(" %d active  %d pending  %d done", active, pending, complete)
+	}
 	right := " [n]ew [↵]attach [s]tatus [d]el [?]help [q]uit "
 
 	gap := sb.width - lipgloss.Width(left) - lipgloss.Width(right)


### PR DESCRIPTION
Add Phase 2: agent package for backend resolution/command building, Enter key launches configured backend via tea.ExecProcess (suspends TUI), status advances to in_review on clean exit or shows error in status bar. Includes full test coverage for backend resolution priority, command building, and shell quoting.

Co-Authored-By: Claude <noreply@anthropic.com>