### PR TITLE
Add split-pane layout with agent output preview

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -197,6 +197,14 @@ func (s *Session) Stop() error {
 	return s.Signal(syscall.SIGTERM)
 }
 
+// RecentOutput returns the last n bytes from the ring buffer.
+// Safe to call concurrently.
+func (s *Session) RecentOutput() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Bytes()
+}
+
 // Resize sets the PTY window size.
 func (s *Session) Resize(rows, cols uint16) error {
 	return pty.Setsize(s.ptmx, &pty.Winsize{

--- a/internal/ui/preview.go
+++ b/internal/ui/preview.go
@@ -1,0 +1,89 @@
+package ui
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/drn/argus/internal/agent"
+)
+
+// ansiRe matches ANSI escape sequences (CSI, OSC, etc.)
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x1b]*(?:\x1b\\|\x07)|\x1b[()][0-9A-B]|\x1b\[[\?]?[0-9;]*[hlm]`)
+
+// Preview renders the agent output for the selected task.
+type Preview struct {
+	theme  Theme
+	runner *agent.Runner
+	width  int
+	height int
+}
+
+func NewPreview(theme Theme, runner *agent.Runner) Preview {
+	return Preview{theme: theme, runner: runner}
+}
+
+func (p *Preview) SetSize(w, h int) {
+	p.width = w
+	p.height = h
+}
+
+func (p Preview) View(taskID string) string {
+	border := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("238")).
+		Width(p.width - 2).
+		Height(p.height - 2)
+
+	if taskID == "" {
+		return border.Render(p.emptyView("No task selected"))
+	}
+
+	sess := p.runner.Get(taskID)
+	if sess == nil {
+		return border.Render(p.emptyView("No active agent\n\n" +
+			p.theme.Help.Render("Press ENTER to start")))
+	}
+
+	raw := sess.RecentOutput()
+	content := p.formatOutput(raw)
+	return border.Render(content)
+}
+
+func (p Preview) emptyView(msg string) string {
+	style := p.theme.Dimmed.
+		Width(p.width - 4).
+		Height(p.height - 4).
+		AlignHorizontal(lipgloss.Center).
+		AlignVertical(lipgloss.Center)
+	return style.Render(msg)
+}
+
+func (p Preview) formatOutput(raw []byte) string {
+	// Strip ANSI escape sequences for clean preview
+	cleaned := ansiRe.ReplaceAll(raw, nil)
+
+	// Remove carriage returns
+	cleaned = bytes.ReplaceAll(cleaned, []byte("\r"), nil)
+
+	// Split into lines and take the last `height` lines
+	lines := strings.Split(string(cleaned), "\n")
+
+	maxLines := max(p.height-4, 1)
+
+	// Take last N lines
+	if len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+	}
+
+	// Truncate long lines to fit width
+	maxWidth := max(p.width-6, 10)
+	for i, line := range lines {
+		if len(line) > maxWidth {
+			lines[i] = line[:maxWidth-1] + "…"
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -49,6 +49,7 @@ type Model struct {
 	statusbar StatusBar
 	helpview  HelpView
 	newtask   NewTaskForm
+	preview   Preview
 	current   view
 	width     int
 	height    int
@@ -63,6 +64,8 @@ func NewModel(cfg config.Config, s *store.Store, runner *agent.Runner) Model {
 	sb := NewStatusBar(theme)
 	hv := NewHelpView(keys, theme)
 
+	pv := NewPreview(theme, runner)
+
 	m := Model{
 		cfg:       cfg,
 		store:     s,
@@ -72,6 +75,7 @@ func NewModel(cfg config.Config, s *store.Store, runner *agent.Runner) Model {
 		tasklist:  tl,
 		statusbar: sb,
 		helpview:  hv,
+		preview:   pv,
 		current:   viewTaskList,
 	}
 	m.refreshTasks()
@@ -89,8 +93,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		// Reserve space: banner(7) + divider(2) + section header(1) + gap(1) + statusbar(1)
-		m.tasklist.SetSize(msg.Width, msg.Height-12)
+		leftWidth, rightWidth := m.splitWidths()
+		// Reserve space: section header(1) + gap(1) + statusbar(1)
+		contentHeight := msg.Height - 3
+		m.tasklist.SetSize(leftWidth, contentHeight)
+		m.preview.SetSize(rightWidth, contentHeight)
 		m.statusbar.SetWidth(msg.Width)
 		return m, nil
 
@@ -326,13 +333,20 @@ func (m Model) View() string {
 		return m.padToBottom(content, bar)
 	}
 
-	// Main task list view with banner
-	banner := renderBanner(m.width)
-	divider := m.renderDivider()
+	// Split layout: task list on left, agent preview on right
 	section := m.renderSectionHeader()
 	tasks := m.tasklist.View()
+	leftContent := section + "\n" + tasks
 
-	content := "\n" + banner + "\n\n" + divider + "\n" + section + "\n" + tasks
+	// Preview pane for selected task
+	var taskID string
+	if t := m.tasklist.Selected(); t != nil {
+		taskID = t.ID
+	}
+	rightContent := m.preview.View(taskID)
+
+	// Join horizontally
+	content := lipgloss.JoinHorizontal(lipgloss.Top, leftContent, rightContent)
 	return m.padToBottom(content, bar)
 }
 
@@ -347,6 +361,20 @@ func (m Model) padToBottom(content, bar string) string {
 		padding = strings.Repeat("\n", contentHeight-contentLines)
 	}
 	return content + padding + "\n" + bar
+}
+
+// splitWidths returns the left (task list) and right (preview) pane widths.
+func (m Model) splitWidths() (int, int) {
+	// Give ~40% to task list, rest to preview. Minimum 30 for tasks.
+	left := m.width * 2 / 5
+	if left < 30 {
+		left = 30
+	}
+	if left > m.width-20 {
+		left = m.width - 20
+	}
+	right := m.width - left
+	return left, right
 }
 
 func (m Model) renderDivider() string {


### PR DESCRIPTION
Replace full-width task list with a left nav (40%) + right preview pane (60%). Moving the cursor up/down updates the preview to show the selected task's recent agent output, read from the ring buffer and stripped of ANSI escapes.

Co-Authored-By: Claude <noreply@anthropic.com>