### PR TITLE
Fix agent session restore by stripping --worktree on resume

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -60,7 +60,10 @@ func BuildCmd(task *model.Task, cfg config.Config, resume bool) (*exec.Cmd, erro
 	cmdStr := backend.Command
 
 	if resume && task.SessionID != "" {
-		// Resume an existing session — no prompt needed
+		// Resume an existing session — no prompt needed.
+		// Strip --worktree/-w since the worktree already exists from the
+		// original session; passing it again would create a second one.
+		cmdStr = stripWorktreeFlag(cmdStr)
 		cmdStr += " --resume " + shellQuote(task.SessionID)
 	} else {
 		// New session — pin the session ID so we can resume later
@@ -78,11 +81,42 @@ func BuildCmd(task *model.Task, cfg config.Config, resume bool) (*exec.Cmd, erro
 
 	cmd := exec.Command("sh", "-c", cmdStr)
 
-	if dir := ResolveDir(task, cfg); dir != "" {
+	// For resume, prefer the task's existing worktree as the working
+	// directory so Claude Code finds the right project/session context.
+	dir := ResolveDir(task, cfg)
+	if resume && dir == "" && task.Worktree != "" {
+		dir = task.Worktree
+	}
+	if dir != "" {
 		cmd.Dir = dir
 	}
 
 	return cmd, nil
+}
+
+// stripWorktreeFlag removes --worktree / -w (and an optional value) from a
+// command string. The flag accepts an optional name argument, e.g.
+// "--worktree my-branch" or "-w my-branch". We remove both the flag and
+// any non-flag token that follows it.
+func stripWorktreeFlag(cmd string) string {
+	parts := strings.Fields(cmd)
+	var out []string
+	for i := 0; i < len(parts); i++ {
+		p := parts[i]
+		if p == "--worktree" || p == "-w" {
+			// Skip the flag; also skip a following non-flag argument if present.
+			if i+1 < len(parts) && !strings.HasPrefix(parts[i+1], "-") {
+				i++
+			}
+			continue
+		}
+		// Handle --worktree=value
+		if strings.HasPrefix(p, "--worktree=") || strings.HasPrefix(p, "-w=") {
+			continue
+		}
+		out = append(out, p)
+	}
+	return strings.Join(out, " ")
 }
 
 // shellQuote wraps a string in single quotes with proper escaping.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -187,10 +187,52 @@ func TestBuildCmd_Resume(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Resume should use --resume and ignore the prompt
-	expected := "claude --dangerously-skip-permissions --worktree --resume 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee'"
+	// Resume should use --resume, strip --worktree, and ignore the prompt
+	expected := "claude --dangerously-skip-permissions --resume 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee'"
 	if cmd.Args[2] != expected {
 		t.Errorf("expected %q, got %q", expected, cmd.Args[2])
+	}
+}
+
+func TestBuildCmd_ResumeWithWorktree(t *testing.T) {
+	cfg := testConfig()
+	task := &model.Task{
+		Prompt:    "fix the bug",
+		SessionID: "aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee",
+		Worktree:  "/tmp/worktree-test",
+	}
+
+	cmd, err := BuildCmd(task, cfg, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Resume should set cmd.Dir to the existing worktree
+	if cmd.Dir != "/tmp/worktree-test" {
+		t.Errorf("expected Dir %q, got %q", "/tmp/worktree-test", cmd.Dir)
+	}
+}
+
+func TestStripWorktreeFlag(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"claude --worktree", "claude"},
+		{"claude --worktree --resume id", "claude --resume id"},
+		{"claude --dangerously-skip-permissions --worktree", "claude --dangerously-skip-permissions"},
+		{"claude -w", "claude"},
+		{"claude -w my-branch --resume id", "claude --resume id"},
+		{"claude --worktree=my-branch --resume id", "claude --resume id"},
+		{"claude --resume id", "claude --resume id"},
+		{"claude", "claude"},
+	}
+
+	for _, tt := range tests {
+		got := stripWorktreeFlag(tt.input)
+		if got != tt.expected {
+			t.Errorf("stripWorktreeFlag(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
 	}
 }
 

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -656,16 +656,29 @@ func discoverClaudeWorktree(baseDir, _ string) string {
 	return ""
 }
 
-// killStaleProcess sends SIGTERM to a process if it's still alive.
-// Used to clean up orphaned agent processes from a previous Argus session.
+// killStaleProcess sends SIGTERM to a process if it's still alive and waits
+// briefly for it to exit. Used to clean up orphaned agent processes from a
+// previous Argus session before resuming with --resume.
 func killStaleProcess(pid int) {
 	if pid <= 0 {
 		return
 	}
 	// Signal 0 checks if the process exists without sending a signal.
-	if syscall.Kill(pid, 0) == nil {
-		_ = syscall.Kill(pid, syscall.SIGTERM)
+	if syscall.Kill(pid, 0) != nil {
+		return // already dead
 	}
+	_ = syscall.Kill(pid, syscall.SIGTERM)
+
+	// Wait up to 2 seconds for the process to exit so that any session
+	// locks it holds are released before we start a new --resume process.
+	for i := 0; i < 20; i++ {
+		time.Sleep(100 * time.Millisecond)
+		if syscall.Kill(pid, 0) != nil {
+			return // exited
+		}
+	}
+	// Force-kill if it's still hanging around.
+	_ = syscall.Kill(pid, syscall.SIGKILL)
 }
 
 func removeWorktree(worktreePath string) {


### PR DESCRIPTION
Strip --worktree/-w from the backend command when resuming sessions via --resume, since the flag creates a new worktree which conflicts with the existing one. Also sets cmd.Dir to the task's worktree path for correct project context, and waits for stale processes to exit before starting the resume.

Co-Authored-By: Claude <noreply@anthropic.com>