### PR TITLE
Fix preview pane rendering after attach/detach cycles

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -25,6 +25,8 @@ type Session struct {
 	err      error
 	attached bool
 	detachCh chan struct{}
+	ptyCols  uint16 // current PTY width
+	ptyRows  uint16 // current PTY height
 }
 
 // StartSession allocates a PTY with the given initial size, starts the command,
@@ -33,6 +35,8 @@ func StartSession(taskID string, cmd *exec.Cmd, rows, cols uint16) (*Session, er
 	size := &pty.Winsize{Rows: rows, Cols: cols}
 	if rows == 0 || cols == 0 {
 		size = &pty.Winsize{Rows: 24, Cols: 80}
+		rows = 24
+		cols = 80
 	}
 
 	ptmx, err := pty.StartWithSize(cmd, size)
@@ -47,6 +51,8 @@ func StartSession(taskID string, cmd *exec.Cmd, rows, cols uint16) (*Session, er
 		buf:      newRingBuffer(defaultBufSize),
 		done:     make(chan struct{}),
 		detachCh: make(chan struct{}),
+		ptyCols:  cols,
+		ptyRows:  rows,
 	}
 
 	// Single reader: PTY → ring buffer (+ attached writer when set)
@@ -207,8 +213,19 @@ func (s *Session) RecentOutput() []byte {
 
 // Resize sets the PTY window size.
 func (s *Session) Resize(rows, cols uint16) error {
+	s.mu.Lock()
+	s.ptyCols = cols
+	s.ptyRows = rows
+	s.mu.Unlock()
 	return pty.Setsize(s.ptmx, &pty.Winsize{
 		Rows: rows,
 		Cols: cols,
 	})
+}
+
+// PTYSize returns the current PTY dimensions (cols, rows).
+func (s *Session) PTYSize() (cols, rows int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return int(s.ptyCols), int(s.ptyRows)
 }

--- a/internal/ui/preview.go
+++ b/internal/ui/preview.go
@@ -44,7 +44,8 @@ func (p Preview) View(taskID string) string {
 	}
 
 	raw := sess.RecentOutput()
-	content := p.formatOutput(raw)
+	ptyCols, ptyRows := sess.PTYSize()
+	content := p.formatOutput(raw, ptyCols, ptyRows)
 	return border.Render(content)
 }
 
@@ -57,15 +58,22 @@ func (p Preview) emptyView(msg string) string {
 	return style.Render(msg)
 }
 
-func (p Preview) formatOutput(raw []byte) string {
+func (p Preview) formatOutput(raw []byte, ptyCols, ptyRows int) string {
 	if len(raw) == 0 {
 		return ""
 	}
 
-	// The PTY output was generated for the full terminal width, so we
-	// interpret it with a wide virtual terminal, then crop to fit.
-	vtCols := 200
-	vtRows := 500
+	// Use the actual PTY dimensions so the vt10x interpretation matches
+	// what the child process was rendering for. Fall back to wide defaults
+	// if dimensions are unknown.
+	vtCols := ptyCols
+	vtRows := ptyRows
+	if vtCols < 40 {
+		vtCols = 200
+	}
+	if vtRows < 10 {
+		vtRows = 500
+	}
 	vt := vt10x.New(vt10x.WithSize(vtCols, vtRows))
 	vt.Write(raw)
 


### PR DESCRIPTION
Track actual PTY dimensions in Session and use them for vt10x interpretation in the preview pane, fixing misaligned rendering after entering/exiting agent sessions multiple times.

Co-Authored-By: Claude <noreply@anthropic.com>