### PR TITLE
Add keyword-based task name generation

### DIFF
--- a/internal/model/namegen.go
+++ b/internal/model/namegen.go
@@ -1,0 +1,119 @@
+package model
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"regexp"
+	"strings"
+)
+
+var (
+	// Fallback word lists for random name generation.
+	adjectives = []string{
+		"ancient", "bright", "calm", "dark", "eager",
+		"fading", "gentle", "hidden", "iron", "jade",
+		"keen", "lone", "misty", "noble", "pale",
+		"quick", "rare", "silent", "thin", "vast",
+		"warm", "young", "bold", "crisp", "deep",
+		"swift", "wild", "cold", "soft", "still",
+	}
+
+	nouns = []string{
+		"autumn", "bloom", "cedar", "dawn", "ember",
+		"flame", "grove", "heron", "iris", "jewel",
+		"kite", "lake", "moon", "night", "ocean",
+		"pine", "quail", "river", "stone", "thorn",
+		"dusk", "vale", "willow", "cloud", "ridge",
+		"frost", "crane", "spark", "drift", "storm",
+		"dream", "light", "shade", "brook", "trail",
+		"lark", "reef", "snow", "wind", "tide",
+	}
+
+	stopWords = map[string]bool{
+		"a": true, "an": true, "the": true, "and": true, "or": true,
+		"but": true, "in": true, "on": true, "at": true, "to": true,
+		"for": true, "of": true, "with": true, "by": true, "from": true,
+		"is": true, "are": true, "was": true, "were": true, "be": true,
+		"been": true, "being": true, "have": true, "has": true, "had": true,
+		"do": true, "does": true, "did": true, "will": true, "would": true,
+		"could": true, "should": true, "may": true, "might": true, "must": true,
+		"shall": true, "can": true, "need": true, "that": true, "which": true,
+		"who": true, "whom": true, "this": true, "these": true, "those": true,
+		"it": true, "its": true, "i": true, "we": true, "you": true,
+		"they": true, "me": true, "him": true, "her": true, "us": true,
+		"them": true, "my": true, "our": true, "your": true, "their": true,
+		"not": true, "no": true, "so": true, "if": true, "then": true,
+		"than": true, "when": true, "where": true, "how": true, "what": true,
+		"all": true, "each": true, "every": true, "both": true, "few": true,
+		"more": true, "most": true, "some": true, "any": true, "also": true,
+		"just": true, "about": true, "into": true, "through": true, "during": true,
+		"before": true, "after": true, "above": true, "below": true, "between": true,
+		"same": true, "up": true, "out": true, "as": true, "very": true,
+		"there": true, "here": true, "please": true, "make": true, "sure": true,
+	}
+
+	nonAlpha = regexp.MustCompile(`[^a-z0-9 ]+`)
+)
+
+// GenerateName creates a random fallback name like "silent-morning-frost".
+func GenerateName() string {
+	adj := pick(adjectives)
+	n1 := pick(nouns)
+	n2 := pick(nouns)
+	for n2 == n1 {
+		n2 = pick(nouns)
+	}
+	return fmt.Sprintf("%s-%s-%s", adj, n1, n2)
+}
+
+// GenerateNameFromPrompt extracts keywords from the prompt to build a
+// kebab-case slug like "fix-auth-token-refresh". Falls back to a random
+// name if the prompt yields no useful keywords.
+func GenerateNameFromPrompt(prompt string) string {
+	slug := extractKeywords(prompt, 4)
+	if slug == "" {
+		return GenerateName()
+	}
+	return slug
+}
+
+// extractKeywords pulls up to maxWords meaningful words from the prompt.
+func extractKeywords(prompt string, maxWords int) string {
+	// Normalize: lowercase, strip punctuation, collapse whitespace
+	s := strings.ToLower(prompt)
+	s = nonAlpha.ReplaceAllString(s, " ")
+	words := strings.Fields(s)
+
+	var keywords []string
+	for _, w := range words {
+		if stopWords[w] || len(w) < 2 {
+			continue
+		}
+		keywords = append(keywords, w)
+		if len(keywords) >= maxWords {
+			break
+		}
+	}
+
+	if len(keywords) == 0 {
+		return ""
+	}
+
+	slug := strings.Join(keywords, "-")
+
+	// Cap at 40 chars, break at hyphen boundary
+	if len(slug) > 40 {
+		slug = slug[:40]
+		if i := strings.LastIndex(slug, "-"); i > 5 {
+			slug = slug[:i]
+		}
+	}
+
+	return slug
+}
+
+func pick(list []string) string {
+	n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(list))))
+	return list[n.Int64()]
+}

--- a/internal/model/namegen_test.go
+++ b/internal/model/namegen_test.go
@@ -1,0 +1,74 @@
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateName(t *testing.T) {
+	name := GenerateName()
+	parts := strings.Split(name, "-")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 parts, got %d: %q", len(parts), name)
+	}
+	if parts[1] == parts[2] {
+		t.Errorf("nouns should not repeat: %q", name)
+	}
+}
+
+func TestGenerateNameFromPrompt(t *testing.T) {
+	tests := []struct {
+		prompt string
+		want   string
+	}{
+		{"fix the authentication token refresh bug", "fix-authentication-token-refresh"},
+		{"add retry logic to the API client", "add-retry-logic-api"},
+		{"refactor database connection pooling", "refactor-database-connection-pooling"},
+		{"update the nav styles for mobile", "update-nav-styles-mobile"},
+	}
+	for _, tt := range tests {
+		got := GenerateNameFromPrompt(tt.prompt)
+		if got != tt.want {
+			t.Errorf("GenerateNameFromPrompt(%q) = %q, want %q", tt.prompt, got, tt.want)
+		}
+	}
+}
+
+func TestGenerateNameFromPromptFallback(t *testing.T) {
+	// All stop words should fall back to random name
+	name := GenerateNameFromPrompt("the and or but")
+	parts := strings.Split(name, "-")
+	if len(parts) != 3 {
+		t.Fatalf("fallback should produce 3-part random name, got %q", name)
+	}
+}
+
+func TestExtractKeywords(t *testing.T) {
+	tests := []struct {
+		prompt string
+		max    int
+		want   string
+	}{
+		{"Fix the broken login page", 4, "fix-broken-login-page"},
+		{"UPPERCASE words SHOULD work", 3, "uppercase-words-work"},
+		{"a the an or but", 4, ""},
+		{"add --verbose flag to CLI", 4, "add-verbose-flag-cli"},
+		{"x", 4, ""},
+	}
+	for _, tt := range tests {
+		got := extractKeywords(tt.prompt, tt.max)
+		if got != tt.want {
+			t.Errorf("extractKeywords(%q, %d) = %q, want %q", tt.prompt, tt.max, got, tt.want)
+		}
+	}
+}
+
+func TestGenerateNameUniqueness(t *testing.T) {
+	seen := make(map[string]bool)
+	for range 100 {
+		seen[GenerateName()] = true
+	}
+	if len(seen) < 90 {
+		t.Errorf("expected at least 90 unique names in 100 draws, got %d", len(seen))
+	}
+}

--- a/internal/ui/newtask.go
+++ b/internal/ui/newtask.go
@@ -101,15 +101,8 @@ func (f *NewTaskForm) Task() *model.Task {
 	project := strings.TrimSpace(f.inputs[fieldProject].Value())
 	prompt := strings.TrimSpace(f.inputs[fieldPrompt].Value())
 
-	// Auto-generate name from prompt (truncate to 60 chars at word boundary)
-	name := prompt
-	if len(name) > 60 {
-		name = name[:60]
-		if i := strings.LastIndex(name, " "); i > 20 {
-			name = name[:i]
-		}
-		name += "…"
-	}
+	// Extract keywords from prompt as task name (e.g., "fix-auth-token-refresh")
+	name := model.GenerateNameFromPrompt(prompt)
 
 	branch := "main"
 	if p, ok := f.projects[project]; ok {


### PR DESCRIPTION
Replace truncated-prompt task names with kebab-case keyword extraction from the prompt (e.g., "fix-auth-token-refresh"). Falls back to random haiku-style names when no meaningful keywords found.

Co-Authored-By: Claude <noreply@anthropic.com>