### PR TITLE
Fix preview rendering and auto-cleanup worktrees on delete

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,9 +44,19 @@ type Keybindings struct {
 }
 
 type UIConfig struct {
-	Theme       string `toml:"theme"`
-	ShowElapsed bool   `toml:"show_elapsed"`
-	ShowIcons   bool   `toml:"show_icons"`
+	Theme            string `toml:"theme"`
+	ShowElapsed      bool   `toml:"show_elapsed"`
+	ShowIcons        bool   `toml:"show_icons"`
+	CleanupWorktrees *bool  `toml:"cleanup_worktrees,omitempty"`
+}
+
+// ShouldCleanupWorktrees returns whether worktrees should be auto-removed on task delete.
+// Defaults to true if not explicitly set.
+func (u UIConfig) ShouldCleanupWorktrees() bool {
+	if u.CleanupWorktrees == nil {
+		return true
+	}
+	return *u.CleanupWorktrees
 }
 
 // DefaultConfig returns a config with sensible defaults.

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -307,6 +309,14 @@ func (m Model) handleConfirmDeleteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch {
 	case key.Matches(msg, m.keys.Confirm):
 		if t := m.tasklist.Selected(); t != nil {
+			// Stop the agent session if running
+			if m.runner.HasSession(t.ID) {
+				_ = m.runner.Stop(t.ID)
+			}
+			// Clean up worktree if configured
+			if t.Worktree != "" && m.cfg.UI.ShouldCleanupWorktrees() {
+				removeWorktree(t.Worktree)
+			}
 			_ = m.store.Delete(t.ID)
 			m.refreshTasks()
 		}
@@ -449,4 +459,21 @@ func (m Model) confirmDeleteView() string {
 func dirExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.IsDir()
+}
+
+// removeWorktree removes a git worktree directory. It first tries
+// "git worktree remove" (which cleans up .git/worktrees metadata),
+// falling back to a plain directory removal if the git command fails.
+func removeWorktree(worktreePath string) {
+	if !dirExists(worktreePath) {
+		return
+	}
+	// Find the parent repo by looking for .git in the worktree's parent chain.
+	// Git worktree remove needs to run from within the main repo or the worktree itself.
+	cmd := exec.Command("git", "worktree", "remove", "--force", filepath.Clean(worktreePath))
+	cmd.Dir = filepath.Dir(worktreePath)
+	if err := cmd.Run(); err != nil {
+		// Fallback: just remove the directory
+		_ = os.RemoveAll(worktreePath)
+	}
 }


### PR DESCRIPTION
- Fix garbled agent preview output by adding a virtual terminal emulator
- Auto-remove git worktrees when deleting tasks (configurable via cleanup_worktrees)

Co-Authored-By: Claude <noreply@anthropic.com>