### PR TITLE
Clear expired session ID on agent error to allow fresh restart

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -266,7 +266,14 @@ func (m Model) handleAgentFinished(msg AgentFinishedMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if msg.Err != nil {
-		m.statusbar.SetError("agent error: " + msg.Err.Error())
+		// If the agent failed and had a session ID, clear it so the next
+		// attempt starts a fresh session instead of retrying a broken resume.
+		if t.SessionID != "" {
+			t.SessionID = ""
+			m.statusbar.SetError("session expired — press enter to start a new session")
+		} else {
+			m.statusbar.SetError("agent error: " + msg.Err.Error())
+		}
 		_ = m.store.Update(t)
 	} else {
 		t.SetStatus(model.StatusInReview)


### PR DESCRIPTION
When resuming a task from a previous argus session, the stored SessionID causes `--resume` to fail repeatedly since the Claude Code session no longer exists. This clears the SessionID on error and shows a helpful message so the next attach starts a fresh session.

Co-Authored-By: Claude <noreply@anthropic.com>