### PR TITLE
Async git status resolution to eliminate UI blocking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ go test ./internal/store/   # run tests for a single package
 
 **Agent pattern:** A single `readLoop` goroutine is the sole reader of the PTY master fd. It always writes to the ring buffer, and when a writer is attached (via `session.attachW`), also tees output there. This avoids competing readers on the same fd. The detach key (`ctrl+q`) is intercepted by `detachReader` wrapping stdin.
 
+**Git status pattern:** Git operations (worktree discovery, diff, status) must **never** run synchronously on the UI thread. The `resolvedDirs` cache on `Model` stores task ID → worktree dir mappings. On cache hit, `scheduleGitRefresh()` kicks off `FetchGitStatus` as a `tea.Cmd`. On cache miss, it fires `resolveTaskDirAsync()` which returns a `ResolveTaskDirMsg` — only then does the git status fetch begin. This two-phase async pattern keeps the UI responsive. Maps are reference types in Go, so the cache works correctly even through Bubble Tea's value-receiver `Update` method.
+
 ## Config & Persistence
 
 - Data dir: `~/.argus/`
@@ -53,11 +55,19 @@ go test ./internal/store/   # run tests for a single package
 - Use `charmbracelet/x/term` for raw mode (cross-platform) instead of platform-specific ioctls (`TIOCGETA` is macOS-only, `TCGETS` is Linux-only).
 - `tea.ExecCommand.SetStdin/SetStdout` must capture and use Bubble Tea's `p.input`/`p.output` — don't hardcode `os.Stdin`/`os.Stdout`.
 - The single-reader-tee pattern (one goroutine reads PTY, tees to buffer + optional writer) is critical. Two goroutines reading the same fd causes data loss.
+- **Never run git commands or filesystem discovery synchronously in `Update()`.** Even fast git commands take 50-500ms which freezes the entire TUI. Use `tea.Cmd` to run them in background goroutines and deliver results via messages. Cache resolved paths in a `map` on the model to avoid repeated lookups.
 - **Backend default config must be self-healing.** The default claude backend command MUST include `--dangerously-skip-permissions` and MUST NOT use `-p` as the prompt flag. `-p` puts Claude in non-interactive print mode (process prompt → exit), which silently breaks agent sessions — they show "waiting for output" then auto-complete. The `fixupBackends()` method in `internal/db/migrate.go` runs on every `Open()` to detect and repair outdated backend configs. Any change to `DefaultConfig()` backend values must be mirrored in `fixupBackends()` detection logic, or existing databases will retain stale values.
 
 ## Development Rules
 
 - **Every change must include tests.** When adding new functionality, fixing bugs, or refactoring, always add or update corresponding tests. Run `go test ./...` to verify all tests pass before considering work complete.
+
+## Context Directory
+
+- `context/` stores durable cross-session knowledge, research, and plans
+- `context/knowledge/index.md` is the knowledge graph index — read it when you need project history or domain context
+- `context/research/` holds investigation notes and spike results
+- `context/plans/` holds strategic plans and proposals
 
 ## Planned but Not Yet Implemented
 

--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -1,0 +1,13 @@
+# Knowledge Index
+
+Structured knowledge for cross-session persistence. Each file covers a topic/domain.
+
+| File | Topic | Key Entities | Last Updated |
+|------|-------|-------------|-------------|
+
+## Coverage Map
+
+Which context files are captured in knowledge:
+
+| Context File | Knowledge File(s) | Coverage |
+|-------------|-------------------|----------|

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -59,6 +59,12 @@ type AgentDetachedMsg struct {
 	TaskID string
 }
 
+// ResolveTaskDirMsg carries the result of async worktree directory resolution.
+type ResolveTaskDirMsg struct {
+	TaskID string
+	Dir    string
+}
+
 // SessionResumedMsg is sent when a background session resume completes.
 type SessionResumedMsg struct {
 	TaskID string
@@ -81,11 +87,12 @@ type Model struct {
 	preview     Preview
 	gitstatus   GitStatus
 	agentview   *AgentView
-	current     view
-	activeTab   tab
-	width       int
-	height      int
-	quitting    bool
+	current      view
+	activeTab    tab
+	width        int
+	height       int
+	quitting     bool
+	resolvedDirs map[string]string // taskID → resolved worktree dir (cache)
 }
 
 func NewModel(database *db.DB, runner *agent.Runner) Model {
@@ -103,10 +110,11 @@ func NewModel(database *db.DB, runner *agent.Runner) Model {
 	av := &avv
 
 	m := Model{
-		db:          database,
-		runner:      runner,
-		keys:        keys,
-		theme:       theme,
+		db:           database,
+		runner:       runner,
+		keys:         keys,
+		theme:        theme,
+		resolvedDirs: make(map[string]string),
 		tasklist:    tl,
 		projectlist: pl,
 		statusbar:   sb,
@@ -151,6 +159,7 @@ func (m Model) Init() tea.Cmd {
 					expected := filepath.Join(projDir, ".claude", "worktrees", "argus", task.Name)
 					if dirExists(expected) {
 						task.Worktree = expected
+						m.resolvedDirs[task.ID] = expected
 					}
 				}
 			}
@@ -195,41 +204,39 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case TickMsg:
 		// Keep running state fresh so idle tasks display correctly.
 		m.refreshTasks()
-		// Kick off git status refresh if needed
 		var cmds []tea.Cmd
 		cmds = append(cmds, tea.Tick(time.Second, func(_ time.Time) tea.Msg {
 			return TickMsg{}
 		}))
-		// In agent view, also schedule the fast refresh tick
 		if m.current == viewAgent {
 			cmds = append(cmds, tea.Tick(100*time.Millisecond, func(_ time.Time) tea.Msg {
 				return AgentViewTickMsg{}
 			}))
 		}
-		if t := m.selectedTaskForGit(); t != nil {
-			dir := m.resolveTaskDir(t)
-			if dir != "" {
-				m.gitstatus.SetTask(t.ID)
-				if m.gitstatus.NeedsRefresh() {
-					taskID := t.ID
-					cmds = append(cmds, func() tea.Msg {
-						return FetchGitStatus(taskID, dir)
-					})
-				}
-				// Also refresh agent view's git status
-				if m.current == viewAgent && m.agentview.NeedsGitRefresh() {
-					taskID := t.ID
-					cmds = append(cmds, func() tea.Msg {
-						return FetchGitStatus(taskID, dir)
-					})
-				}
-			} else {
-				m.gitstatus.SetTask("")
-			}
-		} else {
-			m.gitstatus.SetTask("")
+		if cmd := m.scheduleGitRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
 		}
 		return m, tea.Batch(cmds...)
+
+	case ResolveTaskDirMsg:
+		if msg.Dir != "" {
+			m.resolvedDirs[msg.TaskID] = msg.Dir
+			// Persist discovered worktree to the task record.
+			if t, err := m.db.Get(msg.TaskID); err == nil && t.Worktree == "" {
+				t.Worktree = msg.Dir
+				_ = m.db.Update(t)
+			}
+		}
+		// Now that we have the dir, kick off git status fetch
+		if t := m.selectedTaskForGit(); t != nil && t.ID == msg.TaskID && msg.Dir != "" {
+			m.gitstatus.SetTask(t.ID)
+			taskID := t.ID
+			dir := msg.Dir
+			return m, func() tea.Msg {
+				return FetchGitStatus(taskID, dir)
+			}
+		}
+		return m, nil
 
 	case AgentViewTickMsg:
 		// Fast tick for agent view — just triggers a re-render
@@ -331,11 +338,11 @@ func (m Model) handleTaskListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, m.keys.Up):
 		m.tasklist.CursorUp()
-		return m, nil
+		return m, m.scheduleGitRefresh()
 
 	case key.Matches(msg, m.keys.Down):
 		m.tasklist.CursorDown()
-		return m, nil
+		return m, m.scheduleGitRefresh()
 
 	case key.Matches(msg, m.keys.New):
 		m.newtask = NewNewTaskForm(m.theme, m.db.Projects())
@@ -442,6 +449,7 @@ func (m Model) startOrAttach(t *model.Task) (tea.Model, tea.Cmd) {
 	if !resume && t.Name != "" && t.Worktree == "" {
 		if projDir := agent.ResolveDir(t, m.db.Config()); projDir != "" {
 			t.Worktree = filepath.Join(projDir, ".claude", "worktrees", "argus", t.Name)
+			m.resolvedDirs[t.ID] = t.Worktree
 		}
 	}
 
@@ -713,34 +721,89 @@ func (m Model) selectedTaskForGit() *model.Task {
 	return m.tasklist.Selected()
 }
 
-// resolveTaskDir finds the working directory for a task's git status.
-func (m Model) resolveTaskDir(t *model.Task) string {
+// scheduleGitRefresh checks the selected task and returns a tea.Cmd to
+// refresh git status asynchronously. Directory resolution is cached; on a
+// cache miss the slow discovery runs in a background goroutine.
+func (m Model) scheduleGitRefresh() tea.Cmd {
+	t := m.selectedTaskForGit()
+	if t == nil {
+		m.gitstatus.SetTask("")
+		return nil
+	}
+
+	// Fast path: dir already cached.
+	if dir, ok := m.resolvedDirs[t.ID]; ok && dir != "" {
+		m.gitstatus.SetTask(t.ID)
+		needsMain := m.gitstatus.NeedsRefresh()
+		needsAgent := m.current == viewAgent && m.agentview.NeedsGitRefresh()
+		if needsMain || needsAgent {
+			taskID := t.ID
+			return func() tea.Msg {
+				return FetchGitStatus(taskID, dir)
+			}
+		}
+		return nil
+	}
+
+	// Try cheap resolution first (stored worktree, project config, runner).
+	dir := m.resolveTaskDirFast(t)
+	if dir != "" {
+		m.resolvedDirs[t.ID] = dir
+		m.gitstatus.SetTask(t.ID)
+		taskID := t.ID
+		return func() tea.Msg {
+			return FetchGitStatus(taskID, dir)
+		}
+	}
+
+	// Slow path: need to discover worktree — run async.
+	// Compute the base dir cheaply (project path or runner work dir).
+	baseDir := agent.ResolveDir(t, m.db.Config())
+	if baseDir == "" {
+		baseDir = m.runner.WorkDir(t.ID)
+	}
+	if baseDir == "" {
+		m.gitstatus.SetTask("")
+		return nil
+	}
+	taskID := t.ID
+	taskName := t.Name
+	return func() tea.Msg {
+		return resolveTaskDirAsync(taskID, taskName, baseDir)
+	}
+}
+
+// resolveTaskDirFast returns the task's working directory using only cheap
+// lookups (cached worktree path, project config, runner). Returns "" if the
+// directory cannot be determined without running git commands.
+func (m Model) resolveTaskDirFast(t *model.Task) string {
 	dir := t.Worktree
 
 	// Validate stored worktree: must exist and match the task name.
 	if dir != "" {
 		if !dirExists(dir) || filepath.Base(dir) != t.Name {
-			// Stale or mismatched — clear and re-discover.
 			t.Worktree = ""
 			_ = m.db.Update(t)
+			delete(m.resolvedDirs, t.ID)
 			dir = ""
 		}
 	}
 
-	if dir == "" {
-		dir = agent.ResolveDir(t, m.db.Config())
+	if dir != "" {
+		return dir
 	}
-	if dir == "" {
-		dir = m.runner.WorkDir(t.ID)
+
+	// No stored worktree — can't resolve without async discovery.
+	return ""
+}
+
+// resolveTaskDirAsync performs the slow worktree discovery off the main thread.
+func resolveTaskDirAsync(taskID, taskName, baseDir string) ResolveTaskDirMsg {
+	dir := baseDir
+	if wt := discoverClaudeWorktree(baseDir, taskName); wt != "" {
+		dir = wt
 	}
-	if dir != "" && t.Worktree == "" {
-		if wt := discoverClaudeWorktree(dir, t.Name); wt != "" {
-			t.Worktree = wt
-			_ = m.db.Update(t)
-			dir = wt
-		}
-	}
-	return dir
+	return ResolveTaskDirMsg{TaskID: taskID, Dir: dir}
 }
 
 func (m *Model) refreshTasks() {

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -776,3 +776,85 @@ func TestInit_ResumesOnlyInProgressWithSessionID(t *testing.T) {
 		t.Errorf("expected 1 task eligible for resume, got %d", count)
 	}
 }
+
+func TestResolveTaskDirMsg_CachesDir(t *testing.T) {
+	task := &model.Task{
+		ID:     "t1",
+		Name:   "cached-task",
+		Status: model.StatusPending,
+	}
+	m := testModel(t, task)
+
+	// Simulate receiving an async ResolveTaskDirMsg
+	updated, _ := m.Update(ResolveTaskDirMsg{TaskID: "t1", Dir: "/tmp/worktree"})
+	um := updated.(Model)
+
+	// The resolved dir should be cached
+	if dir, ok := um.resolvedDirs["t1"]; !ok || dir != "/tmp/worktree" {
+		t.Errorf("expected cached dir /tmp/worktree, got %q (ok=%v)", dir, ok)
+	}
+
+	// The task's Worktree field should be persisted to the DB
+	got, err := um.db.Get("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Worktree != "/tmp/worktree" {
+		t.Errorf("expected task Worktree=/tmp/worktree, got %q", got.Worktree)
+	}
+}
+
+func TestScheduleGitRefresh_UsesCachedDir(t *testing.T) {
+	task := &model.Task{
+		ID:     "t1",
+		Name:   "cached-task",
+		Status: model.StatusPending,
+	}
+	m := testModel(t, task)
+
+	// Pre-populate the cache
+	m.resolvedDirs["t1"] = "/tmp/worktree"
+
+	// scheduleGitRefresh should use the cached dir and return a command
+	cmd := m.scheduleGitRefresh()
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd when dir is cached")
+	}
+
+	// Execute the command and verify it produces a GitStatusRefreshMsg
+	msg := cmd()
+	if gsMsg, ok := msg.(GitStatusRefreshMsg); !ok {
+		t.Errorf("expected GitStatusRefreshMsg, got %T", msg)
+	} else if gsMsg.TaskID != "t1" {
+		t.Errorf("expected task ID t1, got %q", gsMsg.TaskID)
+	}
+}
+
+func TestScheduleGitRefresh_NoTaskReturnsNil(t *testing.T) {
+	m := testModel(t) // no tasks
+
+	cmd := m.scheduleGitRefresh()
+	if cmd != nil {
+		t.Error("expected nil cmd when no tasks")
+	}
+}
+
+func TestCursorChange_TriggersGitRefresh(t *testing.T) {
+	tasks := []*model.Task{
+		{ID: "t1", Name: "first", Status: model.StatusPending},
+		{ID: "t2", Name: "second", Status: model.StatusPending},
+	}
+	m := testModel(t, tasks...)
+
+	// Pre-populate cache for second task
+	m.resolvedDirs["t2"] = "/tmp/second-worktree"
+
+	// Move cursor down
+	msg := tea.KeyMsg{Type: tea.KeyDown}
+	_, cmd := m.Update(msg)
+
+	// Should return a command (git refresh triggered by cursor change)
+	if cmd == nil {
+		t.Error("expected non-nil cmd on cursor change with cached dir")
+	}
+}


### PR DESCRIPTION
Move worktree directory resolution off the main Bubble Tea thread. Previously, resolveTaskDir ran git commands synchronously during every TickMsg, causing 100-500ms UI freezes when switching tasks. Now uses a two-phase async pattern with a resolvedDirs cache for instant lookups and background discovery via tea.Cmd. Cursor changes trigger immediate git refresh.

Co-Authored-By: Claude <noreply@anthropic.com>