### PR TITLE
Add .worktrees to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ Thumbs.db
 
 # Claude Code worktrees (ephemeral, per-session)
 .claude/worktrees/
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION
Ignore git worktree directories used for parallel agent sessions.

Co-Authored-By: Claude <noreply@anthropic.com>