### PR TITLE
Preserve agent terminal output after process exit

### DIFF
--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -21,9 +21,9 @@ func main() {
 	// Create runner — the onFinish callback sends a message to the tea.Program.
 	// We need to create the program first, so we use a closure that captures p.
 	var p *tea.Program
-	runner := agent.NewRunner(func(taskID string, err error, stopped bool) {
+	runner := agent.NewRunner(func(taskID string, err error, stopped bool, lastOutput []byte) {
 		if p != nil {
-			p.Send(ui.AgentFinishedMsg{TaskID: taskID, Err: err, Stopped: stopped})
+			p.Send(ui.AgentFinishedMsg{TaskID: taskID, Err: err, Stopped: stopped, LastOutput: lastOutput})
 		}
 	})
 	m := ui.NewModel(database, runner)

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -14,12 +14,13 @@ type Runner struct {
 	mu       sync.Mutex
 	sessions map[string]*Session
 	stopped  map[string]bool // tracks task IDs where Stop was explicitly called
-	onFinish func(taskID string, err error, stopped bool)
+	onFinish func(taskID string, err error, stopped bool, lastOutput []byte)
 }
 
 // NewRunner creates a Runner. The onFinish callback is called (in a goroutine)
-// when any managed session's process exits.
-func NewRunner(onFinish func(taskID string, err error, stopped bool)) *Runner {
+// when any managed session's process exits. lastOutput contains the final ring
+// buffer contents so callers can display error messages after the session is gone.
+func NewRunner(onFinish func(taskID string, err error, stopped bool, lastOutput []byte)) *Runner {
 	return &Runner{
 		sessions: make(map[string]*Session),
 		stopped:  make(map[string]bool),
@@ -56,13 +57,16 @@ func (r *Runner) Start(task *model.Task, cfg config.Config, rows, cols uint16, r
 	// Watch for process exit
 	go func() {
 		<-sess.Done()
+		// Capture last output before removing the session so callers
+		// can display error messages after the session is gone.
+		lastOutput := sess.RecentOutput()
 		r.mu.Lock()
 		delete(r.sessions, task.ID)
 		wasStopped := r.stopped[task.ID]
 		delete(r.stopped, task.ID)
 		r.mu.Unlock()
 		if r.onFinish != nil {
-			r.onFinish(task.ID, sess.Err(), wasStopped)
+			r.onFinish(task.ID, sess.Err(), wasStopped, lastOutput)
 		}
 	}()
 

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -20,7 +20,7 @@ func runnerTestConfig() config.Config {
 
 func TestRunner_StartAndGet(t *testing.T) {
 	finished := make(chan string, 1)
-	r := NewRunner(func(taskID string, err error, stopped bool) {
+	r := NewRunner(func(taskID string, err error, stopped bool, _ []byte) {
 		finished <- taskID
 	})
 
@@ -118,7 +118,7 @@ func TestRunner_StopSetsStopped(t *testing.T) {
 		stopped bool
 	}
 	finished := make(chan result, 1)
-	r := NewRunner(func(taskID string, err error, stopped bool) {
+	r := NewRunner(func(taskID string, err error, stopped bool, _ []byte) {
 		finished <- result{taskID, err, stopped}
 	})
 	cfg := config.Config{
@@ -155,7 +155,7 @@ func TestRunner_NaturalExitNotStopped(t *testing.T) {
 		stopped bool
 	}
 	finished := make(chan result, 1)
-	r := NewRunner(func(taskID string, err error, stopped bool) {
+	r := NewRunner(func(taskID string, err error, stopped bool, _ []byte) {
 		finished <- result{taskID, stopped}
 	})
 	cfg := runnerTestConfig() // "echo hello" exits naturally

--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -43,6 +43,10 @@ type AgentView struct {
 	// Terminal render cache — avoids replaying entire ring buffer every tick
 	cachedWriteCount uint64
 	cachedTerminal   string
+
+	// lastOutput holds the final ring buffer contents from a finished session
+	// so we can display error output even after the session is removed.
+	lastOutput []byte
 }
 
 func NewAgentView(theme Theme, runner *agent.Runner) AgentView {
@@ -62,6 +66,15 @@ func (av *AgentView) Enter(taskID, taskName string) {
 	av.focus = panelAgent
 	av.gitstatus.SetTask(taskID)
 	av.lastGitRefresh = time.Time{}
+	av.lastOutput = nil
+	av.cachedTerminal = ""
+	av.cachedWriteCount = 0
+}
+
+// SetLastOutput stores the final ring buffer from a finished session
+// so the terminal can still display output after the session is gone.
+func (av *AgentView) SetLastOutput(output []byte) {
+	av.lastOutput = output
 }
 
 func (av *AgentView) SetSize(w, h int) {
@@ -201,8 +214,12 @@ func (av *AgentView) renderTerminal(w, h int) string {
 
 	sess := av.runner.Get(av.taskID)
 	if sess == nil {
-		// Show cached terminal output if available so the user can see
+		// Show last output from the finished session so the user can see
 		// why the process exited (e.g. error messages from the agent).
+		if len(av.lastOutput) > 0 {
+			content := av.formatTerminalOutput(av.lastOutput, w, h)
+			return border.Render(content)
+		}
 		if av.cachedTerminal != "" {
 			return border.Render(av.cachedTerminal)
 		}

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -48,9 +48,10 @@ type TickMsg struct{}
 
 // AgentFinishedMsg is sent when an agent process exits.
 type AgentFinishedMsg struct {
-	TaskID  string
-	Err     error
-	Stopped bool // true if the process was explicitly stopped via Runner.Stop
+	TaskID     string
+	Err        error
+	Stopped    bool   // true if the process was explicitly stopped via Runner.Stop
+	LastOutput []byte // final ring buffer contents for displaying errors
 }
 
 // AgentDetachedMsg is sent when the user detaches from a running agent.
@@ -486,6 +487,11 @@ func (m Model) handleAgentFinished(msg AgentFinishedMsg) (tea.Model, tea.Cmd) {
 	} else {
 		// Agent session exited on its own — task is complete
 		t.SetStatus(model.StatusComplete)
+	}
+
+	// Preserve last output so the agent view can display it after session cleanup.
+	if m.current == viewAgent && m.agentview.taskID == msg.TaskID {
+		m.agentview.SetLastOutput(msg.LastOutput)
 	}
 
 	// On normal completion or explicit stop, return to task list.


### PR DESCRIPTION
Capture the session ring buffer before removing it from the runner so the agent view can display error output even when the process exits before the first render tick. Previously always showed 'Agent not running' with no diagnostic info.

Co-Authored-By: Claude <noreply@anthropic.com>