### PR TITLE
Forward Option/Alt modifier to PTY for word navigation

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -549,7 +549,12 @@ func padHeight(s string, h int) string {
 func keyMsgToBytes(msg tea.KeyMsg) []byte {
 	switch msg.Type {
 	case tea.KeyRunes:
-		return []byte(string(msg.Runes))
+		b := []byte(string(msg.Runes))
+		if msg.Alt {
+			// Option/Alt + key: prepend ESC so the PTY receives e.g. \x1bb (word back)
+			return append([]byte{0x1b}, b...)
+		}
+		return b
 	case tea.KeySpace:
 		return []byte{' '}
 	case tea.KeyEnter:

--- a/internal/ui/agentview_test.go
+++ b/internal/ui/agentview_test.go
@@ -626,3 +626,55 @@ func TestKeyMsgToBytes_SpecialKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestKeyMsgToBytes_AltRunes(t *testing.T) {
+	// Option+b on macOS sends ESC b (word back in readline)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}, Alt: true}
+	got := keyMsgToBytes(msg)
+	want := []byte{0x1b, 'b'}
+	if string(got) != string(want) {
+		t.Errorf("Alt+b: got %q, want %q", got, want)
+	}
+
+	// Option+f on macOS sends ESC f (word forward in readline)
+	msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}, Alt: true}
+	got = keyMsgToBytes(msg)
+	want = []byte{0x1b, 'f'}
+	if string(got) != string(want) {
+		t.Errorf("Alt+f: got %q, want %q", got, want)
+	}
+
+	// Plain rune without Alt should not get ESC prefix
+	msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}}
+	got = keyMsgToBytes(msg)
+	want = []byte{'b'}
+	if string(got) != string(want) {
+		t.Errorf("plain b: got %q, want %q", got, want)
+	}
+}
+
+func TestKeyMsgToBytes_AltArrows(t *testing.T) {
+	// Alt+Left should send modified CSI sequence
+	msg := tea.KeyMsg{Type: tea.KeyLeft, Alt: true}
+	got := keyMsgToBytes(msg)
+	want := []byte("\x1b[1;3D")
+	if string(got) != string(want) {
+		t.Errorf("Alt+Left: got %q, want %q", got, want)
+	}
+
+	// Alt+Right should send modified CSI sequence
+	msg = tea.KeyMsg{Type: tea.KeyRight, Alt: true}
+	got = keyMsgToBytes(msg)
+	want = []byte("\x1b[1;3C")
+	if string(got) != string(want) {
+		t.Errorf("Alt+Right: got %q, want %q", got, want)
+	}
+
+	// Plain Left without Alt
+	msg = tea.KeyMsg{Type: tea.KeyLeft}
+	got = keyMsgToBytes(msg)
+	want = []byte("\x1b[D")
+	if string(got) != string(want) {
+		t.Errorf("plain Left: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
keyMsgToBytes was dropping the Alt modifier on KeyRunes messages, so Option+B/F (word back/forward) sent plain characters instead of ESC sequences. Prepend ESC byte when msg.Alt is set on rune-type keys.

Co-Authored-By: Claude <noreply@anthropic.com>