### PR TITLE
Fix race between process exit and StartedAt persistence

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -140,8 +140,12 @@ func (m Model) Init() tea.Cmd {
 			if task.AgentPID > 0 {
 				killStaleProcess(task.AgentPID)
 				task.AgentPID = 0
-				_ = m.db.Update(task)
 			}
+
+			// Reset StartedAt before starting so the quick-exit check in
+			// handleAgentFinished uses the resume time, not the original start.
+			task.StartedAt = time.Now()
+			_ = m.db.Update(task)
 
 			cmds = append(cmds, func() tea.Msg {
 				sess, err := m.runner.Start(task, m.db.Config(), 24, 80, true)
@@ -418,6 +422,13 @@ func (m Model) startOrAttach(t *model.Task) (tea.Model, tea.Cmd) {
 		t.SessionID = model.GenerateSessionID()
 	}
 
+	// Persist status and StartedAt BEFORE starting the process so that
+	// handleAgentFinished always sees fresh data even if the process exits
+	// immediately (race between Start returning and the wait goroutine).
+	t.SetStatus(model.StatusInProgress)
+	t.StartedAt = time.Now()
+	_ = m.db.Update(t)
+
 	// Start a new session — use agent view panel dimensions for PTY size
 	_, centerW, _ := m.agentview.splitWidths()
 	contentH := m.height - 1
@@ -430,10 +441,6 @@ func (m Model) startOrAttach(t *model.Task) (tea.Model, tea.Cmd) {
 	}
 
 	t.AgentPID = sess.PID()
-	t.SetStatus(model.StatusInProgress)
-	// Always reset StartedAt so the quick-exit check in handleAgentFinished
-	// uses the time this session was launched, not the original task start.
-	t.StartedAt = time.Now()
 	_ = m.db.Update(t)
 	m.refreshTasks()
 

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -512,6 +512,33 @@ func TestDeleteProject_ModalView(t *testing.T) {
 	}
 }
 
+func TestInit_ResetsStartedAtBeforeResume(t *testing.T) {
+	oldStart := time.Now().Add(-10 * time.Minute)
+	task := &model.Task{
+		ID:        "t1",
+		Name:      "old task",
+		Status:    model.StatusInProgress,
+		SessionID: "sess-1",
+		StartedAt: oldStart,
+		AgentPID:  0,
+	}
+	m := testModel(t, task)
+
+	// Init() should reset StartedAt before launching the resume goroutine.
+	// We can't easily intercept the goroutine, but we can verify the DB
+	// was updated with a fresh StartedAt during Init().
+	_ = m.Init()
+
+	got, err := m.db.Get("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// StartedAt should have been reset to approximately now, not 10 min ago
+	if time.Since(got.StartedAt) > 5*time.Second {
+		t.Errorf("expected StartedAt reset to ~now, but got %v ago", time.Since(got.StartedAt))
+	}
+}
+
 func TestInit_ResumesOnlyInProgressWithSessionID(t *testing.T) {
 	tasks := []*model.Task{
 		{ID: "t1", Name: "in-progress with session", Status: model.StatusInProgress, SessionID: "sess-1"},


### PR DESCRIPTION
Persist task status and StartedAt to DB before calling runner.Start() so handleAgentFinished always sees fresh data even if the process exits immediately. Also reset StartedAt in the Init() resume path so resumed tasks that fail quickly are correctly detected as startup errors instead of being auto-completed.

Co-Authored-By: Claude <noreply@anthropic.com>