### PR TITLE
Add ctrl+r to prune completed tasks

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -126,6 +126,30 @@ func (s *Store) Delete(id string) error {
 	return fmt.Errorf("task not found: %s", id)
 }
 
+// PruneCompleted removes all tasks with status "complete" and returns them.
+func (s *Store) PruneCompleted() ([]*model.Task, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var pruned []*model.Task
+	var kept []*model.Task
+	for _, t := range s.tasks {
+		if t.Status == model.StatusComplete {
+			pruned = append(pruned, t)
+		} else {
+			kept = append(kept, t)
+		}
+	}
+	if len(pruned) == 0 {
+		return nil, nil
+	}
+	s.tasks = kept
+	if err := s.saveLocked(); err != nil {
+		return nil, err
+	}
+	return pruned, nil
+}
+
 // Get returns a task by ID.
 func (s *Store) Get(id string) (*model.Task, error) {
 	s.mu.Lock()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -162,6 +162,55 @@ func TestStore_TasksReturnsCopy(t *testing.T) {
 	}
 }
 
+func TestStore_PruneCompleted(t *testing.T) {
+	s := tmpStore(t)
+	_ = s.Load()
+
+	pending := &model.Task{Name: "pending", Status: model.StatusPending}
+	done1 := &model.Task{Name: "done1", Status: model.StatusComplete}
+	inProg := &model.Task{Name: "in progress", Status: model.StatusInProgress}
+	done2 := &model.Task{Name: "done2", Status: model.StatusComplete}
+	_ = s.Add(pending)
+	_ = s.Add(done1)
+	_ = s.Add(inProg)
+	_ = s.Add(done2)
+
+	pruned, err := s.PruneCompleted()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pruned) != 2 {
+		t.Errorf("expected 2 pruned, got %d", len(pruned))
+	}
+	remaining := s.Tasks()
+	if len(remaining) != 2 {
+		t.Errorf("expected 2 remaining, got %d", len(remaining))
+	}
+	for _, r := range remaining {
+		if r.Status == model.StatusComplete {
+			t.Errorf("completed task %q should have been pruned", r.Name)
+		}
+	}
+}
+
+func TestStore_PruneCompleted_NoneToRemove(t *testing.T) {
+	s := tmpStore(t)
+	_ = s.Load()
+
+	_ = s.Add(&model.Task{Name: "pending", Status: model.StatusPending})
+
+	pruned, err := s.PruneCompleted()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pruned != nil {
+		t.Errorf("expected nil pruned, got %d", len(pruned))
+	}
+	if len(s.Tasks()) != 1 {
+		t.Error("expected task count unchanged")
+	}
+}
+
 func TestStore_CreatesDirectory(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sub", "dir", "tasks.json")

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -14,6 +14,7 @@ type KeyMap struct {
 	Filter    key.Binding
 	Prompt    key.Binding
 	Worktree  key.Binding
+	Prune     key.Binding
 	Up        key.Binding
 	Down      key.Binding
 	Confirm   key.Binding
@@ -62,6 +63,10 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("w"),
 			key.WithHelp("w", "worktree info"),
 		),
+		Prune: key.NewBinding(
+			key.WithKeys("ctrl+r"),
+			key.WithHelp("ctrl+r", "prune completed"),
+		),
 		Up: key.NewBinding(
 			key.WithKeys("up", "k"),
 			key.WithHelp("↑/k", "up"),
@@ -92,6 +97,6 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 		{k.New, k.Attach, k.Delete},
 		{k.StatusFwd, k.StatusRev, k.Prompt},
 		{k.Up, k.Down, k.Filter},
-		{k.Worktree, k.Help, k.Quit},
+		{k.Worktree, k.Prune, k.Help, k.Quit},
 	}
 }

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -318,6 +318,23 @@ func (m Model) handleTaskListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.current = viewPrompt
 		}
 		return m, nil
+
+	case key.Matches(msg, m.keys.Prune):
+		pruned, err := m.store.PruneCompleted()
+		if err != nil {
+			m.statusbar.SetError(err.Error())
+			return m, nil
+		}
+		for _, t := range pruned {
+			if m.runner.HasSession(t.ID) {
+				_ = m.runner.Stop(t.ID)
+			}
+			if t.Worktree != "" && m.cfg.UI.ShouldCleanupWorktrees() {
+				removeWorktree(t.Worktree)
+			}
+		}
+		m.refreshTasks()
+		return m, nil
 	}
 
 	return m, nil

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/drn/argus/internal/agent"
 	"github.com/drn/argus/internal/config"
 	"github.com/drn/argus/internal/model"
@@ -91,6 +92,31 @@ func TestSessionResumed_MissingTask(t *testing.T) {
 		t.Error("expected nil cmd for missing task")
 	}
 	_ = updated.(Model)
+}
+
+func TestPruneCompleted(t *testing.T) {
+	tasks := []*model.Task{
+		{ID: "t1", Name: "pending", Status: model.StatusPending},
+		{ID: "t2", Name: "done1", Status: model.StatusComplete},
+		{ID: "t3", Name: "in-progress", Status: model.StatusInProgress},
+		{ID: "t4", Name: "done2", Status: model.StatusComplete},
+	}
+	m := testModel(t, tasks...)
+
+	// Send ctrl+r
+	msg := tea.KeyMsg{Type: tea.KeyCtrlR}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	remaining := um.store.Tasks()
+	if len(remaining) != 2 {
+		t.Fatalf("expected 2 remaining tasks, got %d", len(remaining))
+	}
+	for _, r := range remaining {
+		if r.Status == model.StatusComplete {
+			t.Errorf("completed task %q should have been pruned", r.Name)
+		}
+	}
 }
 
 func TestInit_ResumesOnlyInProgressWithSessionID(t *testing.T) {


### PR DESCRIPTION
Adds a keybinding (ctrl+r) to the task list view that removes all completed tasks in one operation. Includes Store.PruneCompleted() method, worktree/session cleanup for pruned tasks, and tests for both store and UI layers.

Co-Authored-By: Claude <noreply@anthropic.com>