### PR TITLE
Center focus label in agent status bar and fix tasks view extra line

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -408,7 +408,7 @@ func (av AgentView) renderStatusBar() string {
 	}
 	right := strings.Join(parts, "  ") + " "
 
-	// Focus indicator
+	// Focus indicator — truly centered on the bar
 	var focusLabel string
 	switch av.focus {
 	case panelGit:
@@ -420,14 +420,19 @@ func (av AgentView) renderStatusBar() string {
 	}
 	center := av.theme.Section.Render(" [" + focusLabel + "] ")
 
-	gap1 := av.width - lipgloss.Width(left) - lipgloss.Width(center) - lipgloss.Width(right)
-	leftGap := gap1 / 2
-	rightGap := gap1 - leftGap
-	if leftGap < 0 {
-		leftGap = 0
+	centerW := lipgloss.Width(center)
+	leftW := lipgloss.Width(left)
+	rightW := lipgloss.Width(right)
+
+	// Place center at the true midpoint of the bar
+	centerStart := (av.width - centerW) / 2
+	leftGap := centerStart - leftW
+	if leftGap < 1 {
+		leftGap = 1
 	}
-	if rightGap < 0 {
-		rightGap = 0
+	rightGap := av.width - leftW - leftGap - centerW - rightW
+	if rightGap < 1 {
+		rightGap = 1
 	}
 
 	bar := av.theme.StatusBar.

--- a/internal/ui/agentview_test.go
+++ b/internal/ui/agentview_test.go
@@ -397,6 +397,57 @@ func TestAgentView_RenderStatusBar(t *testing.T) {
 	}
 }
 
+func TestAgentView_RenderStatusBar_FocusLabelCentered(t *testing.T) {
+	av := newTestAgentView()
+	av.focus = panelAgent
+	bar := av.renderStatusBar()
+
+	// Strip ANSI to find the position of [TERMINAL]
+	plain := stripANSI(bar)
+	idx := strings.Index(plain, "[TERMINAL]")
+	if idx < 0 {
+		t.Fatal("expected [TERMINAL] in status bar")
+	}
+	// The label should be approximately centered. lipgloss styles may add
+	// extra padding characters, so we allow a small tolerance.
+	labelLen := len("[TERMINAL]")
+	labelCenter := idx + labelLen/2
+	barCenter := len(plain) / 2
+	if abs(labelCenter-barCenter) > 5 {
+		t.Errorf("[TERMINAL] not centered: label center=%d, bar center=%d (bar len=%d)",
+			labelCenter, barCenter, len(plain))
+	}
+
+	// [TERMINAL] should be closer to center than the task name on the left
+	taskIdx := strings.Index(plain, "test task")
+	if taskIdx >= 0 && idx <= taskIdx {
+		t.Error("[TERMINAL] should appear after the task name, not before")
+	}
+
+	// Verify for FILES panel too
+	av.focus = panelFiles
+	bar = av.renderStatusBar()
+	plain = stripANSI(bar)
+	idx = strings.Index(plain, "[FILES]")
+	if idx < 0 {
+		t.Fatal("expected [FILES] in status bar")
+	}
+	labelLen = len("[FILES]")
+	labelCenter = idx + labelLen/2
+	barCenter = len(plain) / 2
+	if abs(labelCenter-barCenter) > 5 {
+		t.Errorf("[FILES] not centered: label center=%d, bar center=%d (bar len=%d)",
+			labelCenter, barCenter, len(plain))
+	}
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
 func TestAgentView_RenderStatusBar_Exited(t *testing.T) {
 	av := newTestAgentView()
 	// No session → should show "(exited — ctrl+q to return)"

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -871,7 +871,8 @@ func (m Model) View() string {
 }
 
 func (m Model) padToBottom(content, bar string) string {
-	contentHeight := m.height - lipgloss.Height(bar) - 1
+	barHeight := lipgloss.Height(bar)
+	contentHeight := m.height - barHeight
 	if contentHeight < 0 {
 		contentHeight = 0
 	}

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -863,6 +863,25 @@ func TestModel_PadToBottom(t *testing.T) {
 	}
 }
 
+func TestModel_PadToBottom_NoExtraLine(t *testing.T) {
+	m := testModel(t)
+	m.height = 20
+
+	bar := "status bar"
+	content := "line1\nline2"
+	result := m.padToBottom(content, bar)
+
+	// Total lines should equal m.height (content fills to height - barHeight, then bar)
+	lines := strings.Split(result, "\n")
+	if len(lines) != m.height {
+		t.Errorf("padToBottom produced %d lines, want %d", len(lines), m.height)
+	}
+	// Last line should be the bar
+	if lines[len(lines)-1] != bar {
+		t.Errorf("last line = %q, want %q", lines[len(lines)-1], bar)
+	}
+}
+
 func TestModel_WindowSizeMsg(t *testing.T) {
 	m := testModel(t)
 	updated, cmd := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})


### PR DESCRIPTION
Center the [TERMINAL]/[FILES] focus indicator in the agent view status bar using true center positioning. Fix off-by-one in padToBottom that caused an extra blank line at the bottom of the tasks view.

Co-Authored-By: Claude <noreply@anthropic.com>