### PR TITLE
Polish: reduce duplication and improve code structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ go test ./internal/store/   # run tests for a single package
 
 - `cmd/argus/main.go` — Entry point. Opens SQLite database, creates agent runner, starts `tea.Program` with alt screen.
 - `internal/ui/root.go` — **Top-level Bubble Tea model**. Owns all sub-views and routes key events based on current view state (`viewTaskList`, `viewNewTask`, `viewHelp`, `viewPrompt`, `viewConfirmDelete`). This is the orchestration hub.
+- `internal/ui/worktree.go` — Git worktree discovery, cleanup, and process management helpers. Extracted from root.go to separate infrastructure concerns from UI logic.
 - `internal/ui/tasklist.go` — Task list with cursor, scrolling, filtering. Not a `tea.Model` itself — it's a plain struct that `root.Model` drives.
 - `internal/ui/newtask.go` — New task form using `bubbles/textinput`. Has its own `Update` method but is called by root.
 - `internal/model/` — Core domain types. `Task` struct and `Status` enum with `pending → in_progress → in_review → complete` workflow. Status implements `encoding.TextMarshaler` for JSON serialization.
@@ -83,14 +84,6 @@ go test ./internal/store/   # run tests for a single package
 ## Context Directory
 
 - `context/` stores durable cross-session knowledge checked into git
-- `context/knowledge/index.md` is the knowledge graph index
-- `context/research/` holds investigation notes and spike results
-- `context/plans/` holds strategic plans and proposals
-- Read `context/knowledge/index.md` when you need project history or domain context
-
-## Context Directory
-
-- `context/` stores durable cross-session knowledge, research, and plans
 - `context/knowledge/index.md` is the knowledge graph index — read it when you need project history or domain context
 - `context/research/` holds investigation notes and spike results
 - `context/plans/` holds strategic plans and proposals

--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -1,0 +1,27 @@
+# Code Quality Patterns
+
+## Refactoring Session: 2026-03-14
+
+### Key Duplication Patterns Found
+- **Config key-value mapping** duplicated 3x across db.go and migrate.go — fixed with table-driven field mapping
+- **Modal rendering** duplicated 3x across confirm dialogs — fixed with `renderCenteredModal` helper
+- **SQL column scan** duplicated 5x — fixed with `scanTask`/`taskColumns` helpers
+- **Modal width calc** duplicated in NewTaskForm and NewProjectForm — fixed with shared `clampModalWidth`
+- **Project detection** tables duplicated between DetectIcon and DetectLanguage — merged into single `signatures` table
+
+### Concurrency Bug Found
+- `DB.Config()` released mutex before iterating rows cursor, allowing concurrent writes during iteration. Fixed by holding lock through full iteration.
+
+### Performance Optimization
+- `ringBuffer.Write` was byte-at-a-time loop; replaced with bulk `copy()` for the 256KB buffer.
+
+### Structural Split
+- Infrastructure functions (worktree discovery, process cleanup, git operations) extracted from root.go (1250 lines) into worktree.go, reducing root.go to ~1100 lines.
+
+### Deferred Items for Future Sessions
+- Extract shared cursor/scroll logic from TaskList/ProjectList/FileExplorer
+- Add error handling for silently ignored `_ = m.db.Update()` calls
+- Handle `os.UserHomeDir()` errors in db.go and config.go
+- Remove dead `store` package
+- Extract shared vt10x rendering from preview.go and agentview.go
+- Define interfaces for DB and Runner to improve testability

--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -4,6 +4,7 @@ Structured knowledge for cross-session persistence. Each file covers a topic/dom
 
 | File | Topic | Key Entities | Last Updated |
 |------|-------|-------------|-------------|
+| code-quality.md | Refactoring patterns and deferred items | DB.Config mutex bug, ringBuffer optimization, worktree.go extraction | 2026-03-14 |
 
 ## Coverage Map
 

--- a/internal/agent/ringbuffer.go
+++ b/internal/agent/ringbuffer.go
@@ -17,16 +17,18 @@ func newRingBuffer(size int) *ringBuffer {
 	}
 }
 
-// Write appends data to the ring buffer.
+// Write appends data to the ring buffer using bulk copy operations.
 func (rb *ringBuffer) Write(p []byte) {
-	for _, b := range p {
-		rb.data[rb.pos] = b
-		rb.pos = (rb.pos + 1) % rb.size
-		if rb.pos == 0 {
+	rb.total += uint64(len(p))
+	for len(p) > 0 {
+		n := copy(rb.data[rb.pos:], p)
+		p = p[n:]
+		rb.pos += n
+		if rb.pos >= rb.size {
+			rb.pos = 0
 			rb.full = true
 		}
 	}
-	rb.total += uint64(len(p))
 }
 
 // TotalWritten returns the monotonic count of bytes written to the buffer.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -127,11 +127,33 @@ func (d *DB) createTables() error {
 
 // --- Tasks ---
 
+// taskColumns is the canonical column list for task queries.
+const taskColumns = `id, name, status, project, branch, prompt, backend, worktree, agent_pid, session_id, created_at, started_at, ended_at`
+
+// scanner is implemented by both *sql.Row and *sql.Rows.
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+// scanTask reads a task from a row using the canonical column order.
+func scanTask(row scanner) (*model.Task, error) {
+	t := &model.Task{}
+	var status, createdAt, startedAt, endedAt string
+	if err := row.Scan(&t.ID, &t.Name, &status, &t.Project, &t.Branch, &t.Prompt, &t.Backend, &t.Worktree, &t.AgentPID, &t.SessionID, &createdAt, &startedAt, &endedAt); err != nil {
+		return nil, err
+	}
+	t.Status, _ = model.ParseStatus(status)
+	t.CreatedAt = parseTime(createdAt)
+	t.StartedAt = parseTime(startedAt)
+	t.EndedAt = parseTime(endedAt)
+	return t, nil
+}
+
 func (d *DB) Tasks() []*model.Task {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	rows, err := d.conn.Query(`SELECT id, name, status, project, branch, prompt, backend, worktree, agent_pid, session_id, created_at, started_at, ended_at FROM tasks ORDER BY created_at ASC`)
+	rows, err := d.conn.Query(`SELECT ` + taskColumns + ` FROM tasks ORDER BY created_at ASC`)
 	if err != nil {
 		return nil
 	}
@@ -139,16 +161,9 @@ func (d *DB) Tasks() []*model.Task {
 
 	var tasks []*model.Task
 	for rows.Next() {
-		t := &model.Task{}
-		var status, createdAt, startedAt, endedAt string
-		if err := rows.Scan(&t.ID, &t.Name, &status, &t.Project, &t.Branch, &t.Prompt, &t.Backend, &t.Worktree, &t.AgentPID, &t.SessionID, &createdAt, &startedAt, &endedAt); err != nil {
-			continue
+		if t, err := scanTask(rows); err == nil {
+			tasks = append(tasks, t)
 		}
-		t.Status, _ = model.ParseStatus(status)
-		t.CreatedAt = parseTime(createdAt)
-		t.StartedAt = parseTime(startedAt)
-		t.EndedAt = parseTime(endedAt)
-		tasks = append(tasks, t)
 	}
 	return tasks
 }
@@ -206,20 +221,14 @@ func (d *DB) Get(id string) (*model.Task, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	t := &model.Task{}
-	var status, createdAt, startedAt, endedAt string
-	err := d.conn.QueryRow(`SELECT id, name, status, project, branch, prompt, backend, worktree, agent_pid, session_id, created_at, started_at, ended_at FROM tasks WHERE id=?`, id).
-		Scan(&t.ID, &t.Name, &status, &t.Project, &t.Branch, &t.Prompt, &t.Backend, &t.Worktree, &t.AgentPID, &t.SessionID, &createdAt, &startedAt, &endedAt)
+	row := d.conn.QueryRow(`SELECT `+taskColumns+` FROM tasks WHERE id=?`, id)
+	t, err := scanTask(row)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("task not found: %s", id)
 	}
 	if err != nil {
 		return nil, err
 	}
-	t.Status, _ = model.ParseStatus(status)
-	t.CreatedAt = parseTime(createdAt)
-	t.StartedAt = parseTime(startedAt)
-	t.EndedAt = parseTime(endedAt)
 	return t, nil
 }
 
@@ -228,7 +237,7 @@ func (d *DB) PruneCompleted() ([]*model.Task, error) {
 	defer d.mu.Unlock()
 
 	// Fetch completed tasks first
-	rows, err := d.conn.Query(`SELECT id, name, status, project, branch, prompt, backend, worktree, agent_pid, session_id, created_at, started_at, ended_at FROM tasks WHERE status='complete'`)
+	rows, err := d.conn.Query(`SELECT ` + taskColumns + ` FROM tasks WHERE status='complete'`)
 	if err != nil {
 		return nil, err
 	}
@@ -236,16 +245,9 @@ func (d *DB) PruneCompleted() ([]*model.Task, error) {
 
 	var pruned []*model.Task
 	for rows.Next() {
-		t := &model.Task{}
-		var status, createdAt, startedAt, endedAt string
-		if err := rows.Scan(&t.ID, &t.Name, &status, &t.Project, &t.Branch, &t.Prompt, &t.Backend, &t.Worktree, &t.AgentPID, &t.SessionID, &createdAt, &startedAt, &endedAt); err != nil {
-			continue
+		if t, err := scanTask(rows); err == nil {
+			pruned = append(pruned, t)
 		}
-		t.Status, _ = model.ParseStatus(status)
-		t.CreatedAt = parseTime(createdAt)
-		t.StartedAt = parseTime(startedAt)
-		t.EndedAt = parseTime(endedAt)
-		pruned = append(pruned, t)
 	}
 
 	if len(pruned) == 0 {
@@ -344,16 +346,15 @@ func (d *DB) Config() config.Config {
 	// Load projects
 	cfg.Projects = d.Projects()
 
-	// Load scalar config values
+	// Load scalar config values — hold mutex through iteration
+	// to prevent concurrent writes while the rows cursor is open.
 	d.mu.Lock()
+	kv := make(map[string]string)
 	rows, err := d.conn.Query(`SELECT key, value FROM config`)
-	d.mu.Unlock()
 	if err != nil {
+		d.mu.Unlock()
 		return cfg
 	}
-	defer rows.Close()
-
-	kv := make(map[string]string)
 	for rows.Next() {
 		var k, v string
 		if err := rows.Scan(&k, &v); err != nil {
@@ -361,46 +362,47 @@ func (d *DB) Config() config.Config {
 		}
 		kv[k] = v
 	}
+	rows.Close()
+	d.mu.Unlock()
 
-	if v, ok := kv["defaults.backend"]; ok {
-		cfg.Defaults.Backend = v
+	// String config fields: map config key → pointer to struct field.
+	stringFields := []struct {
+		key  string
+		dest *string
+	}{
+		{"defaults.backend", &cfg.Defaults.Backend},
+		{"keybindings.new", &cfg.Keybindings.New},
+		{"keybindings.attach", &cfg.Keybindings.Attach},
+		{"keybindings.status", &cfg.Keybindings.Status},
+		{"keybindings.delete", &cfg.Keybindings.Delete},
+		{"keybindings.quit", &cfg.Keybindings.Quit},
+		{"keybindings.help", &cfg.Keybindings.Help},
+		{"keybindings.filter", &cfg.Keybindings.Filter},
+		{"keybindings.prompt", &cfg.Keybindings.Prompt},
+		{"keybindings.worktree", &cfg.Keybindings.Worktree},
+		{"ui.theme", &cfg.UI.Theme},
 	}
-	if v, ok := kv["keybindings.new"]; ok {
-		cfg.Keybindings.New = v
+	for _, f := range stringFields {
+		if v, ok := kv[f.key]; ok {
+			*f.dest = v
+		}
 	}
-	if v, ok := kv["keybindings.attach"]; ok {
-		cfg.Keybindings.Attach = v
+
+	// Bool config fields
+	boolFields := []struct {
+		key  string
+		dest *bool
+	}{
+		{"ui.show_elapsed", &cfg.UI.ShowElapsed},
+		{"ui.show_icons", &cfg.UI.ShowIcons},
 	}
-	if v, ok := kv["keybindings.status"]; ok {
-		cfg.Keybindings.Status = v
+	for _, f := range boolFields {
+		if v, ok := kv[f.key]; ok {
+			*f.dest = v == "true"
+		}
 	}
-	if v, ok := kv["keybindings.delete"]; ok {
-		cfg.Keybindings.Delete = v
-	}
-	if v, ok := kv["keybindings.quit"]; ok {
-		cfg.Keybindings.Quit = v
-	}
-	if v, ok := kv["keybindings.help"]; ok {
-		cfg.Keybindings.Help = v
-	}
-	if v, ok := kv["keybindings.filter"]; ok {
-		cfg.Keybindings.Filter = v
-	}
-	if v, ok := kv["keybindings.prompt"]; ok {
-		cfg.Keybindings.Prompt = v
-	}
-	if v, ok := kv["keybindings.worktree"]; ok {
-		cfg.Keybindings.Worktree = v
-	}
-	if v, ok := kv["ui.theme"]; ok {
-		cfg.UI.Theme = v
-	}
-	if v, ok := kv["ui.show_elapsed"]; ok {
-		cfg.UI.ShowElapsed = v == "true"
-	}
-	if v, ok := kv["ui.show_icons"]; ok {
-		cfg.UI.ShowIcons = v == "true"
-	}
+
+	// Optional bool (pointer) config fields
 	if v, ok := kv["ui.cleanup_worktrees"]; ok {
 		val := v == "true"
 		cfg.UI.CleanupWorktrees = &val

--- a/internal/project/detect.go
+++ b/internal/project/detect.go
@@ -2,30 +2,34 @@ package project
 
 import "os"
 
+// projectSignature maps a file marker to its icon and language.
+type projectSignature struct {
+	file string
+	icon string
+	lang string
+}
+
+var signatures = []projectSignature{
+	{"go.mod", "\ue627", "go"},
+	{"Cargo.toml", "\ue7a8", "rust"},
+	{"package.json", "\ue718", "node"},
+	{"tsconfig.json", "\ue628", "typescript"},
+	{"Gemfile", "\ue23e", "ruby"},
+	{"requirements.txt", "\ue73c", "python"},
+	{"setup.py", "\ue73c", "python"},
+	{"pyproject.toml", "\ue73c", "python"},
+	{"pom.xml", "\ue256", "java"},
+	{"build.gradle", "\ue256", "java"},
+	{"mix.exs", "\ue62d", "elixir"},
+	{"Makefile", "\ue615", ""},
+	{".git", "\ue725", ""},
+}
+
 // DetectIcon returns a Nerd Font icon based on project files found at the given path.
 func DetectIcon(path string) string {
-	checks := []struct {
-		file string
-		icon string
-	}{
-		{"go.mod", "\ue627"},         // Go
-		{"Cargo.toml", "\ue7a8"},     // Rust
-		{"package.json", "\ue718"},   // JavaScript/Node
-		{"tsconfig.json", "\ue628"},  // TypeScript
-		{"Gemfile", "\ue23e"},        // Ruby
-		{"requirements.txt", "\ue73c"}, // Python
-		{"setup.py", "\ue73c"},       // Python
-		{"pyproject.toml", "\ue73c"}, // Python
-		{"pom.xml", "\ue256"},        // Java
-		{"build.gradle", "\ue256"},   // Java/Gradle
-		{"mix.exs", "\ue62d"},        // Elixir
-		{"Makefile", "\ue615"},       // Generic/Make
-		{".git", "\ue725"},           // Git repo fallback
-	}
-
-	for _, c := range checks {
-		if _, err := os.Stat(path + "/" + c.file); err == nil {
-			return c.icon
+	for _, s := range signatures {
+		if _, err := os.Stat(path + "/" + s.file); err == nil {
+			return s.icon
 		}
 	}
 	return "\uf115" // folder icon fallback
@@ -33,26 +37,12 @@ func DetectIcon(path string) string {
 
 // DetectLanguage returns a language name based on project files.
 func DetectLanguage(path string) string {
-	checks := []struct {
-		file string
-		lang string
-	}{
-		{"go.mod", "go"},
-		{"Cargo.toml", "rust"},
-		{"package.json", "node"},
-		{"tsconfig.json", "typescript"},
-		{"Gemfile", "ruby"},
-		{"requirements.txt", "python"},
-		{"setup.py", "python"},
-		{"pyproject.toml", "python"},
-		{"pom.xml", "java"},
-		{"build.gradle", "java"},
-		{"mix.exs", "elixir"},
-	}
-
-	for _, c := range checks {
-		if _, err := os.Stat(path + "/" + c.file); err == nil {
-			return c.lang
+	for _, s := range signatures {
+		if s.lang == "" {
+			continue
+		}
+		if _, err := os.Stat(path + "/" + s.file); err == nil {
+			return s.lang
 		}
 	}
 	return ""

--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -102,7 +102,6 @@ func (av *AgentView) SetSize(w, h int) {
 		ptyCols := uint16(max(centerW-4, 20))
 		sess.Resize(ptyRows, ptyCols)
 	}
-	_ = centerW // used in View
 }
 
 // UpdateGitStatus handles a git status refresh message.
@@ -545,131 +544,101 @@ func padHeight(s string, h int) string {
 	return strings.Join(lines, "\n")
 }
 
+// keyByteMap maps Bubble Tea key types to their raw terminal byte sequences.
+var keyByteMap = map[tea.KeyType][]byte{
+	tea.KeySpace:     {' '},
+	tea.KeyEnter:     {'\r'},
+	tea.KeyBackspace: {0x7f},
+	tea.KeyTab:       {'\t'},
+	tea.KeyShiftTab:  []byte("\x1b[Z"),
+	tea.KeyEscape:    {0x1b},
+	tea.KeyHome:      []byte("\x1b[H"),
+	tea.KeyEnd:       []byte("\x1b[F"),
+	tea.KeyPgUp:      []byte("\x1b[5~"),
+	tea.KeyPgDown:    []byte("\x1b[6~"),
+	tea.KeyDelete:    []byte("\x1b[3~"),
+	tea.KeyCtrlA:     {0x01},
+	tea.KeyCtrlB:     {0x02},
+	tea.KeyCtrlC:     {0x03},
+	tea.KeyCtrlD:     {0x04},
+	tea.KeyCtrlE:     {0x05},
+	tea.KeyCtrlF:     {0x06},
+	tea.KeyCtrlG:     {0x07},
+	tea.KeyCtrlH:     {0x08},
+	tea.KeyCtrlK:     {0x0b},
+	tea.KeyCtrlL:     {0x0c},
+	tea.KeyCtrlN:     {0x0e},
+	tea.KeyCtrlO:     {0x0f},
+	tea.KeyCtrlP:     {0x10},
+	tea.KeyCtrlR:     {0x12},
+	tea.KeyCtrlS:     {0x13},
+	tea.KeyCtrlT:     {0x14},
+	tea.KeyCtrlU:     {0x15},
+	tea.KeyCtrlV:     {0x16},
+	tea.KeyCtrlW:     {0x17},
+	tea.KeyCtrlX:     {0x18},
+	tea.KeyCtrlY:     {0x19},
+	tea.KeyCtrlZ:     {0x1a},
+	tea.KeyF1:        []byte("\x1bOP"),
+	tea.KeyF2:        []byte("\x1bOQ"),
+	tea.KeyF3:        []byte("\x1bOR"),
+	tea.KeyF4:        []byte("\x1bOS"),
+	tea.KeyF5:        []byte("\x1b[15~"),
+	tea.KeyF6:        []byte("\x1b[17~"),
+	tea.KeyF7:        []byte("\x1b[18~"),
+	tea.KeyF8:        []byte("\x1b[19~"),
+	tea.KeyF9:        []byte("\x1b[20~"),
+	tea.KeyF10:       []byte("\x1b[21~"),
+	tea.KeyF11:       []byte("\x1b[23~"),
+	tea.KeyF12:       []byte("\x1b[24~"),
+}
+
+// altArrowMap maps arrow key types to their Alt-modified escape sequences.
+var altArrowMap = map[tea.KeyType][]byte{
+	tea.KeyUp:    []byte("\x1b[1;3A"),
+	tea.KeyDown:  []byte("\x1b[1;3B"),
+	tea.KeyRight: []byte("\x1b[1;3C"),
+	tea.KeyLeft:  []byte("\x1b[1;3D"),
+}
+
+// arrowMap maps arrow key types to their standard escape sequences.
+var arrowMap = map[tea.KeyType][]byte{
+	tea.KeyUp:    []byte("\x1b[A"),
+	tea.KeyDown:  []byte("\x1b[B"),
+	tea.KeyRight: []byte("\x1b[C"),
+	tea.KeyLeft:  []byte("\x1b[D"),
+}
+
 // keyMsgToBytes converts a Bubble Tea key message to raw terminal bytes.
 func keyMsgToBytes(msg tea.KeyMsg) []byte {
-	switch msg.Type {
-	case tea.KeyRunes:
+	// Runes: raw character input, with Alt prefix when modifier is held
+	if msg.Type == tea.KeyRunes {
 		b := []byte(string(msg.Runes))
 		if msg.Alt {
-			// Option/Alt + key: prepend ESC so the PTY receives e.g. \x1bb (word back)
 			return append([]byte{0x1b}, b...)
 		}
 		return b
-	case tea.KeySpace:
-		return []byte{' '}
-	case tea.KeyEnter:
-		return []byte{'\r'}
-	case tea.KeyBackspace:
-		return []byte{0x7f}
-	case tea.KeyTab:
-		return []byte{'\t'}
-	case tea.KeyShiftTab:
-		return []byte("\x1b[Z")
-	case tea.KeyEscape:
-		return []byte{0x1b}
-	case tea.KeyUp:
-		if msg.Alt {
-			return []byte("\x1b[1;3A")
+	}
+
+	// Arrow keys with Alt modifier
+	if msg.Alt {
+		if b, ok := altArrowMap[msg.Type]; ok {
+			return b
 		}
-		return []byte("\x1b[A")
-	case tea.KeyDown:
-		if msg.Alt {
-			return []byte("\x1b[1;3B")
-		}
-		return []byte("\x1b[B")
-	case tea.KeyRight:
-		if msg.Alt {
-			return []byte("\x1b[1;3C")
-		}
-		return []byte("\x1b[C")
-	case tea.KeyLeft:
-		if msg.Alt {
-			return []byte("\x1b[1;3D")
-		}
-		return []byte("\x1b[D")
-	case tea.KeyHome:
-		return []byte("\x1b[H")
-	case tea.KeyEnd:
-		return []byte("\x1b[F")
-	case tea.KeyPgUp:
-		return []byte("\x1b[5~")
-	case tea.KeyPgDown:
-		return []byte("\x1b[6~")
-	case tea.KeyDelete:
-		return []byte("\x1b[3~")
-	case tea.KeyCtrlA:
-		return []byte{0x01}
-	case tea.KeyCtrlB:
-		return []byte{0x02}
-	case tea.KeyCtrlC:
-		return []byte{0x03}
-	case tea.KeyCtrlD:
-		return []byte{0x04}
-	case tea.KeyCtrlE:
-		return []byte{0x05}
-	case tea.KeyCtrlF:
-		return []byte{0x06}
-	case tea.KeyCtrlG:
-		return []byte{0x07}
-	case tea.KeyCtrlH:
-		return []byte{0x08}
-	case tea.KeyCtrlK:
-		return []byte{0x0b}
-	case tea.KeyCtrlL:
-		return []byte{0x0c}
-	case tea.KeyCtrlN:
-		return []byte{0x0e}
-	case tea.KeyCtrlO:
-		return []byte{0x0f}
-	case tea.KeyCtrlP:
-		return []byte{0x10}
-	case tea.KeyCtrlR:
-		return []byte{0x12}
-	case tea.KeyCtrlS:
-		return []byte{0x13}
-	case tea.KeyCtrlT:
-		return []byte{0x14}
-	case tea.KeyCtrlU:
-		return []byte{0x15}
-	case tea.KeyCtrlV:
-		return []byte{0x16}
-	case tea.KeyCtrlW:
-		return []byte{0x17}
-	case tea.KeyCtrlX:
-		return []byte{0x18}
-	case tea.KeyCtrlY:
-		return []byte{0x19}
-	case tea.KeyCtrlZ:
-		return []byte{0x1a}
-	case tea.KeyF1:
-		return []byte("\x1bOP")
-	case tea.KeyF2:
-		return []byte("\x1bOQ")
-	case tea.KeyF3:
-		return []byte("\x1bOR")
-	case tea.KeyF4:
-		return []byte("\x1bOS")
-	case tea.KeyF5:
-		return []byte("\x1b[15~")
-	case tea.KeyF6:
-		return []byte("\x1b[17~")
-	case tea.KeyF7:
-		return []byte("\x1b[18~")
-	case tea.KeyF8:
-		return []byte("\x1b[19~")
-	case tea.KeyF9:
-		return []byte("\x1b[20~")
-	case tea.KeyF10:
-		return []byte("\x1b[21~")
-	case tea.KeyF11:
-		return []byte("\x1b[23~")
-	case tea.KeyF12:
-		return []byte("\x1b[24~")
+	}
+
+	// Arrow keys without modifier
+	if b, ok := arrowMap[msg.Type]; ok {
+		return b
+	}
+
+	// All other keys
+	if b, ok := keyByteMap[msg.Type]; ok {
+		return b
 	}
 
 	// Fallback: use the string representation
-	s := msg.String()
-	if s != "" {
+	if s := msg.String(); s != "" {
 		return []byte(s)
 	}
 	return nil

--- a/internal/ui/newproject.go
+++ b/internal/ui/newproject.go
@@ -132,17 +132,7 @@ func (f *NewProjectForm) SetSize(w, h int) {
 }
 
 func (f NewProjectForm) modalWidth() int {
-	w := f.width * 2 / 5
-	if w < 50 {
-		w = 50
-	}
-	if w > 80 {
-		w = 80
-	}
-	if w > f.width-4 {
-		w = f.width - 4
-	}
-	return w
+	return clampModalWidth(f.width)
 }
 
 func (f NewProjectForm) View() string {

--- a/internal/ui/newtask.go
+++ b/internal/ui/newtask.go
@@ -29,7 +29,6 @@ type NewTaskForm struct {
 const (
 	fieldProject = 0
 	fieldPrompt  = 1
-	fieldCount   = 2
 )
 
 func NewNewTaskForm(theme Theme, projects map[string]config.Project) NewTaskForm {
@@ -153,17 +152,7 @@ func (f *NewTaskForm) SetSize(w, h int) {
 }
 
 func (f NewTaskForm) modalWidth() int {
-	w := f.width * 2 / 5
-	if w < 50 {
-		w = 50
-	}
-	if w > 80 {
-		w = 80
-	}
-	if w > f.width-4 {
-		w = f.width - 4
-	}
-	return w
+	return clampModalWidth(f.width)
 }
 
 func (f NewTaskForm) View() string {

--- a/internal/ui/projectlist.go
+++ b/internal/ui/projectlist.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -41,11 +42,9 @@ func (pl *ProjectList) SetProjects(projects map[string]config.Project) {
 }
 
 func sortProjects(entries []projectEntry) {
-	for i := 1; i < len(entries); i++ {
-		for j := i; j > 0 && entries[j].Name < entries[j-1].Name; j-- {
-			entries[j], entries[j-1] = entries[j-1], entries[j]
-		}
-	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name < entries[j].Name
+	})
 }
 
 func (pl *ProjectList) SetSize(w, h int) {

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -1,11 +1,8 @@
 package ui
 
 import (
-	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -1013,8 +1010,6 @@ func (m Model) renderProjectDetail() string {
 	return lipgloss.NewStyle().Width(rightWidth).Height(contentHeight).Render(b.String())
 }
 
-
-
 func (m Model) emptyStateView() string {
 	banner := renderBanner(m.width)
 	hint := m.theme.Dimmed.Render("Press [n] to create your first task")
@@ -1049,35 +1044,32 @@ func (m Model) promptView() string {
 		m.theme.Help.Render("  Press any key to close")
 }
 
-func (m Model) confirmDeleteProjectView() string {
-	entry := m.projectlist.Selected()
-	if entry == nil {
-		return ""
-	}
-
-	// Build modal content
-	title := m.theme.Title.Render("Delete project?")
-	name := "  " + m.theme.Normal.Render(entry.Name)
-	path := "  " + m.theme.Dimmed.Render(entry.Project.Path)
-	hint := m.theme.Help.Render("  [enter] confirm  [esc] cancel")
-
-	body := title + "\n\n" + name + "\n" + path + "\n\n" + hint
-
-	// Render as a bordered modal centered on screen
-	modalWidth := 50
-	if m.width > 0 && modalWidth > m.width-4 {
-		modalWidth = m.width - 4
+// renderCenteredModal renders a bordered modal centered on screen.
+func (m Model) renderCenteredModal(body string, preferredWidth int) string {
+	w := preferredWidth
+	if m.width > 0 && w > m.width-4 {
+		w = m.width - 4
 	}
 	modal := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color("238")).
 		Padding(1, 2).
-		Width(modalWidth).
+		Width(w).
 		Render(body)
+	return lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, modal)
+}
 
-	// Center horizontally and vertically
-	centered := lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, modal)
-	return centered
+func (m Model) confirmDeleteProjectView() string {
+	entry := m.projectlist.Selected()
+	if entry == nil {
+		return ""
+	}
+	title := m.theme.Title.Render("Delete project?")
+	name := "  " + m.theme.Normal.Render(entry.Name)
+	path := "  " + m.theme.Dimmed.Render(entry.Project.Path)
+	hint := m.theme.Help.Render("  [enter] confirm  [esc] cancel")
+	body := title + "\n\n" + name + "\n" + path + "\n\n" + hint
+	return m.renderCenteredModal(body, 50)
 }
 
 func (m Model) confirmDeleteView() string {
@@ -1085,25 +1077,11 @@ func (m Model) confirmDeleteView() string {
 	if t == nil {
 		return ""
 	}
-
 	title := m.theme.Title.Render("Delete task?")
 	name := "  " + m.theme.Normal.Render(t.Name)
 	hint := m.theme.Help.Render("  [enter] confirm  [esc] cancel")
-
 	body := title + "\n\n" + name + "\n\n" + hint
-
-	modalWidth := 50
-	if m.width > 0 && modalWidth > m.width-4 {
-		modalWidth = m.width - 4
-	}
-	modal := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("238")).
-		Padding(1, 2).
-		Width(modalWidth).
-		Render(body)
-
-	return lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, modal)
+	return m.renderCenteredModal(body, 50)
 }
 
 func (m Model) confirmDestroyView() string {
@@ -1119,164 +1097,11 @@ func (m Model) confirmDestroyView() string {
 	if t.Branch != "" {
 		details = append(details, "  "+m.theme.Dimmed.Render("branch: "+t.Branch))
 	}
-
 	title := m.theme.Title.Render("Destroy task?")
 	subtitle := m.theme.Help.Render("  This will terminate the agent, remove the worktree and branch, and delete the task.")
 	hint := m.theme.Help.Render("  [enter] confirm  [esc] cancel")
-
 	body := title + "\n" + subtitle + "\n\n" +
 		strings.Join(details, "\n") + "\n\n" + hint
-
-	modalWidth := 60
-	if m.width > 0 && modalWidth > m.width-4 {
-		modalWidth = m.width - 4
-	}
-	modal := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("238")).
-		Padding(1, 2).
-		Width(modalWidth).
-		Render(body)
-
-	return lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, modal)
+	return m.renderCenteredModal(body, 60)
 }
 
-func dirExists(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && info.IsDir()
-}
-
-// discoverClaudeWorktree looks for a Claude Code worktree under baseDir/.claude/worktrees/
-// that matches the given task name. Worktrees are created as "argus/<taskName>" so we first
-// check the expected path directly, then fall back to git worktree list and directory scan.
-func discoverClaudeWorktree(baseDir, taskName string) string {
-	claudeWtDir := filepath.Join(baseDir, ".claude", "worktrees")
-	if !dirExists(claudeWtDir) {
-		return ""
-	}
-
-	if taskName == "" {
-		return ""
-	}
-
-	// Fast path: check the expected path directly (argus/<task-name>).
-	expected := filepath.Join(claudeWtDir, "argus", taskName)
-	if _, err := os.Stat(filepath.Join(expected, ".git")); err == nil {
-		return expected
-	}
-
-	// Try git worktree list for accuracy
-	out, err := runGit(baseDir, "worktree", "list", "--porcelain")
-	if err == nil {
-		// First pass: look for a worktree matching the task name
-		for _, block := range strings.Split(out, "\n\n") {
-			for _, line := range strings.Split(block, "\n") {
-				if strings.HasPrefix(line, "worktree ") {
-					wt := strings.TrimPrefix(line, "worktree ")
-					if !strings.HasPrefix(wt, claudeWtDir+string(filepath.Separator)) && !strings.HasPrefix(wt, claudeWtDir+"/") {
-						continue
-					}
-					// Match: worktree path ends with /<taskName>
-					if filepath.Base(wt) == taskName {
-						return wt
-					}
-				}
-			}
-		}
-	}
-
-	// Fallback: scan directory recursively for a worktree matching the task name
-	// Worktrees may be nested (e.g., .claude/worktrees/argus/<taskName>/)
-	return findWorktreeByName(claudeWtDir, taskName)
-}
-
-// findWorktreeByName recursively scans a directory for a git worktree whose
-// directory name matches the given task name. Returns empty string if not found.
-func findWorktreeByName(dir, taskName string) string {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return ""
-	}
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		candidate := filepath.Join(dir, e.Name())
-		if e.Name() == taskName {
-			// Verify it's a git worktree (has .git file)
-			if _, err := os.Stat(filepath.Join(candidate, ".git")); err == nil {
-				return candidate
-			}
-		}
-		// Recurse one level (worktrees are at .claude/worktrees/<repo>/<name>/)
-		if found := findWorktreeByName(candidate, taskName); found != "" {
-			return found
-		}
-	}
-	return ""
-}
-
-// killStaleProcess sends SIGTERM to a process if it's still alive and waits
-// briefly for it to exit. Used to clean up orphaned agent processes from a
-// previous Argus session before resuming with --resume.
-func killStaleProcess(pid int) {
-	if pid <= 0 {
-		return
-	}
-	// Signal 0 checks if the process exists without sending a signal.
-	if syscall.Kill(pid, 0) != nil {
-		return // already dead
-	}
-	_ = syscall.Kill(pid, syscall.SIGTERM)
-
-	// Wait up to 2 seconds for the process to exit so that any session
-	// locks it holds are released before we start a new --resume process.
-	for i := 0; i < 20; i++ {
-		time.Sleep(100 * time.Millisecond)
-		if syscall.Kill(pid, 0) != nil {
-			return // exited
-		}
-	}
-	// Force-kill if it's still hanging around.
-	_ = syscall.Kill(pid, syscall.SIGKILL)
-}
-
-// removeWorktreeAndBranch removes a git worktree and deletes its associated branch.
-// repoDir is the main repository directory used for branch deletion; if empty,
-// the worktree's parent directory is used as a fallback.
-func removeWorktreeAndBranch(worktreePath, branch, repoDir string) {
-	removeWorktree(worktreePath)
-	if branch == "" {
-		return
-	}
-	// Use main repo dir for branch deletion; fall back to worktree parent.
-	dir := repoDir
-	if dir == "" {
-		dir = filepath.Dir(worktreePath)
-	}
-	deleteBranch(dir, branch)
-}
-
-// deleteBranch force-deletes a local git branch.
-func deleteBranch(repoDir, branch string) {
-	if branch == "" || repoDir == "" {
-		return
-	}
-	cmd := exec.Command("git", "branch", "-D", branch)
-	cmd.Dir = repoDir
-	_ = cmd.Run()
-}
-
-func removeWorktree(worktreePath string) {
-	if !dirExists(worktreePath) {
-		return
-	}
-	// Find the parent repo by looking for .git in the worktree's parent chain.
-	// Git worktree remove needs to run from within the main repo or the worktree itself.
-	cmd := exec.Command("git", "worktree", "remove", "--force", filepath.Clean(worktreePath))
-	cmd.Dir = filepath.Dir(worktreePath)
-	if err := cmd.Run(); err != nil {
-		// Fallback: just remove the directory
-		_ = os.RemoveAll(worktreePath)
-	}
-}

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -23,6 +23,22 @@ type Theme struct {
 	Error       lipgloss.Style
 }
 
+// clampModalWidth computes a modal width from the total terminal width,
+// clamping to a reasonable range (50–80, constrained to width-4).
+func clampModalWidth(totalWidth int) int {
+	w := totalWidth * 2 / 5
+	if w < 50 {
+		w = 50
+	}
+	if w > 80 {
+		w = 80
+	}
+	if w > totalWidth-4 {
+		w = totalWidth - 4
+	}
+	return w
+}
+
 func DefaultTheme() Theme {
 	return Theme{
 		Title: lipgloss.NewStyle().

--- a/internal/ui/worktree.go
+++ b/internal/ui/worktree.go
@@ -1,0 +1,135 @@
+package ui
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// discoverClaudeWorktree looks for a Claude Code worktree under baseDir/.claude/worktrees/
+// that matches the given task name. Worktrees are created as "argus/<taskName>" so we first
+// check the expected path directly, then fall back to git worktree list and directory scan.
+func discoverClaudeWorktree(baseDir, taskName string) string {
+	claudeWtDir := filepath.Join(baseDir, ".claude", "worktrees")
+	if !dirExists(claudeWtDir) {
+		return ""
+	}
+
+	if taskName == "" {
+		return ""
+	}
+
+	// Fast path: check the expected path directly (argus/<task-name>).
+	expected := filepath.Join(claudeWtDir, "argus", taskName)
+	if _, err := os.Stat(filepath.Join(expected, ".git")); err == nil {
+		return expected
+	}
+
+	// Try git worktree list for accuracy
+	out, err := runGit(baseDir, "worktree", "list", "--porcelain")
+	if err == nil {
+		for _, block := range strings.Split(out, "\n\n") {
+			for _, line := range strings.Split(block, "\n") {
+				if strings.HasPrefix(line, "worktree ") {
+					wt := strings.TrimPrefix(line, "worktree ")
+					if !strings.HasPrefix(wt, claudeWtDir+string(filepath.Separator)) && !strings.HasPrefix(wt, claudeWtDir+"/") {
+						continue
+					}
+					if filepath.Base(wt) == taskName {
+						return wt
+					}
+				}
+			}
+		}
+	}
+
+	// Fallback: scan directory recursively for a worktree matching the task name
+	return findWorktreeByName(claudeWtDir, taskName)
+}
+
+// findWorktreeByName recursively scans a directory for a git worktree whose
+// directory name matches the given task name. Returns empty string if not found.
+func findWorktreeByName(dir, taskName string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(dir, e.Name())
+		if e.Name() == taskName {
+			if _, err := os.Stat(filepath.Join(candidate, ".git")); err == nil {
+				return candidate
+			}
+		}
+		if found := findWorktreeByName(candidate, taskName); found != "" {
+			return found
+		}
+	}
+	return ""
+}
+
+// killStaleProcess sends SIGTERM to a process if it's still alive and waits
+// briefly for it to exit. Used to clean up orphaned agent processes from a
+// previous Argus session before resuming with --resume.
+func killStaleProcess(pid int) {
+	if pid <= 0 {
+		return
+	}
+	if syscall.Kill(pid, 0) != nil {
+		return // already dead
+	}
+	_ = syscall.Kill(pid, syscall.SIGTERM)
+
+	for i := 0; i < 20; i++ {
+		time.Sleep(100 * time.Millisecond)
+		if syscall.Kill(pid, 0) != nil {
+			return
+		}
+	}
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+}
+
+// removeWorktreeAndBranch removes a git worktree and deletes its associated branch.
+func removeWorktreeAndBranch(worktreePath, branch, repoDir string) {
+	removeWorktree(worktreePath)
+	if branch == "" {
+		return
+	}
+	dir := repoDir
+	if dir == "" {
+		dir = filepath.Dir(worktreePath)
+	}
+	deleteBranch(dir, branch)
+}
+
+// deleteBranch force-deletes a local git branch.
+func deleteBranch(repoDir, branch string) {
+	if branch == "" || repoDir == "" {
+		return
+	}
+	cmd := exec.Command("git", "branch", "-D", branch)
+	cmd.Dir = repoDir
+	_ = cmd.Run()
+}
+
+func removeWorktree(worktreePath string) {
+	if !dirExists(worktreePath) {
+		return
+	}
+	cmd := exec.Command("git", "worktree", "remove", "--force", filepath.Clean(worktreePath))
+	cmd.Dir = filepath.Dir(worktreePath)
+	if err := cmd.Run(); err != nil {
+		_ = os.RemoveAll(worktreePath)
+	}
+}


### PR DESCRIPTION
- Convert 128-line keyMsgToBytes switch to map lookup tables
- Extract renderCenteredModal helper for 3 duplicate confirm dialogs
- Extract shared clampModalWidth, scanTask/taskColumns, and signature table helpers
- Fix mutex race in DB.Config() (released before rows iteration)
- Optimize ringBuffer.Write with bulk copy()
- Move worktree/process infrastructure from root.go to worktree.go
- Fix duplicate Context Directory section in CLAUDE.md

Net: -218 lines of production code, 0 test regressions

Co-Authored-By: Claude <noreply@anthropic.com>