### PR TITLE
Add agent runner with interactive PTY management

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -56,8 +56,12 @@ func BuildCmd(task *model.Task, cfg config.Config) (*exec.Cmd, error) {
 	}
 
 	cmdStr := backend.Command
-	if backend.PromptFlag != "" && task.Prompt != "" {
-		cmdStr += " " + backend.PromptFlag + " " + shellQuote(task.Prompt)
+	if task.Prompt != "" {
+		if backend.PromptFlag != "" {
+			cmdStr += " " + backend.PromptFlag + " " + shellQuote(task.Prompt)
+		} else {
+			cmdStr += " " + shellQuote(task.Prompt)
+		}
 	}
 
 	cmd := exec.Command("sh", "-c", cmdStr)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -11,7 +11,7 @@ func testConfig() config.Config {
 	return config.Config{
 		Defaults: config.Defaults{Backend: "claude"},
 		Backends: map[string]config.Backend{
-			"claude": {Command: "claude --dangerously-skip-permissions", PromptFlag: "-p"},
+			"claude": {Command: "claude --dangerously-skip-permissions --worktree", PromptFlag: ""},
 			"codex":  {Command: "codex", PromptFlag: "--prompt"},
 			"bare":   {Command: "my-agent", PromptFlag: ""},
 		},
@@ -30,8 +30,8 @@ func TestResolveBackend_DefaultFallback(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if b.Command != "claude --dangerously-skip-permissions" {
-		t.Errorf("expected claude command, got %q", b.Command)
+	if b.Command != "claude --dangerously-skip-permissions --worktree" {
+		t.Errorf("expected claude --worktree command, got %q", b.Command)
 	}
 }
 
@@ -56,8 +56,8 @@ func TestResolveBackend_TaskOverride(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if b.Command != "claude --dangerously-skip-permissions" {
-		t.Errorf("expected claude command, got %q", b.Command)
+	if b.Command != "claude --dangerously-skip-permissions --worktree" {
+		t.Errorf("expected claude --worktree command, got %q", b.Command)
 	}
 }
 
@@ -70,8 +70,8 @@ func TestResolveBackend_ProjectWithoutBackend(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Falls back to default since project "other" has no backend
-	if b.Command != "claude --dangerously-skip-permissions" {
-		t.Errorf("expected claude command, got %q", b.Command)
+	if b.Command != "claude --dangerously-skip-permissions --worktree" {
+		t.Errorf("expected claude --worktree command, got %q", b.Command)
 	}
 }
 
@@ -124,7 +124,7 @@ func TestBuildCmd(t *testing.T) {
 	if args[0] != "sh" || args[1] != "-c" {
 		t.Errorf("expected sh -c, got %v", args[:2])
 	}
-	expected := "claude --dangerously-skip-permissions -p 'fix the bug'"
+	expected := "claude --dangerously-skip-permissions --worktree 'fix the bug'"
 	if args[2] != expected {
 		t.Errorf("expected %q, got %q", expected, args[2])
 	}
@@ -157,8 +157,9 @@ func TestBuildCmd_EmptyPromptFlag(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if cmd.Args[2] != "my-agent" {
-		t.Errorf("expected bare command without prompt, got %q", cmd.Args[2])
+	// Empty PromptFlag means prompt is passed as positional arg
+	if cmd.Args[2] != "my-agent 'do stuff'" {
+		t.Errorf("expected command with positional prompt, got %q", cmd.Args[2])
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,8 +55,8 @@ func DefaultConfig() Config {
 		Defaults: Defaults{Backend: "claude"},
 		Backends: map[string]Backend{
 			"claude": {
-				Command:    "claude --dangerously-skip-permissions",
-				PromptFlag: "-p",
+				Command:    "claude --dangerously-skip-permissions --worktree",
+				PromptFlag: "",
 			},
 		},
 		Projects:    make(map[string]Project),

--- a/internal/ui/newtask.go
+++ b/internal/ui/newtask.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -38,6 +40,9 @@ func NewNewTaskForm(theme Theme, projects map[string]config.Project) NewTaskForm
 	projInput := textinput.New()
 	projInput.Placeholder = "Project (from config)"
 	projInput.CharLimit = 40
+	if cwd, err := os.Getwd(); err == nil {
+		projInput.SetValue(filepath.Base(cwd))
+	}
 	inputs[fieldProject] = projInput
 
 	promptInput := textinput.New()

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -182,11 +182,6 @@ func (m Model) attachAgent() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if t.Prompt == "" {
-		m.statusbar.SetError("no prompt set — press [p] to view/set prompt")
-		return m, nil
-	}
-
 	if t.AgentPID != 0 {
 		m.statusbar.SetError("agent already running")
 		return m, nil


### PR DESCRIPTION
Phase 2: agent package for backend resolution and command building. Enter key launches configured backend (claude --worktree) interactively via tea.ExecProcess, suspending TUI while the agent runs. Status advances to in_review on clean exit. New tasks default project to cwd basename.

Co-Authored-By: Claude <noreply@anthropic.com>