### PR TITLE
Fix aborted agents showing as review instead of being deleted

### DIFF
--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -27,9 +27,9 @@ func main() {
 	// Create runner — the onFinish callback sends a message to the tea.Program.
 	// We need to create the program first, so we use a closure that captures p.
 	var p *tea.Program
-	runner := agent.NewRunner(func(taskID string, err error) {
+	runner := agent.NewRunner(func(taskID string, err error, stopped bool) {
 		if p != nil {
-			p.Send(ui.AgentFinishedMsg{TaskID: taskID, Err: err})
+			p.Send(ui.AgentFinishedMsg{TaskID: taskID, Err: err, Stopped: stopped})
 		}
 	})
 	defer runner.StopAll()

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -13,14 +13,16 @@ import (
 type Runner struct {
 	mu       sync.Mutex
 	sessions map[string]*Session
-	onFinish func(taskID string, err error)
+	stopped  map[string]bool // tracks task IDs where Stop was explicitly called
+	onFinish func(taskID string, err error, stopped bool)
 }
 
 // NewRunner creates a Runner. The onFinish callback is called (in a goroutine)
 // when any managed session's process exits.
-func NewRunner(onFinish func(taskID string, err error)) *Runner {
+func NewRunner(onFinish func(taskID string, err error, stopped bool)) *Runner {
 	return &Runner{
 		sessions: make(map[string]*Session),
+		stopped:  make(map[string]bool),
 		onFinish: onFinish,
 	}
 }
@@ -56,9 +58,11 @@ func (r *Runner) Start(task *model.Task, cfg config.Config, rows, cols uint16, r
 		<-sess.Done()
 		r.mu.Lock()
 		delete(r.sessions, task.ID)
+		wasStopped := r.stopped[task.ID]
+		delete(r.stopped, task.ID)
 		r.mu.Unlock()
 		if r.onFinish != nil {
-			r.onFinish(task.ID, sess.Err())
+			r.onFinish(task.ID, sess.Err(), wasStopped)
 		}
 	}()
 
@@ -91,10 +95,14 @@ func (r *Runner) Detach(taskID string) {
 
 // Stop sends SIGTERM to a running session.
 func (r *Runner) Stop(taskID string) error {
-	sess := r.Get(taskID)
+	r.mu.Lock()
+	sess := r.sessions[taskID]
 	if sess == nil {
+		r.mu.Unlock()
 		return ErrSessionNotFound
 	}
+	r.stopped[taskID] = true
+	r.mu.Unlock()
 	return sess.Stop()
 }
 

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -20,7 +20,7 @@ func runnerTestConfig() config.Config {
 
 func TestRunner_StartAndGet(t *testing.T) {
 	finished := make(chan string, 1)
-	r := NewRunner(func(taskID string, err error) {
+	r := NewRunner(func(taskID string, err error, stopped bool) {
 		finished <- taskID
 	})
 
@@ -108,6 +108,71 @@ func TestRunner_StopAndRunning(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 	if r.HasSession("t3") {
 		t.Error("should be cleaned up after stop")
+	}
+}
+
+func TestRunner_StopSetsStopped(t *testing.T) {
+	type result struct {
+		taskID  string
+		err     error
+		stopped bool
+	}
+	finished := make(chan result, 1)
+	r := NewRunner(func(taskID string, err error, stopped bool) {
+		finished <- result{taskID, err, stopped}
+	})
+	cfg := config.Config{
+		Defaults: config.Defaults{Backend: "test"},
+		Backends: map[string]config.Backend{
+			"test": {Command: "sleep 60", PromptFlag: ""},
+		},
+		Projects: make(map[string]config.Project),
+	}
+
+	task := &model.Task{ID: "t-stop", Name: "test"}
+	_, err := r.Start(task, cfg, 24, 80, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.Stop("t-stop"); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case res := <-finished:
+		if !res.stopped {
+			t.Error("expected stopped=true after explicit Stop")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestRunner_NaturalExitNotStopped(t *testing.T) {
+	type result struct {
+		taskID  string
+		stopped bool
+	}
+	finished := make(chan result, 1)
+	r := NewRunner(func(taskID string, err error, stopped bool) {
+		finished <- result{taskID, stopped}
+	})
+	cfg := runnerTestConfig() // "echo hello" exits naturally
+
+	task := &model.Task{ID: "t-natural", Name: "test"}
+	_, err := r.Start(task, cfg, 24, 80, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case res := <-finished:
+		if res.stopped {
+			t.Error("expected stopped=false for natural exit")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
 	}
 }
 

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -32,8 +32,9 @@ type TickMsg struct{}
 
 // AgentFinishedMsg is sent when an agent process exits.
 type AgentFinishedMsg struct {
-	TaskID string
-	Err    error
+	TaskID  string
+	Err     error
+	Stopped bool // true if the process was explicitly stopped via Runner.Stop
 }
 
 // AgentDetachedMsg is sent when the user detaches from a running agent.
@@ -341,8 +342,8 @@ func (m Model) handleAgentFinished(msg AgentFinishedMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if msg.Err != nil {
-		// Agent was aborted/crashed — clean up the task and worktree
+	if msg.Err != nil || msg.Stopped {
+		// Agent was aborted/crashed/stopped — clean up the task and worktree
 		if t.Worktree != "" && m.cfg.UI.ShouldCleanupWorktrees() {
 			removeWorktree(t.Worktree)
 		}


### PR DESCRIPTION
Track explicit stops in Runner via a `stopped` map so processes that catch SIGTERM and exit cleanly (code 0) are still recognized as aborted and auto-deleted from the task list.

Co-Authored-By: Claude <noreply@anthropic.com>