### PR TITLE
Add three-panel agent view with sidebars

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -241,3 +241,9 @@ func (s *Session) PTYSize() (cols, rows int) {
 	defer s.mu.Unlock()
 	return int(s.ptyCols), int(s.ptyRows)
 }
+
+// WriteInput writes raw bytes to the PTY master (stdin of the child process).
+// Used by the agent view to forward keyboard input without full Attach.
+func (s *Session) WriteInput(p []byte) (int, error) {
+	return s.ptmx.Write(p)
+}

--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -1,0 +1,487 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/drn/argus/internal/agent"
+	"github.com/hinshun/vt10x"
+)
+
+// AgentPanel identifies which panel has focus in the agent view.
+type AgentPanel int
+
+const (
+	panelGit   AgentPanel = iota
+	panelAgent            // center — terminal
+	panelFiles            // right — changed files
+)
+
+// AgentViewTickMsg triggers a fast refresh of the agent terminal output.
+type AgentViewTickMsg struct{}
+
+// AgentView renders a three-panel layout: git status | agent terminal | file explorer.
+type AgentView struct {
+	theme    Theme
+	runner   *agent.Runner
+	taskID   string
+	taskName string
+	focus    AgentPanel
+	width    int
+	height   int
+
+	gitstatus GitStatus
+	files     FileExplorer
+
+	// Cached git status for file explorer
+	lastGitRefresh time.Time
+}
+
+func NewAgentView(theme Theme, runner *agent.Runner) AgentView {
+	return AgentView{
+		theme:     theme,
+		runner:    runner,
+		focus:     panelAgent,
+		gitstatus: NewGitStatus(theme),
+		files:     NewFileExplorer(theme),
+	}
+}
+
+// Enter sets up the agent view for a specific task.
+func (av *AgentView) Enter(taskID, taskName string) {
+	av.taskID = taskID
+	av.taskName = taskName
+	av.focus = panelAgent
+	av.gitstatus.SetTask(taskID)
+	av.lastGitRefresh = time.Time{}
+}
+
+func (av *AgentView) SetSize(w, h int) {
+	av.width = w
+	av.height = h
+	leftW, centerW, rightW := av.splitWidths()
+	// Reserve 1 for status bar
+	contentH := h - 1
+	av.gitstatus.SetSize(leftW, contentH)
+	av.files.SetSize(rightW, contentH)
+	// Resize PTY to match center panel (minus border)
+	if sess := av.runner.Get(av.taskID); sess != nil {
+		ptyRows := uint16(max(contentH-2, 5))
+		ptyCols := uint16(max(centerW-4, 20))
+		sess.Resize(ptyRows, ptyCols)
+	}
+	_ = centerW // used in View
+}
+
+// UpdateGitStatus handles a git status refresh message.
+func (av *AgentView) UpdateGitStatus(msg GitStatusRefreshMsg) {
+	if msg.TaskID == av.taskID {
+		av.gitstatus.Update(msg)
+		av.files.SetFiles(ParseGitStatus(msg.Status))
+		av.lastGitRefresh = time.Now()
+	}
+}
+
+// NeedsGitRefresh returns true if git status should be refreshed.
+func (av *AgentView) NeedsGitRefresh() bool {
+	if av.taskID == "" {
+		return false
+	}
+	return time.Since(av.lastGitRefresh) > 3*time.Second
+}
+
+// FocusLeft moves focus to the left panel.
+func (av *AgentView) FocusLeft() {
+	if av.focus > panelGit {
+		av.focus--
+	}
+}
+
+// FocusRight moves focus to the right panel.
+func (av *AgentView) FocusRight() {
+	if av.focus < panelFiles {
+		av.focus++
+	}
+}
+
+// HandleKey processes a key event. Returns true if the user wants to detach.
+func (av *AgentView) HandleKey(msg tea.KeyMsg) (detach bool) {
+	keyStr := msg.String()
+
+	// Global agent view keys (regardless of focus)
+	if keyStr == "ctrl+q" {
+		return true
+	}
+	if keyStr == "ctrl+left" {
+		av.FocusLeft()
+		return false
+	}
+	if keyStr == "ctrl+right" {
+		av.FocusRight()
+		return false
+	}
+
+	// Panel-specific key handling
+	switch av.focus {
+	case panelAgent:
+		// Forward all other keys to the PTY
+		if sess := av.runner.Get(av.taskID); sess != nil {
+			if b := keyMsgToBytes(msg); len(b) > 0 {
+				sess.WriteInput(b)
+			}
+		}
+	case panelGit:
+		// Sidebar navigation (no-op for now, git status is read-only)
+	case panelFiles:
+		switch keyStr {
+		case "up", "k":
+			av.files.CursorUp()
+		case "down", "j":
+			av.files.CursorDown()
+		}
+	}
+	return false
+}
+
+// View renders the three-panel layout.
+func (av AgentView) View() string {
+	_, centerW, _ := av.splitWidths()
+	contentH := av.height - 1
+
+	// Left panel: git status
+	av.gitstatus.SetFocused(av.focus == panelGit)
+	leftView := av.gitstatus.View()
+
+	// Center panel: agent terminal
+	centerView := av.renderTerminal(centerW, contentH)
+
+	// Right panel: file explorer
+	rightView := av.files.View(av.focus == panelFiles)
+
+	// Ensure all panels are the right height
+	leftView = padHeight(leftView, contentH)
+	centerView = padHeight(centerView, contentH)
+	rightView = padHeight(rightView, contentH)
+
+	content := lipgloss.JoinHorizontal(lipgloss.Top, leftView, centerView, rightView)
+
+	// Status bar
+	bar := av.renderStatusBar()
+
+	return content + "\n" + bar
+}
+
+func (av AgentView) renderTerminal(w, h int) string {
+	borderColor := "238"
+	if av.focus == panelAgent {
+		borderColor = "87"
+	}
+	innerH := max(h-2, 1)
+	border := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(borderColor)).
+		Width(w - 2).
+		Height(innerH)
+
+	sess := av.runner.Get(av.taskID)
+	if sess == nil {
+		empty := av.theme.Dimmed.
+			Width(w - 4).
+			Height(innerH).
+			AlignHorizontal(lipgloss.Center).
+			AlignVertical(lipgloss.Center)
+		return border.Render(empty.Render("Agent not running\n\nPress ctrl+q to return"))
+	}
+
+	raw := sess.RecentOutput()
+	if len(raw) == 0 {
+		empty := av.theme.Dimmed.
+			Width(w - 4).
+			Height(innerH).
+			AlignHorizontal(lipgloss.Center).
+			AlignVertical(lipgloss.Center)
+		return border.Render(empty.Render("Waiting for output..."))
+	}
+
+	content := av.formatTerminalOutput(raw, w, h)
+	return border.Render(content)
+}
+
+func (av AgentView) formatTerminalOutput(raw []byte, panelW, panelH int) string {
+	dispW := max(panelW-4, 10)
+	dispH := max(panelH-4, 3)
+
+	sess := av.runner.Get(av.taskID)
+	vtCols, vtRows := dispW, dispH
+	if sess != nil {
+		c, r := sess.PTYSize()
+		if c > 0 {
+			vtCols = c
+		}
+		if r > 0 {
+			vtRows = r
+		}
+	}
+
+	vt := vt10x.New(vt10x.WithSize(vtCols, vtRows))
+	vt.Write(raw)
+
+	vt.Lock()
+	defer vt.Unlock()
+
+	var lines []string
+	for y := 0; y < vtRows; y++ {
+		line := renderLine(vt, y, vtCols)
+		lines = append(lines, line)
+	}
+
+	// Trim trailing empty lines
+	for len(lines) > 0 && stripANSI(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	if len(lines) == 0 {
+		return ""
+	}
+
+	// Take the tail and truncate
+	if len(lines) > dispH {
+		lines = lines[len(lines)-dispH:]
+	}
+	for i, line := range lines {
+		lines[i] = ansi.Truncate(line, dispW, "\x1b[0m")
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func (av AgentView) renderStatusBar() string {
+	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("87"))
+	labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+
+	// Left: task name
+	left := " " + av.theme.Normal.Render(av.taskName)
+
+	// Right: keybinding hints
+	keys := []struct{ key, label string }{
+		{"ctrl+←", "panel left"},
+		{"ctrl+→", "panel right"},
+		{"ctrl+q", "detach"},
+	}
+	var parts []string
+	for _, k := range keys {
+		parts = append(parts, keyStyle.Render(k.key)+labelStyle.Render(" "+k.label))
+	}
+	right := strings.Join(parts, "  ") + " "
+
+	// Focus indicator
+	var focusLabel string
+	switch av.focus {
+	case panelGit:
+		focusLabel = "GIT STATUS"
+	case panelAgent:
+		focusLabel = "TERMINAL"
+	case panelFiles:
+		focusLabel = "FILES"
+	}
+	center := av.theme.Section.Render(" [" + focusLabel + "] ")
+
+	gap1 := av.width - lipgloss.Width(left) - lipgloss.Width(center) - lipgloss.Width(right)
+	leftGap := gap1 / 2
+	rightGap := gap1 - leftGap
+	if leftGap < 0 {
+		leftGap = 0
+	}
+	if rightGap < 0 {
+		rightGap = 0
+	}
+
+	bar := av.theme.StatusBar.
+		Width(av.width).
+		Render(left + fmt.Sprintf("%*s", leftGap, "") + center + fmt.Sprintf("%*s", rightGap, "") + right)
+
+	return bar
+}
+
+// splitWidths returns left, center, right panel widths.
+// Center gets ~60%, left and right split the remainder, with min widths.
+func (av AgentView) splitWidths() (int, int, int) {
+	minLeft := 20
+	minCenter := 60
+	minRight := 20
+
+	// If terminal is too narrow, compress proportionally
+	if av.width < minLeft+minCenter+minRight {
+		center := av.width * 6 / 10
+		if center < 30 {
+			center = 30
+		}
+		side := (av.width - center) / 2
+		if side < 10 {
+			side = 10
+		}
+		right := av.width - center - side
+		if right < 0 {
+			right = 0
+		}
+		return side, center, right
+	}
+
+	center := av.width * 6 / 10
+	if center < minCenter {
+		center = minCenter
+	}
+	remaining := av.width - center
+	left := remaining / 2
+	right := remaining - left
+	if left < minLeft {
+		left = minLeft
+		right = remaining - left
+	}
+	if right < minRight {
+		right = minRight
+		left = remaining - right
+	}
+	return left, center, right
+}
+
+// padHeight ensures a rendered string fills exactly h lines.
+func padHeight(s string, h int) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) >= h {
+		return strings.Join(lines[:h], "\n")
+	}
+	for len(lines) < h {
+		lines = append(lines, "")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// keyMsgToBytes converts a Bubble Tea key message to raw terminal bytes.
+func keyMsgToBytes(msg tea.KeyMsg) []byte {
+	switch msg.Type {
+	case tea.KeyRunes:
+		return []byte(string(msg.Runes))
+	case tea.KeySpace:
+		return []byte{' '}
+	case tea.KeyEnter:
+		return []byte{'\r'}
+	case tea.KeyBackspace:
+		return []byte{0x7f}
+	case tea.KeyTab:
+		return []byte{'\t'}
+	case tea.KeyShiftTab:
+		return []byte("\x1b[Z")
+	case tea.KeyEscape:
+		return []byte{0x1b}
+	case tea.KeyUp:
+		if msg.Alt {
+			return []byte("\x1b[1;3A")
+		}
+		return []byte("\x1b[A")
+	case tea.KeyDown:
+		if msg.Alt {
+			return []byte("\x1b[1;3B")
+		}
+		return []byte("\x1b[B")
+	case tea.KeyRight:
+		if msg.Alt {
+			return []byte("\x1b[1;3C")
+		}
+		return []byte("\x1b[C")
+	case tea.KeyLeft:
+		if msg.Alt {
+			return []byte("\x1b[1;3D")
+		}
+		return []byte("\x1b[D")
+	case tea.KeyHome:
+		return []byte("\x1b[H")
+	case tea.KeyEnd:
+		return []byte("\x1b[F")
+	case tea.KeyPgUp:
+		return []byte("\x1b[5~")
+	case tea.KeyPgDown:
+		return []byte("\x1b[6~")
+	case tea.KeyDelete:
+		return []byte("\x1b[3~")
+	case tea.KeyCtrlA:
+		return []byte{0x01}
+	case tea.KeyCtrlB:
+		return []byte{0x02}
+	case tea.KeyCtrlC:
+		return []byte{0x03}
+	case tea.KeyCtrlD:
+		return []byte{0x04}
+	case tea.KeyCtrlE:
+		return []byte{0x05}
+	case tea.KeyCtrlF:
+		return []byte{0x06}
+	case tea.KeyCtrlG:
+		return []byte{0x07}
+	case tea.KeyCtrlH:
+		return []byte{0x08}
+	case tea.KeyCtrlK:
+		return []byte{0x0b}
+	case tea.KeyCtrlL:
+		return []byte{0x0c}
+	case tea.KeyCtrlN:
+		return []byte{0x0e}
+	case tea.KeyCtrlO:
+		return []byte{0x0f}
+	case tea.KeyCtrlP:
+		return []byte{0x10}
+	case tea.KeyCtrlR:
+		return []byte{0x12}
+	case tea.KeyCtrlS:
+		return []byte{0x13}
+	case tea.KeyCtrlT:
+		return []byte{0x14}
+	case tea.KeyCtrlU:
+		return []byte{0x15}
+	case tea.KeyCtrlV:
+		return []byte{0x16}
+	case tea.KeyCtrlW:
+		return []byte{0x17}
+	case tea.KeyCtrlX:
+		return []byte{0x18}
+	case tea.KeyCtrlY:
+		return []byte{0x19}
+	case tea.KeyCtrlZ:
+		return []byte{0x1a}
+	case tea.KeyF1:
+		return []byte("\x1bOP")
+	case tea.KeyF2:
+		return []byte("\x1bOQ")
+	case tea.KeyF3:
+		return []byte("\x1bOR")
+	case tea.KeyF4:
+		return []byte("\x1bOS")
+	case tea.KeyF5:
+		return []byte("\x1b[15~")
+	case tea.KeyF6:
+		return []byte("\x1b[17~")
+	case tea.KeyF7:
+		return []byte("\x1b[18~")
+	case tea.KeyF8:
+		return []byte("\x1b[19~")
+	case tea.KeyF9:
+		return []byte("\x1b[20~")
+	case tea.KeyF10:
+		return []byte("\x1b[21~")
+	case tea.KeyF11:
+		return []byte("\x1b[23~")
+	case tea.KeyF12:
+		return []byte("\x1b[24~")
+	}
+
+	// Fallback: use the string representation
+	s := msg.String()
+	if s != "" {
+		return []byte(s)
+	}
+	return nil
+}

--- a/internal/ui/fileexplorer.go
+++ b/internal/ui/fileexplorer.go
@@ -1,0 +1,183 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ChangedFile represents a file from git status output.
+type ChangedFile struct {
+	Status string // e.g. "M", "A", "D", "??"
+	Path   string
+}
+
+// FileExplorer displays changed files in a scrollable sidebar.
+type FileExplorer struct {
+	theme  Theme
+	width  int
+	height int
+	files  []ChangedFile
+	cursor int
+	offset int
+}
+
+func NewFileExplorer(theme Theme) FileExplorer {
+	return FileExplorer{theme: theme}
+}
+
+func (fe *FileExplorer) SetSize(w, h int) {
+	fe.width = w
+	fe.height = h
+}
+
+func (fe *FileExplorer) SetFiles(files []ChangedFile) {
+	fe.files = files
+	if fe.cursor >= len(fe.files) {
+		fe.cursor = max(0, len(fe.files)-1)
+	}
+}
+
+func (fe *FileExplorer) CursorUp() {
+	if fe.cursor > 0 {
+		fe.cursor--
+		if fe.cursor < fe.offset {
+			fe.offset = fe.cursor
+		}
+	}
+}
+
+func (fe *FileExplorer) CursorDown() {
+	if fe.cursor < len(fe.files)-1 {
+		fe.cursor++
+		visible := fe.visibleRows()
+		if fe.cursor >= fe.offset+visible {
+			fe.offset = fe.cursor - visible + 1
+		}
+	}
+}
+
+func (fe *FileExplorer) visibleRows() int {
+	// Reserve 3 for border + header
+	rows := fe.height - 3
+	if rows < 1 {
+		rows = 1
+	}
+	return rows
+}
+
+func (fe FileExplorer) View(focused bool) string {
+	innerW := max(fe.width-4, 10)
+	innerH := max(fe.height-2, 1)
+
+	borderColor := "238"
+	if focused {
+		borderColor = "87"
+	}
+	border := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(borderColor)).
+		Width(fe.width - 2).
+		Height(innerH)
+
+	header := fe.theme.Section.Render("  FILES")
+	if len(fe.files) > 0 {
+		header += fe.theme.Dimmed.Render(fmt.Sprintf(" (%d)", len(fe.files)))
+	}
+
+	if len(fe.files) == 0 {
+		content := header + "\n" + fe.theme.Dimmed.Render("  No changes")
+		return border.Render(content)
+	}
+
+	var b strings.Builder
+	b.WriteString(header + "\n")
+
+	visible := fe.visibleRows()
+	end := fe.offset + visible
+	if end > len(fe.files) {
+		end = len(fe.files)
+	}
+
+	for i := fe.offset; i < end; i++ {
+		f := fe.files[i]
+		selected := focused && i == fe.cursor
+
+		// Status indicator with color
+		statusStyle := fe.statusStyle(f.Status)
+		indicator := statusStyle.Render(fe.statusIcon(f.Status))
+
+		// File path (just the filename, not full path)
+		name := f.Path
+		// Truncate to fit
+		maxNameW := innerW - 6
+		if len(name) > maxNameW && maxNameW > 3 {
+			name = "…" + name[len(name)-maxNameW+1:]
+		}
+
+		nameStyle := fe.theme.Normal
+		if selected {
+			nameStyle = fe.theme.Selected
+		}
+
+		cursor := "  "
+		if selected {
+			cursor = fe.theme.Selected.Render(" ▸")
+		}
+
+		b.WriteString(fmt.Sprintf("%s %s %s\n", cursor, indicator, nameStyle.Render(name)))
+	}
+
+	return border.Render(b.String())
+}
+
+func (fe FileExplorer) statusIcon(status string) string {
+	switch status {
+	case "M", "MM":
+		return "M"
+	case "A":
+		return "A"
+	case "D":
+		return "D"
+	case "??":
+		return "?"
+	case "R":
+		return "R"
+	default:
+		return status
+	}
+}
+
+func (fe FileExplorer) statusStyle(status string) lipgloss.Style {
+	switch status {
+	case "M", "MM":
+		return fe.theme.InReview
+	case "A", "??":
+		return fe.theme.Complete
+	case "D":
+		return fe.theme.Error
+	default:
+		return fe.theme.Normal
+	}
+}
+
+// ParseGitStatus parses `git status --short` output into ChangedFile entries.
+func ParseGitStatus(output string) []ChangedFile {
+	if output == "" {
+		return nil
+	}
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	var files []ChangedFile
+	for _, line := range lines {
+		if len(line) < 4 {
+			continue
+		}
+		status := strings.TrimSpace(line[:2])
+		path := strings.TrimSpace(line[3:])
+		if path != "" {
+			files = append(files, ChangedFile{Status: status, Path: path})
+		}
+	}
+	return files
+}

--- a/internal/ui/gitstatus.go
+++ b/internal/ui/gitstatus.go
@@ -27,6 +27,7 @@ type GitStatus struct {
 	diffText    string
 	loaded      bool
 	lastRefresh time.Time
+	focused     bool
 }
 
 func NewGitStatus(theme Theme) GitStatus {
@@ -67,13 +68,22 @@ func (g *GitStatus) NeedsRefresh() bool {
 	return time.Since(g.lastRefresh) > 3*time.Second
 }
 
+// SetFocused sets whether this panel has focus (changes border color).
+func (g *GitStatus) SetFocused(focused bool) {
+	g.focused = focused
+}
+
 func (g GitStatus) View() string {
 	innerW := max(g.width-4, 10) // padding inside border
 	innerH := max(g.height-2, 1) // border top/bottom
 
+	borderColor := "238"
+	if g.focused {
+		borderColor = "87"
+	}
 	border := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("238")).
+		BorderForeground(lipgloss.Color(borderColor)).
 		Width(g.width - 2).
 		Height(innerH)
 

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -29,6 +29,7 @@ const (
 	viewNewProject
 	viewConfirmDeleteProject
 	viewConfirmDestroy
+	viewAgent
 )
 
 type tab int
@@ -75,6 +76,7 @@ type Model struct {
 	newproject  NewProjectForm
 	preview     Preview
 	gitstatus   GitStatus
+	agentview   AgentView
 	current     view
 	activeTab   tab
 	width       int
@@ -93,6 +95,7 @@ func NewModel(cfg config.Config, s *store.Store, runner *agent.Runner) Model {
 
 	pv := NewPreview(theme, runner)
 	gs := NewGitStatus(theme)
+	av := NewAgentView(theme, runner)
 
 	m := Model{
 		cfg:         cfg,
@@ -106,6 +109,7 @@ func NewModel(cfg config.Config, s *store.Store, runner *agent.Runner) Model {
 		helpview:    hv,
 		preview:     pv,
 		gitstatus:   gs,
+		agentview:   av,
 		current:     viewTaskList,
 		activeTab:   tabTasks,
 	}
@@ -165,6 +169,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusbar.SetWidth(msg.Width)
 		m.newtask.SetSize(msg.Width, msg.Height)
 		m.newproject.SetSize(msg.Width, msg.Height)
+		m.agentview.SetSize(msg.Width, msg.Height)
 		return m, nil
 
 	case TickMsg:
@@ -175,27 +180,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, tea.Tick(time.Second, func(_ time.Time) tea.Msg {
 			return TickMsg{}
 		}))
-		if t := m.tasklist.Selected(); t != nil {
-			// Use explicit worktree path, or fall back to project path from config,
-			// or fall back to the running session's working directory.
-			dir := t.Worktree
-			if dir == "" {
-				dir = agent.ResolveDir(t, m.cfg)
-			}
-			if dir == "" {
-				dir = m.runner.WorkDir(t.ID)
-			}
-			// If we have a base dir, check for Claude Code worktrees
-			if dir != "" && t.Worktree == "" {
-				if wt := discoverClaudeWorktree(dir, t.ID); wt != "" {
-					t.Worktree = wt
-					_ = m.store.Update(t)
-					dir = wt
-				}
-			}
+		// In agent view, also schedule the fast refresh tick
+		if m.current == viewAgent {
+			cmds = append(cmds, tea.Tick(100*time.Millisecond, func(_ time.Time) tea.Msg {
+				return AgentViewTickMsg{}
+			}))
+		}
+		if t := m.selectedTaskForGit(); t != nil {
+			dir := m.resolveTaskDir(t)
 			if dir != "" {
 				m.gitstatus.SetTask(t.ID)
 				if m.gitstatus.NeedsRefresh() {
+					taskID := t.ID
+					cmds = append(cmds, func() tea.Msg {
+						return FetchGitStatus(taskID, dir)
+					})
+				}
+				// Also refresh agent view's git status
+				if m.current == viewAgent && m.agentview.NeedsGitRefresh() {
 					taskID := t.ID
 					cmds = append(cmds, func() tea.Msg {
 						return FetchGitStatus(taskID, dir)
@@ -209,8 +211,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Batch(cmds...)
 
+	case AgentViewTickMsg:
+		// Fast tick for agent view — just triggers a re-render
+		if m.current == viewAgent {
+			var cmds []tea.Cmd
+			cmds = append(cmds, tea.Tick(100*time.Millisecond, func(_ time.Time) tea.Msg {
+				return AgentViewTickMsg{}
+			}))
+			return m, tea.Batch(cmds...)
+		}
+		return m, nil
+
 	case GitStatusRefreshMsg:
 		m.gitstatus.Update(msg)
+		m.agentview.UpdateGitStatus(msg)
 		return m, nil
 
 	case SessionResumedMsg:
@@ -250,6 +264,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleConfirmDestroyKey(msg)
 	case viewConfirmDeleteProject:
 		return m.handleConfirmDeleteProjectKey(msg)
+	case viewAgent:
+		return m.handleAgentViewKey(msg)
 	default:
 		// Tab switching with 1/2 keys
 		switch msg.String() {
@@ -265,6 +281,14 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m.handleTaskListKey(msg)
 	}
+}
+
+func (m Model) handleAgentViewKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if detach := m.agentview.HandleKey(msg); detach {
+		m.current = viewTaskList
+		m.refreshTasks()
+	}
+	return m, nil
 }
 
 func (m Model) handleTaskListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -362,15 +386,13 @@ func (m Model) attachAgent() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) startOrAttach(t *model.Task) (tea.Model, tea.Cmd) {
-	// If session already exists in runner, reattach to it
-	if sess := m.runner.Get(t.ID); sess != nil {
-		attachCmd := &agent.AttachCmd{Session: sess, TaskName: t.Name}
-		return m, tea.Exec(attachCmd, func(err error) tea.Msg {
-			// err == nil means user detached; process may still be running
-			if err != nil {
-				return AgentFinishedMsg{TaskID: t.ID, Err: err}
-			}
-			return AgentDetachedMsg{TaskID: t.ID}
+	// If session already exists in runner, switch to agent view
+	if m.runner.Get(t.ID) != nil {
+		m.agentview.Enter(t.ID, t.Name)
+		m.agentview.SetSize(m.width, m.height)
+		m.current = viewAgent
+		return m, tea.Tick(100*time.Millisecond, func(_ time.Time) tea.Msg {
+			return AgentViewTickMsg{}
 		})
 	}
 
@@ -381,8 +403,12 @@ func (m Model) startOrAttach(t *model.Task) (tea.Model, tea.Cmd) {
 		t.SessionID = model.GenerateSessionID()
 	}
 
-	// Start a new session with current terminal dimensions
-	sess, err := m.runner.Start(t, m.cfg, uint16(m.height), uint16(m.width), resume)
+	// Start a new session — use agent view panel dimensions for PTY size
+	_, centerW, _ := m.agentview.splitWidths()
+	contentH := m.height - 1
+	ptyRows := uint16(max(contentH-4, 10))
+	ptyCols := uint16(max(centerW-4, 40))
+	sess, err := m.runner.Start(t, m.cfg, ptyRows, ptyCols, resume)
 	if err != nil {
 		m.statusbar.SetError(err.Error())
 		return m, nil
@@ -393,12 +419,11 @@ func (m Model) startOrAttach(t *model.Task) (tea.Model, tea.Cmd) {
 	_ = m.store.Update(t)
 	m.refreshTasks()
 
-	attachCmd := &agent.AttachCmd{Session: sess, TaskName: t.Name}
-	return m, tea.Exec(attachCmd, func(err error) tea.Msg {
-		if err != nil {
-			return AgentFinishedMsg{TaskID: t.ID, Err: err}
-		}
-		return AgentDetachedMsg{TaskID: t.ID}
+	m.agentview.Enter(t.ID, t.Name)
+	m.agentview.SetSize(m.width, m.height)
+	m.current = viewAgent
+	return m, tea.Tick(100*time.Millisecond, func(_ time.Time) tea.Msg {
+		return AgentViewTickMsg{}
 	})
 }
 
@@ -411,9 +436,17 @@ func (m Model) handleAgentFinished(msg AgentFinishedMsg) (tea.Model, tea.Cmd) {
 
 	t.AgentPID = 0
 
+	// If we're viewing this agent, return to task list
+	if m.current == viewAgent && m.agentview.taskID == msg.TaskID {
+		m.current = viewTaskList
+	}
+
 	if msg.Stopped {
 		// Explicitly stopped via Runner.Stop — mark for review
 		t.SetStatus(model.StatusInReview)
+	} else if t.Worktree != "" && !dirExists(t.Worktree) {
+		// Worktree removed — auto-complete
+		t.SetStatus(model.StatusComplete)
 	} else {
 		// Agent session exited on its own — task is complete
 		t.SetStatus(model.StatusComplete)
@@ -589,6 +622,36 @@ func (m *Model) refreshProjects() {
 	m.projectlist.SetProjects(m.cfg.Projects)
 }
 
+// selectedTaskForGit returns the task whose git status should be refreshed.
+func (m Model) selectedTaskForGit() *model.Task {
+	if m.current == viewAgent {
+		if t, err := m.store.Get(m.agentview.taskID); err == nil {
+			return t
+		}
+		return nil
+	}
+	return m.tasklist.Selected()
+}
+
+// resolveTaskDir finds the working directory for a task's git status.
+func (m Model) resolveTaskDir(t *model.Task) string {
+	dir := t.Worktree
+	if dir == "" {
+		dir = agent.ResolveDir(t, m.cfg)
+	}
+	if dir == "" {
+		dir = m.runner.WorkDir(t.ID)
+	}
+	if dir != "" && t.Worktree == "" {
+		if wt := discoverClaudeWorktree(dir, t.ID); wt != "" {
+			t.Worktree = wt
+			_ = m.store.Update(t)
+			dir = wt
+		}
+	}
+	return dir
+}
+
 func (m *Model) refreshTasks() {
 	tasks := m.store.Tasks()
 	running := m.runner.Running()
@@ -606,6 +669,11 @@ func (m Model) View() string {
 	// Status bar at the bottom
 	m.statusbar.SetProjectTab(m.activeTab == tabProjects)
 	bar := m.statusbar.View()
+
+	// Agent view: full-screen three-panel layout
+	if m.current == viewAgent {
+		return m.agentview.View()
+	}
 
 	// For overlay views, show them without the banner
 	switch m.current {


### PR DESCRIPTION
Replace full-screen agent attachment with a three-panel Bubble Tea view: git status (left), vt10x terminal (center ~60% width), and changed files explorer (right). Navigate between panels with ctrl+left/right, detach with ctrl+q. Keystrokes forwarded to PTY when terminal panel is focused.

Co-Authored-By: Claude <noreply@anthropic.com>