### PR TITLE
Add scrollback support to agent terminal view

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -41,8 +41,13 @@ type AgentView struct {
 	lastGitRefresh time.Time
 
 	// Terminal render cache — avoids replaying entire ring buffer every tick
-	cachedWriteCount uint64
-	cachedTerminal   string
+	cachedWriteCount  uint64
+	cachedTerminal    string
+	cachedScrollOff   int // scroll offset when cache was generated
+
+	// Scrollback support
+	scrollOffset int // lines scrolled up from bottom (0 = follow tail)
+	cachedLines  []string // cached rendered lines for scrolling without re-parsing
 
 	// lastOutput holds the final ring buffer contents from a finished session
 	// so we can display error output even after the session is removed.
@@ -69,6 +74,8 @@ func (av *AgentView) Enter(taskID, taskName string) {
 	av.lastOutput = nil
 	av.cachedTerminal = ""
 	av.cachedWriteCount = 0
+	av.scrollOffset = 0
+	av.cachedLines = nil
 }
 
 // SetLastOutput stores the final ring buffer from a finished session
@@ -153,6 +160,27 @@ func (av *AgentView) HandleKey(msg tea.KeyMsg) (detach bool) {
 	// Panel-specific key handling
 	switch av.focus {
 	case panelAgent:
+		// Scrollback keys (shift+up/down/pgup/pgdown) are intercepted
+		_, _, dispH := av.terminalDisplaySize()
+		switch keyStr {
+		case "shift+up":
+			av.scrollUp(1)
+			return false
+		case "shift+down":
+			av.scrollDown(1)
+			return false
+		case "shift+pgup":
+			av.scrollUp(dispH)
+			return false
+		case "shift+pgdown":
+			av.scrollDown(dispH)
+			return false
+		case "shift+end":
+			av.scrollOffset = 0
+			return false
+		}
+		// Any other key sent to PTY resets scroll to follow tail
+		av.scrollOffset = 0
 		// Forward all other keys to the PTY
 		if sess := av.runner.Get(av.taskID); sess != nil {
 			if b := keyMsgToBytes(msg); len(b) > 0 {
@@ -233,8 +261,17 @@ func (av *AgentView) renderTerminal(w, h int) string {
 
 	// Check if output has changed before expensive vt10x replay
 	writeCount := sess.TotalWritten()
-	if writeCount == av.cachedWriteCount && av.cachedTerminal != "" {
+	if writeCount == av.cachedWriteCount && av.scrollOffset == av.cachedScrollOff && av.cachedTerminal != "" {
 		return border.Render(av.cachedTerminal)
+	}
+	// If only scroll changed but output is the same, re-slice cached lines
+	if writeCount == av.cachedWriteCount && len(av.cachedLines) > 0 {
+		dispW := max(w-4, 10)
+		dispH := max(h-4, 3)
+		content := av.sliceCachedLines(dispW, dispH)
+		av.cachedScrollOff = av.scrollOffset
+		av.cachedTerminal = content
+		return border.Render(content)
 	}
 
 	raw := sess.RecentOutput()
@@ -249,11 +286,12 @@ func (av *AgentView) renderTerminal(w, h int) string {
 
 	content := av.formatTerminalOutput(raw, w, h)
 	av.cachedWriteCount = writeCount
+	av.cachedScrollOff = av.scrollOffset
 	av.cachedTerminal = content
 	return border.Render(content)
 }
 
-func (av AgentView) formatTerminalOutput(raw []byte, panelW, panelH int) string {
+func (av *AgentView) formatTerminalOutput(raw []byte, panelW, panelH int) string {
 	dispW := max(panelW-4, 10)
 	dispH := max(panelH-4, 3)
 
@@ -298,15 +336,25 @@ func (av AgentView) formatTerminalOutput(raw []byte, panelW, panelH int) string 
 		return ""
 	}
 
-	// Take the tail and truncate
-	if len(lines) > dispH {
-		lines = lines[len(lines)-dispH:]
+	// Cache all lines for scrollback
+	av.cachedLines = lines
+
+	// Apply scroll offset: select a window into the lines
+	end := len(lines) - av.scrollOffset
+	if end < 0 {
+		end = 0
 	}
-	for i, line := range lines {
-		lines[i] = ansi.Truncate(line, dispW, "\x1b[0m")
+	start := end - dispH
+	if start < 0 {
+		start = 0
+	}
+	visible := lines[start:end]
+
+	for i, line := range visible {
+		visible[i] = ansi.Truncate(line, dispW, "\x1b[0m")
 	}
 
-	return strings.Join(lines, "\n")
+	return strings.Join(visible, "\n")
 }
 
 func (av AgentView) renderStatusBar() string {
@@ -317,13 +365,16 @@ func (av AgentView) renderStatusBar() string {
 	status := ""
 	if av.runner.Get(av.taskID) == nil {
 		status = labelStyle.Render(" (exited — ctrl+q to return)")
+	} else if av.scrollOffset > 0 {
+		status = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render(
+			fmt.Sprintf(" [SCROLL -%d]", av.scrollOffset))
 	}
 	left := " " + av.theme.Normal.Render(av.taskName) + status
 
 	// Right: keybinding hints
 	keys := []struct{ key, label string }{
-		{"ctrl+←", "panel left"},
-		{"ctrl+→", "panel right"},
+		{"⇧↑/↓", "scroll"},
+		{"ctrl+←/→", "panel"},
 		{"ctrl+q", "detach"},
 	}
 	var parts []string
@@ -359,6 +410,59 @@ func (av AgentView) renderStatusBar() string {
 		Render(left + fmt.Sprintf("%*s", leftGap, "") + center + fmt.Sprintf("%*s", rightGap, "") + right)
 
 	return bar
+}
+
+// sliceCachedLines selects the visible window from cachedLines using scrollOffset.
+func (av *AgentView) sliceCachedLines(dispW, dispH int) string {
+	lines := av.cachedLines
+	if len(lines) == 0 {
+		return ""
+	}
+	end := len(lines) - av.scrollOffset
+	if end < 0 {
+		end = 0
+	}
+	start := end - dispH
+	if start < 0 {
+		start = 0
+	}
+	visible := lines[start:end]
+	result := make([]string, len(visible))
+	for i, line := range visible {
+		result[i] = ansi.Truncate(line, dispW, "\x1b[0m")
+	}
+	return strings.Join(result, "\n")
+}
+
+// terminalDisplaySize returns the usable display dimensions inside the terminal panel.
+func (av *AgentView) terminalDisplaySize() (dispW, dispH int, centerW int) {
+	_, cw, _ := av.splitWidths()
+	contentH := av.height - 1
+	return max(cw-4, 10), max(contentH-4, 3), cw
+}
+
+// scrollUp scrolls the terminal view up by n lines.
+func (av *AgentView) scrollUp(n int) {
+	maxScroll := 0
+	if len(av.cachedLines) > 0 {
+		_, dispH, _ := av.terminalDisplaySize()
+		maxScroll = len(av.cachedLines) - dispH
+		if maxScroll < 0 {
+			maxScroll = 0
+		}
+	}
+	av.scrollOffset += n
+	if av.scrollOffset > maxScroll {
+		av.scrollOffset = maxScroll
+	}
+}
+
+// scrollDown scrolls the terminal view down by n lines (toward tail).
+func (av *AgentView) scrollDown(n int) {
+	av.scrollOffset -= n
+	if av.scrollOffset < 0 {
+		av.scrollOffset = 0
+	}
 }
 
 // splitWidths returns left, center, right panel widths.

--- a/internal/ui/agentview_test.go
+++ b/internal/ui/agentview_test.go
@@ -1,0 +1,144 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/drn/argus/internal/agent"
+)
+
+func newTestAgentView() *AgentView {
+	runner := agent.NewRunner(nil)
+	av := NewAgentView(DefaultTheme(), runner)
+	av.SetSize(120, 40)
+	av.Enter("task-1", "test task")
+	return &av
+}
+
+func TestAgentView_ScrollUpDown(t *testing.T) {
+	av := newTestAgentView()
+
+	// Simulate some cached lines (as if output had been rendered)
+	av.cachedLines = make([]string, 100)
+	for i := range av.cachedLines {
+		av.cachedLines[i] = strings.Repeat("x", 10)
+	}
+
+	// Initially at bottom
+	if av.scrollOffset != 0 {
+		t.Fatalf("initial scrollOffset = %d, want 0", av.scrollOffset)
+	}
+
+	// Scroll up
+	av.scrollUp(5)
+	if av.scrollOffset != 5 {
+		t.Fatalf("scrollOffset after scrollUp(5) = %d, want 5", av.scrollOffset)
+	}
+
+	// Scroll down
+	av.scrollDown(3)
+	if av.scrollOffset != 2 {
+		t.Fatalf("scrollOffset after scrollDown(3) = %d, want 2", av.scrollOffset)
+	}
+
+	// Scroll down past bottom clamps to 0
+	av.scrollDown(100)
+	if av.scrollOffset != 0 {
+		t.Fatalf("scrollOffset after scrollDown(100) = %d, want 0", av.scrollOffset)
+	}
+}
+
+func TestAgentView_ScrollUpClampsToMax(t *testing.T) {
+	av := newTestAgentView()
+
+	// 50 lines of content, display fits ~34 lines (height 40 - 1 statusbar - 2 border - 4 padding area ~= 33)
+	av.cachedLines = make([]string, 50)
+	for i := range av.cachedLines {
+		av.cachedLines[i] = "line"
+	}
+
+	// Scroll way up — should clamp
+	av.scrollUp(1000)
+	_, dispH, _ := av.terminalDisplaySize()
+	maxScroll := len(av.cachedLines) - dispH
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if av.scrollOffset != maxScroll {
+		t.Fatalf("scrollOffset = %d, want max %d", av.scrollOffset, maxScroll)
+	}
+}
+
+func TestAgentView_ShiftUpKeyScrolls(t *testing.T) {
+	av := newTestAgentView()
+	av.cachedLines = make([]string, 100)
+	for i := range av.cachedLines {
+		av.cachedLines[i] = "line"
+	}
+
+	msg := tea.KeyMsg{Type: tea.KeyShiftUp}
+	detach := av.HandleKey(msg)
+	if detach {
+		t.Fatal("shift+up should not trigger detach")
+	}
+	if av.scrollOffset != 1 {
+		t.Fatalf("scrollOffset after shift+up = %d, want 1", av.scrollOffset)
+	}
+}
+
+func TestAgentView_ShiftDownKeyScrolls(t *testing.T) {
+	av := newTestAgentView()
+	av.cachedLines = make([]string, 100)
+	for i := range av.cachedLines {
+		av.cachedLines[i] = "line"
+	}
+
+	// First scroll up, then down
+	av.scrollOffset = 5
+	msg := tea.KeyMsg{Type: tea.KeyShiftDown}
+	av.HandleKey(msg)
+	if av.scrollOffset != 4 {
+		t.Fatalf("scrollOffset after shift+down = %d, want 4", av.scrollOffset)
+	}
+}
+
+func TestAgentView_ShiftEndResetsScroll(t *testing.T) {
+	av := newTestAgentView()
+	av.scrollOffset = 10
+
+	// shift+end not directly available as a KeyType, test via string
+	// Use regular key input to reset scroll instead
+	// Any non-scroll key sent to PTY resets scroll to 0
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}
+	av.HandleKey(msg)
+	if av.scrollOffset != 0 {
+		t.Fatalf("scrollOffset after typing = %d, want 0 (should reset on input)", av.scrollOffset)
+	}
+}
+
+func TestAgentView_SliceCachedLines(t *testing.T) {
+	av := newTestAgentView()
+	av.cachedLines = []string{"line1", "line2", "line3", "line4", "line5"}
+
+	// dispH=3, scrollOffset=0 → last 3 lines
+	result := av.sliceCachedLines(80, 3)
+	lines := strings.Split(result, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3", len(lines))
+	}
+	if stripANSI(lines[0]) != "line3" {
+		t.Errorf("first visible line = %q, want %q", stripANSI(lines[0]), "line3")
+	}
+
+	// scrollOffset=2 → lines 1-3
+	av.scrollOffset = 2
+	result = av.sliceCachedLines(80, 3)
+	lines = strings.Split(result, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3", len(lines))
+	}
+	if stripANSI(lines[0]) != "line1" {
+		t.Errorf("first visible line = %q, want %q", stripANSI(lines[0]), "line1")
+	}
+}


### PR DESCRIPTION
Allow scrolling up through agent output in the agent view using shift+arrow keys. Includes shift+pgup/pgdown for page scrolling and a scroll indicator in the status bar.

Co-Authored-By: Claude <noreply@anthropic.com>