### PR TITLE
Fix status indicators showing 'progress' for idle agents

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -353,9 +353,11 @@ func (m Model) handleConfirmDeleteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m *Model) refreshTasks() {
 	tasks := m.store.Tasks()
+	running := m.runner.Running()
 	m.tasklist.SetTasks(tasks)
-	m.tasklist.SetRunning(m.runner.Running())
+	m.tasklist.SetRunning(running)
 	m.statusbar.SetTasks(tasks)
+	m.statusbar.SetRunning(running)
 }
 
 func (m Model) View() string {
@@ -455,10 +457,14 @@ func (m Model) renderDivider() string {
 }
 
 func (m Model) renderSectionHeader() string {
+	running := make(map[string]bool)
+	for _, id := range m.runner.Running() {
+		running[id] = true
+	}
 	active := 0
 	total := len(m.store.Tasks())
 	for _, t := range m.store.Tasks() {
-		if t.Status == model.StatusInProgress {
+		if t.Status == model.StatusInProgress && running[t.ID] {
 			active++
 		}
 	}

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -10,10 +10,11 @@ import (
 
 // StatusBar renders the bottom status bar.
 type StatusBar struct {
-	theme  Theme
-	width  int
-	tasks  []*model.Task
-	errMsg string
+	theme   Theme
+	width   int
+	tasks   []*model.Task
+	running map[string]bool
+	errMsg  string
 }
 
 func NewStatusBar(theme Theme) StatusBar {
@@ -26,6 +27,13 @@ func (sb *StatusBar) SetWidth(w int) {
 
 func (sb *StatusBar) SetTasks(tasks []*model.Task) {
 	sb.tasks = tasks
+}
+
+func (sb *StatusBar) SetRunning(ids []string) {
+	sb.running = make(map[string]bool, len(ids))
+	for _, id := range ids {
+		sb.running[id] = true
+	}
 }
 
 func (sb *StatusBar) SetError(msg string) {
@@ -47,7 +55,9 @@ func (sb StatusBar) View() string {
 		for _, t := range sb.tasks {
 			switch t.Status {
 			case model.StatusInProgress:
-				active++
+				if sb.running[t.ID] {
+					active++
+				}
 			case model.StatusPending:
 				pending++
 			case model.StatusComplete:

--- a/internal/ui/statusbar_test.go
+++ b/internal/ui/statusbar_test.go
@@ -11,13 +11,14 @@ func TestStatusBar_TaskCounts(t *testing.T) {
 	sb := NewStatusBar(DefaultTheme())
 	sb.SetWidth(120)
 	sb.SetTasks([]*model.Task{
-		{Status: model.StatusInProgress},
-		{Status: model.StatusInProgress},
+		{ID: "a", Status: model.StatusInProgress},
+		{ID: "b", Status: model.StatusInProgress},
 		{Status: model.StatusPending},
 		{Status: model.StatusComplete},
 		{Status: model.StatusComplete},
 		{Status: model.StatusComplete},
 	})
+	sb.SetRunning([]string{"a", "b"})
 
 	v := sb.View()
 	if !strings.Contains(v, "2 active") {


### PR DESCRIPTION
Section header and status bar counted any InProgress task as active without checking if the agent process was actually running. Now both use runner.Running() to only count tasks with live agent sessions.

Co-Authored-By: Claude <noreply@anthropic.com>