### PR TITLE
Refresh running state on tick so idle tasks show correctly

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -149,6 +149,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case TickMsg:
+		// Keep running state fresh so idle tasks display correctly.
+		m.refreshTasks()
 		// Kick off git status refresh if needed
 		var cmds []tea.Cmd
 		cmds = append(cmds, tea.Tick(time.Second, func(_ time.Time) tea.Msg {


### PR DESCRIPTION
Call refreshTasks() in the TickMsg handler so the running map stays current every second. Without this, tasks whose agent exited between UI events kept showing '⏳ progress' instead of '● idle'.

Co-Authored-By: Claude <noreply@anthropic.com>