### PR TITLE
Size vt10x terminal dynamically for full scrollback

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"time"
@@ -296,17 +297,28 @@ func (av *AgentView) formatTerminalOutput(raw []byte, panelW, panelH int) string
 	dispH := max(panelH-4, 3)
 
 	sess := av.runner.Get(av.taskID)
-	vtCols, vtRows := dispW, dispH
+	vtCols := dispW
 	if sess != nil {
-		c, r := sess.PTYSize()
+		c, _ := sess.PTYSize()
 		if c > 0 {
 			vtCols = c
 		}
-		if r > 0 {
-			vtRows = r
-		}
 	}
 
+	// Size the virtual terminal tall enough to capture all content.
+	// Count newlines to estimate how many rows the output needs, then
+	// add the display height for the active screen area.
+	vtRows := dispH
+	if n := bytes.Count(raw, []byte{'\n'}); n > vtRows {
+		vtRows = n + dispH
+	}
+	// Also account for long lines that wrap.
+	if vtCols > 0 {
+		wrappedEstimate := len(raw)/vtCols + dispH
+		if wrappedEstimate > vtRows {
+			vtRows = wrappedEstimate
+		}
+	}
 	vt := vt10x.New(vt10x.WithSize(vtCols, vtRows))
 	vt.Write(raw)
 

--- a/internal/ui/agentview_test.go
+++ b/internal/ui/agentview_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -114,6 +115,31 @@ func TestAgentView_ShiftEndResetsScroll(t *testing.T) {
 	av.HandleKey(msg)
 	if av.scrollOffset != 0 {
 		t.Fatalf("scrollOffset after typing = %d, want 0 (should reset on input)", av.scrollOffset)
+	}
+}
+
+func TestAgentView_FormatTerminalOutputCapturesScrollback(t *testing.T) {
+	av := newTestAgentView()
+
+	// Generate terminal output with many more lines than display height.
+	// Each "line\n" produces one row in the virtual terminal.
+	var buf []byte
+	numLines := 200
+	for i := 0; i < numLines; i++ {
+		buf = append(buf, []byte(fmt.Sprintf("line %03d\r\n", i))...)
+	}
+
+	av.formatTerminalOutput(buf, 120, 40)
+
+	// The display area is about 36 lines (40 - 4), but cachedLines should
+	// capture much more than that thanks to the scrollback multiplier.
+	_, dispH, _ := av.terminalDisplaySize()
+	if len(av.cachedLines) <= dispH {
+		t.Fatalf("cachedLines = %d, want > %d (display height); scrollback not working", len(av.cachedLines), dispH)
+	}
+	// Should capture most of the lines we wrote
+	if len(av.cachedLines) < numLines/2 {
+		t.Fatalf("cachedLines = %d, want at least %d; not enough scrollback", len(av.cachedLines), numLines/2)
 	}
 }
 


### PR DESCRIPTION
Dynamically size the virtual terminal based on actual content (newline count + wrap estimate) instead of a static multiplier, ensuring the agent view scrollback captures all available output from the ring buffer.

Co-Authored-By: Claude <noreply@anthropic.com>