### PR TITLE
Fix session restore to use worktree CWD for --resume

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -86,10 +86,15 @@ func BuildCmd(task *model.Task, cfg config.Config, resume bool) (*exec.Cmd, erro
 
 	cmd := exec.Command("sh", "-c", cmdStr)
 
-	// For resume, prefer the task's existing worktree as the working
-	// directory so Claude Code finds the right project/session context.
+	// For resume, the working directory MUST match where the session was
+	// originally created. Sessions are project-scoped in Claude Code, so
+	// --resume only finds sessions stored under the CWD's project hash.
+	// Since sessions are created from the worktree (via --worktree flag),
+	// we must resume from the worktree, not the main project directory.
 	dir := ResolveDir(task, cfg)
-	if resume && dir == "" && task.Worktree != "" {
+	if resume && task.Worktree != "" {
+		dir = task.Worktree
+	} else if !resume && dir == "" && task.Worktree != "" {
 		dir = task.Worktree
 	}
 	if dir != "" {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -213,6 +213,28 @@ func TestBuildCmd_ResumeWithWorktree(t *testing.T) {
 	}
 }
 
+func TestBuildCmd_ResumeWithProjectAndWorktree(t *testing.T) {
+	cfg := testConfig()
+	task := &model.Task{
+		Project:   "other",
+		Prompt:    "fix the bug",
+		SessionID: "aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee",
+		Worktree:  "/tmp/worktree-test",
+	}
+
+	cmd, err := BuildCmd(task, cfg, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Resume MUST use the worktree (not the project dir) because sessions
+	// are project-scoped in Claude Code — the session was created from the
+	// worktree directory, not the main project directory.
+	if cmd.Dir != "/tmp/worktree-test" {
+		t.Errorf("expected Dir %q (worktree), got %q (likely project path)", "/tmp/worktree-test", cmd.Dir)
+	}
+}
+
 func TestInjectWorktreeName(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -143,6 +143,18 @@ func (m Model) Init() tea.Cmd {
 				task.AgentPID = 0
 			}
 
+			// Backfill worktree path for tasks created before proactive
+			// worktree tracking was added. The session is stored under the
+			// worktree's project hash, so --resume needs the correct CWD.
+			if task.Worktree == "" && task.Name != "" {
+				if projDir := agent.ResolveDir(task, m.db.Config()); projDir != "" {
+					expected := filepath.Join(projDir, ".claude", "worktrees", "argus", task.Name)
+					if dirExists(expected) {
+						task.Worktree = expected
+					}
+				}
+			}
+
 			// Reset StartedAt before starting so the quick-exit check in
 			// handleAgentFinished uses the resume time, not the original start.
 			task.StartedAt = time.Now()
@@ -423,6 +435,16 @@ func (m Model) startOrAttach(t *model.Task) (tea.Model, tea.Cmd) {
 		t.SessionID = model.GenerateSessionID()
 	}
 
+	// Proactively compute the expected worktree path for new sessions.
+	// Claude Code creates worktrees under <project>/.claude/worktrees/<name>,
+	// and sessions are scoped to that directory. We need to store this path
+	// so that resume can use the correct working directory.
+	if !resume && t.Name != "" && t.Worktree == "" {
+		if projDir := agent.ResolveDir(t, m.db.Config()); projDir != "" {
+			t.Worktree = filepath.Join(projDir, ".claude", "worktrees", "argus", t.Name)
+		}
+	}
+
 	// Persist status and StartedAt BEFORE starting the process so that
 	// handleAgentFinished always sees fresh data even if the process exits
 	// immediately (race between Start returning and the wait goroutine).
@@ -701,7 +723,7 @@ func (m Model) resolveTaskDir(t *model.Task) string {
 		dir = m.runner.WorkDir(t.ID)
 	}
 	if dir != "" && t.Worktree == "" {
-		if wt := discoverClaudeWorktree(dir, t.ID); wt != "" {
+		if wt := discoverClaudeWorktree(dir, t.Name); wt != "" {
 			t.Worktree = wt
 			_ = m.db.Update(t)
 			dir = wt
@@ -1054,15 +1076,24 @@ func dirExists(path string) bool {
 // "git worktree remove" (which cleans up .git/worktrees metadata),
 // falling back to a plain directory removal if the git command fails.
 // discoverClaudeWorktree looks for a Claude Code worktree under baseDir/.claude/worktrees/.
-// It parses `git worktree list --porcelain` to find worktrees in that subdirectory.
-// Falls back to scanning the directory if git fails. Returns empty string if none found.
-func discoverClaudeWorktree(baseDir, _ string) string {
+// When taskName is provided, it first looks for a worktree matching "argus/<taskName>"
+// (the naming convention used by Argus). Falls back to the first worktree found.
+func discoverClaudeWorktree(baseDir, taskName string) string {
 	claudeWtDir := filepath.Join(baseDir, ".claude", "worktrees")
 	if !dirExists(claudeWtDir) {
 		return ""
 	}
 
-	// Try git worktree list first for accuracy
+	// If we know the task name, check the expected path directly.
+	// Argus creates worktrees as argus/<task-name>.
+	if taskName != "" {
+		expected := filepath.Join(claudeWtDir, "argus", taskName)
+		if _, err := os.Stat(filepath.Join(expected, ".git")); err == nil {
+			return expected
+		}
+	}
+
+	// Try git worktree list for accuracy
 	out, err := runGit(baseDir, "worktree", "list", "--porcelain")
 	if err == nil {
 		for _, block := range strings.Split(out, "\n\n") {


### PR DESCRIPTION
Sessions are project-scoped in Claude Code, so --resume only finds sessions under the CWD's project hash. Resume was using the main project dir instead of the worktree dir where the session was created. Now BuildCmd always uses task.Worktree for resume, worktree paths are computed proactively on start, and discoverClaudeWorktree matches by task name.

Co-Authored-By: Claude <noreply@anthropic.com>