### PR TITLE
Show idle status for agents waiting on input

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -131,6 +131,19 @@ func (r *Runner) Running() []string {
 	return ids
 }
 
+// Idle returns the task IDs of sessions that are alive but waiting for input.
+func (r *Runner) Idle() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var ids []string
+	for id, sess := range r.sessions {
+		if sess.IsIdle() {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
 // WorkDir returns the effective working directory for a task's session.
 // Returns empty string if no session exists.
 func (r *Runner) WorkDir(taskID string) string {

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -6,11 +6,15 @@ import (
 	"os/exec"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/creack/pty"
 )
 
 const defaultBufSize = 256 * 1024 // 256KB ring buffer
+
+// idleThreshold is how long without output before a session is considered idle.
+const idleThreshold = 3 * time.Second
 
 // Session manages a single agent process with PTY.
 type Session struct {
@@ -18,15 +22,16 @@ type Session struct {
 	Cmd    *exec.Cmd
 	ptmx   *os.File // PTY master
 
-	mu       sync.Mutex
-	buf      *ringBuffer
-	attachW  io.Writer // when non-nil, readLoop tees output here
-	done     chan struct{}
-	err      error
-	attached bool
-	detachCh chan struct{}
-	ptyCols  uint16 // current PTY width
-	ptyRows  uint16 // current PTY height
+	mu         sync.Mutex
+	buf        *ringBuffer
+	attachW    io.Writer // when non-nil, readLoop tees output here
+	done       chan struct{}
+	err        error
+	attached   bool
+	detachCh   chan struct{}
+	ptyCols    uint16    // current PTY width
+	ptyRows    uint16    // current PTY height
+	lastOutput time.Time // last time output was received from PTY
 }
 
 // StartSession allocates a PTY with the given initial size, starts the command,
@@ -75,6 +80,7 @@ func (s *Session) readLoop() {
 			copy(chunk, tmp[:n])
 			s.mu.Lock()
 			s.buf.Write(chunk)
+			s.lastOutput = time.Now()
 			w := s.attachW
 			s.mu.Unlock()
 			if w != nil {
@@ -112,6 +118,21 @@ func (s *Session) Alive() bool {
 	default:
 		return true
 	}
+}
+
+// IsIdle returns true if the session is alive but has not produced output recently,
+// indicating the agent is likely waiting for user input.
+func (s *Session) IsIdle() bool {
+	if !s.Alive() {
+		return false
+	}
+	s.mu.Lock()
+	last := s.lastOutput
+	s.mu.Unlock()
+	if last.IsZero() {
+		return false // still starting up
+	}
+	return time.Since(last) >= idleThreshold
 }
 
 // PID returns the process ID, or 0 if not started.

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -79,6 +79,51 @@ func TestStartSession_Stop(t *testing.T) {
 	}
 }
 
+func TestSession_IsIdle_AfterOutput(t *testing.T) {
+	// Start a command that produces output then goes silent
+	cmd := exec.Command("echo", "done")
+	sess, err := StartSession("idle-1", cmd, 24, 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for process to finish and output to be captured
+	select {
+	case <-sess.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for process")
+	}
+
+	// Dead session should not be idle
+	if sess.IsIdle() {
+		t.Error("dead session should not report idle")
+	}
+}
+
+func TestSession_IsIdle_LongRunning(t *testing.T) {
+	// Start a long-running process that produces no output after start
+	cmd := exec.Command("sleep", "60")
+	sess, err := StartSession("idle-2", cmd, 24, 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sess.Stop()
+
+	// Immediately after start, lastOutput is zero → not idle (still starting)
+	if sess.IsIdle() {
+		t.Error("should not be idle immediately after start")
+	}
+
+	// Simulate output then wait for idle threshold
+	sess.mu.Lock()
+	sess.lastOutput = time.Now().Add(-4 * time.Second)
+	sess.mu.Unlock()
+
+	if !sess.IsIdle() {
+		t.Error("should be idle after no output for longer than threshold")
+	}
+}
+
 func TestStartSession_Detach_NotAttached(t *testing.T) {
 	cmd := exec.Command("sleep", "10")
 	sess, err := StartSession("test-4", cmd, 24, 80)

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -670,8 +670,10 @@ func (m Model) resolveTaskDir(t *model.Task) string {
 func (m *Model) refreshTasks() {
 	tasks := m.store.Tasks()
 	running := m.runner.Running()
+	idle := m.runner.Idle()
 	m.tasklist.SetTasks(tasks)
 	m.tasklist.SetRunning(running)
+	m.tasklist.SetIdle(idle)
 	m.statusbar.SetTasks(tasks)
 	m.statusbar.SetRunning(running)
 }

--- a/internal/ui/tasklist.go
+++ b/internal/ui/tasklist.go
@@ -19,16 +19,24 @@ type TaskList struct {
 	filter   string
 	filtered []*model.Task
 	running  map[string]bool // task IDs with active agent sessions
+	idle     map[string]bool // task IDs with sessions waiting for input
 }
 
 func NewTaskList(theme Theme) TaskList {
-	return TaskList{theme: theme, running: make(map[string]bool)}
+	return TaskList{theme: theme, running: make(map[string]bool), idle: make(map[string]bool)}
 }
 
 func (tl *TaskList) SetRunning(ids []string) {
 	tl.running = make(map[string]bool, len(ids))
 	for _, id := range ids {
 		tl.running[id] = true
+	}
+}
+
+func (tl *TaskList) SetIdle(ids []string) {
+	tl.idle = make(map[string]bool, len(ids))
+	for _, id := range ids {
+		tl.idle[id] = true
 	}
 }
 
@@ -142,7 +150,7 @@ func (tl TaskList) View() string {
 
 		// Status label (right-aligned)
 		displayText := t.Status.Display()
-		if t.Status == model.StatusInProgress && !tl.running[t.ID] {
+		if t.Status == model.StatusInProgress && (!tl.running[t.ID] || tl.idle[t.ID]) {
 			displayText = "● idle"
 		}
 		statusLabel := statusStyle.Render(displayText)


### PR DESCRIPTION
## Summary
- Track last PTY output time in agent sessions to detect when agents are waiting for user input
- Display "● idle" instead of "⏳ progress" when no output received for 3+ seconds
- Add `IsIdle()` to Session and `Idle()` to Runner for idle detection

## Test plan
- [x] `go test ./...` — all tests pass
- [x] Added `TestSession_IsIdle_AfterOutput` — dead sessions not reported idle
- [x] Added `TestSession_IsIdle_LongRunning` — idle detected after threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)