### PR TITLE
Add ctrl+d to destroy task with full cleanup

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -9,6 +9,7 @@ type KeyMap struct {
 	StatusFwd key.Binding
 	StatusRev key.Binding
 	Delete    key.Binding
+	Destroy   key.Binding
 	Quit      key.Binding
 	Help      key.Binding
 	Filter    key.Binding
@@ -42,6 +43,10 @@ func DefaultKeyMap() KeyMap {
 		Delete: key.NewBinding(
 			key.WithKeys("d"),
 			key.WithHelp("d", "delete"),
+		),
+		Destroy: key.NewBinding(
+			key.WithKeys("ctrl+d"),
+			key.WithHelp("ctrl+d", "destroy (kill+cleanup+delete)"),
 		),
 		Quit: key.NewBinding(
 			key.WithKeys("q", "ctrl+c"),
@@ -94,7 +99,7 @@ func (k KeyMap) ShortHelp() []key.Binding {
 // FullHelp returns keybindings for the expanded help view.
 func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.New, k.Attach, k.Delete},
+		{k.New, k.Attach, k.Delete, k.Destroy},
 		{k.StatusFwd, k.StatusRev, k.Prompt},
 		{k.Up, k.Down, k.Filter},
 		{k.Worktree, k.Prune, k.Help, k.Quit},

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -28,6 +28,7 @@ const (
 	viewConfirmDelete
 	viewNewProject
 	viewConfirmDeleteProject
+	viewConfirmDestroy
 )
 
 type tab int
@@ -245,6 +246,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case viewConfirmDelete:
 		return m.handleConfirmDeleteKey(msg)
+	case viewConfirmDestroy:
+		return m.handleConfirmDestroyKey(msg)
 	case viewConfirmDeleteProject:
 		return m.handleConfirmDeleteProjectKey(msg)
 	default:
@@ -316,6 +319,12 @@ func (m Model) handleTaskListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Prompt):
 		if t := m.tasklist.Selected(); t != nil && t.Status != model.StatusComplete {
 			m.current = viewPrompt
+		}
+		return m, nil
+
+	case key.Matches(msg, m.keys.Destroy):
+		if m.tasklist.Selected() != nil {
+			m.current = viewConfirmDestroy
 		}
 		return m, nil
 
@@ -477,6 +486,35 @@ func (m Model) handleConfirmDeleteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 }
 
+func (m Model) handleConfirmDestroyKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, m.keys.Confirm):
+		if t := m.tasklist.Selected(); t != nil {
+			// Stop the agent session if running
+			if m.runner.HasSession(t.ID) {
+				_ = m.runner.Stop(t.ID)
+			}
+			// Remove worktree and delete branch
+			if t.Worktree != "" {
+				repoDir := agent.ResolveDir(t, m.cfg)
+				removeWorktreeAndBranch(t.Worktree, t.Branch, repoDir)
+			} else if t.Branch != "" {
+				// No worktree but has a branch — try to delete it from project dir
+				if repoDir := agent.ResolveDir(t, m.cfg); repoDir != "" {
+					deleteBranch(repoDir, t.Branch)
+				}
+			}
+			_ = m.store.Delete(t.ID)
+			m.refreshTasks()
+		}
+		m.current = viewTaskList
+		return m, nil
+	default:
+		m.current = viewTaskList
+		return m, nil
+	}
+}
+
 func (m Model) handleProjectListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch {
 	case key.Matches(msg, m.keys.Quit):
@@ -571,7 +609,7 @@ func (m Model) View() string {
 
 	// For overlay views, show them without the banner
 	switch m.current {
-	case viewHelp, viewPrompt, viewConfirmDelete, viewConfirmDeleteProject:
+	case viewHelp, viewPrompt, viewConfirmDelete, viewConfirmDeleteProject, viewConfirmDestroy:
 		var content string
 		switch m.current {
 		case viewHelp:
@@ -580,6 +618,8 @@ func (m Model) View() string {
 			content = m.promptView()
 		case viewConfirmDelete:
 			content = m.confirmDeleteView()
+		case viewConfirmDestroy:
+			content = m.confirmDestroyView()
 		case viewConfirmDeleteProject:
 			content = m.confirmDeleteProjectView()
 		}
@@ -821,6 +861,25 @@ func (m Model) confirmDeleteView() string {
 		m.theme.Help.Render("  [y] confirm  [any other key] cancel")
 }
 
+func (m Model) confirmDestroyView() string {
+	t := m.tasklist.Selected()
+	if t == nil {
+		return ""
+	}
+	var details []string
+	details = append(details, "  "+m.theme.Normal.Render(t.Name))
+	if t.Worktree != "" {
+		details = append(details, "  "+m.theme.Dimmed.Render("worktree: "+t.Worktree))
+	}
+	if t.Branch != "" {
+		details = append(details, "  "+m.theme.Dimmed.Render("branch: "+t.Branch))
+	}
+	return m.theme.Title.Render("Destroy task?") + "\n" +
+		m.theme.Help.Render("  This will terminate the agent, remove the worktree and branch, and delete the task.") + "\n\n" +
+		strings.Join(details, "\n") + "\n\n" +
+		m.theme.Help.Render("  [y] confirm  [any other key] cancel")
+}
+
 func dirExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.IsDir()
@@ -893,6 +952,32 @@ func killStaleProcess(pid int) {
 	}
 	// Force-kill if it's still hanging around.
 	_ = syscall.Kill(pid, syscall.SIGKILL)
+}
+
+// removeWorktreeAndBranch removes a git worktree and deletes its associated branch.
+// repoDir is the main repository directory used for branch deletion; if empty,
+// the worktree's parent directory is used as a fallback.
+func removeWorktreeAndBranch(worktreePath, branch, repoDir string) {
+	removeWorktree(worktreePath)
+	if branch == "" {
+		return
+	}
+	// Use main repo dir for branch deletion; fall back to worktree parent.
+	dir := repoDir
+	if dir == "" {
+		dir = filepath.Dir(worktreePath)
+	}
+	deleteBranch(dir, branch)
+}
+
+// deleteBranch force-deletes a local git branch.
+func deleteBranch(repoDir, branch string) {
+	if branch == "" || repoDir == "" {
+		return
+	}
+	cmd := exec.Command("git", "branch", "-D", branch)
+	cmd.Dir = repoDir
+	_ = cmd.Run()
 }
 
 func removeWorktree(worktreePath string) {

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -119,6 +119,84 @@ func TestPruneCompleted(t *testing.T) {
 	}
 }
 
+func TestDestroyCtrlD_ShowsConfirmation(t *testing.T) {
+	task := &model.Task{
+		ID:     "t1",
+		Name:   "my task",
+		Status: model.StatusInProgress,
+	}
+	m := testModel(t, task)
+
+	// Press ctrl+d
+	msg := tea.KeyMsg{Type: tea.KeyCtrlD}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	if um.current != viewConfirmDestroy {
+		t.Errorf("expected viewConfirmDestroy, got %d", um.current)
+	}
+}
+
+func TestDestroyCtrlD_NoTaskSelected(t *testing.T) {
+	m := testModel(t) // no tasks
+
+	msg := tea.KeyMsg{Type: tea.KeyCtrlD}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	if um.current != viewTaskList {
+		t.Errorf("expected viewTaskList when no task selected, got %d", um.current)
+	}
+}
+
+func TestDestroyConfirm_DeletesTask(t *testing.T) {
+	task := &model.Task{
+		ID:     "t1",
+		Name:   "destroy me",
+		Status: model.StatusPending,
+	}
+	m := testModel(t, task)
+
+	// Enter confirm destroy state
+	m.current = viewConfirmDestroy
+
+	// Press y to confirm
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	if um.current != viewTaskList {
+		t.Errorf("expected viewTaskList after confirm, got %d", um.current)
+	}
+	if _, err := um.store.Get("t1"); err == nil {
+		t.Error("expected task to be deleted after destroy confirm")
+	}
+}
+
+func TestDestroyCancel_KeepsTask(t *testing.T) {
+	task := &model.Task{
+		ID:     "t1",
+		Name:   "keep me",
+		Status: model.StatusPending,
+	}
+	m := testModel(t, task)
+
+	// Enter confirm destroy state
+	m.current = viewConfirmDestroy
+
+	// Press any other key to cancel
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	if um.current != viewTaskList {
+		t.Errorf("expected viewTaskList after cancel, got %d", um.current)
+	}
+	if _, err := um.store.Get("t1"); err != nil {
+		t.Error("expected task to still exist after cancel")
+	}
+}
+
 func TestInit_ResumesOnlyInProgressWithSessionID(t *testing.T) {
 	tasks := []*model.Task{
 		{ID: "t1", Name: "in-progress with session", Status: model.StatusInProgress, SessionID: "sess-1"},


### PR DESCRIPTION
Adds a ctrl+d hotkey that terminates the agent session, removes the git worktree and branch, and deletes the task from the store. Includes a confirmation dialog showing task name, worktree path, and branch before proceeding.

Co-Authored-By: Claude <noreply@anthropic.com>