### PR TITLE
Mark tasks complete when agent session exits naturally

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -351,17 +351,13 @@ func (m Model) handleAgentFinished(msg AgentFinishedMsg) (tea.Model, tea.Cmd) {
 
 	t.AgentPID = 0
 
-	// If the worktree has been removed, auto-complete the task
-	if t.Worktree != "" && !dirExists(t.Worktree) {
+	if msg.Stopped {
+		// Explicitly stopped via Runner.Stop — mark for review
+		t.SetStatus(model.StatusInReview)
+	} else {
+		// Agent session exited on its own — task is complete
 		t.SetStatus(model.StatusComplete)
-		_ = m.store.Update(t)
-		m.refreshTasks()
-		return m, nil
 	}
-
-	// Agent finished (clean exit or interrupted) — mark for review.
-	// Explicit task deletion is handled in handleConfirmDeleteKey.
-	t.SetStatus(model.StatusInReview)
 	_ = m.store.Update(t)
 
 	m.refreshTasks()


### PR DESCRIPTION
Natural agent session exits (user types /exit, agent completes) now mark tasks as complete instead of in_review. Only explicitly stopped sessions go to in_review.

Co-Authored-By: Claude <noreply@anthropic.com>