### PR TITLE
Confirm project deletion in modal with enter key

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -619,8 +619,8 @@ func (m Model) handleNewProjectKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleConfirmDeleteProjectKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch {
-	case key.Matches(msg, m.keys.Confirm):
+	switch msg.Type {
+	case tea.KeyEnter:
 		if entry := m.projectlist.Selected(); entry != nil {
 			delete(m.cfg.Projects, entry.Name)
 			_ = config.Save(m.cfg)
@@ -628,7 +628,11 @@ func (m Model) handleConfirmDeleteProjectKey(msg tea.KeyMsg) (tea.Model, tea.Cmd
 		}
 		m.current = viewTaskList
 		return m, nil
+	case tea.KeyEsc:
+		m.current = viewTaskList
+		return m, nil
 	default:
+		// Any other key cancels
 		m.current = viewTaskList
 		return m, nil
 	}
@@ -693,9 +697,14 @@ func (m Model) View() string {
 		return m.agentview.View()
 	}
 
+	// Project delete modal is fully placed (centered), render directly with status bar
+	if m.current == viewConfirmDeleteProject {
+		return m.confirmDeleteProjectView() + "\n" + bar
+	}
+
 	// For overlay views, show them without the banner
 	switch m.current {
-	case viewHelp, viewPrompt, viewConfirmDelete, viewConfirmDeleteProject, viewConfirmDestroy:
+	case viewHelp, viewPrompt, viewConfirmDelete, viewConfirmDestroy:
 		var content string
 		switch m.current {
 		case viewHelp:
@@ -706,8 +715,6 @@ func (m Model) View() string {
 			content = m.confirmDeleteView()
 		case viewConfirmDestroy:
 			content = m.confirmDestroyView()
-		case viewConfirmDeleteProject:
-			content = m.confirmDeleteProjectView()
 		}
 		return m.padToBottom(content, bar)
 	}
@@ -912,10 +919,30 @@ func (m Model) confirmDeleteProjectView() string {
 	if entry == nil {
 		return ""
 	}
-	return m.theme.Title.Render("Delete project?") + "\n\n" +
-		"  " + m.theme.Normal.Render(entry.Name) + "\n" +
-		"  " + m.theme.Dimmed.Render(entry.Project.Path) + "\n\n" +
-		m.theme.Help.Render("  [y] confirm  [any other key] cancel")
+
+	// Build modal content
+	title := m.theme.Title.Render("Delete project?")
+	name := "  " + m.theme.Normal.Render(entry.Name)
+	path := "  " + m.theme.Dimmed.Render(entry.Project.Path)
+	hint := m.theme.Help.Render("  [enter] confirm  [esc] cancel")
+
+	body := title + "\n\n" + name + "\n" + path + "\n\n" + hint
+
+	// Render as a bordered modal centered on screen
+	modalWidth := 50
+	if m.width > 0 && modalWidth > m.width-4 {
+		modalWidth = m.width - 4
+	}
+	modal := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("238")).
+		Padding(1, 2).
+		Width(modalWidth).
+		Render(body)
+
+	// Center horizontally and vertically
+	centered := lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, modal)
+	return centered
 }
 
 func (m Model) confirmDeleteView() string {

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -328,6 +329,110 @@ func TestTabHeader_Centered(t *testing.T) {
 	// Header should be padded to full width (centered)
 	if len(header) < 40 {
 		t.Errorf("expected centered header to have padding, got len=%d", len(header))
+	}
+}
+
+func testModelWithProjects(t *testing.T, projects map[string]config.Project) Model {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "tasks.json")
+	s := store.NewWithPath(path)
+	runner := agent.NewRunner(nil)
+	cfg := config.Config{
+		Defaults: config.Defaults{Backend: "claude"},
+		Backends: map[string]config.Backend{
+			"claude": {Command: "echo", PromptFlag: ""},
+		},
+		Projects: projects,
+	}
+	return NewModel(cfg, s, runner)
+}
+
+func TestDeleteProject_EnterConfirms(t *testing.T) {
+	projects := map[string]config.Project{
+		"myproject": {Path: "/tmp/myproject"},
+	}
+	m := testModelWithProjects(t, projects)
+	m.activeTab = tabProjects
+	m.current = viewConfirmDeleteProject
+
+	// Press Enter to confirm
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	if um.current != viewTaskList {
+		t.Errorf("expected viewTaskList after enter confirm, got %d", um.current)
+	}
+	if _, ok := um.cfg.Projects["myproject"]; ok {
+		t.Error("expected project to be deleted after enter confirm")
+	}
+}
+
+func TestDeleteProject_EscCancels(t *testing.T) {
+	projects := map[string]config.Project{
+		"myproject": {Path: "/tmp/myproject"},
+	}
+	m := testModelWithProjects(t, projects)
+	m.activeTab = tabProjects
+	m.current = viewConfirmDeleteProject
+
+	// Press Esc to cancel
+	msg := tea.KeyMsg{Type: tea.KeyEsc}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	if um.current != viewTaskList {
+		t.Errorf("expected viewTaskList after esc cancel, got %d", um.current)
+	}
+	if _, ok := um.cfg.Projects["myproject"]; !ok {
+		t.Error("expected project to still exist after esc cancel")
+	}
+}
+
+func TestDeleteProject_YKeyNoLongerConfirms(t *testing.T) {
+	projects := map[string]config.Project{
+		"myproject": {Path: "/tmp/myproject"},
+	}
+	m := testModelWithProjects(t, projects)
+	m.activeTab = tabProjects
+	m.current = viewConfirmDeleteProject
+
+	// Press y — should cancel (no longer confirms)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	if um.current != viewTaskList {
+		t.Errorf("expected viewTaskList after y key, got %d", um.current)
+	}
+	if _, ok := um.cfg.Projects["myproject"]; !ok {
+		t.Error("expected project to still exist — y should no longer confirm deletion")
+	}
+}
+
+func TestDeleteProject_ModalView(t *testing.T) {
+	projects := map[string]config.Project{
+		"myproject": {Path: "/tmp/myproject"},
+	}
+	m := testModelWithProjects(t, projects)
+	m.activeTab = tabProjects
+	m.current = viewConfirmDeleteProject
+	m.width = 80
+	m.height = 24
+
+	view := m.confirmDeleteProjectView()
+	if view == "" {
+		t.Fatal("expected non-empty modal view")
+	}
+	// Should contain project name and path
+	if !strings.Contains(view, "myproject") {
+		t.Error("expected modal to contain project name")
+	}
+	if !strings.Contains(view, "Delete project?") {
+		t.Error("expected modal to contain title")
+	}
+	if !strings.Contains(view, "[enter] confirm") {
+		t.Error("expected modal to show enter key hint")
 	}
 }
 


### PR DESCRIPTION
Replace the simple text overlay for project deletion confirmation with a centered bordered modal dialog. Change the confirm key from y to enter for a more deliberate confirmation action.

Co-Authored-By: Claude <noreply@anthropic.com>