### PR TITLE
Fix agent view cursor visibility and input lag

### DIFF
--- a/internal/agent/ringbuffer.go
+++ b/internal/agent/ringbuffer.go
@@ -3,10 +3,11 @@ package agent
 // ringBuffer is a fixed-size circular byte buffer.
 // When full, new writes overwrite the oldest data.
 type ringBuffer struct {
-	data []byte
-	size int
-	pos  int
-	full bool
+	data  []byte
+	size  int
+	pos   int
+	full  bool
+	total uint64 // monotonic count of bytes written
 }
 
 func newRingBuffer(size int) *ringBuffer {
@@ -25,6 +26,12 @@ func (rb *ringBuffer) Write(p []byte) {
 			rb.full = true
 		}
 	}
+	rb.total += uint64(len(p))
+}
+
+// TotalWritten returns the monotonic count of bytes written to the buffer.
+func (rb *ringBuffer) TotalWritten() uint64 {
+	return rb.total
 }
 
 // Bytes returns the buffered data in order (oldest first).

--- a/internal/agent/ringbuffer_test.go
+++ b/internal/agent/ringbuffer_test.go
@@ -66,3 +66,23 @@ func TestRingBuffer_Empty(t *testing.T) {
 		t.Errorf("Bytes() = %q", rb.Bytes())
 	}
 }
+
+func TestRingBuffer_TotalWritten(t *testing.T) {
+	rb := newRingBuffer(5)
+	if rb.TotalWritten() != 0 {
+		t.Errorf("TotalWritten() = %d, want 0", rb.TotalWritten())
+	}
+	rb.Write([]byte("abc"))
+	if rb.TotalWritten() != 3 {
+		t.Errorf("TotalWritten() = %d, want 3", rb.TotalWritten())
+	}
+	rb.Write([]byte("defgh"))
+	if rb.TotalWritten() != 8 {
+		t.Errorf("TotalWritten() = %d, want 8", rb.TotalWritten())
+	}
+	// TotalWritten keeps counting even after wrap
+	rb.Write([]byte("ij"))
+	if rb.TotalWritten() != 10 {
+		t.Errorf("TotalWritten() = %d, want 10", rb.TotalWritten())
+	}
+}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -232,6 +232,14 @@ func (s *Session) RecentOutput() []byte {
 	return s.buf.Bytes()
 }
 
+// TotalWritten returns the monotonic count of bytes written to the ring buffer.
+// Safe to call concurrently. Used to detect new output without copying the buffer.
+func (s *Session) TotalWritten() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.TotalWritten()
+}
+
 // WorkDir returns the effective working directory of the session.
 // Returns Cmd.Dir if set, otherwise falls back to the process's inherited cwd.
 func (s *Session) WorkDir() string {

--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -39,6 +39,10 @@ type AgentView struct {
 
 	// Cached git status for file explorer
 	lastGitRefresh time.Time
+
+	// Terminal render cache — avoids replaying entire ring buffer every tick
+	cachedWriteCount uint64
+	cachedTerminal   string
 }
 
 func NewAgentView(theme Theme, runner *agent.Runner) AgentView {
@@ -61,6 +65,9 @@ func (av *AgentView) Enter(taskID, taskName string) {
 }
 
 func (av *AgentView) SetSize(w, h int) {
+	if av.width != w || av.height != h {
+		av.cachedTerminal = "" // invalidate cache on resize
+	}
 	av.width = w
 	av.height = h
 	leftW, centerW, rightW := av.splitWidths()
@@ -153,7 +160,7 @@ func (av *AgentView) HandleKey(msg tea.KeyMsg) (detach bool) {
 }
 
 // View renders the three-panel layout.
-func (av AgentView) View() string {
+func (av *AgentView) View() string {
 	_, centerW, _ := av.splitWidths()
 	contentH := av.height - 1
 
@@ -180,7 +187,7 @@ func (av AgentView) View() string {
 	return content + "\n" + bar
 }
 
-func (av AgentView) renderTerminal(w, h int) string {
+func (av *AgentView) renderTerminal(w, h int) string {
 	borderColor := "238"
 	if av.focus == panelAgent {
 		borderColor = "87"
@@ -202,6 +209,12 @@ func (av AgentView) renderTerminal(w, h int) string {
 		return border.Render(empty.Render("Agent not running\n\nPress ctrl+q to return"))
 	}
 
+	// Check if output has changed before expensive vt10x replay
+	writeCount := sess.TotalWritten()
+	if writeCount == av.cachedWriteCount && av.cachedTerminal != "" {
+		return border.Render(av.cachedTerminal)
+	}
+
 	raw := sess.RecentOutput()
 	if len(raw) == 0 {
 		empty := av.theme.Dimmed.
@@ -213,6 +226,8 @@ func (av AgentView) renderTerminal(w, h int) string {
 	}
 
 	content := av.formatTerminalOutput(raw, w, h)
+	av.cachedWriteCount = writeCount
+	av.cachedTerminal = content
 	return border.Render(content)
 }
 
@@ -238,9 +253,17 @@ func (av AgentView) formatTerminalOutput(raw []byte, panelW, panelH int) string 
 	vt.Lock()
 	defer vt.Unlock()
 
+	// Get cursor position for rendering
+	cur := vt.Cursor()
+	curVisible := vt.CursorVisible()
+
 	var lines []string
 	for y := 0; y < vtRows; y++ {
-		line := renderLine(vt, y, vtCols)
+		cursorX := -1
+		if curVisible && y == cur.Y {
+			cursorX = cur.X
+		}
+		line := renderLine(vt, y, vtCols, cursorX)
 		lines = append(lines, line)
 	}
 

--- a/internal/ui/preview.go
+++ b/internal/ui/preview.go
@@ -94,7 +94,7 @@ func (p Preview) formatOutput(raw []byte, ptyCols, ptyRows int) string {
 
 	var lines []string
 	for y := 0; y < vtRows; y++ {
-		line := renderLine(vt, y, vtCols)
+		line := renderLine(vt, y, vtCols, -1)
 		lines = append(lines, line)
 	}
 
@@ -123,13 +123,15 @@ func (p Preview) formatOutput(raw []byte, ptyCols, ptyRows int) string {
 }
 
 // renderLine builds a single line from the vt10x screen with ANSI colors.
-func renderLine(vt vt10x.Terminal, y, cols int) string {
+// cursorX is the column to render a cursor at (-1 for no cursor on this line).
+func renderLine(vt vt10x.Terminal, y, cols int, cursorX int) string {
 	var b strings.Builder
 	var curFG, curBG vt10x.Color
 	var curMode int16
 	active := false // whether we have an active SGR state
 
 	// Find the last non-empty column to trim trailing spaces
+	// (extend to cursor position if cursor is on this line)
 	lastCol := -1
 	for x := cols - 1; x >= 0; x-- {
 		cell := vt.Cell(x, y)
@@ -142,6 +144,9 @@ func renderLine(vt vt10x.Terminal, y, cols int) string {
 			break
 		}
 	}
+	if cursorX > lastCol {
+		lastCol = cursorX
+	}
 
 	for x := 0; x <= lastCol; x++ {
 		cell := vt.Cell(x, y)
@@ -150,16 +155,24 @@ func renderLine(vt vt10x.Terminal, y, cols int) string {
 			ch = ' '
 		}
 
-		// Emit SGR sequence if attributes changed
-		if cell.FG != curFG || cell.BG != curBG || cell.Mode != curMode || !active {
-			b.WriteString(buildSGR(cell.FG, cell.BG, cell.Mode))
-			curFG = cell.FG
-			curBG = cell.BG
-			curMode = cell.Mode
-			active = true
+		if x == cursorX {
+			// Render cursor cell with reverse video
+			b.WriteString("\x1b[7m")
+			b.WriteRune(ch)
+			b.WriteString("\x1b[27m")
+			// Force SGR re-emit on next cell
+			active = false
+		} else {
+			// Emit SGR sequence if attributes changed
+			if cell.FG != curFG || cell.BG != curBG || cell.Mode != curMode || !active {
+				b.WriteString(buildSGR(cell.FG, cell.BG, cell.Mode))
+				curFG = cell.FG
+				curBG = cell.BG
+				curMode = cell.Mode
+				active = true
+			}
+			b.WriteRune(ch)
 		}
-
-		b.WriteRune(ch)
 	}
 
 	// Reset at end of line if we emitted any SGR

--- a/internal/ui/preview_test.go
+++ b/internal/ui/preview_test.go
@@ -1,0 +1,53 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hinshun/vt10x"
+)
+
+func TestRenderLine_NoCursor(t *testing.T) {
+	vt := vt10x.New(vt10x.WithSize(20, 5))
+	vt.Write([]byte("hello"))
+	vt.Lock()
+	defer vt.Unlock()
+
+	line := renderLine(vt, 0, 20, -1)
+	stripped := stripANSI(line)
+	if stripped != "hello" {
+		t.Errorf("renderLine without cursor = %q, want %q", stripped, "hello")
+	}
+	// Should NOT contain reverse video escape
+	if strings.Contains(line, "\x1b[7m") {
+		t.Error("renderLine without cursor should not contain reverse video")
+	}
+}
+
+func TestRenderLine_WithCursor(t *testing.T) {
+	vt := vt10x.New(vt10x.WithSize(20, 5))
+	vt.Write([]byte("hello"))
+	vt.Lock()
+	defer vt.Unlock()
+
+	// Cursor at position 2 (on the 'l')
+	line := renderLine(vt, 0, 20, 2)
+	// Should contain reverse video escape for the cursor
+	if !strings.Contains(line, "\x1b[7m") {
+		t.Error("renderLine with cursor should contain reverse video escape")
+	}
+}
+
+func TestRenderLine_CursorBeyondText(t *testing.T) {
+	vt := vt10x.New(vt10x.WithSize(20, 5))
+	vt.Write([]byte("hi"))
+	vt.Lock()
+	defer vt.Unlock()
+
+	// Cursor at position 5, beyond "hi" (at position 2 would be after text)
+	line := renderLine(vt, 0, 20, 5)
+	// Should still render cursor (extends lastCol)
+	if !strings.Contains(line, "\x1b[7m") {
+		t.Error("renderLine with cursor beyond text should still render cursor")
+	}
+}

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -75,7 +75,7 @@ type Model struct {
 	newproject  NewProjectForm
 	preview     Preview
 	gitstatus   GitStatus
-	agentview   AgentView
+	agentview   *AgentView
 	current     view
 	activeTab   tab
 	width       int
@@ -94,7 +94,8 @@ func NewModel(cfg config.Config, s *store.Store, runner *agent.Runner) Model {
 
 	pv := NewPreview(theme, runner)
 	gs := NewGitStatus(theme)
-	av := NewAgentView(theme, runner)
+	avv := NewAgentView(theme, runner)
+	av := &avv
 
 	m := Model{
 		cfg:         cfg,


### PR DESCRIPTION
- Render cursor with reverse video at vt10x cursor position in the agent terminal panel
- Cache rendered terminal output using monotonic write counter to skip expensive vt10x replay when no new data
- Store AgentView as pointer in root model so cache persists across View() calls
- Add TotalWritten() to ring buffer and session for cheap change detection

Co-Authored-By: Claude <noreply@anthropic.com>