### PR TITLE
Fix black cursor in agent view by preserving cell colors

### DIFF
--- a/internal/ui/preview.go
+++ b/internal/ui/preview.go
@@ -156,10 +156,10 @@ func renderLine(vt vt10x.Terminal, y, cols int, cursorX int) string {
 		}
 
 		if x == cursorX {
-			// Render cursor cell with reverse video
-			b.WriteString("\x1b[7m")
+			// Render cursor cell with reverse video, preserving cell colors
+			b.WriteString(buildSGR(cell.FG, cell.BG, cell.Mode|vtAttrReverse))
 			b.WriteRune(ch)
-			b.WriteString("\x1b[27m")
+			b.WriteString("\x1b[0m")
 			// Force SGR re-emit on next cell
 			active = false
 		} else {

--- a/internal/ui/preview_test.go
+++ b/internal/ui/preview_test.go
@@ -32,8 +32,8 @@ func TestRenderLine_WithCursor(t *testing.T) {
 
 	// Cursor at position 2 (on the 'l')
 	line := renderLine(vt, 0, 20, 2)
-	// Should contain reverse video escape for the cursor
-	if !strings.Contains(line, "\x1b[7m") {
+	// Should contain reverse video attribute (;7 in SGR sequence)
+	if !strings.Contains(line, ";7m") && !strings.Contains(line, ";7;") {
 		t.Error("renderLine with cursor should contain reverse video escape")
 	}
 }
@@ -47,7 +47,7 @@ func TestRenderLine_CursorBeyondText(t *testing.T) {
 	// Cursor at position 5, beyond "hi" (at position 2 would be after text)
 	line := renderLine(vt, 0, 20, 5)
 	// Should still render cursor (extends lastCol)
-	if !strings.Contains(line, "\x1b[7m") {
+	if !strings.Contains(line, ";7m") && !strings.Contains(line, ";7;") {
 		t.Error("renderLine with cursor beyond text should still render cursor")
 	}
 }


### PR DESCRIPTION
Cursor rendering used bare reverse video without the cell's actual colors, causing a black cursor. Now emits the cell's SGR attributes with the reverse bit, ensuring correct cursor appearance.

Co-Authored-By: Claude <noreply@anthropic.com>