### PR TITLE
Fix git diff panels to show committed branch changes

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -81,7 +81,12 @@ func (av *AgentView) SetSize(w, h int) {
 func (av *AgentView) UpdateGitStatus(msg GitStatusRefreshMsg) {
 	if msg.TaskID == av.taskID {
 		av.gitstatus.Update(msg)
-		av.files.SetFiles(ParseGitStatus(msg.Status))
+		// Prefer uncommitted files; fall back to committed branch files
+		if files := ParseGitStatus(msg.Status); len(files) > 0 {
+			av.files.SetFiles(files)
+		} else {
+			av.files.SetFiles(ParseGitDiffNameStatus(msg.BranchFiles))
+		}
 		av.lastGitRefresh = time.Now()
 	}
 }

--- a/internal/ui/fileexplorer.go
+++ b/internal/ui/fileexplorer.go
@@ -181,3 +181,24 @@ func ParseGitStatus(output string) []ChangedFile {
 	}
 	return files
 }
+
+// ParseGitDiffNameStatus parses `git diff --name-status` output into ChangedFile entries.
+func ParseGitDiffNameStatus(output string) []ChangedFile {
+	if output == "" {
+		return nil
+	}
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	var files []ChangedFile
+	for _, line := range lines {
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		status := strings.TrimSpace(parts[0])
+		path := strings.TrimSpace(parts[1])
+		if path != "" {
+			files = append(files, ChangedFile{Status: status, Path: path})
+		}
+	}
+	return files
+}

--- a/internal/ui/gitstatus.go
+++ b/internal/ui/gitstatus.go
@@ -12,9 +12,11 @@ import (
 
 // GitStatusRefreshMsg carries the result of a background git status check.
 type GitStatusRefreshMsg struct {
-	TaskID string
-	Status string // git status --short output
-	Diff   string // git diff --stat output
+	TaskID      string
+	Status      string // git status --short output
+	Diff        string // git diff --stat (unstaged + staged) output
+	BranchDiff  string // git diff --stat against merge-base (committed changes)
+	BranchFiles string // git diff --name-status against merge-base (for file list)
 }
 
 // GitStatus renders worktree git status and diff stat above the preview pane.
@@ -22,10 +24,11 @@ type GitStatus struct {
 	theme       Theme
 	width       int
 	height      int
-	taskID      string
-	statusText  string
-	diffText    string
-	loaded      bool
+	taskID         string
+	statusText     string
+	diffText       string
+	branchDiffText string
+	loaded         bool
 	lastRefresh time.Time
 	focused     bool
 }
@@ -44,6 +47,7 @@ func (g *GitStatus) Update(msg GitStatusRefreshMsg) {
 	if msg.TaskID == g.taskID {
 		g.statusText = msg.Status
 		g.diffText = msg.Diff
+		g.branchDiffText = msg.BranchDiff
 		g.loaded = true
 		g.lastRefresh = time.Now()
 	}
@@ -55,6 +59,7 @@ func (g *GitStatus) SetTask(taskID string) {
 		g.taskID = taskID
 		g.statusText = ""
 		g.diffText = ""
+		g.branchDiffText = ""
 		g.loaded = false
 		g.lastRefresh = time.Time{}
 	}
@@ -95,7 +100,7 @@ func (g GitStatus) View() string {
 		return border.Render(g.theme.Dimmed.Render(" Loading..."))
 	}
 
-	if g.statusText == "" && g.diffText == "" {
+	if g.statusText == "" && g.diffText == "" && g.branchDiffText == "" {
 		return border.Render(g.theme.Dimmed.Render(" Clean — no changes"))
 	}
 
@@ -110,6 +115,12 @@ func (g GitStatus) View() string {
 	if g.diffText != "" {
 		header := g.theme.Section.Render("  DIFF")
 		lines := g.truncateLines(g.diffText, innerW, innerH-2)
+		sections = append(sections, header+"\n"+g.colorizeDiff(lines))
+	}
+
+	if g.branchDiffText != "" {
+		header := g.theme.Section.Render("  BRANCH")
+		lines := g.truncateLines(g.branchDiffText, innerW, innerH-2)
 		sections = append(sections, header+"\n"+g.colorizeDiff(lines))
 	}
 
@@ -177,12 +188,41 @@ func FetchGitStatus(taskID, worktree string) GitStatusRefreshMsg {
 		msg.Status = strings.TrimRight(out, "\n")
 	}
 
-	// git diff --stat
-	if out, err := runGit(worktree, "diff", "--stat"); err == nil {
+	// git diff HEAD --stat (unstaged + staged changes)
+	if out, err := runGit(worktree, "diff", "HEAD", "--stat"); err == nil {
 		msg.Diff = strings.TrimRight(out, "\n")
 	}
 
+	// git diff against merge-base with default branch (committed branch changes)
+	if base := findMergeBase(worktree); base != "" {
+		if out, err := runGit(worktree, "diff", "--stat", base+"..HEAD"); err == nil {
+			msg.BranchDiff = strings.TrimRight(out, "\n")
+		}
+		if out, err := runGit(worktree, "diff", "--name-status", base+"..HEAD"); err == nil {
+			msg.BranchFiles = strings.TrimRight(out, "\n")
+		}
+	}
+
 	return msg
+}
+
+// findMergeBase finds the merge-base between HEAD and the upstream or default branch.
+func findMergeBase(worktree string) string {
+	// Try upstream first
+	if base, err := runGit(worktree, "merge-base", "HEAD", "HEAD@{upstream}"); err == nil {
+		if b := strings.TrimSpace(base); b != "" {
+			return b
+		}
+	}
+	// Fallback: try common default branch names
+	for _, branch := range []string{"main", "master"} {
+		if base, err := runGit(worktree, "merge-base", "HEAD", branch); err == nil {
+			if b := strings.TrimSpace(base); b != "" {
+				return b
+			}
+		}
+	}
+	return ""
 }
 
 func runGit(dir string, args ...string) (string, error) {

--- a/internal/ui/gitstatus_test.go
+++ b/internal/ui/gitstatus_test.go
@@ -1,0 +1,157 @@
+package ui
+
+import (
+	"testing"
+)
+
+func TestGitStatusUpdate(t *testing.T) {
+	gs := NewGitStatus(DefaultTheme())
+	gs.SetSize(40, 10)
+	gs.SetTask("task-1")
+
+	msg := GitStatusRefreshMsg{
+		TaskID:      "task-1",
+		Status:      " M file.go",
+		Diff:        " file.go | 2 +-",
+		BranchDiff:  " file.go | 10 +++++++---",
+		BranchFiles: "M\tfile.go",
+	}
+	gs.Update(msg)
+
+	if !gs.loaded {
+		t.Error("expected loaded to be true after Update")
+	}
+	if gs.statusText != msg.Status {
+		t.Errorf("statusText = %q, want %q", gs.statusText, msg.Status)
+	}
+	if gs.diffText != msg.Diff {
+		t.Errorf("diffText = %q, want %q", gs.diffText, msg.Diff)
+	}
+	if gs.branchDiffText != msg.BranchDiff {
+		t.Errorf("branchDiffText = %q, want %q", gs.branchDiffText, msg.BranchDiff)
+	}
+}
+
+func TestGitStatusUpdateIgnoresMismatchedTask(t *testing.T) {
+	gs := NewGitStatus(DefaultTheme())
+	gs.SetTask("task-1")
+
+	gs.Update(GitStatusRefreshMsg{
+		TaskID: "task-2",
+		Status: " M file.go",
+	})
+
+	if gs.loaded {
+		t.Error("should not update for mismatched task ID")
+	}
+}
+
+func TestGitStatusSetTaskClears(t *testing.T) {
+	gs := NewGitStatus(DefaultTheme())
+	gs.SetTask("task-1")
+	gs.Update(GitStatusRefreshMsg{
+		TaskID:      "task-1",
+		Status:      " M file.go",
+		BranchDiff:  " file.go | 5 ++---",
+		BranchFiles: "M\tfile.go",
+	})
+
+	gs.SetTask("task-2")
+
+	if gs.loaded {
+		t.Error("expected loaded to be false after task change")
+	}
+	if gs.branchDiffText != "" {
+		t.Error("expected branchDiffText cleared on task change")
+	}
+}
+
+func TestGitStatusViewShowsBranchDiff(t *testing.T) {
+	gs := NewGitStatus(DefaultTheme())
+	gs.SetSize(60, 20)
+	gs.SetTask("task-1")
+
+	// Simulate committed changes only (no uncommitted)
+	gs.Update(GitStatusRefreshMsg{
+		TaskID:     "task-1",
+		BranchDiff: " file.go | 10 +++++++---",
+	})
+
+	view := gs.View()
+	if view == "" {
+		t.Error("expected non-empty view when BranchDiff is set")
+	}
+	// Should not show "Clean — no changes"
+	if contains(view, "Clean") {
+		t.Error("view should not say 'Clean' when BranchDiff has content")
+	}
+}
+
+func TestGitStatusViewClean(t *testing.T) {
+	gs := NewGitStatus(DefaultTheme())
+	gs.SetSize(40, 10)
+	gs.SetTask("task-1")
+	gs.Update(GitStatusRefreshMsg{TaskID: "task-1"})
+
+	view := gs.View()
+	if !contains(view, "Clean") {
+		t.Error("expected 'Clean' in view when all fields empty")
+	}
+}
+
+func TestParseGitDiffNameStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect []ChangedFile
+	}{
+		{
+			name:   "empty",
+			input:  "",
+			expect: nil,
+		},
+		{
+			name:  "single modified file",
+			input: "M\tinternal/ui/root.go",
+			expect: []ChangedFile{
+				{Status: "M", Path: "internal/ui/root.go"},
+			},
+		},
+		{
+			name:  "multiple files",
+			input: "M\tfile1.go\nA\tfile2.go\nD\tfile3.go",
+			expect: []ChangedFile{
+				{Status: "M", Path: "file1.go"},
+				{Status: "A", Path: "file2.go"},
+				{Status: "D", Path: "file3.go"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseGitDiffNameStatus(tt.input)
+			if len(got) != len(tt.expect) {
+				t.Fatalf("got %d files, want %d", len(got), len(tt.expect))
+			}
+			for i, f := range got {
+				if f.Status != tt.expect[i].Status || f.Path != tt.expect[i].Path {
+					t.Errorf("file[%d] = %+v, want %+v", i, f, tt.expect[i])
+				}
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Git diff panels in task list and agent view never displayed content because FetchGitStatus only checked unstaged changes. Now diffs against the merge-base to show committed branch changes, includes staged+unstaged in the working diff, and populates the file explorer from branch files when there are no uncommitted changes.

Co-Authored-By: Claude <noreply@anthropic.com>