### PR TITLE
Fix agent view panel switching with ctrl/alt+arrow keys

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -149,13 +149,27 @@ func (av *AgentView) HandleKey(msg tea.KeyMsg) (detach bool) {
 	if keyStr == "ctrl+q" {
 		return true
 	}
-	if keyStr == "ctrl+left" {
+	// Panel switching: ctrl+left/right or alt+left/right
+	// Use type-based matching to handle terminals that set the Alt flag on
+	// ctrl+arrow sequences (urxvt sends \x1b[Od which parses as
+	// KeyCtrlLeft with Alt=true, producing "alt+ctrl+left").
+	switch msg.Type {
+	case tea.KeyCtrlLeft:
 		av.FocusLeft()
 		return false
-	}
-	if keyStr == "ctrl+right" {
+	case tea.KeyCtrlRight:
 		av.FocusRight()
 		return false
+	case tea.KeyLeft:
+		if msg.Alt {
+			av.FocusLeft()
+			return false
+		}
+	case tea.KeyRight:
+		if msg.Alt {
+			av.FocusRight()
+			return false
+		}
 	}
 
 	// Panel-specific key handling
@@ -386,7 +400,7 @@ func (av AgentView) renderStatusBar() string {
 	// Right: keybinding hints
 	keys := []struct{ key, label string }{
 		{"⇧↑/↓", "scroll"},
-		{"ctrl+←/→", "panel"},
+		{"ctrl/alt+←/→", "panel"},
 		{"ctrl+q", "detach"},
 	}
 	var parts []string

--- a/internal/ui/ctrl_arrow_test.go
+++ b/internal/ui/ctrl_arrow_test.go
@@ -1,0 +1,105 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestAgentView_CtrlLeftRight(t *testing.T) {
+	av := newTestAgentView()
+
+	// Initial focus should be panelAgent (center)
+	if av.focus != panelAgent {
+		t.Fatalf("initial focus = %d, want panelAgent(%d)", av.focus, panelAgent)
+	}
+
+	// Ctrl+left should move to panelGit
+	msg := tea.KeyMsg{Type: tea.KeyCtrlLeft}
+	detach := av.HandleKey(msg)
+	if detach {
+		t.Fatal("ctrl+left should not trigger detach")
+	}
+	if av.focus != panelGit {
+		t.Fatalf("focus after ctrl+left = %d, want panelGit(%d)", av.focus, panelGit)
+	}
+
+	// Reset to center
+	av.focus = panelAgent
+
+	// Ctrl+right should move to panelFiles
+	msg2 := tea.KeyMsg{Type: tea.KeyCtrlRight}
+	detach = av.HandleKey(msg2)
+	if detach {
+		t.Fatal("ctrl+right should not trigger detach")
+	}
+	if av.focus != panelFiles {
+		t.Fatalf("focus after ctrl+right = %d, want panelFiles(%d)", av.focus, panelFiles)
+	}
+}
+
+func TestAgentView_CtrlLeftRightWithAlt(t *testing.T) {
+	av := newTestAgentView()
+
+	// Ctrl+left with Alt flag (urxvt sends \x1b[Od → KeyCtrlLeft + Alt)
+	msg := tea.KeyMsg{Type: tea.KeyCtrlLeft, Alt: true}
+	detach := av.HandleKey(msg)
+	if detach {
+		t.Fatal("alt+ctrl+left should not trigger detach")
+	}
+	if av.focus != panelGit {
+		t.Fatalf("focus after alt+ctrl+left = %d, want panelGit(%d)", av.focus, panelGit)
+	}
+
+	// Reset to center
+	av.focus = panelAgent
+
+	// Ctrl+right with Alt flag
+	msg2 := tea.KeyMsg{Type: tea.KeyCtrlRight, Alt: true}
+	detach = av.HandleKey(msg2)
+	if detach {
+		t.Fatal("alt+ctrl+right should not trigger detach")
+	}
+	if av.focus != panelFiles {
+		t.Fatalf("focus after alt+ctrl+right = %d, want panelFiles(%d)", av.focus, panelFiles)
+	}
+}
+
+func TestAgentView_AltLeftRight(t *testing.T) {
+	av := newTestAgentView()
+
+	// Alt+left should move to panelGit
+	msg := tea.KeyMsg{Type: tea.KeyLeft, Alt: true}
+	detach := av.HandleKey(msg)
+	if detach {
+		t.Fatal("alt+left should not trigger detach")
+	}
+	if av.focus != panelGit {
+		t.Fatalf("focus after alt+left = %d, want panelGit(%d)", av.focus, panelGit)
+	}
+
+	// Reset to center
+	av.focus = panelAgent
+
+	// Alt+right should move to panelFiles
+	msg2 := tea.KeyMsg{Type: tea.KeyRight, Alt: true}
+	detach = av.HandleKey(msg2)
+	if detach {
+		t.Fatal("alt+right should not trigger detach")
+	}
+	if av.focus != panelFiles {
+		t.Fatalf("focus after alt+right = %d, want panelFiles(%d)", av.focus, panelFiles)
+	}
+}
+
+func TestAgentView_PlainLeftRightNotIntercepted(t *testing.T) {
+	av := newTestAgentView()
+
+	// Plain left arrow (no modifier) should NOT switch panels —
+	// it should be forwarded to the PTY when terminal is focused.
+	msg := tea.KeyMsg{Type: tea.KeyLeft}
+	av.HandleKey(msg)
+	if av.focus != panelAgent {
+		t.Fatalf("focus after plain left = %d, want panelAgent(%d) (should not change)", av.focus, panelAgent)
+	}
+}


### PR DESCRIPTION
Use type-based key matching instead of string comparison to handle terminals that set the Alt flag on ctrl+arrow sequences. Add alt+left/right as alternative bindings for broader terminal compatibility.

Co-Authored-By: Claude <noreply@anthropic.com>