### PR TITLE
Add git status/diff panel above agent preview pane

### DIFF
--- a/internal/ui/gitstatus.go
+++ b/internal/ui/gitstatus.go
@@ -1,0 +1,178 @@
+package ui
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// GitStatusRefreshMsg carries the result of a background git status check.
+type GitStatusRefreshMsg struct {
+	TaskID string
+	Status string // git status --short output
+	Diff   string // git diff --stat output
+}
+
+// GitStatus renders worktree git status and diff stat above the preview pane.
+type GitStatus struct {
+	theme      Theme
+	width      int
+	height     int
+	taskID     string
+	statusText string
+	diffText   string
+	lastRefresh time.Time
+}
+
+func NewGitStatus(theme Theme) GitStatus {
+	return GitStatus{theme: theme}
+}
+
+func (g *GitStatus) SetSize(w, h int) {
+	g.width = w
+	g.height = h
+}
+
+// Update caches the git status result if it matches the current task.
+func (g *GitStatus) Update(msg GitStatusRefreshMsg) {
+	if msg.TaskID == g.taskID {
+		g.statusText = msg.Status
+		g.diffText = msg.Diff
+		g.lastRefresh = time.Now()
+	}
+}
+
+// SetTask updates the tracked task; clears cached data on change.
+func (g *GitStatus) SetTask(taskID string) {
+	if taskID != g.taskID {
+		g.taskID = taskID
+		g.statusText = ""
+		g.diffText = ""
+		g.lastRefresh = time.Time{}
+	}
+}
+
+// NeedsRefresh returns true if we should kick off a new git status check.
+func (g *GitStatus) NeedsRefresh() bool {
+	if g.taskID == "" {
+		return false
+	}
+	return time.Since(g.lastRefresh) > 3*time.Second
+}
+
+func (g GitStatus) View() string {
+	innerW := max(g.width-4, 10) // padding inside border
+	innerH := max(g.height-2, 1) // border top/bottom
+
+	border := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("238")).
+		Width(g.width - 2).
+		Height(innerH)
+
+	if g.taskID == "" {
+		return border.Render(g.theme.Dimmed.Render(" No worktree"))
+	}
+
+	if g.statusText == "" && g.diffText == "" {
+		return border.Render(g.theme.Dimmed.Render(" Loading..."))
+	}
+
+	var sections []string
+
+	if g.statusText != "" {
+		header := g.theme.Section.Render("  FILES")
+		lines := g.truncateLines(g.statusText, innerW, innerH-2)
+		sections = append(sections, header+"\n"+g.colorizeStatus(lines))
+	}
+
+	if g.diffText != "" {
+		header := g.theme.Section.Render("  DIFF")
+		lines := g.truncateLines(g.diffText, innerW, innerH-2)
+		sections = append(sections, header+"\n"+g.colorizeDiff(lines))
+	}
+
+	content := strings.Join(sections, "\n")
+
+	// Truncate to fit
+	contentLines := strings.Split(content, "\n")
+	if len(contentLines) > innerH {
+		contentLines = contentLines[:innerH]
+	}
+
+	return border.Render(strings.Join(contentLines, "\n"))
+}
+
+func (g GitStatus) truncateLines(text string, maxWidth, maxLines int) string {
+	lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+	if len(lines) > maxLines {
+		lines = lines[:maxLines]
+	}
+	for i, line := range lines {
+		if len(line) > maxWidth {
+			lines[i] = line[:maxWidth-1] + "…"
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (g GitStatus) colorizeStatus(text string) string {
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "M "), strings.HasPrefix(trimmed, "MM"):
+			lines[i] = g.theme.InReview.Render("  " + trimmed)
+		case strings.HasPrefix(trimmed, "A "), strings.HasPrefix(trimmed, "??"):
+			lines[i] = g.theme.Complete.Render("  " + trimmed)
+		case strings.HasPrefix(trimmed, "D "):
+			lines[i] = g.theme.Error.Render("  " + trimmed)
+		default:
+			lines[i] = g.theme.Normal.Render("  " + trimmed)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (g GitStatus) colorizeDiff(text string) string {
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		lines[i] = g.theme.Dimmed.Render("  " + line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// FetchGitStatus runs git commands in the given worktree directory.
+// Intended to be called from a tea.Cmd (off the main goroutine).
+func FetchGitStatus(taskID, worktree string) GitStatusRefreshMsg {
+	msg := GitStatusRefreshMsg{TaskID: taskID}
+
+	if worktree == "" {
+		return msg
+	}
+
+	// git status --short
+	if out, err := runGit(worktree, "status", "--short"); err == nil {
+		msg.Status = strings.TrimRight(out, "\n")
+	}
+
+	// git diff --stat
+	if out, err := runGit(worktree, "diff", "--stat"); err == nil {
+		msg.Diff = strings.TrimRight(out, "\n")
+	}
+
+	return msg
+}
+
+func runGit(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	err := cmd.Run()
+	return out.String(), err
+}

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -53,6 +53,7 @@ type Model struct {
 	helpview  HelpView
 	newtask   NewTaskForm
 	preview   Preview
+	gitstatus GitStatus
 	current   view
 	width     int
 	height    int
@@ -68,6 +69,7 @@ func NewModel(cfg config.Config, s *store.Store, runner *agent.Runner) Model {
 	hv := NewHelpView(keys, theme)
 
 	pv := NewPreview(theme, runner)
+	gs := NewGitStatus(theme)
 
 	m := Model{
 		cfg:       cfg,
@@ -79,6 +81,7 @@ func NewModel(cfg config.Config, s *store.Store, runner *agent.Runner) Model {
 		statusbar: sb,
 		helpview:  hv,
 		preview:   pv,
+		gitstatus: gs,
 		current:   viewTaskList,
 	}
 	m.refreshTasks()
@@ -100,15 +103,35 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Reserve space: section header(1) + gap(1) + statusbar(1)
 		contentHeight := msg.Height - 3
 		m.tasklist.SetSize(leftWidth, contentHeight)
-		m.preview.SetSize(rightWidth, contentHeight)
+		gitH, previewH := m.splitRightHeights(contentHeight)
+		m.gitstatus.SetSize(rightWidth, gitH)
+		m.preview.SetSize(rightWidth, previewH)
 		m.statusbar.SetWidth(msg.Width)
 		return m, nil
 
 	case TickMsg:
-		// Just re-render for elapsed time updates
-		return m, tea.Tick(time.Second, func(_ time.Time) tea.Msg {
+		// Kick off git status refresh if needed
+		var cmds []tea.Cmd
+		cmds = append(cmds, tea.Tick(time.Second, func(_ time.Time) tea.Msg {
 			return TickMsg{}
-		})
+		}))
+		if t := m.tasklist.Selected(); t != nil && t.Worktree != "" {
+			m.gitstatus.SetTask(t.ID)
+			if m.gitstatus.NeedsRefresh() {
+				worktree := t.Worktree
+				taskID := t.ID
+				cmds = append(cmds, func() tea.Msg {
+					return FetchGitStatus(taskID, worktree)
+				})
+			}
+		} else {
+			m.gitstatus.SetTask("")
+		}
+		return m, tea.Batch(cmds...)
+
+	case GitStatusRefreshMsg:
+		m.gitstatus.Update(msg)
+		return m, nil
 
 	case AgentFinishedMsg:
 		return m.handleAgentFinished(msg)
@@ -365,12 +388,14 @@ func (m Model) View() string {
 	tasks := m.tasklist.View()
 	leftContent := section + "\n" + tasks
 
-	// Preview pane for selected task
+	// Git status + Preview pane for selected task
 	var taskID string
 	if t := m.tasklist.Selected(); t != nil {
 		taskID = t.ID
 	}
-	rightContent := m.preview.View(taskID)
+	gitView := m.gitstatus.View()
+	previewView := m.preview.View(taskID)
+	rightContent := lipgloss.JoinVertical(lipgloss.Left, gitView, previewView)
 
 	// Join horizontally
 	content := lipgloss.JoinHorizontal(lipgloss.Top, leftContent, rightContent)
@@ -388,6 +413,23 @@ func (m Model) padToBottom(content, bar string) string {
 		padding = strings.Repeat("\n", contentHeight-contentLines)
 	}
 	return content + padding + "\n" + bar
+}
+
+// splitRightHeights returns the git status and preview pane heights.
+// Git status gets ~30% of the right pane, preview gets the rest.
+func (m Model) splitRightHeights(total int) (int, int) {
+	gitH := total * 3 / 10
+	if gitH < 5 {
+		gitH = 5
+	}
+	if gitH > 15 {
+		gitH = 15
+	}
+	previewH := total - gitH
+	if previewH < 5 {
+		previewH = 5
+	}
+	return gitH, previewH
 }
 
 // splitWidths returns the left (task list) and right (preview) pane widths.


### PR DESCRIPTION
Display worktree git status and diff stat in a bordered panel above the agent output preview on the right side. Refreshes asynchronously every 3 seconds with colorized file status indicators.

Co-Authored-By: Claude <noreply@anthropic.com>