### PR TITLE
Auto-repair outdated backend configs on startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ go test ./internal/store/   # run tests for a single package
 - Use `charmbracelet/x/term` for raw mode (cross-platform) instead of platform-specific ioctls (`TIOCGETA` is macOS-only, `TCGETS` is Linux-only).
 - `tea.ExecCommand.SetStdin/SetStdout` must capture and use Bubble Tea's `p.input`/`p.output` — don't hardcode `os.Stdin`/`os.Stdout`.
 - The single-reader-tee pattern (one goroutine reads PTY, tees to buffer + optional writer) is critical. Two goroutines reading the same fd causes data loss.
+- **Backend default config must be self-healing.** The default claude backend command MUST include `--dangerously-skip-permissions` and MUST NOT use `-p` as the prompt flag. `-p` puts Claude in non-interactive print mode (process prompt → exit), which silently breaks agent sessions — they show "waiting for output" then auto-complete. The `fixupBackends()` method in `internal/db/migrate.go` runs on every `Open()` to detect and repair outdated backend configs. Any change to `DefaultConfig()` backend values must be mirrored in `fixupBackends()` detection logic, or existing databases will retain stale values.
 
 ## Development Rules
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -53,6 +53,10 @@ func Open(path string) (*DB, error) {
 		conn.Close()
 		return nil, err
 	}
+	if err := d.fixupBackends(); err != nil {
+		conn.Close()
+		return nil, err
+	}
 	return d, nil
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -422,6 +422,106 @@ func TestSeedDefaults_FixesPlaceholderBackend(t *testing.T) {
 	}
 }
 
+func TestFixupBackends_MissingDangerouslySkipPermissions(t *testing.T) {
+	d, err := OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	// Simulate an outdated backend missing --dangerously-skip-permissions
+	if err := d.SetBackend("claude", config.Backend{
+		Command:    "claude --worktree",
+		PromptFlag: "-p",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// fixupBackends should correct both the command and prompt flag
+	if err := d.fixupBackends(); err != nil {
+		t.Fatal(err)
+	}
+
+	backends := d.Backends()
+	b, ok := backends["claude"]
+	if !ok {
+		t.Fatal("expected claude backend")
+	}
+	defaultCfg := config.DefaultConfig()
+	if b.Command != defaultCfg.Backends["claude"].Command {
+		t.Errorf("expected command %q, got %q", defaultCfg.Backends["claude"].Command, b.Command)
+	}
+	if b.PromptFlag != defaultCfg.Backends["claude"].PromptFlag {
+		t.Errorf("expected prompt_flag %q, got %q", defaultCfg.Backends["claude"].PromptFlag, b.PromptFlag)
+	}
+}
+
+func TestFixupBackends_SkipsCorrectConfig(t *testing.T) {
+	d, err := OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	defaultCfg := config.DefaultConfig()
+	want := defaultCfg.Backends["claude"]
+
+	// Set the correct defaults — fixupBackends should not change them
+	if err := d.SetBackend("claude", want); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.fixupBackends(); err != nil {
+		t.Fatal(err)
+	}
+
+	backends := d.Backends()
+	got := backends["claude"]
+	if got.Command != want.Command || got.PromptFlag != want.PromptFlag {
+		t.Errorf("fixupBackends should not modify correct config: got command=%q flag=%q", got.Command, got.PromptFlag)
+	}
+}
+
+func TestFixupBackends_RunsOnOpen(t *testing.T) {
+	old := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	defer os.Setenv("XDG_CONFIG_HOME", old)
+
+	dbPath := filepath.Join(t.TempDir(), "data.sql")
+
+	// First open — creates DB with correct defaults
+	d1, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Manually corrupt the backend to simulate an outdated config
+	if err := d1.SetBackend("claude", config.Backend{
+		Command:    "claude --worktree",
+		PromptFlag: "-p",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	d1.Close()
+
+	// Second open — fixupBackends should repair it
+	d2, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d2.Close()
+
+	backends := d2.Backends()
+	b := backends["claude"]
+	defaultCfg := config.DefaultConfig()
+	if b.Command != defaultCfg.Backends["claude"].Command {
+		t.Errorf("expected command %q after reopen, got %q", defaultCfg.Backends["claude"].Command, b.Command)
+	}
+	if b.PromptFlag != "" {
+		t.Errorf("expected empty prompt_flag after reopen, got %q", b.PromptFlag)
+	}
+}
+
 func TestMigration_OnlyRunsOnce(t *testing.T) {
 	old := os.Getenv("XDG_CONFIG_HOME")
 	os.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/drn/argus/internal/config"
@@ -232,6 +233,51 @@ func (d *DB) importLegacyConfig() error {
 	for k, v := range kv {
 		if _, err := d.conn.Exec(`INSERT OR IGNORE INTO config (key, value) VALUES (?, ?)`, k, v); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+// fixupBackends runs on every Open and corrects known-outdated backend
+// configurations. This is separate from seedDefaults (which only runs during
+// migration) so that improvements to the default command propagate to
+// existing databases on the next startup.
+func (d *DB) fixupBackends() error {
+	cfg := config.DefaultConfig()
+
+	for name, want := range cfg.Backends {
+		var command, promptFlag string
+		err := d.conn.QueryRow(
+			`SELECT command, prompt_flag FROM backends WHERE name=?`, name,
+		).Scan(&command, &promptFlag)
+		if err != nil {
+			continue // backend doesn't exist — seedDefaults handles insertion
+		}
+
+		needsUpdate := false
+
+		// Fix: command references "claude" but is missing --dangerously-skip-permissions.
+		// This catches old defaults like "claude --worktree" that were persisted
+		// before the flag was added to DefaultConfig.
+		if strings.Contains(command, "claude") && !strings.Contains(command, "--dangerously-skip-permissions") {
+			needsUpdate = true
+		}
+
+		// Fix: prompt_flag is "-p" (print/non-interactive mode) when the
+		// default is empty (interactive mode). Print mode causes agents to
+		// process the prompt and exit instead of running interactively.
+		if promptFlag == "-p" && want.PromptFlag == "" {
+			needsUpdate = true
+		}
+
+		if needsUpdate {
+			if _, err := d.conn.Exec(
+				`UPDATE backends SET command=?, prompt_flag=? WHERE name=?`,
+				want.Command, want.PromptFlag, name,
+			); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Add fixupBackends() to DB Open that detects and corrects stale backend commands (missing --dangerously-skip-permissions) and wrong prompt flags (-p print mode). These persisted from legacy migrations and caused agent sessions to silently fail—showing 'waiting for output' then auto-completing. Includes CLAUDE.md learning and 4 new tests.

Co-Authored-By: Claude <noreply@anthropic.com>