### PR TITLE
Prevent tasks from being auto-completed on quick agent exit

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -38,6 +38,12 @@ const (
 	tabProjects
 )
 
+// minAgentRunTime is the minimum time an agent must run before a clean exit
+// is treated as a successful completion. Exits faster than this are treated
+// as startup or configuration errors (the session ID is cleared so the user
+// can retry).
+const minAgentRunTime = 3 * time.Second
+
 // TickMsg is sent periodically to update elapsed times.
 type TickMsg struct{}
 
@@ -459,6 +465,10 @@ func (m Model) handleAgentFinished(msg AgentFinishedMsg) (tea.Model, tea.Cmd) {
 	} else if msg.Err != nil {
 		// Process exited with an error (e.g. failed resume, crash) —
 		// keep the task in progress so the user can retry.
+		t.SessionID = ""
+	} else if !t.StartedAt.IsZero() && time.Since(t.StartedAt) < minAgentRunTime {
+		// Agent exited too quickly — likely a startup or config error.
+		// Keep in progress so the user can retry.
 		t.SessionID = ""
 	} else if t.Worktree != "" && !dirExists(t.Worktree) {
 		// Worktree removed — auto-complete

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/drn/argus/internal/agent"
@@ -238,6 +239,8 @@ func TestAgentFinished_SuccessMarksComplete(t *testing.T) {
 		SessionID: "sess-abc",
 		AgentPID:  100,
 	}
+	task.SetStatus(model.StatusInProgress) // sets StartedAt
+	task.StartedAt = task.StartedAt.Add(-time.Minute) // ran for a minute
 	m := testModel(t, task)
 
 	updated, _ := m.Update(AgentFinishedMsg{
@@ -253,6 +256,37 @@ func TestAgentFinished_SuccessMarksComplete(t *testing.T) {
 	}
 	if got.Status != model.StatusComplete {
 		t.Errorf("expected status Complete, got %v", got.Status)
+	}
+}
+
+func TestAgentFinished_QuickExitKeepsInProgress(t *testing.T) {
+	task := &model.Task{
+		ID:        "task-1",
+		Name:      "quick exit task",
+		Status:    model.StatusInProgress,
+		SessionID: "sess-abc",
+		AgentPID:  100,
+	}
+	task.SetStatus(model.StatusInProgress) // sets StartedAt to now
+	m := testModel(t, task)
+
+	// Agent exits cleanly but almost immediately — should NOT mark complete
+	updated, _ := m.Update(AgentFinishedMsg{
+		TaskID:  "task-1",
+		Err:     nil,
+		Stopped: false,
+	})
+	um := updated.(Model)
+
+	got, err := um.store.Get("task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != model.StatusInProgress {
+		t.Errorf("expected status InProgress for quick exit, got %v", got.Status)
+	}
+	if got.SessionID != "" {
+		t.Errorf("expected SessionID cleared on quick exit, got %q", got.SessionID)
 	}
 }
 


### PR DESCRIPTION
When an agent process exits cleanly within 3 seconds of starting, treat it as a startup/config error instead of marking the task complete. The task stays in_progress with its session ID cleared so the user can retry.

Co-Authored-By: Claude <noreply@anthropic.com>