### PR TITLE
Name git worktrees after their tasks

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -59,6 +59,11 @@ func BuildCmd(task *model.Task, cfg config.Config, resume bool) (*exec.Cmd, erro
 
 	cmdStr := backend.Command
 
+	// Inject the task name as the worktree name so worktrees match tasks (argus/<name>).
+	if !resume && task.Name != "" {
+		cmdStr = injectWorktreeName(cmdStr, "argus/"+task.Name)
+	}
+
 	if resume && task.SessionID != "" {
 		// Resume an existing session — no prompt needed.
 		// Strip --worktree/-w since the worktree already exists from the
@@ -112,6 +117,32 @@ func stripWorktreeFlag(cmd string) string {
 		}
 		// Handle --worktree=value
 		if strings.HasPrefix(p, "--worktree=") || strings.HasPrefix(p, "-w=") {
+			continue
+		}
+		out = append(out, p)
+	}
+	return strings.Join(out, " ")
+}
+
+// injectWorktreeName finds the --worktree / -w flag in a command string
+// and ensures it has the given name as its argument. If the flag already
+// has a value, it is replaced. If the flag has no value, the name is inserted.
+// If the flag is absent, the command is returned unchanged.
+func injectWorktreeName(cmd, name string) string {
+	parts := strings.Fields(cmd)
+	var out []string
+	for i := 0; i < len(parts); i++ {
+		p := parts[i]
+		if p == "--worktree" || p == "-w" {
+			out = append(out, p, name)
+			// Skip an existing non-flag argument if present.
+			if i+1 < len(parts) && !strings.HasPrefix(parts[i+1], "-") {
+				i++
+			}
+			continue
+		}
+		if strings.HasPrefix(p, "--worktree=") || strings.HasPrefix(p, "-w=") {
+			out = append(out, "--worktree", name)
 			continue
 		}
 		out = append(out, p)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -112,7 +112,7 @@ func TestResolveDir(t *testing.T) {
 
 func TestBuildCmd(t *testing.T) {
 	cfg := testConfig()
-	task := &model.Task{Prompt: "fix the bug"}
+	task := &model.Task{Name: "fix-bug", Prompt: "fix the bug"}
 
 	cmd, err := BuildCmd(task, cfg, false)
 	if err != nil {
@@ -124,7 +124,7 @@ func TestBuildCmd(t *testing.T) {
 	if args[0] != "sh" || args[1] != "-c" {
 		t.Errorf("expected sh -c, got %v", args[:2])
 	}
-	expected := "claude --dangerously-skip-permissions --worktree 'fix the bug'"
+	expected := "claude --dangerously-skip-permissions --worktree argus/fix-bug 'fix the bug'"
 	if args[2] != expected {
 		t.Errorf("expected %q, got %q", expected, args[2])
 	}
@@ -165,14 +165,14 @@ func TestBuildCmd_EmptyPromptFlag(t *testing.T) {
 
 func TestBuildCmd_NewSessionWithID(t *testing.T) {
 	cfg := testConfig()
-	task := &model.Task{Prompt: "fix the bug", SessionID: "aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee"}
+	task := &model.Task{Name: "fix-bug", Prompt: "fix the bug", SessionID: "aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee"}
 
 	cmd, err := BuildCmd(task, cfg, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	expected := "claude --dangerously-skip-permissions --worktree --session-id 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee' 'fix the bug'"
+	expected := "claude --dangerously-skip-permissions --worktree argus/fix-bug --session-id 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee' 'fix the bug'"
 	if cmd.Args[2] != expected {
 		t.Errorf("expected %q, got %q", expected, cmd.Args[2])
 	}
@@ -210,6 +210,32 @@ func TestBuildCmd_ResumeWithWorktree(t *testing.T) {
 	// Resume should set cmd.Dir to the existing worktree
 	if cmd.Dir != "/tmp/worktree-test" {
 		t.Errorf("expected Dir %q, got %q", "/tmp/worktree-test", cmd.Dir)
+	}
+}
+
+func TestInjectWorktreeName(t *testing.T) {
+	tests := []struct {
+		input    string
+		name     string
+		expected string
+	}{
+		{"claude --worktree", "argus/fix-bug", "claude --worktree argus/fix-bug"},
+		{"claude --worktree --resume id", "argus/fix-bug", "claude --worktree argus/fix-bug --resume id"},
+		{"claude --worktree old-name", "argus/fix-bug", "claude --worktree argus/fix-bug"},
+		{"claude -w", "argus/fix-bug", "claude -w argus/fix-bug"},
+		{"claude -w old-name --flag", "argus/fix-bug", "claude -w argus/fix-bug --flag"},
+		{"claude --worktree=old-name", "argus/fix-bug", "claude --worktree argus/fix-bug"},
+		{"claude -w=old-name", "argus/fix-bug", "claude --worktree argus/fix-bug"},
+		{"claude --resume id", "argus/fix-bug", "claude --resume id"},
+		{"claude", "argus/fix-bug", "claude"},
+		{"claude --dangerously-skip-permissions --worktree", "argus/fix-bug", "claude --dangerously-skip-permissions --worktree argus/fix-bug"},
+	}
+
+	for _, tt := range tests {
+		got := injectWorktreeName(tt.input, tt.name)
+		if got != tt.expected {
+			t.Errorf("injectWorktreeName(%q, %q) = %q, want %q", tt.input, tt.name, got, tt.expected)
+		}
 	}
 }
 


### PR DESCRIPTION
Inject task name as the --worktree flag value (argus/<task-name>) for new agent sessions, so worktree directories clearly correspond to their argus tasks instead of getting random names. Adds injectWorktreeName() with full test coverage.

Co-Authored-By: Claude <noreply@anthropic.com>