### PR TITLE
Keep agent view open on quick exit to show error output

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -201,6 +201,11 @@ func (av *AgentView) renderTerminal(w, h int) string {
 
 	sess := av.runner.Get(av.taskID)
 	if sess == nil {
+		// Show cached terminal output if available so the user can see
+		// why the process exited (e.g. error messages from the agent).
+		if av.cachedTerminal != "" {
+			return border.Render(av.cachedTerminal)
+		}
 		empty := av.theme.Dimmed.
 			Width(w - 4).
 			Height(innerH).
@@ -291,8 +296,12 @@ func (av AgentView) renderStatusBar() string {
 	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("87"))
 	labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 
-	// Left: task name
-	left := " " + av.theme.Normal.Render(av.taskName)
+	// Left: task name + status indicator
+	status := ""
+	if av.runner.Get(av.taskID) == nil {
+		status = labelStyle.Render(" (exited — ctrl+q to return)")
+	}
+	left := " " + av.theme.Normal.Render(av.taskName) + status
 
 	// Right: keybinding hints
 	keys := []struct{ key, label string }{

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -436,6 +436,10 @@ func (m Model) startOrAttach(t *model.Task) (tea.Model, tea.Cmd) {
 	ptyCols := uint16(max(centerW-4, 40))
 	sess, err := m.runner.Start(t, m.db.Config(), ptyRows, ptyCols, resume)
 	if err != nil {
+		// Start failed — revert the session ID so the next attempt
+		// doesn't try to --resume a session that was never created.
+		t.SessionID = ""
+		_ = m.db.Update(t)
 		m.statusbar.SetError(err.Error())
 		return m, nil
 	}
@@ -461,10 +465,7 @@ func (m Model) handleAgentFinished(msg AgentFinishedMsg) (tea.Model, tea.Cmd) {
 
 	t.AgentPID = 0
 
-	// If we're viewing this agent, return to task list
-	if m.current == viewAgent && m.agentview.taskID == msg.TaskID {
-		m.current = viewTaskList
-	}
+	quickExit := false
 
 	if msg.Stopped {
 		// Explicitly stopped via Runner.Stop — mark for review
@@ -473,16 +474,25 @@ func (m Model) handleAgentFinished(msg AgentFinishedMsg) (tea.Model, tea.Cmd) {
 		// Process exited with an error (e.g. failed resume, crash) —
 		// keep the task in progress so the user can retry.
 		t.SessionID = ""
+		quickExit = true
 	} else if !t.StartedAt.IsZero() && time.Since(t.StartedAt) < minAgentRunTime {
 		// Agent exited too quickly — likely a startup or config error.
 		// Keep in progress so the user can retry.
 		t.SessionID = ""
+		quickExit = true
 	} else if t.Worktree != "" && !dirExists(t.Worktree) {
 		// Worktree removed — auto-complete
 		t.SetStatus(model.StatusComplete)
 	} else {
 		// Agent session exited on its own — task is complete
 		t.SetStatus(model.StatusComplete)
+	}
+
+	// On normal completion or explicit stop, return to task list.
+	// On quick exit or error, stay on agent view so the user can see
+	// the terminal output (error messages, stack traces, etc.).
+	if m.current == viewAgent && m.agentview.taskID == msg.TaskID && !quickExit {
+		m.current = viewTaskList
 	}
 	_ = m.db.Update(t)
 

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -255,6 +255,82 @@ func TestAgentFinished_SuccessMarksComplete(t *testing.T) {
 	}
 }
 
+func TestAgentFinished_QuickExitStaysOnAgentView(t *testing.T) {
+	task := &model.Task{
+		ID:        "task-1",
+		Name:      "quick exit task",
+		Status:    model.StatusInProgress,
+		SessionID: "sess-abc",
+		AgentPID:  100,
+	}
+	task.SetStatus(model.StatusInProgress) // sets StartedAt to now
+	m := testModel(t, task)
+	m.current = viewAgent
+	m.agentview.Enter("task-1", "quick exit task")
+
+	// Agent exits cleanly but almost immediately — should stay on agent view
+	updated, _ := m.Update(AgentFinishedMsg{
+		TaskID:  "task-1",
+		Err:     nil,
+		Stopped: false,
+	})
+	um := updated.(Model)
+
+	if um.current != viewAgent {
+		t.Errorf("expected to stay on viewAgent after quick exit, got view %d", um.current)
+	}
+}
+
+func TestAgentFinished_ErrorStaysOnAgentView(t *testing.T) {
+	task := &model.Task{
+		ID:        "task-1",
+		Name:      "error task",
+		Status:    model.StatusInProgress,
+		SessionID: "sess-abc",
+		AgentPID:  100,
+	}
+	m := testModel(t, task)
+	m.current = viewAgent
+	m.agentview.Enter("task-1", "error task")
+
+	updated, _ := m.Update(AgentFinishedMsg{
+		TaskID:  "task-1",
+		Err:     errors.New("exit status 1"),
+		Stopped: false,
+	})
+	um := updated.(Model)
+
+	if um.current != viewAgent {
+		t.Errorf("expected to stay on viewAgent after error exit, got view %d", um.current)
+	}
+}
+
+func TestAgentFinished_NormalCompletionExitsAgentView(t *testing.T) {
+	task := &model.Task{
+		ID:        "task-1",
+		Name:      "completed task",
+		Status:    model.StatusInProgress,
+		SessionID: "sess-abc",
+		AgentPID:  100,
+	}
+	task.SetStatus(model.StatusInProgress)
+	task.StartedAt = task.StartedAt.Add(-time.Minute) // ran for a minute
+	m := testModel(t, task)
+	m.current = viewAgent
+	m.agentview.Enter("task-1", "completed task")
+
+	updated, _ := m.Update(AgentFinishedMsg{
+		TaskID:  "task-1",
+		Err:     nil,
+		Stopped: false,
+	})
+	um := updated.(Model)
+
+	if um.current != viewTaskList {
+		t.Errorf("expected viewTaskList after normal completion, got view %d", um.current)
+	}
+}
+
 func TestAgentFinished_QuickExitKeepsInProgress(t *testing.T) {
 	task := &model.Task{
 		ID:        "task-1",


### PR DESCRIPTION
Stay on agent view when process exits quickly instead of flashing back to task list. Preserves cached terminal output so user can see why the process failed. Also cleans up SessionID when Start fails to prevent stale --resume attempts.

Co-Authored-By: Claude <noreply@anthropic.com>