### PR TITLE
Default to master instead of main for new projects

### DIFF
--- a/internal/ui/gitstatus.go
+++ b/internal/ui/gitstatus.go
@@ -215,7 +215,7 @@ func findMergeBase(worktree string) string {
 		}
 	}
 	// Fallback: try common default branch names
-	for _, branch := range []string{"main", "master"} {
+	for _, branch := range []string{"master", "main"} {
 		if base, err := runGit(worktree, "merge-base", "HEAD", branch); err == nil {
 			if b := strings.TrimSpace(base); b != "" {
 				return b

--- a/internal/ui/newproject.go
+++ b/internal/ui/newproject.go
@@ -42,9 +42,9 @@ func NewNewProjectForm(theme Theme) NewProjectForm {
 	inputs[projFieldPath] = pathInput
 
 	branchInput := textinput.New()
-	branchInput.Placeholder = "Default branch (e.g. main)"
+	branchInput.Placeholder = "Default branch (e.g. master)"
 	branchInput.CharLimit = 60
-	branchInput.SetValue("main")
+	branchInput.SetValue("master")
 	inputs[projFieldBranch] = branchInput
 
 	backendInput := textinput.New()

--- a/internal/ui/newtask.go
+++ b/internal/ui/newtask.go
@@ -123,7 +123,7 @@ func (f *NewTaskForm) Task() *model.Task {
 
 	name := model.GenerateNameFromPrompt(prompt)
 
-	branch := "main"
+	branch := "master"
 	if p, ok := f.projects[project]; ok {
 		if p.Branch != "" {
 			branch = p.Branch


### PR DESCRIPTION
Change the default branch from "main" to "master" in the new project form, task creation fallback, and merge-base detection order.

Co-Authored-By: Claude <noreply@anthropic.com>