### PR TITLE
Add tabbed UI with Projects view and agent fixes

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 
@@ -91,6 +92,19 @@ func DefaultKeybindings() Keybindings {
 		Prompt:   "p",
 		Worktree: "w",
 	}
+}
+
+// Save writes the config to the standard path.
+func Save(cfg Config) error {
+	dir := ConfigDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(cfg); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "config.toml"), buf.Bytes(), 0o644)
 }
 
 // ConfigDir returns the argus config directory path.

--- a/internal/ui/newproject.go
+++ b/internal/ui/newproject.go
@@ -1,0 +1,173 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/drn/argus/internal/config"
+)
+
+// NewProjectForm handles the new project creation UI.
+type NewProjectForm struct {
+	inputs   []textinput.Model
+	focused  int
+	theme    Theme
+	done     bool
+	canceled bool
+	width    int
+	height   int
+}
+
+const (
+	projFieldName = iota
+	projFieldPath
+	projFieldBranch
+	projFieldBackend
+	projFieldCount
+)
+
+func NewNewProjectForm(theme Theme) NewProjectForm {
+	inputs := make([]textinput.Model, projFieldCount)
+
+	nameInput := textinput.New()
+	nameInput.Placeholder = "Project name (e.g. argus)"
+	nameInput.CharLimit = 40
+	inputs[projFieldName] = nameInput
+
+	pathInput := textinput.New()
+	pathInput.Placeholder = "Path to repository"
+	pathInput.CharLimit = 200
+	inputs[projFieldPath] = pathInput
+
+	branchInput := textinput.New()
+	branchInput.Placeholder = "Default branch (e.g. main)"
+	branchInput.CharLimit = 60
+	branchInput.SetValue("main")
+	inputs[projFieldBranch] = branchInput
+
+	backendInput := textinput.New()
+	backendInput.Placeholder = "Backend (leave empty for default)"
+	backendInput.CharLimit = 40
+	inputs[projFieldBackend] = backendInput
+
+	return NewProjectForm{
+		inputs:  inputs,
+		focused: projFieldName,
+		theme:   theme,
+	}
+}
+
+func (f *NewProjectForm) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			f.canceled = true
+			return nil
+		case "tab", "down":
+			f.focused = (f.focused + 1) % projFieldCount
+			return f.focusCurrent()
+		case "shift+tab", "up":
+			f.focused = (f.focused - 1 + projFieldCount) % projFieldCount
+			return f.focusCurrent()
+		case "enter":
+			if f.focused == projFieldCount-1 {
+				// Submit on enter at last field
+				if strings.TrimSpace(f.inputs[projFieldName].Value()) != "" &&
+					strings.TrimSpace(f.inputs[projFieldPath].Value()) != "" {
+					f.done = true
+				}
+				return nil
+			}
+			f.focused++
+			return f.focusCurrent()
+		}
+	}
+
+	var cmd tea.Cmd
+	f.inputs[f.focused], cmd = f.inputs[f.focused].Update(msg)
+	return cmd
+}
+
+func (f *NewProjectForm) focusCurrent() tea.Cmd {
+	cmds := make([]tea.Cmd, len(f.inputs))
+	for i := range f.inputs {
+		if i == f.focused {
+			cmds[i] = f.inputs[i].Focus()
+		} else {
+			f.inputs[i].Blur()
+		}
+	}
+	return tea.Batch(cmds...)
+}
+
+func (f *NewProjectForm) ProjectEntry() (string, config.Project) {
+	name := strings.TrimSpace(f.inputs[projFieldName].Value())
+	path := strings.TrimSpace(f.inputs[projFieldPath].Value())
+	branch := strings.TrimSpace(f.inputs[projFieldBranch].Value())
+	backend := strings.TrimSpace(f.inputs[projFieldBackend].Value())
+
+	return name, config.Project{
+		Path:    path,
+		Branch:  branch,
+		Backend: backend,
+	}
+}
+
+func (f *NewProjectForm) Done() bool     { return f.done }
+func (f *NewProjectForm) Canceled() bool { return f.canceled }
+
+func (f *NewProjectForm) SetSize(w, h int) {
+	f.width = w
+	f.height = h
+	inputWidth := f.modalWidth() - 6
+	if inputWidth < 20 {
+		inputWidth = 20
+	}
+	for i := range f.inputs {
+		f.inputs[i].Width = inputWidth
+	}
+}
+
+func (f NewProjectForm) modalWidth() int {
+	w := f.width * 2 / 5
+	if w < 50 {
+		w = 50
+	}
+	if w > 80 {
+		w = 80
+	}
+	if w > f.width-4 {
+		w = f.width - 4
+	}
+	return w
+}
+
+func (f NewProjectForm) View() string {
+	var b strings.Builder
+
+	labels := []string{"Name:", "Path:", "Branch:", "Backend:"}
+	for i, label := range labels {
+		style := f.theme.Dimmed
+		if i == f.focused {
+			style = f.theme.Selected
+		}
+		b.WriteString(style.Render(label) + "\n")
+		b.WriteString(f.inputs[i].View() + "\n\n")
+	}
+
+	b.WriteString(f.theme.Help.Render("tab/shift+tab: navigate  enter: submit  esc: cancel"))
+
+	mw := f.modalWidth()
+
+	modal := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("87")).
+		Padding(1, 2).
+		Width(mw).
+		Render(f.theme.Title.Render("New Project") + "\n\n" + b.String())
+
+	return lipgloss.Place(f.width, f.height, lipgloss.Center, lipgloss.Center, modal)
+}

--- a/internal/ui/projectlist.go
+++ b/internal/ui/projectlist.go
@@ -1,0 +1,150 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/drn/argus/internal/config"
+)
+
+// ProjectList renders the project list view.
+type ProjectList struct {
+	projects []projectEntry
+	cursor   int
+	theme    Theme
+	width    int
+	height   int
+	offset   int
+}
+
+// projectEntry is a flattened project for display.
+type projectEntry struct {
+	Name    string
+	Project config.Project
+}
+
+func NewProjectList(theme Theme) ProjectList {
+	return ProjectList{theme: theme}
+}
+
+func (pl *ProjectList) SetProjects(projects map[string]config.Project) {
+	pl.projects = nil
+	for name, proj := range projects {
+		pl.projects = append(pl.projects, projectEntry{Name: name, Project: proj})
+	}
+	// Sort alphabetically for stable ordering
+	sortProjects(pl.projects)
+	if pl.cursor >= len(pl.projects) {
+		pl.cursor = max(0, len(pl.projects)-1)
+	}
+}
+
+func sortProjects(entries []projectEntry) {
+	for i := 1; i < len(entries); i++ {
+		for j := i; j > 0 && entries[j].Name < entries[j-1].Name; j-- {
+			entries[j], entries[j-1] = entries[j-1], entries[j]
+		}
+	}
+}
+
+func (pl *ProjectList) SetSize(w, h int) {
+	pl.width = w
+	pl.height = h
+}
+
+func (pl *ProjectList) CursorUp() {
+	if pl.cursor > 0 {
+		pl.cursor--
+		if pl.cursor < pl.offset {
+			pl.offset = pl.cursor
+		}
+	}
+}
+
+func (pl *ProjectList) CursorDown() {
+	if pl.cursor < len(pl.projects)-1 {
+		pl.cursor++
+		visible := pl.visibleRows()
+		if pl.cursor >= pl.offset+visible {
+			pl.offset = pl.cursor - visible + 1
+		}
+	}
+}
+
+func (pl *ProjectList) Selected() *projectEntry {
+	if len(pl.projects) == 0 {
+		return nil
+	}
+	if pl.cursor >= 0 && pl.cursor < len(pl.projects) {
+		return &pl.projects[pl.cursor]
+	}
+	return nil
+}
+
+func (pl *ProjectList) visibleRows() int {
+	// Each project takes 2 lines (name + path)
+	rows := pl.height / 2
+	if rows < 1 {
+		rows = 1
+	}
+	return rows
+}
+
+func (pl ProjectList) View() string {
+	if len(pl.projects) == 0 {
+		return "\n" + pl.theme.Dimmed.Render("    No projects configured. Press [n] to add one.")
+	}
+
+	var b strings.Builder
+	visible := pl.visibleRows()
+	end := pl.offset + visible
+	if end > len(pl.projects) {
+		end = len(pl.projects)
+	}
+
+	for i := pl.offset; i < end; i++ {
+		entry := pl.projects[i]
+		selected := i == pl.cursor
+
+		// Project name
+		nameStyle := pl.theme.Normal
+		if selected {
+			nameStyle = pl.theme.Selected
+		}
+		name := nameStyle.Render(entry.Name)
+
+		// Cursor indicator
+		cursor := "  "
+		if selected {
+			cursor = pl.theme.Selected.Render(" >")
+		}
+
+		// Backend label (right-aligned)
+		backend := entry.Project.Backend
+		if backend == "" {
+			backend = "default"
+		}
+		right := pl.theme.Dimmed.Render(backend)
+
+		// Build first line
+		left := fmt.Sprintf("%s  %s", cursor, name)
+		gap := pl.width - lipgloss.Width(left) - lipgloss.Width(right) - 2
+		if gap < 1 {
+			gap = 1
+		}
+		b.WriteString(left + strings.Repeat(" ", gap) + right + "\n")
+
+		// Second line: path + branch
+		detail := "      "
+		if entry.Project.Path != "" {
+			detail += pl.theme.Dimmed.Render(entry.Project.Path)
+		}
+		if entry.Project.Branch != "" {
+			detail += pl.theme.Dimmed.Render(" (" + entry.Project.Branch + ")")
+		}
+		b.WriteString(detail + "\n")
+	}
+
+	return b.String()
+}

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -26,6 +26,15 @@ const (
 	viewHelp
 	viewPrompt
 	viewConfirmDelete
+	viewNewProject
+	viewConfirmDeleteProject
+)
+
+type tab int
+
+const (
+	tabTasks tab = iota
+	tabProjects
 )
 
 // TickMsg is sent periodically to update elapsed times.
@@ -52,21 +61,24 @@ type SessionResumedMsg struct {
 
 // Model is the top-level Bubble Tea model.
 type Model struct {
-	cfg       config.Config
-	store     *store.Store
-	runner    *agent.Runner
-	keys      KeyMap
-	theme     Theme
-	tasklist  TaskList
-	statusbar StatusBar
-	helpview  HelpView
-	newtask   NewTaskForm
-	preview   Preview
-	gitstatus GitStatus
-	current   view
-	width     int
-	height    int
-	quitting  bool
+	cfg         config.Config
+	store       *store.Store
+	runner      *agent.Runner
+	keys        KeyMap
+	theme       Theme
+	tasklist    TaskList
+	projectlist ProjectList
+	statusbar   StatusBar
+	helpview    HelpView
+	newtask     NewTaskForm
+	newproject  NewProjectForm
+	preview     Preview
+	gitstatus   GitStatus
+	current     view
+	activeTab   tab
+	width       int
+	height      int
+	quitting    bool
 }
 
 func NewModel(cfg config.Config, s *store.Store, runner *agent.Runner) Model {
@@ -74,6 +86,7 @@ func NewModel(cfg config.Config, s *store.Store, runner *agent.Runner) Model {
 	keys := DefaultKeyMap()
 
 	tl := NewTaskList(theme)
+	pl := NewProjectList(theme)
 	sb := NewStatusBar(theme)
 	hv := NewHelpView(keys, theme)
 
@@ -81,19 +94,22 @@ func NewModel(cfg config.Config, s *store.Store, runner *agent.Runner) Model {
 	gs := NewGitStatus(theme)
 
 	m := Model{
-		cfg:       cfg,
-		store:     s,
-		runner:    runner,
-		keys:      keys,
-		theme:     theme,
-		tasklist:  tl,
-		statusbar: sb,
-		helpview:  hv,
-		preview:   pv,
-		gitstatus: gs,
-		current:   viewTaskList,
+		cfg:         cfg,
+		store:       s,
+		runner:      runner,
+		keys:        keys,
+		theme:       theme,
+		tasklist:    tl,
+		projectlist: pl,
+		statusbar:   sb,
+		helpview:    hv,
+		preview:     pv,
+		gitstatus:   gs,
+		current:     viewTaskList,
+		activeTab:   tabTasks,
 	}
 	m.refreshTasks()
+	m.refreshProjects()
 	return m
 }
 
@@ -141,11 +157,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Reserve space: section header(1) + gap(1) + statusbar(1)
 		contentHeight := msg.Height - 3
 		m.tasklist.SetSize(leftWidth, contentHeight)
+		m.projectlist.SetSize(leftWidth, contentHeight)
 		gitH, previewH := m.splitRightHeights(contentHeight)
 		m.gitstatus.SetSize(rightWidth, gitH)
 		m.preview.SetSize(rightWidth, previewH)
 		m.statusbar.SetWidth(msg.Width)
 		m.newtask.SetSize(msg.Width, msg.Height)
+		m.newproject.SetSize(msg.Width, msg.Height)
 		return m, nil
 
 	case TickMsg:
@@ -217,6 +235,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch m.current {
 	case viewNewTask:
 		return m.handleNewTaskKey(msg)
+	case viewNewProject:
+		return m.handleNewProjectKey(msg)
 	case viewHelp:
 		m.current = viewTaskList
 		return m, nil
@@ -225,7 +245,21 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case viewConfirmDelete:
 		return m.handleConfirmDeleteKey(msg)
+	case viewConfirmDeleteProject:
+		return m.handleConfirmDeleteProjectKey(msg)
 	default:
+		// Tab switching with 1/2 keys
+		switch msg.String() {
+		case "1":
+			m.activeTab = tabTasks
+			return m, nil
+		case "2":
+			m.activeTab = tabProjects
+			return m, nil
+		}
+		if m.activeTab == tabProjects {
+			return m.handleProjectListKey(msg)
+		}
 		return m.handleTaskListKey(msg)
 	}
 }
@@ -426,6 +460,80 @@ func (m Model) handleConfirmDeleteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 }
 
+func (m Model) handleProjectListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, m.keys.Quit):
+		m.quitting = true
+		return m, tea.Quit
+
+	case key.Matches(msg, m.keys.Up):
+		m.projectlist.CursorUp()
+		return m, nil
+
+	case key.Matches(msg, m.keys.Down):
+		m.projectlist.CursorDown()
+		return m, nil
+
+	case key.Matches(msg, m.keys.New):
+		m.newproject = NewNewProjectForm(m.theme)
+		m.newproject.SetSize(m.width, m.height)
+		m.current = viewNewProject
+		return m, m.newproject.inputs[0].Focus()
+
+	case key.Matches(msg, m.keys.Delete):
+		if m.projectlist.Selected() != nil {
+			m.current = viewConfirmDeleteProject
+		}
+		return m, nil
+
+	case key.Matches(msg, m.keys.Help):
+		m.current = viewHelp
+		return m, nil
+	}
+
+	return m, nil
+}
+
+func (m Model) handleNewProjectKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	cmd := m.newproject.Update(msg)
+
+	if m.newproject.Canceled() {
+		m.current = viewTaskList
+		return m, nil
+	}
+
+	if m.newproject.Done() {
+		name, proj := m.newproject.ProjectEntry()
+		m.cfg.Projects[name] = proj
+		_ = config.Save(m.cfg)
+		m.refreshProjects()
+		m.current = viewTaskList
+		return m, nil
+	}
+
+	return m, cmd
+}
+
+func (m Model) handleConfirmDeleteProjectKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, m.keys.Confirm):
+		if entry := m.projectlist.Selected(); entry != nil {
+			delete(m.cfg.Projects, entry.Name)
+			_ = config.Save(m.cfg)
+			m.refreshProjects()
+		}
+		m.current = viewTaskList
+		return m, nil
+	default:
+		m.current = viewTaskList
+		return m, nil
+	}
+}
+
+func (m *Model) refreshProjects() {
+	m.projectlist.SetProjects(m.cfg.Projects)
+}
+
 func (m *Model) refreshTasks() {
 	tasks := m.store.Tasks()
 	running := m.runner.Running()
@@ -441,11 +549,12 @@ func (m Model) View() string {
 	}
 
 	// Status bar at the bottom
+	m.statusbar.SetProjectTab(m.activeTab == tabProjects)
 	bar := m.statusbar.View()
 
 	// For overlay views, show them without the banner
 	switch m.current {
-	case viewHelp, viewPrompt, viewConfirmDelete:
+	case viewHelp, viewPrompt, viewConfirmDelete, viewConfirmDeleteProject:
 		var content string
 		switch m.current {
 		case viewHelp:
@@ -454,39 +563,29 @@ func (m Model) View() string {
 			content = m.promptView()
 		case viewConfirmDelete:
 			content = m.confirmDeleteView()
+		case viewConfirmDeleteProject:
+			content = m.confirmDeleteProjectView()
 		}
 		return m.padToBottom(content, bar)
 	}
 
-	// Overlay modal for new task form
+	// Overlay modals
 	if m.current == viewNewTask {
 		return m.newtask.View() + "\n" + bar
 	}
-
-	// Empty state: show banner centered on page
-	if len(m.store.Tasks()) == 0 {
-		content := m.emptyStateView()
-		return m.padToBottom(content, bar)
+	if m.current == viewNewProject {
+		return m.newproject.View() + "\n" + bar
 	}
 
-	// Split layout: task list on left, agent preview on right
-	section := m.renderSectionHeader()
-	tasks := m.tasklist.View()
-	leftContent := section + "\n" + tasks
+	// Tab header
+	tabHeader := m.renderTabHeader()
 
-	// Git status + Preview pane for selected task
-	var taskID string
-	if t := m.tasklist.Selected(); t != nil {
-		taskID = t.ID
+	switch m.activeTab {
+	case tabProjects:
+		return m.renderProjectsView(tabHeader, bar)
+	default:
+		return m.renderTasksView(tabHeader, bar)
 	}
-	gitView := m.gitstatus.View()
-	previewView := m.preview.View(taskID)
-	rightContent := lipgloss.JoinVertical(lipgloss.Left, gitView, previewView)
-
-	// Join horizontally
-	content := lipgloss.JoinHorizontal(lipgloss.Top, leftContent, rightContent)
-
-	return m.padToBottom(content, bar)
 }
 
 func (m Model) padToBottom(content, bar string) string {
@@ -533,15 +632,102 @@ func (m Model) splitWidths() (int, int) {
 	return left, right
 }
 
-func (m Model) renderDivider() string {
-	if m.width < 1 {
-		return ""
+func (m Model) renderTabHeader() string {
+	activeStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("87")).
+		Underline(true)
+	inactiveStyle := m.theme.Dimmed
+
+	tabs := []struct {
+		label string
+		key   string
+		t     tab
+	}{
+		{"TASKS", "1", tabTasks},
+		{"PROJECTS", "2", tabProjects},
 	}
-	line := strings.Repeat("─", m.width)
-	return m.theme.Divider.Render(line)
+
+	var parts []string
+	for _, t := range tabs {
+		style := inactiveStyle
+		if t.t == m.activeTab {
+			style = activeStyle
+		}
+		parts = append(parts, style.Render("  "+t.label+" "))
+	}
+	return strings.Join(parts, m.theme.Dimmed.Render("│"))
 }
 
-func (m Model) renderSectionHeader() string {
+func (m Model) renderTasksView(tabHeader, bar string) string {
+	// Empty state: show banner centered on page
+	if len(m.store.Tasks()) == 0 {
+		content := m.emptyStateView()
+		return m.padToBottom(content, bar)
+	}
+
+	// Split layout: task list on left, agent preview on right
+	section := tabHeader + "  " + m.renderTaskCounts()
+	tasks := m.tasklist.View()
+	leftContent := section + "\n" + tasks
+
+	// Git status + Preview pane for selected task
+	var taskID string
+	if t := m.tasklist.Selected(); t != nil {
+		taskID = t.ID
+	}
+	gitView := m.gitstatus.View()
+	previewView := m.preview.View(taskID)
+	rightContent := lipgloss.JoinVertical(lipgloss.Left, gitView, previewView)
+
+	// Join horizontally
+	content := lipgloss.JoinHorizontal(lipgloss.Top, leftContent, rightContent)
+
+	return m.padToBottom(content, bar)
+}
+
+func (m Model) renderProjectsView(tabHeader, bar string) string {
+	section := tabHeader + "  " + m.theme.Dimmed.Render(fmt.Sprintf("%d projects", len(m.cfg.Projects)))
+	projects := m.projectlist.View()
+	leftContent := section + "\n" + projects
+
+	// Right pane: project details for selected project
+	rightContent := m.renderProjectDetail()
+
+	content := lipgloss.JoinHorizontal(lipgloss.Top, leftContent, rightContent)
+	return m.padToBottom(content, bar)
+}
+
+func (m Model) renderProjectDetail() string {
+	entry := m.projectlist.Selected()
+	_, rightWidth := m.splitWidths()
+	contentHeight := m.height - 3
+
+	if entry == nil {
+		empty := m.theme.Dimmed.Render("  No project selected")
+		return lipgloss.NewStyle().Width(rightWidth).Height(contentHeight).Render(empty)
+	}
+
+	var b strings.Builder
+	b.WriteString(m.theme.Title.Render("  "+entry.Name) + "\n\n")
+
+	fields := []struct{ label, value string }{
+		{"Path", entry.Project.Path},
+		{"Branch", entry.Project.Branch},
+		{"Backend", entry.Project.Backend},
+	}
+	for _, f := range fields {
+		val := f.value
+		if val == "" {
+			val = "(default)"
+		}
+		b.WriteString("  " + m.theme.Dimmed.Render(f.label+": ") + m.theme.Normal.Render(val) + "\n")
+	}
+
+	return lipgloss.NewStyle().Width(rightWidth).Height(contentHeight).Render(b.String())
+}
+
+func (m Model) renderTaskCounts() string {
 	running := make(map[string]bool)
 	for _, id := range m.runner.Running() {
 		running[id] = true
@@ -553,15 +739,15 @@ func (m Model) renderSectionHeader() string {
 			active++
 		}
 	}
-
-	label := m.theme.Section.Render("  TASKS")
-	count := m.theme.Dimmed.Render(fmt.Sprintf("  %d total", total))
+	count := m.theme.Dimmed.Render(fmt.Sprintf("%d total", total))
 	if active > 0 {
-		count = m.theme.InProgress.Render(fmt.Sprintf("  %d active", active)) +
-			m.theme.Dimmed.Render(fmt.Sprintf("  %d total", total))
+		count = m.theme.InProgress.Render(fmt.Sprintf("%d active", active)) +
+			"  " + m.theme.Dimmed.Render(fmt.Sprintf("%d total", total))
 	}
-	return label + count
+	return count
 }
+
+
 
 func (m Model) emptyStateView() string {
 	banner := renderBanner(m.width)
@@ -595,6 +781,17 @@ func (m Model) promptView() string {
 
 	return title + "\n\n  " + prompt + "\n\n" +
 		m.theme.Help.Render("  Press any key to close")
+}
+
+func (m Model) confirmDeleteProjectView() string {
+	entry := m.projectlist.Selected()
+	if entry == nil {
+		return ""
+	}
+	return m.theme.Title.Render("Delete project?") + "\n\n" +
+		"  " + m.theme.Normal.Render(entry.Name) + "\n" +
+		"  " + m.theme.Dimmed.Render(entry.Project.Path) + "\n\n" +
+		m.theme.Help.Render("  [y] confirm  [any other key] cancel")
 }
 
 func (m Model) confirmDeleteView() string {

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -10,11 +10,12 @@ import (
 
 // StatusBar renders the bottom status bar.
 type StatusBar struct {
-	theme   Theme
-	width   int
-	tasks   []*model.Task
-	running map[string]bool
-	errMsg  string
+	theme      Theme
+	width      int
+	tasks      []*model.Task
+	running    map[string]bool
+	errMsg     string
+	projectTab bool
 }
 
 func NewStatusBar(theme Theme) StatusBar {
@@ -34,6 +35,10 @@ func (sb *StatusBar) SetRunning(ids []string) {
 	for _, id := range ids {
 		sb.running[id] = true
 	}
+}
+
+func (sb *StatusBar) SetProjectTab(active bool) {
+	sb.projectTab = active
 }
 
 func (sb *StatusBar) SetError(msg string) {
@@ -68,14 +73,25 @@ func (sb StatusBar) View() string {
 	}
 
 	// Keybinding hints with highlighted keys
-	keys := []struct{ key, label string }{
-		{"n", "new"},
-		{"RET", "attach"},
-		{"s", "status"},
-		{"d", "del"},
-		{"p", "prompt"},
-		{"?", "help"},
-		{"q", "quit"},
+	var keys []struct{ key, label string }
+	if sb.projectTab {
+		keys = []struct{ key, label string }{
+			{"n", "new"},
+			{"d", "del"},
+			{"1", "tasks"},
+			{"?", "help"},
+			{"q", "quit"},
+		}
+	} else {
+		keys = []struct{ key, label string }{
+			{"n", "new"},
+			{"RET", "attach"},
+			{"s", "status"},
+			{"d", "del"},
+			{"2", "projects"},
+			{"?", "help"},
+			{"q", "quit"},
+		}
 	}
 	var parts []string
 	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("87"))


### PR DESCRIPTION
Introduces a tab system (1/2 keys) to switch between Tasks and Projects views. Projects tab provides full CRUD with config.toml persistence. Also fixes agent session restore (--worktree stripping on resume), git status panel stuck on Loading, and simplifies backend resolution.

Co-Authored-By: Claude <noreply@anthropic.com>