### PR TITLE
Replace project text input with select list in new task form

### DIFF
--- a/internal/ui/newtask.go
+++ b/internal/ui/newtask.go
@@ -1,8 +1,8 @@
 package ui
 
 import (
-	"os"
-	"path/filepath"
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -14,44 +14,44 @@ import (
 
 // NewTaskForm handles the new task creation UI.
 type NewTaskForm struct {
-	inputs   []textinput.Model
-	focused  int
-	theme    Theme
-	projects map[string]config.Project
-	done     bool
-	canceled bool
-	width    int
-	height   int
+	promptInput  textinput.Model
+	projectNames []string
+	projectIdx   int
+	focused      int // 0 = project, 1 = prompt
+	theme        Theme
+	projects     map[string]config.Project
+	done         bool
+	canceled     bool
+	width        int
+	height       int
 }
 
 const (
-	fieldProject = iota
-	fieldPrompt
-	fieldCount
+	fieldProject = 0
+	fieldPrompt  = 1
+	fieldCount   = 2
 )
 
 func NewNewTaskForm(theme Theme, projects map[string]config.Project) NewTaskForm {
-	inputs := make([]textinput.Model, fieldCount)
-
-	projInput := textinput.New()
-	projInput.Placeholder = "Project (from config)"
-	projInput.CharLimit = 40
-	if cwd, err := os.Getwd(); err == nil {
-		projInput.SetValue(filepath.Base(cwd))
-	}
-	inputs[fieldProject] = projInput
-
 	promptInput := textinput.New()
 	promptInput.Placeholder = "Prompt for the agent"
 	promptInput.CharLimit = 500
 	promptInput.Focus()
-	inputs[fieldPrompt] = promptInput
+
+	// Build sorted project name list
+	names := make([]string, 0, len(projects))
+	for name := range projects {
+		names = append(names, name)
+	}
+	sort.Strings(names)
 
 	return NewTaskForm{
-		inputs:   inputs,
-		focused:  fieldPrompt,
-		theme:    theme,
-		projects: projects,
+		promptInput:  promptInput,
+		projectNames: names,
+		projectIdx:   0,
+		focused:      fieldPrompt,
+		theme:        theme,
+		projects:     projects,
 	}
 }
 
@@ -63,46 +63,64 @@ func (f *NewTaskForm) Update(msg tea.Msg) tea.Cmd {
 			f.canceled = true
 			return nil
 		case "tab", "down":
-			f.focused = (f.focused + 1) % fieldCount
-			return f.focusCurrent()
+			if f.focused == fieldProject {
+				f.focused = fieldPrompt
+				return f.promptInput.Focus()
+			}
+			f.focused = fieldProject
+			f.promptInput.Blur()
+			return nil
 		case "shift+tab", "up":
-			f.focused = (f.focused - 1 + fieldCount) % fieldCount
-			return f.focusCurrent()
-		case "enter":
-			if f.focused == fieldCount-1 {
-				// Submit on enter at last field
-				if strings.TrimSpace(f.inputs[fieldPrompt].Value()) != "" {
-					f.done = true
-				}
+			if f.focused == fieldPrompt {
+				f.focused = fieldProject
+				f.promptInput.Blur()
 				return nil
 			}
-			f.focused++
-			return f.focusCurrent()
+			f.focused = fieldPrompt
+			return f.promptInput.Focus()
+		case "left":
+			if f.focused == fieldProject && len(f.projectNames) > 0 {
+				f.projectIdx = (f.projectIdx - 1 + len(f.projectNames)) % len(f.projectNames)
+				return nil
+			}
+		case "right":
+			if f.focused == fieldProject && len(f.projectNames) > 0 {
+				f.projectIdx = (f.projectIdx + 1) % len(f.projectNames)
+				return nil
+			}
+		case "enter":
+			if f.focused == fieldProject {
+				f.focused = fieldPrompt
+				return f.promptInput.Focus()
+			}
+			// Submit on enter at prompt field
+			if strings.TrimSpace(f.promptInput.Value()) != "" {
+				f.done = true
+			}
+			return nil
 		}
 	}
 
-	var cmd tea.Cmd
-	f.inputs[f.focused], cmd = f.inputs[f.focused].Update(msg)
-	return cmd
+	if f.focused == fieldPrompt {
+		var cmd tea.Cmd
+		f.promptInput, cmd = f.promptInput.Update(msg)
+		return cmd
+	}
+
+	return nil
 }
 
-func (f *NewTaskForm) focusCurrent() tea.Cmd {
-	cmds := make([]tea.Cmd, len(f.inputs))
-	for i := range f.inputs {
-		if i == f.focused {
-			cmds[i] = f.inputs[i].Focus()
-		} else {
-			f.inputs[i].Blur()
-		}
+func (f *NewTaskForm) SelectedProject() string {
+	if len(f.projectNames) == 0 {
+		return ""
 	}
-	return tea.Batch(cmds...)
+	return f.projectNames[f.projectIdx]
 }
 
 func (f *NewTaskForm) Task() *model.Task {
-	project := strings.TrimSpace(f.inputs[fieldProject].Value())
-	prompt := strings.TrimSpace(f.inputs[fieldPrompt].Value())
+	project := f.SelectedProject()
+	prompt := strings.TrimSpace(f.promptInput.Value())
 
-	// Extract keywords from prompt as task name (e.g., "fix-auth-token-refresh")
 	name := model.GenerateNameFromPrompt(prompt)
 
 	branch := "main"
@@ -127,14 +145,11 @@ func (f *NewTaskForm) Canceled() bool { return f.canceled }
 func (f *NewTaskForm) SetSize(w, h int) {
 	f.width = w
 	f.height = h
-	// Set input widths to fit inside the modal
-	inputWidth := f.modalWidth() - 6 // account for border + padding
+	inputWidth := f.modalWidth() - 6
 	if inputWidth < 20 {
 		inputWidth = 20
 	}
-	for i := range f.inputs {
-		f.inputs[i].Width = inputWidth
-	}
+	f.promptInput.Width = inputWidth
 }
 
 func (f NewTaskForm) modalWidth() int {
@@ -154,17 +169,23 @@ func (f NewTaskForm) modalWidth() int {
 func (f NewTaskForm) View() string {
 	var b strings.Builder
 
-	labels := []string{"Project:", "Prompt:"}
-	for i, label := range labels {
-		style := f.theme.Dimmed
-		if i == f.focused {
-			style = f.theme.Selected
-		}
-		b.WriteString(style.Render(label) + "\n")
-		b.WriteString(f.inputs[i].View() + "\n\n")
+	// Project selector
+	projStyle := f.theme.Dimmed
+	if f.focused == fieldProject {
+		projStyle = f.theme.Selected
 	}
+	b.WriteString(projStyle.Render("Project:") + "\n")
+	b.WriteString(f.renderProjectSelector() + "\n\n")
 
-	b.WriteString(f.theme.Help.Render("tab/shift+tab: navigate  enter: submit  esc: cancel"))
+	// Prompt input
+	promptStyle := f.theme.Dimmed
+	if f.focused == fieldPrompt {
+		promptStyle = f.theme.Selected
+	}
+	b.WriteString(promptStyle.Render("Prompt:") + "\n")
+	b.WriteString(f.promptInput.View() + "\n\n")
+
+	b.WriteString(f.theme.Help.Render("tab/shift+tab: navigate  \u2190/\u2192: select project  enter: submit  esc: cancel"))
 
 	mw := f.modalWidth()
 
@@ -176,4 +197,22 @@ func (f NewTaskForm) View() string {
 		Render(f.theme.Title.Render("New Task") + "\n\n" + b.String())
 
 	return lipgloss.Place(f.width, f.height, lipgloss.Center, lipgloss.Center, modal)
+}
+
+func (f NewTaskForm) renderProjectSelector() string {
+	if len(f.projectNames) == 0 {
+		return f.theme.Dimmed.Render("  (no projects configured)")
+	}
+
+	arrow := f.theme.Dimmed
+	selected := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("87"))
+
+	left := arrow.Render("\u25c0 ")
+	right := arrow.Render(" \u25b6")
+	name := selected.Render(f.projectNames[f.projectIdx])
+
+	counter := f.theme.Dimmed.Render(
+		fmt.Sprintf(" (%d/%d)", f.projectIdx+1, len(f.projectNames)))
+
+	return "  " + left + name + right + counter
 }

--- a/internal/ui/newtask_test.go
+++ b/internal/ui/newtask_test.go
@@ -1,0 +1,179 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/drn/argus/internal/config"
+)
+
+func testProjects() map[string]config.Project {
+	return map[string]config.Project{
+		"alpha":   {Path: "/tmp/alpha", Branch: "main"},
+		"bravo":   {Path: "/tmp/bravo", Branch: "develop"},
+		"charlie": {Path: "/tmp/charlie"},
+	}
+}
+
+func TestNewTaskForm_ProjectListSorted(t *testing.T) {
+	theme := DefaultTheme()
+	f := NewNewTaskForm(theme, testProjects())
+
+	if len(f.projectNames) != 3 {
+		t.Fatalf("expected 3 project names, got %d", len(f.projectNames))
+	}
+	expected := []string{"alpha", "bravo", "charlie"}
+	for i, name := range expected {
+		if f.projectNames[i] != name {
+			t.Errorf("projectNames[%d] = %q, want %q", i, f.projectNames[i], name)
+		}
+	}
+}
+
+func TestNewTaskForm_DefaultSelectsFirst(t *testing.T) {
+	theme := DefaultTheme()
+	f := NewNewTaskForm(theme, testProjects())
+
+	if got := f.SelectedProject(); got != "alpha" {
+		t.Errorf("SelectedProject() = %q, want %q", got, "alpha")
+	}
+}
+
+func TestNewTaskForm_RightCyclesForward(t *testing.T) {
+	theme := DefaultTheme()
+	f := NewNewTaskForm(theme, testProjects())
+	f.focused = fieldProject
+
+	f.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got := f.SelectedProject(); got != "bravo" {
+		t.Errorf("after right: SelectedProject() = %q, want %q", got, "bravo")
+	}
+
+	f.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got := f.SelectedProject(); got != "charlie" {
+		t.Errorf("after right x2: SelectedProject() = %q, want %q", got, "charlie")
+	}
+
+	// Wraps around
+	f.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got := f.SelectedProject(); got != "alpha" {
+		t.Errorf("after right x3 (wrap): SelectedProject() = %q, want %q", got, "alpha")
+	}
+}
+
+func TestNewTaskForm_LeftCyclesBackward(t *testing.T) {
+	theme := DefaultTheme()
+	f := NewNewTaskForm(theme, testProjects())
+	f.focused = fieldProject
+
+	// Wraps to last
+	f.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if got := f.SelectedProject(); got != "charlie" {
+		t.Errorf("after left (wrap): SelectedProject() = %q, want %q", got, "charlie")
+	}
+
+	f.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if got := f.SelectedProject(); got != "bravo" {
+		t.Errorf("after left x2: SelectedProject() = %q, want %q", got, "bravo")
+	}
+}
+
+func TestNewTaskForm_TabNavigatesBetweenFields(t *testing.T) {
+	theme := DefaultTheme()
+	f := NewNewTaskForm(theme, testProjects())
+
+	// Starts on prompt
+	if f.focused != fieldPrompt {
+		t.Fatalf("expected initial focus on prompt, got %d", f.focused)
+	}
+
+	// Tab goes to project
+	f.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if f.focused != fieldProject {
+		t.Errorf("after tab: focused = %d, want %d", f.focused, fieldProject)
+	}
+
+	// Tab goes back to prompt
+	f.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if f.focused != fieldPrompt {
+		t.Errorf("after tab x2: focused = %d, want %d", f.focused, fieldPrompt)
+	}
+}
+
+func TestNewTaskForm_EnterOnProjectMovesToPrompt(t *testing.T) {
+	theme := DefaultTheme()
+	f := NewNewTaskForm(theme, testProjects())
+	f.focused = fieldProject
+
+	f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if f.focused != fieldPrompt {
+		t.Errorf("after enter on project: focused = %d, want %d", f.focused, fieldPrompt)
+	}
+}
+
+func TestNewTaskForm_TaskUsesBranchFromProject(t *testing.T) {
+	theme := DefaultTheme()
+	f := NewNewTaskForm(theme, testProjects())
+	f.focused = fieldProject
+
+	// Select bravo (has branch "develop")
+	f.Update(tea.KeyMsg{Type: tea.KeyRight})
+
+	// Set prompt
+	f.focused = fieldPrompt
+	f.promptInput.SetValue("fix the bug")
+
+	task := f.Task()
+	if task.Project != "bravo" {
+		t.Errorf("task.Project = %q, want %q", task.Project, "bravo")
+	}
+	if task.Branch != "develop" {
+		t.Errorf("task.Branch = %q, want %q", task.Branch, "develop")
+	}
+}
+
+func TestNewTaskForm_EmptyProjects(t *testing.T) {
+	theme := DefaultTheme()
+	f := NewNewTaskForm(theme, map[string]config.Project{})
+
+	if got := f.SelectedProject(); got != "" {
+		t.Errorf("SelectedProject() with no projects = %q, want empty", got)
+	}
+
+	// Left/right should not panic
+	f.focused = fieldProject
+	f.Update(tea.KeyMsg{Type: tea.KeyRight})
+	f.Update(tea.KeyMsg{Type: tea.KeyLeft})
+
+	if got := f.SelectedProject(); got != "" {
+		t.Errorf("SelectedProject() still empty = %q, want empty", got)
+	}
+}
+
+func TestNewTaskForm_EscCancels(t *testing.T) {
+	theme := DefaultTheme()
+	f := NewNewTaskForm(theme, testProjects())
+
+	f.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if !f.Canceled() {
+		t.Error("expected Canceled() to be true after esc")
+	}
+}
+
+func TestNewTaskForm_SubmitRequiresPrompt(t *testing.T) {
+	theme := DefaultTheme()
+	f := NewNewTaskForm(theme, testProjects())
+
+	// Enter with empty prompt should not submit
+	f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if f.Done() {
+		t.Error("should not be done with empty prompt")
+	}
+
+	// Set prompt and submit
+	f.promptInput.SetValue("do something")
+	f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !f.Done() {
+		t.Error("expected Done() to be true after enter with prompt")
+	}
+}

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -309,7 +309,7 @@ func (m Model) handleTaskListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.newtask = NewNewTaskForm(m.theme, m.cfg.Projects)
 		m.newtask.SetSize(m.width, m.height)
 		m.current = viewNewTask
-		return m, m.newtask.inputs[0].Focus()
+		return m, nil
 
 	case key.Matches(msg, m.keys.StatusFwd):
 		if t := m.tasklist.Selected(); t != nil {


### PR DESCRIPTION
Project field in new task form now uses a select list that cycles through configured projects with left/right arrows, instead of free-text input. Includes sorted project names, visual selector with arrows and position counter, and 10 new tests.

Co-Authored-By: Claude <noreply@anthropic.com>