### PR TITLE
Add session resume support for Claude Code sessions

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -49,18 +49,30 @@ func ResolveDir(task *model.Task, cfg config.Config) string {
 }
 
 // BuildCmd constructs the exec.Cmd for running an agent on a task.
-func BuildCmd(task *model.Task, cfg config.Config) (*exec.Cmd, error) {
+// If the task has a SessionID, the command uses --resume to reconnect.
+// If resume is false and SessionID is set, it uses --session-id for a new session with a known ID.
+func BuildCmd(task *model.Task, cfg config.Config, resume bool) (*exec.Cmd, error) {
 	backend, err := ResolveBackend(task, cfg)
 	if err != nil {
 		return nil, err
 	}
 
 	cmdStr := backend.Command
-	if task.Prompt != "" {
-		if backend.PromptFlag != "" {
-			cmdStr += " " + backend.PromptFlag + " " + shellQuote(task.Prompt)
-		} else {
-			cmdStr += " " + shellQuote(task.Prompt)
+
+	if resume && task.SessionID != "" {
+		// Resume an existing session — no prompt needed
+		cmdStr += " --resume " + shellQuote(task.SessionID)
+	} else {
+		// New session — pin the session ID so we can resume later
+		if task.SessionID != "" {
+			cmdStr += " --session-id " + shellQuote(task.SessionID)
+		}
+		if task.Prompt != "" {
+			if backend.PromptFlag != "" {
+				cmdStr += " " + backend.PromptFlag + " " + shellQuote(task.Prompt)
+			} else {
+				cmdStr += " " + shellQuote(task.Prompt)
+			}
 		}
 	}
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -114,7 +114,7 @@ func TestBuildCmd(t *testing.T) {
 	cfg := testConfig()
 	task := &model.Task{Prompt: "fix the bug"}
 
-	cmd, err := BuildCmd(task, cfg)
+	cmd, err := BuildCmd(task, cfg, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestBuildCmd_WithProject(t *testing.T) {
 	cfg := testConfig()
 	task := &model.Task{Project: "myapp", Prompt: "test"}
 
-	cmd, err := BuildCmd(task, cfg)
+	cmd, err := BuildCmd(task, cfg, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestBuildCmd_EmptyPromptFlag(t *testing.T) {
 	cfg := testConfig()
 	task := &model.Task{Backend: "bare", Prompt: "do stuff"}
 
-	cmd, err := BuildCmd(task, cfg)
+	cmd, err := BuildCmd(task, cfg, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,6 +160,37 @@ func TestBuildCmd_EmptyPromptFlag(t *testing.T) {
 	// Empty PromptFlag means prompt is passed as positional arg
 	if cmd.Args[2] != "my-agent 'do stuff'" {
 		t.Errorf("expected command with positional prompt, got %q", cmd.Args[2])
+	}
+}
+
+func TestBuildCmd_NewSessionWithID(t *testing.T) {
+	cfg := testConfig()
+	task := &model.Task{Prompt: "fix the bug", SessionID: "aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee"}
+
+	cmd, err := BuildCmd(task, cfg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "claude --dangerously-skip-permissions --worktree --session-id 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee' 'fix the bug'"
+	if cmd.Args[2] != expected {
+		t.Errorf("expected %q, got %q", expected, cmd.Args[2])
+	}
+}
+
+func TestBuildCmd_Resume(t *testing.T) {
+	cfg := testConfig()
+	task := &model.Task{Prompt: "fix the bug", SessionID: "aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee"}
+
+	cmd, err := BuildCmd(task, cfg, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Resume should use --resume and ignore the prompt
+	expected := "claude --dangerously-skip-permissions --worktree --resume 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee'"
+	if cmd.Args[2] != expected {
+		t.Errorf("expected %q, got %q", expected, cmd.Args[2])
 	}
 }
 

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -35,7 +35,9 @@ func (r *Runner) Start(task *model.Task, cfg config.Config) (*Session, error) {
 	}
 	r.mu.Unlock()
 
-	cmd, err := BuildCmd(task, cfg)
+	// Resume if the task already has a session ID from a previous run
+	resume := task.SessionID != ""
+	cmd, err := BuildCmd(task, cfg, resume)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/model/task.go
+++ b/internal/model/task.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"crypto/rand"
 	"fmt"
 	"time"
 )
@@ -16,6 +17,7 @@ type Task struct {
 	Backend   string    `json:"backend,omitempty"`
 	Worktree  string    `json:"worktree,omitempty"`
 	AgentPID  int       `json:"agent_pid,omitempty"`
+	SessionID string    `json:"session_id,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 	StartedAt time.Time `json:"started_at,omitempty"`
 	EndedAt   time.Time `json:"ended_at,omitempty"`
@@ -50,6 +52,15 @@ func (t *Task) ElapsedString() string {
 		return fmt.Sprintf("%dh", hours)
 	}
 	return fmt.Sprintf("%dd", hours/24)
+}
+
+// GenerateSessionID creates a new UUID v4 session ID for Claude Code.
+func GenerateSessionID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 2
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
 
 // SetStatus updates the task status and manages timestamps.

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -197,7 +197,7 @@ func (m Model) attachAgent() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// If session already exists, reattach to it
+	// If session already exists in runner, reattach to it
 	if sess := m.runner.Get(t.ID); sess != nil {
 		attachCmd := &agent.AttachCmd{Session: sess}
 		return m, tea.Exec(attachCmd, func(err error) tea.Msg {
@@ -209,7 +209,12 @@ func (m Model) attachAgent() (tea.Model, tea.Cmd) {
 		})
 	}
 
-	// Start a new session
+	// Generate a session ID for new sessions so we can resume after restart
+	if t.SessionID == "" {
+		t.SessionID = model.GenerateSessionID()
+	}
+
+	// Start a new session (uses --resume if SessionID already existed)
 	sess, err := m.runner.Start(t, m.cfg)
 	if err != nil {
 		m.statusbar.SetError(err.Error())
@@ -389,4 +394,3 @@ func (m Model) confirmDeleteView() string {
 		"  " + m.theme.Normal.Render(t.Name) + "\n\n" +
 		m.theme.Help.Render("  [y] confirm  [any other key] cancel")
 }
-


### PR DESCRIPTION
Store a UUID session ID per task so agents can be resumed after Argus restarts. First attach generates and pins a --session-id; subsequent attaches use --resume to reconnect to the existing conversation.

Co-Authored-By: Claude <noreply@anthropic.com>