### PR TITLE
Fix resumed agent error exits marking tasks complete

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -444,6 +444,10 @@ func (m Model) handleAgentFinished(msg AgentFinishedMsg) (tea.Model, tea.Cmd) {
 	if msg.Stopped {
 		// Explicitly stopped via Runner.Stop — mark for review
 		t.SetStatus(model.StatusInReview)
+	} else if msg.Err != nil {
+		// Process exited with an error (e.g. failed resume, crash) —
+		// keep the task in progress so the user can retry.
+		t.SessionID = ""
 	} else if t.Worktree != "" && !dirExists(t.Worktree) {
 		// Worktree removed — auto-complete
 		t.SetStatus(model.StatusComplete)

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -197,6 +197,90 @@ func TestDestroyCancel_KeepsTask(t *testing.T) {
 	}
 }
 
+func TestAgentFinished_ErrorKeepsInProgress(t *testing.T) {
+	task := &model.Task{
+		ID:        "task-1",
+		Name:      "resuming task",
+		Status:    model.StatusInProgress,
+		SessionID: "sess-abc",
+		AgentPID:  100,
+	}
+	m := testModel(t, task)
+
+	updated, _ := m.Update(AgentFinishedMsg{
+		TaskID:  "task-1",
+		Err:     errors.New("exit status 1"),
+		Stopped: false,
+	})
+	um := updated.(Model)
+
+	got, err := um.store.Get("task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != model.StatusInProgress {
+		t.Errorf("expected status InProgress, got %v", got.Status)
+	}
+	if got.SessionID != "" {
+		t.Errorf("expected SessionID cleared on error, got %q", got.SessionID)
+	}
+	if got.AgentPID != 0 {
+		t.Errorf("expected AgentPID=0, got %d", got.AgentPID)
+	}
+}
+
+func TestAgentFinished_SuccessMarksComplete(t *testing.T) {
+	task := &model.Task{
+		ID:        "task-1",
+		Name:      "finished task",
+		Status:    model.StatusInProgress,
+		SessionID: "sess-abc",
+		AgentPID:  100,
+	}
+	m := testModel(t, task)
+
+	updated, _ := m.Update(AgentFinishedMsg{
+		TaskID:  "task-1",
+		Err:     nil,
+		Stopped: false,
+	})
+	um := updated.(Model)
+
+	got, err := um.store.Get("task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != model.StatusComplete {
+		t.Errorf("expected status Complete, got %v", got.Status)
+	}
+}
+
+func TestAgentFinished_StoppedMarksInReview(t *testing.T) {
+	task := &model.Task{
+		ID:        "task-1",
+		Name:      "stopped task",
+		Status:    model.StatusInProgress,
+		SessionID: "sess-abc",
+		AgentPID:  100,
+	}
+	m := testModel(t, task)
+
+	updated, _ := m.Update(AgentFinishedMsg{
+		TaskID:  "task-1",
+		Err:     nil,
+		Stopped: true,
+	})
+	um := updated.(Model)
+
+	got, err := um.store.Get("task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != model.StatusInReview {
+		t.Errorf("expected status InReview, got %v", got.Status)
+	}
+}
+
 func TestInit_ResumesOnlyInProgressWithSessionID(t *testing.T) {
 	tasks := []*model.Task{
 		{ID: "t1", Name: "in-progress with session", Status: model.StatusInProgress, SessionID: "sess-1"},


### PR DESCRIPTION
When an agent process exited with an error (e.g. expired session during resume), handleAgentFinished unconditionally marked the task as Complete. Now error exits keep the task InProgress and clear the SessionID so the next start begins a fresh session.

Co-Authored-By: Claude <noreply@anthropic.com>