### PR TITLE
Fix terminal display and clear screen on agent attach

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/creack/pty v1.1.24
+	golang.org/x/sys v0.38.0
 )
 
 require (
@@ -19,7 +21,6 @@ require (
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
-	github.com/creack/pty v1.1.24 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -30,6 +31,5 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/internal/agent/attach.go
+++ b/internal/agent/attach.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/charmbracelet/x/term"
 	"golang.org/x/sys/unix"
 )
 
@@ -37,11 +36,22 @@ func (a *AttachCmd) Run() error {
 		a.stdout = os.Stdout
 	}
 
-	// Put terminal into raw mode so keypresses pass through immediately
-	fd := os.Stdin.Fd()
-	prev, err := term.MakeRaw(fd)
+	// Set raw input (no echo, no canonical, no signals) but keep output
+	// processing (OPOST) so \n → \r\n conversion works. term.MakeRaw
+	// clears OPOST which causes garbled output from PTY children.
+	fd := int(os.Stdin.Fd())
+	orig, err := unix.IoctlGetTermios(fd, ioctlGetTermios)
 	if err == nil {
-		defer term.Restore(fd, prev)
+		raw := *orig
+		// Raw input flags
+		raw.Iflag &^= unix.BRKINT | unix.ICRNL | unix.INPCK | unix.ISTRIP | unix.IXON
+		raw.Cflag |= unix.CS8
+		raw.Lflag &^= unix.ECHO | unix.ICANON | unix.IEXTEN | unix.ISIG
+		raw.Cc[unix.VMIN] = 1
+		raw.Cc[unix.VTIME] = 0
+		// Keep OPOST in Oflag — do NOT clear it
+		unix.IoctlSetTermios(fd, ioctlSetTermios, &raw)
+		defer unix.IoctlSetTermios(fd, ioctlSetTermios, orig)
 	}
 
 	// Clear screen before attaching

--- a/internal/agent/termios_darwin.go
+++ b/internal/agent/termios_darwin.go
@@ -1,0 +1,8 @@
+package agent
+
+import "golang.org/x/sys/unix"
+
+const (
+	ioctlGetTermios = unix.TIOCGETA
+	ioctlSetTermios = unix.TIOCSETA
+)

--- a/internal/agent/termios_linux.go
+++ b/internal/agent/termios_linux.go
@@ -1,0 +1,8 @@
+package agent
+
+import "golang.org/x/sys/unix"
+
+const (
+	ioctlGetTermios = unix.TCGETS
+	ioctlSetTermios = unix.TCSETS
+)


### PR DESCRIPTION
Clear screen when attaching to agent sessions and fix garbled terminal output by preserving OPOST flag in raw mode (manual termios instead of term.MakeRaw). Adds platform-specific ioctl constants for macOS/Linux.

Co-Authored-By: Claude <noreply@anthropic.com>