### PR TITLE
Let agent processes survive Argus exit

### DIFF
--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -32,8 +32,6 @@ func main() {
 			p.Send(ui.AgentFinishedMsg{TaskID: taskID, Err: err, Stopped: stopped})
 		}
 	})
-	defer runner.StopAll()
-
 	m := ui.NewModel(cfg, s, runner)
 	p = tea.NewProgram(m, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -108,6 +109,16 @@ func (m Model) Init() tea.Cmd {
 	for _, t := range m.store.Tasks() {
 		if t.Status == model.StatusInProgress && t.SessionID != "" {
 			task := t // capture loop variable
+
+			// Kill any orphaned process from a previous Argus session.
+			// When Argus exits, PTY master fds close and children get SIGHUP,
+			// but we clean up any that might linger before resuming.
+			if task.AgentPID > 0 {
+				killStaleProcess(task.AgentPID)
+				task.AgentPID = 0
+				_ = m.store.Update(task)
+			}
+
 			cmds = append(cmds, func() tea.Msg {
 				sess, err := m.runner.Start(task, m.cfg, 24, 80, true)
 				if err != nil {
@@ -342,18 +353,10 @@ func (m Model) handleAgentFinished(msg AgentFinishedMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if msg.Err != nil || msg.Stopped {
-		// Agent was aborted/crashed/stopped — clean up the task and worktree
-		if t.Worktree != "" && m.cfg.UI.ShouldCleanupWorktrees() {
-			removeWorktree(t.Worktree)
-		}
-		_ = m.store.Delete(t.ID)
-		m.refreshTasks()
-		return m, nil
-	} else {
-		t.SetStatus(model.StatusInReview)
-		_ = m.store.Update(t)
-	}
+	// Agent finished (clean exit or interrupted) — mark for review.
+	// Explicit task deletion is handled in handleConfirmDeleteKey.
+	t.SetStatus(model.StatusInReview)
+	_ = m.store.Update(t)
 
 	m.refreshTasks()
 	return m, nil
@@ -649,6 +652,18 @@ func discoverClaudeWorktree(baseDir, _ string) string {
 		}
 	}
 	return ""
+}
+
+// killStaleProcess sends SIGTERM to a process if it's still alive.
+// Used to clean up orphaned agent processes from a previous Argus session.
+func killStaleProcess(pid int) {
+	if pid <= 0 {
+		return
+	}
+	// Signal 0 checks if the process exists without sending a signal.
+	if syscall.Kill(pid, 0) == nil {
+		_ = syscall.Kill(pid, syscall.SIGTERM)
+	}
 }
 
 func removeWorktree(worktreePath string) {


### PR DESCRIPTION
Remove defer runner.StopAll() so Claude processes aren't killed on quit. On restart, stale orphaned PIDs are killed before resuming sessions via --resume. Agent finished handler now archives tasks (moves to in_review) on any exit instead of deleting on error.

Co-Authored-By: Claude <noreply@anthropic.com>