### PR TITLE
Remove underline and separator from tab header

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -779,7 +779,7 @@ func (m Model) renderTabHeader() string {
 	activeStyle := lipgloss.NewStyle().
 		Bold(true).
 		Foreground(lipgloss.Color("87")).
-		Underline(true)
+		Underline(false)
 	inactiveStyle := m.theme.Dimmed
 
 	tabs := []struct {
@@ -799,7 +799,7 @@ func (m Model) renderTabHeader() string {
 		}
 		parts = append(parts, style.Render("  "+t.label+" "))
 	}
-	header := strings.Join(parts, m.theme.Dimmed.Render("│"))
+	header := strings.Join(parts, "  ")
 	return lipgloss.PlaceHorizontal(m.width, lipgloss.Center, header)
 }
 


### PR DESCRIPTION
Strip the underline style from the active tab and replace the │ separator between TASKS and PROJECTS tabs with plain spacing.

Co-Authored-By: Claude <noreply@anthropic.com>