### PR TITLE
Resume previous Claude Code session on relaunch

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -27,8 +27,9 @@ func NewRunner(onFinish func(taskID string, err error)) *Runner {
 
 // Start launches a new agent session for the given task.
 // rows and cols set the initial PTY size (falls back to 80x24 if zero).
+// If resume is true, the agent reconnects to an existing conversation via --resume.
 // Returns an error if a session already exists for this task.
-func (r *Runner) Start(task *model.Task, cfg config.Config, rows, cols uint16) (*Session, error) {
+func (r *Runner) Start(task *model.Task, cfg config.Config, rows, cols uint16, resume bool) (*Session, error) {
 	r.mu.Lock()
 	if _, exists := r.sessions[task.ID]; exists {
 		r.mu.Unlock()
@@ -36,9 +37,7 @@ func (r *Runner) Start(task *model.Task, cfg config.Config, rows, cols uint16) (
 	}
 	r.mu.Unlock()
 
-	// Always start fresh — reattach to existing PTY is handled by runner.Get
-	// before reaching here. Use session-id to pin the conversation.
-	cmd, err := BuildCmd(task, cfg, false)
+	cmd, err := BuildCmd(task, cfg, resume)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -27,7 +27,7 @@ func TestRunner_StartAndGet(t *testing.T) {
 	task := &model.Task{ID: "t1", Name: "test"}
 	cfg := runnerTestConfig()
 
-	sess, err := r.Start(task, cfg, 24, 80)
+	sess, err := r.Start(task, cfg, 24, 80, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,13 +67,13 @@ func TestRunner_DuplicateStart(t *testing.T) {
 	}
 
 	task := &model.Task{ID: "t2", Name: "test"}
-	sess, err := r.Start(task, cfg, 24, 80)
+	sess, err := r.Start(task, cfg, 24, 80, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer sess.Stop()
 
-	_, err = r.Start(task, cfg, 24, 80)
+	_, err = r.Start(task, cfg, 24, 80, false)
 	if err == nil {
 		t.Error("expected error for duplicate start")
 	}
@@ -90,7 +90,7 @@ func TestRunner_StopAndRunning(t *testing.T) {
 	}
 
 	task := &model.Task{ID: "t3", Name: "test"}
-	_, err := r.Start(task, cfg, 24, 80)
+	_, err := r.Start(task, cfg, 24, 80, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -212,13 +212,15 @@ func (m Model) startOrAttach(t *model.Task) (tea.Model, tea.Cmd) {
 		})
 	}
 
-	// Generate a session ID for new sessions so we can resume after restart
-	if t.SessionID == "" {
+	// If the task already has a session ID, resume that conversation;
+	// otherwise generate a new one for a fresh start.
+	resume := t.SessionID != ""
+	if !resume {
 		t.SessionID = model.GenerateSessionID()
 	}
 
 	// Start a new session with current terminal dimensions
-	sess, err := m.runner.Start(t, m.cfg, uint16(m.height), uint16(m.width))
+	sess, err := m.runner.Start(t, m.cfg, uint16(m.height), uint16(m.width), resume)
 	if err != nil {
 		m.statusbar.SetError(err.Error())
 		return m, nil


### PR DESCRIPTION
When Argus restarts, tasks with an existing SessionID now use `--resume` to reconnect to the prior Claude Code conversation instead of starting a fresh session with `--session-id`.

Co-Authored-By: Claude <noreply@anthropic.com>