### PR TITLE
Start PTY with correct terminal size

### DIFF
--- a/internal/agent/attach.go
+++ b/internal/agent/attach.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/charmbracelet/x/term"
 	"golang.org/x/sys/unix"
 )
 
@@ -37,22 +38,14 @@ func (a *AttachCmd) Run() error {
 	}
 
 	// Put terminal into raw mode so keypresses pass through immediately
-	fd := int(os.Stdin.Fd())
-	orig, termErr := unix.IoctlGetTermios(fd, unix.TIOCGETA)
-	if termErr == nil {
-		raw := *orig
-		raw.Iflag &^= unix.BRKINT | unix.ICRNL | unix.INPCK | unix.ISTRIP | unix.IXON
-		raw.Oflag &^= unix.OPOST
-		raw.Cflag |= unix.CS8
-		raw.Lflag &^= unix.ECHO | unix.ICANON | unix.IEXTEN | unix.ISIG
-		raw.Cc[unix.VMIN] = 1
-		raw.Cc[unix.VTIME] = 0
-		unix.IoctlSetTermios(fd, unix.TIOCSETA, &raw)
-		defer unix.IoctlSetTermios(fd, unix.TIOCSETA, orig)
+	fd := os.Stdin.Fd()
+	prev, err := term.MakeRaw(fd)
+	if err == nil {
+		defer term.Restore(fd, prev)
 	}
 
 	// Match PTY size to current terminal
-	if ws, err := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ); err == nil {
+	if ws, wsErr := unix.IoctlGetWinsize(int(fd), unix.TIOCGWINSZ); wsErr == nil {
 		a.Session.Resize(ws.Row, ws.Col)
 	}
 

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -26,8 +26,9 @@ func NewRunner(onFinish func(taskID string, err error)) *Runner {
 }
 
 // Start launches a new agent session for the given task.
+// rows and cols set the initial PTY size (falls back to 80x24 if zero).
 // Returns an error if a session already exists for this task.
-func (r *Runner) Start(task *model.Task, cfg config.Config) (*Session, error) {
+func (r *Runner) Start(task *model.Task, cfg config.Config, rows, cols uint16) (*Session, error) {
 	r.mu.Lock()
 	if _, exists := r.sessions[task.ID]; exists {
 		r.mu.Unlock()
@@ -42,7 +43,7 @@ func (r *Runner) Start(task *model.Task, cfg config.Config) (*Session, error) {
 		return nil, err
 	}
 
-	sess, err := StartSession(task.ID, cmd)
+	sess, err := StartSession(task.ID, cmd, rows, cols)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -27,7 +27,7 @@ func TestRunner_StartAndGet(t *testing.T) {
 	task := &model.Task{ID: "t1", Name: "test"}
 	cfg := runnerTestConfig()
 
-	sess, err := r.Start(task, cfg)
+	sess, err := r.Start(task, cfg, 24, 80)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,13 +67,13 @@ func TestRunner_DuplicateStart(t *testing.T) {
 	}
 
 	task := &model.Task{ID: "t2", Name: "test"}
-	sess, err := r.Start(task, cfg)
+	sess, err := r.Start(task, cfg, 24, 80)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer sess.Stop()
 
-	_, err = r.Start(task, cfg)
+	_, err = r.Start(task, cfg, 24, 80)
 	if err == nil {
 		t.Error("expected error for duplicate start")
 	}
@@ -90,7 +90,7 @@ func TestRunner_StopAndRunning(t *testing.T) {
 	}
 
 	task := &model.Task{ID: "t3", Name: "test"}
-	_, err := r.Start(task, cfg)
+	_, err := r.Start(task, cfg, 24, 80)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -27,10 +27,15 @@ type Session struct {
 	detachCh chan struct{}
 }
 
-// StartSession allocates a PTY, starts the command, and begins
-// reading output into a ring buffer.
-func StartSession(taskID string, cmd *exec.Cmd) (*Session, error) {
-	ptmx, err := pty.Start(cmd)
+// StartSession allocates a PTY with the given initial size, starts the command,
+// and begins reading output into a ring buffer.
+func StartSession(taskID string, cmd *exec.Cmd, rows, cols uint16) (*Session, error) {
+	size := &pty.Winsize{Rows: rows, Cols: cols}
+	if rows == 0 || cols == 0 {
+		size = &pty.Winsize{Rows: 24, Cols: 80}
+	}
+
+	ptmx, err := pty.StartWithSize(cmd, size)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +65,8 @@ func (s *Session) readLoop() {
 	for {
 		n, err := s.ptmx.Read(tmp)
 		if n > 0 {
-			chunk := tmp[:n]
+			chunk := make([]byte, n)
+			copy(chunk, tmp[:n])
 			s.mu.Lock()
 			s.buf.Write(chunk)
 			w := s.attachW
@@ -122,10 +128,9 @@ func (s *Session) Attach(stdin io.Reader, stdout io.Writer) error {
 	s.attached = true
 	s.detachCh = make(chan struct{})
 
-	// Replay buffered output so user sees recent context
+	// Replay buffered output so user sees recent context,
+	// then set tee writer — all under one lock so no data is lost.
 	replay := s.buf.Bytes()
-
-	// Set the tee writer so readLoop sends new output to stdout
 	s.attachW = stdout
 	s.mu.Unlock()
 

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestStartSession_EchoCommand(t *testing.T) {
 	cmd := exec.Command("echo", "hello from pty")
-	sess, err := StartSession("test-1", cmd)
+	sess, err := StartSession("test-1", cmd, 24, 80)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestStartSession_EchoCommand(t *testing.T) {
 
 func TestStartSession_PID(t *testing.T) {
 	cmd := exec.Command("sleep", "10")
-	sess, err := StartSession("test-2", cmd)
+	sess, err := StartSession("test-2", cmd, 24, 80)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestStartSession_PID(t *testing.T) {
 
 func TestStartSession_Stop(t *testing.T) {
 	cmd := exec.Command("sleep", "60")
-	sess, err := StartSession("test-3", cmd)
+	sess, err := StartSession("test-3", cmd, 24, 80)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestStartSession_Stop(t *testing.T) {
 
 func TestStartSession_Detach_NotAttached(t *testing.T) {
 	cmd := exec.Command("sleep", "10")
-	sess, err := StartSession("test-4", cmd)
+	sess, err := StartSession("test-4", cmd, 24, 80)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -214,8 +214,8 @@ func (m Model) attachAgent() (tea.Model, tea.Cmd) {
 		t.SessionID = model.GenerateSessionID()
 	}
 
-	// Start a new session (uses --resume if SessionID already existed)
-	sess, err := m.runner.Start(t, m.cfg)
+	// Start a new session with current terminal dimensions
+	sess, err := m.runner.Start(t, m.cfg, uint16(m.height), uint16(m.width))
 	if err != nil {
 		m.statusbar.SetError(err.Error())
 		return m, nil


### PR DESCRIPTION
Use pty.StartWithSize so the child process sees real terminal dimensions from launch. Pass size from Bubble Tea WindowSizeMsg through runner to session. Copy PTY read chunks defensively.

Co-Authored-By: Claude <noreply@anthropic.com>