### PR TITLE
Fix placeholder backend commands from legacy config migration

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -391,6 +391,37 @@ func TestMigration_NoLegacyFiles(t *testing.T) {
 	}
 }
 
+func TestSeedDefaults_FixesPlaceholderBackend(t *testing.T) {
+	d, err := OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	// Simulate a legacy config that had "echo" as the command
+	if err := d.SetBackend("claude", config.Backend{Command: "echo", PromptFlag: ""}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run seedDefaults — should fix the placeholder command
+	if err := d.runSeedDefaults(); err != nil {
+		t.Fatal(err)
+	}
+
+	backends := d.Backends()
+	b, ok := backends["claude"]
+	if !ok {
+		t.Fatal("expected claude backend")
+	}
+	if b.Command == "echo" {
+		t.Errorf("seedDefaults should have replaced placeholder 'echo' command, got %q", b.Command)
+	}
+	defaultCfg := config.DefaultConfig()
+	if b.Command != defaultCfg.Backends["claude"].Command {
+		t.Errorf("expected default command %q, got %q", defaultCfg.Backends["claude"].Command, b.Command)
+	}
+}
+
 func TestMigration_OnlyRunsOnce(t *testing.T) {
 	old := os.Getenv("XDG_CONFIG_HOME")
 	os.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -50,18 +50,31 @@ func (d *DB) migrate() error {
 	return err
 }
 
+// runSeedDefaults is an exported wrapper for testing.
+func (d *DB) runSeedDefaults() error {
+	return d.seedDefaults()
+}
+
 // seedDefaults inserts the default backend and config values if they don't
 // already exist. Safe to call multiple times.
 func (d *DB) seedDefaults() error {
 	cfg := config.DefaultConfig()
 
-	// Default backend — only if no backends exist
-	var backendCount int
-	d.conn.QueryRow(`SELECT COUNT(*) FROM backends`).Scan(&backendCount)
-	if backendCount == 0 {
-		for name, b := range cfg.Backends {
-			if _, err := d.conn.Exec(`INSERT OR IGNORE INTO backends (name, command, prompt_flag) VALUES (?, ?, ?)`,
+	// Default backends — insert if missing, and fix placeholder commands
+	// (e.g. "echo") that may have been written by earlier development builds.
+	for name, b := range cfg.Backends {
+		var existing string
+		err := d.conn.QueryRow(`SELECT command FROM backends WHERE name=?`, name).Scan(&existing)
+		if err == sql.ErrNoRows {
+			// Backend doesn't exist — insert the default
+			if _, err := d.conn.Exec(`INSERT INTO backends (name, command, prompt_flag) VALUES (?, ?, ?)`,
 				name, b.Command, b.PromptFlag); err != nil {
+				return err
+			}
+		} else if err == nil && (existing == "echo" || existing == "cat" || existing == "true") {
+			// Backend exists but has a placeholder command — replace with default
+			if _, err := d.conn.Exec(`UPDATE backends SET command=?, prompt_flag=? WHERE name=?`,
+				b.Command, b.PromptFlag, name); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
seedDefaults now detects placeholder commands (echo, cat, true) left by earlier development builds and replaces them with the real default. Previously a legacy config.toml with command="echo" would persist and seedDefaults would skip since a backend already existed, causing tasks to fail silently.

Co-Authored-By: Claude <noreply@anthropic.com>