### PR TITLE
Replace delete/destroy confirmation with centered modal

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -91,8 +91,8 @@ func DefaultKeyMap() KeyMap {
 			key.WithHelp("→", "next tab"),
 		),
 		Confirm: key.NewBinding(
-			key.WithKeys("y"),
-			key.WithHelp("y", "confirm"),
+			key.WithKeys("enter"),
+			key.WithHelp("↵", "confirm"),
 		),
 		Cancel: key.NewBinding(
 			key.WithKeys("esc"),

--- a/internal/ui/keys_test.go
+++ b/internal/ui/keys_test.go
@@ -19,7 +19,7 @@ func TestDefaultKeyMap(t *testing.T) {
 		"Quit":    "q",
 		"Help":    "?",
 		"Filter":  "/",
-		"Confirm": "y",
+		"Confirm": "enter",
 		"Cancel":  "esc",
 	}
 

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -546,8 +546,8 @@ func (m Model) handleNewTaskKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleConfirmDeleteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch {
-	case key.Matches(msg, m.keys.Confirm):
+	switch msg.Type {
+	case tea.KeyEnter:
 		if t := m.tasklist.Selected(); t != nil {
 			// Stop the agent session if running
 			if m.runner.HasSession(t.ID) {
@@ -562,15 +562,18 @@ func (m Model) handleConfirmDeleteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.current = viewTaskList
 		return m, nil
-	default:
+	case tea.KeyEsc:
 		m.current = viewTaskList
+		return m, nil
+	default:
+		// Only enter confirms, only esc cancels — ignore other keys
 		return m, nil
 	}
 }
 
 func (m Model) handleConfirmDestroyKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch {
-	case key.Matches(msg, m.keys.Confirm):
+	switch msg.Type {
+	case tea.KeyEnter:
 		if t := m.tasklist.Selected(); t != nil {
 			// Stop the agent session if running
 			if m.runner.HasSession(t.ID) {
@@ -592,8 +595,11 @@ func (m Model) handleConfirmDestroyKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.current = viewTaskList
 		return m, nil
-	default:
+	case tea.KeyEsc:
 		m.current = viewTaskList
+		return m, nil
+	default:
+		// Only enter confirms, only esc cancels — ignore other keys
 		return m, nil
 	}
 }
@@ -729,24 +735,25 @@ func (m Model) View() string {
 		return m.agentview.View()
 	}
 
-	// Project delete modal is fully placed (centered), render directly with status bar
-	if m.current == viewConfirmDeleteProject {
+	// Modals are fully placed (centered), render directly with status bar
+	switch m.current {
+	case viewConfirmDeleteProject:
 		return m.confirmDeleteProjectView() + "\n" + bar
+	case viewConfirmDelete:
+		return m.confirmDeleteView() + "\n" + bar
+	case viewConfirmDestroy:
+		return m.confirmDestroyView() + "\n" + bar
 	}
 
 	// For overlay views, show them without the banner
 	switch m.current {
-	case viewHelp, viewPrompt, viewConfirmDelete, viewConfirmDestroy:
+	case viewHelp, viewPrompt:
 		var content string
 		switch m.current {
 		case viewHelp:
 			content = m.helpview.View()
 		case viewPrompt:
 			content = m.promptView()
-		case viewConfirmDelete:
-			content = m.confirmDeleteView()
-		case viewConfirmDestroy:
-			content = m.confirmDestroyView()
 		}
 		return m.padToBottom(content, bar)
 	}
@@ -982,9 +989,25 @@ func (m Model) confirmDeleteView() string {
 	if t == nil {
 		return ""
 	}
-	return m.theme.Title.Render("Delete task?") + "\n\n" +
-		"  " + m.theme.Normal.Render(t.Name) + "\n\n" +
-		m.theme.Help.Render("  [y] confirm  [any other key] cancel")
+
+	title := m.theme.Title.Render("Delete task?")
+	name := "  " + m.theme.Normal.Render(t.Name)
+	hint := m.theme.Help.Render("  [enter] confirm  [esc] cancel")
+
+	body := title + "\n\n" + name + "\n\n" + hint
+
+	modalWidth := 50
+	if m.width > 0 && modalWidth > m.width-4 {
+		modalWidth = m.width - 4
+	}
+	modal := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("238")).
+		Padding(1, 2).
+		Width(modalWidth).
+		Render(body)
+
+	return lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, modal)
 }
 
 func (m Model) confirmDestroyView() string {
@@ -1000,10 +1023,26 @@ func (m Model) confirmDestroyView() string {
 	if t.Branch != "" {
 		details = append(details, "  "+m.theme.Dimmed.Render("branch: "+t.Branch))
 	}
-	return m.theme.Title.Render("Destroy task?") + "\n" +
-		m.theme.Help.Render("  This will terminate the agent, remove the worktree and branch, and delete the task.") + "\n\n" +
-		strings.Join(details, "\n") + "\n\n" +
-		m.theme.Help.Render("  [y] confirm  [any other key] cancel")
+
+	title := m.theme.Title.Render("Destroy task?")
+	subtitle := m.theme.Help.Render("  This will terminate the agent, remove the worktree and branch, and delete the task.")
+	hint := m.theme.Help.Render("  [enter] confirm  [esc] cancel")
+
+	body := title + "\n" + subtitle + "\n\n" +
+		strings.Join(details, "\n") + "\n\n" + hint
+
+	modalWidth := 60
+	if m.width > 0 && modalWidth > m.width-4 {
+		modalWidth = m.width - 4
+	}
+	modal := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("238")).
+		Padding(1, 2).
+		Width(modalWidth).
+		Render(body)
+
+	return lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, modal)
 }
 
 func dirExists(path string) bool {

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -158,8 +158,8 @@ func TestDestroyConfirm_DeletesTask(t *testing.T) {
 	// Enter confirm destroy state
 	m.current = viewConfirmDestroy
 
-	// Press y to confirm
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}
+	// Press enter to confirm
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
 	updated, _ := m.Update(msg)
 	um := updated.(Model)
 
@@ -182,8 +182,8 @@ func TestDestroyCancel_KeepsTask(t *testing.T) {
 	// Enter confirm destroy state
 	m.current = viewConfirmDestroy
 
-	// Press any other key to cancel
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
+	// Press esc to cancel
+	msg := tea.KeyMsg{Type: tea.KeyEsc}
 	updated, _ := m.Update(msg)
 	um := updated.(Model)
 
@@ -192,6 +192,143 @@ func TestDestroyCancel_KeepsTask(t *testing.T) {
 	}
 	if _, err := um.db.Get("t1"); err != nil {
 		t.Error("expected task to still exist after cancel")
+	}
+}
+
+func TestDestroyIgnoresOtherKeys(t *testing.T) {
+	task := &model.Task{
+		ID:     "t1",
+		Name:   "keep me",
+		Status: model.StatusPending,
+	}
+	m := testModel(t, task)
+	m.current = viewConfirmDestroy
+
+	// Press 'n' — should be ignored (stay on modal)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	if um.current != viewConfirmDestroy {
+		t.Errorf("expected to stay on viewConfirmDestroy, got %d", um.current)
+	}
+	if _, err := um.db.Get("t1"); err != nil {
+		t.Error("expected task to still exist")
+	}
+}
+
+func TestDeleteTask_EnterConfirms(t *testing.T) {
+	task := &model.Task{
+		ID:     "t1",
+		Name:   "delete me",
+		Status: model.StatusPending,
+	}
+	m := testModel(t, task)
+	m.current = viewConfirmDelete
+
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	if um.current != viewTaskList {
+		t.Errorf("expected viewTaskList after enter confirm, got %d", um.current)
+	}
+	if _, err := um.db.Get("t1"); err == nil {
+		t.Error("expected task to be deleted after enter confirm")
+	}
+}
+
+func TestDeleteTask_EscCancels(t *testing.T) {
+	task := &model.Task{
+		ID:     "t1",
+		Name:   "keep me",
+		Status: model.StatusPending,
+	}
+	m := testModel(t, task)
+	m.current = viewConfirmDelete
+
+	msg := tea.KeyMsg{Type: tea.KeyEsc}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	if um.current != viewTaskList {
+		t.Errorf("expected viewTaskList after esc cancel, got %d", um.current)
+	}
+	if _, err := um.db.Get("t1"); err != nil {
+		t.Error("expected task to still exist after esc cancel")
+	}
+}
+
+func TestDeleteTask_IgnoresOtherKeys(t *testing.T) {
+	task := &model.Task{
+		ID:     "t1",
+		Name:   "keep me",
+		Status: model.StatusPending,
+	}
+	m := testModel(t, task)
+	m.current = viewConfirmDelete
+
+	// Press 'y' — should be ignored now (no longer confirms)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}
+	updated, _ := m.Update(msg)
+	um := updated.(Model)
+
+	if um.current != viewConfirmDelete {
+		t.Errorf("expected to stay on viewConfirmDelete, got %d", um.current)
+	}
+	if _, err := um.db.Get("t1"); err != nil {
+		t.Error("expected task to still exist — y should no longer confirm deletion")
+	}
+}
+
+func TestDeleteTask_ModalView(t *testing.T) {
+	task := &model.Task{
+		ID:     "t1",
+		Name:   "my task",
+		Status: model.StatusPending,
+	}
+	m := testModel(t, task)
+	m.current = viewConfirmDelete
+	m.width = 80
+	m.height = 24
+
+	view := m.confirmDeleteView()
+	if view == "" {
+		t.Fatal("expected non-empty modal view")
+	}
+	if !strings.Contains(view, "my task") {
+		t.Error("expected modal to contain task name")
+	}
+	if !strings.Contains(view, "Delete task?") {
+		t.Error("expected modal to contain title")
+	}
+	if !strings.Contains(view, "[enter] confirm") {
+		t.Error("expected modal to show enter key hint")
+	}
+}
+
+func TestDestroyTask_ModalView(t *testing.T) {
+	task := &model.Task{
+		ID:       "t1",
+		Name:     "my task",
+		Status:   model.StatusPending,
+		Worktree: "/tmp/wt",
+		Branch:   "feature-x",
+	}
+	m := testModel(t, task)
+	m.current = viewConfirmDestroy
+	m.width = 80
+	m.height = 24
+
+	view := m.confirmDestroyView()
+	if view == "" {
+		t.Fatal("expected non-empty modal view")
+	}
+	if !strings.Contains(view, "Destroy task?") {
+		t.Error("expected modal to contain title")
+	}
+	if !strings.Contains(view, "[enter] confirm") {
+		t.Error("expected modal to show enter key hint")
 	}
 }
 


### PR DESCRIPTION
Change task delete and destroy confirmations from plain text "y to confirm" to centered bordered modals matching the existing project delete pattern. Confirm key changed from "y" to "enter", cancel from "any key" to "esc", and other keys are now ignored (modal stays open).

Co-Authored-By: Claude <noreply@anthropic.com>