### PR TITLE
Polish: eliminate duplication and extract shared abstractions

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -16,6 +16,12 @@ const defaultBufSize = 256 * 1024 // 256KB ring buffer
 // idleThreshold is how long without output before a session is considered idle.
 const idleThreshold = 3 * time.Second
 
+// DefaultTermRows and DefaultTermCols are fallback PTY dimensions.
+const (
+	DefaultTermRows uint16 = 24
+	DefaultTermCols uint16 = 80
+)
+
 // Session manages a single agent process with PTY.
 type Session struct {
 	TaskID string
@@ -39,9 +45,9 @@ type Session struct {
 func StartSession(taskID string, cmd *exec.Cmd, rows, cols uint16) (*Session, error) {
 	size := &pty.Winsize{Rows: rows, Cols: cols}
 	if rows == 0 || cols == 0 {
-		size = &pty.Winsize{Rows: 24, Cols: 80}
-		rows = 24
-		cols = 80
+		size = &pty.Winsize{Rows: DefaultTermRows, Cols: DefaultTermCols}
+		rows = DefaultTermRows
+		cols = DefaultTermCols
 	}
 
 	ptmx, err := pty.StartWithSize(cmd, size)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -223,7 +224,7 @@ func (d *DB) Get(id string) (*model.Task, error) {
 
 	row := d.conn.QueryRow(`SELECT `+taskColumns+` FROM tasks WHERE id=?`, id)
 	t, err := scanTask(row)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("task not found: %s", id)
 	}
 	if err != nil {

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,7 +22,7 @@ func (d *DB) migrate() error {
 	if err == nil {
 		return nil // already migrated
 	}
-	if err != sql.ErrNoRows && err.Error() != "no rows in result set" {
+	if !errors.Is(err, sql.ErrNoRows) {
 		// Table exists but is empty — fall through to migrate.
 		// Any other error means we should check if it's just empty.
 		var count int

--- a/internal/project/detect.go
+++ b/internal/project/detect.go
@@ -1,6 +1,9 @@
 package project
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 // projectSignature maps a file marker to its icon and language.
 type projectSignature struct {
@@ -25,25 +28,25 @@ var signatures = []projectSignature{
 	{".git", "\ue725", ""},
 }
 
-// DetectIcon returns a Nerd Font icon based on project files found at the given path.
-func DetectIcon(path string) string {
+// Detect returns the Nerd Font icon and language name for the project at path.
+// Does a single pass over signatures, returning the first match.
+func Detect(path string) (icon, lang string) {
 	for _, s := range signatures {
-		if _, err := os.Stat(path + "/" + s.file); err == nil {
-			return s.icon
+		if _, err := os.Stat(filepath.Join(path, s.file)); err == nil {
+			return s.icon, s.lang
 		}
 	}
-	return "\uf115" // folder icon fallback
+	return "\uf115", "" // folder icon fallback
+}
+
+// DetectIcon returns a Nerd Font icon based on project files found at the given path.
+func DetectIcon(path string) string {
+	icon, _ := Detect(path)
+	return icon
 }
 
 // DetectLanguage returns a language name based on project files.
 func DetectLanguage(path string) string {
-	for _, s := range signatures {
-		if s.lang == "" {
-			continue
-		}
-		if _, err := os.Stat(path + "/" + s.file); err == nil {
-			return s.lang
-		}
-	}
-	return ""
+	_, lang := Detect(path)
+	return lang
 }

--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 	"time"
@@ -133,7 +132,7 @@ func (av *AgentView) NeedsGitRefresh() bool {
 	if av.taskID == "" {
 		return false
 	}
-	return time.Since(av.lastGitRefresh) > 3*time.Second
+	return time.Since(av.lastGitRefresh) > gitRefreshInterval
 }
 
 // FocusLeft moves focus to the left panel.
@@ -402,68 +401,15 @@ func (av *AgentView) formatTerminalOutput(raw []byte, panelW, panelH int) string
 		}
 	}
 
-	// Size the virtual terminal tall enough to capture all content.
-	// Count newlines to estimate how many rows the output needs, then
-	// add the display height for the active screen area.
-	vtRows := dispH
-	if n := bytes.Count(raw, []byte{'\n'}); n > vtRows {
-		vtRows = n + dispH
-	}
-	// Also account for long lines that wrap.
-	if vtCols > 0 {
-		wrappedEstimate := len(raw)/vtCols + dispH
-		if wrappedEstimate > vtRows {
-			vtRows = wrappedEstimate
-		}
-	}
-	vt := vt10x.New(vt10x.WithSize(vtCols, vtRows))
-	vt.Write(raw)
-
-	vt.Lock()
-	defer vt.Unlock()
-
-	// Get cursor position for rendering
-	cur := vt.Cursor()
-	curVisible := vt.CursorVisible()
-
-	var lines []string
-	for y := 0; y < vtRows; y++ {
-		cursorX := -1
-		if curVisible && y == cur.Y {
-			cursorX = cur.X
-		}
-		line := renderLine(vt, y, vtCols, cursorX)
-		lines = append(lines, line)
-	}
-
-	// Trim trailing empty lines
-	for len(lines) > 0 && stripANSI(lines[len(lines)-1]) == "" {
-		lines = lines[:len(lines)-1]
-	}
+	vtRows := estimateVTRows(raw, vtCols, dispH)
+	lines := replayVT10X(raw, vtCols, vtRows, true)
 
 	if len(lines) == 0 {
 		return ""
 	}
 
-	// Cache all lines for scrollback
 	av.cachedLines = lines
-
-	// Apply scroll offset: select a window into the lines
-	end := len(lines) - av.scrollOffset
-	if end < 0 {
-		end = 0
-	}
-	start := end - dispH
-	if start < 0 {
-		start = 0
-	}
-	visible := lines[start:end]
-
-	for i, line := range visible {
-		visible[i] = ansi.Truncate(line, dispW, "\x1b[0m")
-	}
-
-	return strings.Join(visible, "\n")
+	return av.windowLines(lines, dispW, dispH)
 }
 
 func (av AgentView) renderStatusBar() string {
@@ -526,9 +472,8 @@ func (av AgentView) renderStatusBar() string {
 	return bar
 }
 
-// sliceCachedLines selects the visible window from cachedLines using scrollOffset.
-func (av *AgentView) sliceCachedLines(dispW, dispH int) string {
-	lines := av.cachedLines
+// windowLines applies scroll offset to select a visible window, then truncates.
+func (av *AgentView) windowLines(lines []string, dispW, dispH int) string {
 	if len(lines) == 0 {
 		return ""
 	}
@@ -546,6 +491,11 @@ func (av *AgentView) sliceCachedLines(dispW, dispH int) string {
 		result[i] = ansi.Truncate(line, dispW, "\x1b[0m")
 	}
 	return strings.Join(result, "\n")
+}
+
+// sliceCachedLines selects the visible window from cachedLines using scrollOffset.
+func (av *AgentView) sliceCachedLines(dispW, dispH int) string {
+	return av.windowLines(av.cachedLines, dispW, dispH)
 }
 
 // terminalDisplaySize returns the usable display dimensions inside the terminal panel.
@@ -633,102 +583,3 @@ func padHeight(s string, h int) string {
 	return strings.Join(lines, "\n")
 }
 
-// keyByteMap maps Bubble Tea key types to their raw terminal byte sequences.
-var keyByteMap = map[tea.KeyType][]byte{
-	tea.KeySpace:     {' '},
-	tea.KeyEnter:     {'\r'},
-	tea.KeyBackspace: {0x7f},
-	tea.KeyTab:       {'\t'},
-	tea.KeyShiftTab:  []byte("\x1b[Z"),
-	tea.KeyEscape:    {0x1b},
-	tea.KeyHome:      []byte("\x1b[H"),
-	tea.KeyEnd:       []byte("\x1b[F"),
-	tea.KeyPgUp:      []byte("\x1b[5~"),
-	tea.KeyPgDown:    []byte("\x1b[6~"),
-	tea.KeyDelete:    []byte("\x1b[3~"),
-	tea.KeyCtrlA:     {0x01},
-	tea.KeyCtrlB:     {0x02},
-	tea.KeyCtrlC:     {0x03},
-	tea.KeyCtrlD:     {0x04},
-	tea.KeyCtrlE:     {0x05},
-	tea.KeyCtrlF:     {0x06},
-	tea.KeyCtrlG:     {0x07},
-	tea.KeyCtrlH:     {0x08},
-	tea.KeyCtrlK:     {0x0b},
-	tea.KeyCtrlL:     {0x0c},
-	tea.KeyCtrlN:     {0x0e},
-	tea.KeyCtrlO:     {0x0f},
-	tea.KeyCtrlP:     {0x10},
-	tea.KeyCtrlR:     {0x12},
-	tea.KeyCtrlS:     {0x13},
-	tea.KeyCtrlT:     {0x14},
-	tea.KeyCtrlU:     {0x15},
-	tea.KeyCtrlV:     {0x16},
-	tea.KeyCtrlW:     {0x17},
-	tea.KeyCtrlX:     {0x18},
-	tea.KeyCtrlY:     {0x19},
-	tea.KeyCtrlZ:     {0x1a},
-	tea.KeyF1:        []byte("\x1bOP"),
-	tea.KeyF2:        []byte("\x1bOQ"),
-	tea.KeyF3:        []byte("\x1bOR"),
-	tea.KeyF4:        []byte("\x1bOS"),
-	tea.KeyF5:        []byte("\x1b[15~"),
-	tea.KeyF6:        []byte("\x1b[17~"),
-	tea.KeyF7:        []byte("\x1b[18~"),
-	tea.KeyF8:        []byte("\x1b[19~"),
-	tea.KeyF9:        []byte("\x1b[20~"),
-	tea.KeyF10:       []byte("\x1b[21~"),
-	tea.KeyF11:       []byte("\x1b[23~"),
-	tea.KeyF12:       []byte("\x1b[24~"),
-}
-
-// altArrowMap maps arrow key types to their Alt-modified escape sequences.
-var altArrowMap = map[tea.KeyType][]byte{
-	tea.KeyUp:    []byte("\x1b[1;3A"),
-	tea.KeyDown:  []byte("\x1b[1;3B"),
-	tea.KeyRight: []byte("\x1b[1;3C"),
-	tea.KeyLeft:  []byte("\x1b[1;3D"),
-}
-
-// arrowMap maps arrow key types to their standard escape sequences.
-var arrowMap = map[tea.KeyType][]byte{
-	tea.KeyUp:    []byte("\x1b[A"),
-	tea.KeyDown:  []byte("\x1b[B"),
-	tea.KeyRight: []byte("\x1b[C"),
-	tea.KeyLeft:  []byte("\x1b[D"),
-}
-
-// keyMsgToBytes converts a Bubble Tea key message to raw terminal bytes.
-func keyMsgToBytes(msg tea.KeyMsg) []byte {
-	// Runes: raw character input, with Alt prefix when modifier is held
-	if msg.Type == tea.KeyRunes {
-		b := []byte(string(msg.Runes))
-		if msg.Alt {
-			return append([]byte{0x1b}, b...)
-		}
-		return b
-	}
-
-	// Arrow keys with Alt modifier
-	if msg.Alt {
-		if b, ok := altArrowMap[msg.Type]; ok {
-			return b
-		}
-	}
-
-	// Arrow keys without modifier
-	if b, ok := arrowMap[msg.Type]; ok {
-		return b
-	}
-
-	// All other keys
-	if b, ok := keyByteMap[msg.Type]; ok {
-		return b
-	}
-
-	// Fallback: use the string representation
-	if s := msg.String(); s != "" {
-		return []byte(s)
-	}
-	return nil
-}

--- a/internal/ui/agentview_test.go
+++ b/internal/ui/agentview_test.go
@@ -302,26 +302,26 @@ func TestAgentView_HandleKey_FilePanelKeys(t *testing.T) {
 
 	// j moves down
 	av.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-	if av.files.cursor != 1 {
-		t.Errorf("after j: cursor = %d, want 1", av.files.cursor)
+	if av.files.scroll.Cursor() != 1 {
+		t.Errorf("after j: cursor = %d, want 1", av.files.scroll.Cursor())
 	}
 
 	// down arrow moves down
 	av.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
-	if av.files.cursor != 2 {
-		t.Errorf("after down: cursor = %d, want 2", av.files.cursor)
+	if av.files.scroll.Cursor() != 2 {
+		t.Errorf("after down: cursor = %d, want 2", av.files.scroll.Cursor())
 	}
 
 	// k moves up
 	av.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
-	if av.files.cursor != 1 {
-		t.Errorf("after k: cursor = %d, want 1", av.files.cursor)
+	if av.files.scroll.Cursor() != 1 {
+		t.Errorf("after k: cursor = %d, want 1", av.files.scroll.Cursor())
 	}
 
 	// up arrow moves up
 	av.HandleKey(tea.KeyMsg{Type: tea.KeyUp})
-	if av.files.cursor != 0 {
-		t.Errorf("after up: cursor = %d, want 0", av.files.cursor)
+	if av.files.scroll.Cursor() != 0 {
+		t.Errorf("after up: cursor = %d, want 0", av.files.scroll.Cursor())
 	}
 }
 

--- a/internal/ui/fileexplorer.go
+++ b/internal/ui/fileexplorer.go
@@ -19,8 +19,7 @@ type FileExplorer struct {
 	width  int
 	height int
 	files  []ChangedFile
-	cursor int
-	offset int
+	scroll ScrollState
 }
 
 func NewFileExplorer(theme Theme) FileExplorer {
@@ -34,28 +33,15 @@ func (fe *FileExplorer) SetSize(w, h int) {
 
 func (fe *FileExplorer) SetFiles(files []ChangedFile) {
 	fe.files = files
-	if fe.cursor >= len(fe.files) {
-		fe.cursor = max(0, len(fe.files)-1)
-	}
+	fe.scroll.ClampCursor(len(fe.files))
 }
 
 func (fe *FileExplorer) CursorUp() {
-	if fe.cursor > 0 {
-		fe.cursor--
-		if fe.cursor < fe.offset {
-			fe.offset = fe.cursor
-		}
-	}
+	fe.scroll.CursorUp()
 }
 
 func (fe *FileExplorer) CursorDown() {
-	if fe.cursor < len(fe.files)-1 {
-		fe.cursor++
-		visible := fe.visibleRows()
-		if fe.cursor >= fe.offset+visible {
-			fe.offset = fe.cursor - visible + 1
-		}
-	}
+	fe.scroll.CursorDown(len(fe.files), fe.visibleRows())
 }
 
 func (fe *FileExplorer) visibleRows() int {
@@ -69,17 +55,10 @@ func (fe *FileExplorer) visibleRows() int {
 
 func (fe FileExplorer) View(focused bool) string {
 	innerW := max(fe.width-4, 10)
-	innerH := max(fe.height-2, 1)
 
-	borderColor := "238"
-	if focused {
-		borderColor = "87"
+	renderPanel := func(content string) string {
+		return borderedPanel(fe.width, fe.height, focused, content)
 	}
-	border := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color(borderColor)).
-		Width(fe.width - 2).
-		Height(innerH)
 
 	header := fe.theme.Section.Render("  FILES")
 	if len(fe.files) > 0 {
@@ -88,21 +67,23 @@ func (fe FileExplorer) View(focused bool) string {
 
 	if len(fe.files) == 0 {
 		content := header + "\n" + fe.theme.Dimmed.Render("  No changes")
-		return border.Render(content)
+		return renderPanel(content)
 	}
 
 	var b strings.Builder
 	b.WriteString(header + "\n")
 
 	visible := fe.visibleRows()
-	end := fe.offset + visible
+	offset := fe.scroll.Offset()
+	cursor := fe.scroll.Cursor()
+	end := offset + visible
 	if end > len(fe.files) {
 		end = len(fe.files)
 	}
 
-	for i := fe.offset; i < end; i++ {
+	for i := offset; i < end; i++ {
 		f := fe.files[i]
-		selected := focused && i == fe.cursor
+		selected := focused && i == cursor
 
 		// Status indicator with color
 		statusStyle := fe.statusStyle(f.Status)
@@ -129,7 +110,7 @@ func (fe FileExplorer) View(focused bool) string {
 		b.WriteString(fmt.Sprintf("%s %s %s\n", cursor, indicator, nameStyle.Render(name)))
 	}
 
-	return border.Render(b.String())
+	return renderPanel(b.String())
 }
 
 func (fe FileExplorer) statusIcon(status string) string {

--- a/internal/ui/fileexplorer_test.go
+++ b/internal/ui/fileexplorer_test.go
@@ -84,8 +84,8 @@ func TestParseGitDiffNameStatus_NoTab(t *testing.T) {
 
 func TestNewFileExplorer(t *testing.T) {
 	fe := NewFileExplorer(DefaultTheme())
-	if fe.cursor != 0 {
-		t.Errorf("initial cursor = %d, want 0", fe.cursor)
+	if fe.scroll.Cursor() != 0 {
+		t.Errorf("initial cursor = %d, want 0", fe.scroll.Cursor())
 	}
 	if len(fe.files) != 0 {
 		t.Errorf("initial files should be empty")
@@ -102,7 +102,7 @@ func TestFileExplorer_SetSize(t *testing.T) {
 
 func TestFileExplorer_SetFiles(t *testing.T) {
 	fe := NewFileExplorer(DefaultTheme())
-	fe.cursor = 5
+	fe.scroll.cursor = 5
 	files := []ChangedFile{
 		{Status: "M", Path: "a.go"},
 		{Status: "A", Path: "b.go"},
@@ -111,18 +111,17 @@ func TestFileExplorer_SetFiles(t *testing.T) {
 	if len(fe.files) != 2 {
 		t.Fatalf("expected 2 files, got %d", len(fe.files))
 	}
-	// Cursor should be clamped
-	if fe.cursor != 1 {
-		t.Errorf("cursor should be clamped to 1, got %d", fe.cursor)
+	if fe.scroll.Cursor() != 1 {
+		t.Errorf("cursor should be clamped to 1, got %d", fe.scroll.Cursor())
 	}
 }
 
 func TestFileExplorer_SetFiles_Empty(t *testing.T) {
 	fe := NewFileExplorer(DefaultTheme())
-	fe.cursor = 3
+	fe.scroll.cursor = 3
 	fe.SetFiles(nil)
-	if fe.cursor != 0 {
-		t.Errorf("cursor should be 0 for empty files, got %d", fe.cursor)
+	if fe.scroll.Cursor() != 0 {
+		t.Errorf("cursor should be 0 for empty files, got %d", fe.scroll.Cursor())
 	}
 }
 
@@ -136,35 +135,33 @@ func TestFileExplorer_CursorUpDown(t *testing.T) {
 	})
 
 	fe.CursorDown()
-	if fe.cursor != 1 {
-		t.Errorf("cursor after down = %d, want 1", fe.cursor)
+	if fe.scroll.Cursor() != 1 {
+		t.Errorf("cursor after down = %d, want 1", fe.scroll.Cursor())
 	}
 
 	fe.CursorDown()
-	if fe.cursor != 2 {
-		t.Errorf("cursor after down x2 = %d, want 2", fe.cursor)
+	if fe.scroll.Cursor() != 2 {
+		t.Errorf("cursor after down x2 = %d, want 2", fe.scroll.Cursor())
 	}
 
-	// Should not go past end
 	fe.CursorDown()
-	if fe.cursor != 2 {
-		t.Errorf("cursor after down at end = %d, want 2", fe.cursor)
+	if fe.scroll.Cursor() != 2 {
+		t.Errorf("cursor after down at end = %d, want 2", fe.scroll.Cursor())
 	}
 
 	fe.CursorUp()
-	if fe.cursor != 1 {
-		t.Errorf("cursor after up = %d, want 1", fe.cursor)
+	if fe.scroll.Cursor() != 1 {
+		t.Errorf("cursor after up = %d, want 1", fe.scroll.Cursor())
 	}
 
 	fe.CursorUp()
-	if fe.cursor != 0 {
-		t.Errorf("cursor after up x2 = %d, want 0", fe.cursor)
+	if fe.scroll.Cursor() != 0 {
+		t.Errorf("cursor after up x2 = %d, want 0", fe.scroll.Cursor())
 	}
 
-	// Should not go below 0
 	fe.CursorUp()
-	if fe.cursor != 0 {
-		t.Errorf("cursor after up at start = %d, want 0", fe.cursor)
+	if fe.scroll.Cursor() != 0 {
+		t.Errorf("cursor after up at start = %d, want 0", fe.scroll.Cursor())
 	}
 }
 

--- a/internal/ui/gitcmd.go
+++ b/internal/ui/gitcmd.go
@@ -1,0 +1,71 @@
+package ui
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// FetchGitStatus runs git commands in the given worktree directory.
+// Intended to be called from a tea.Cmd (off the main goroutine).
+func FetchGitStatus(taskID, worktree string) GitStatusRefreshMsg {
+	msg := GitStatusRefreshMsg{TaskID: taskID}
+
+	if worktree == "" {
+		return msg
+	}
+
+	if out, err := runGit(worktree, "status", "--short"); err == nil {
+		msg.Status = strings.TrimRight(out, "\n")
+	}
+
+	if out, err := runGit(worktree, "diff", "HEAD", "--stat"); err == nil {
+		msg.Diff = strings.TrimRight(out, "\n")
+	}
+
+	if base := findMergeBase(worktree); base != "" {
+		if out, err := runGit(worktree, "diff", "--stat", base+"..HEAD"); err == nil {
+			msg.BranchDiff = strings.TrimRight(out, "\n")
+		}
+		if out, err := runGit(worktree, "diff", "--name-status", base+"..HEAD"); err == nil {
+			msg.BranchFiles = strings.TrimRight(out, "\n")
+		}
+	}
+
+	return msg
+}
+
+// findMergeBase finds the merge-base between HEAD and the upstream or default branch.
+func findMergeBase(worktree string) string {
+	if base, err := runGit(worktree, "merge-base", "HEAD", "HEAD@{upstream}"); err == nil {
+		if b := strings.TrimSpace(base); b != "" {
+			return b
+		}
+	}
+	for _, branch := range []string{"master", "main"} {
+		if base, err := runGit(worktree, "merge-base", "HEAD", branch); err == nil {
+			if b := strings.TrimSpace(base); b != "" {
+				return b
+			}
+		}
+	}
+	return ""
+}
+
+func runGit(dir string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", append([]string{"--no-pager"}, args...)...)
+	cmd.Dir = dir
+	cmd.Env = append(cmd.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+	)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	return out.String(), err
+}

--- a/internal/ui/gitstatus.go
+++ b/internal/ui/gitstatus.go
@@ -1,14 +1,12 @@
 package ui
 
 import (
-	"bytes"
-	"context"
-	"os/exec"
 	"strings"
 	"time"
-
-	"github.com/charmbracelet/lipgloss"
 )
+
+// gitRefreshInterval is how long between automatic git status refreshes.
+const gitRefreshInterval = 3 * time.Second
 
 // GitStatusRefreshMsg carries the result of a background git status check.
 type GitStatusRefreshMsg struct {
@@ -70,7 +68,7 @@ func (g *GitStatus) NeedsRefresh() bool {
 	if g.taskID == "" {
 		return false
 	}
-	return time.Since(g.lastRefresh) > 3*time.Second
+	return time.Since(g.lastRefresh) > gitRefreshInterval
 }
 
 // SetFocused sets whether this panel has focus (changes border color).
@@ -79,29 +77,23 @@ func (g *GitStatus) SetFocused(focused bool) {
 }
 
 func (g GitStatus) View() string {
-	innerW := max(g.width-4, 10) // padding inside border
-	innerH := max(g.height-2, 1) // border top/bottom
+	innerW := max(g.width-4, 10)
+	innerH := max(g.height-2, 1)
 
-	borderColor := "238"
-	if g.focused {
-		borderColor = "87"
+	renderPanel := func(content string) string {
+		return borderedPanel(g.width, g.height, g.focused, content)
 	}
-	border := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color(borderColor)).
-		Width(g.width - 2).
-		Height(innerH)
 
 	if g.taskID == "" {
-		return border.Render(g.theme.Dimmed.Render(" No worktree"))
+		return renderPanel(g.theme.Dimmed.Render(" No worktree"))
 	}
 
 	if !g.loaded {
-		return border.Render(g.theme.Dimmed.Render(" Loading..."))
+		return renderPanel(g.theme.Dimmed.Render(" Loading..."))
 	}
 
 	if g.statusText == "" && g.diffText == "" && g.branchDiffText == "" {
-		return border.Render(g.theme.Dimmed.Render(" Clean — no changes"))
+		return renderPanel(g.theme.Dimmed.Render(" Clean — no changes"))
 	}
 
 	var sections []string
@@ -126,13 +118,12 @@ func (g GitStatus) View() string {
 
 	content := strings.Join(sections, "\n")
 
-	// Truncate to fit
 	contentLines := strings.Split(content, "\n")
 	if len(contentLines) > innerH {
 		contentLines = contentLines[:innerH]
 	}
 
-	return border.Render(strings.Join(contentLines, "\n"))
+	return renderPanel(strings.Join(contentLines, "\n"))
 }
 
 func (g GitStatus) truncateLines(text string, maxWidth, maxLines int) string {
@@ -174,68 +165,3 @@ func (g GitStatus) colorizeDiff(text string) string {
 	return strings.Join(lines, "\n")
 }
 
-// FetchGitStatus runs git commands in the given worktree directory.
-// Intended to be called from a tea.Cmd (off the main goroutine).
-func FetchGitStatus(taskID, worktree string) GitStatusRefreshMsg {
-	msg := GitStatusRefreshMsg{TaskID: taskID}
-
-	if worktree == "" {
-		return msg
-	}
-
-	// git status --short
-	if out, err := runGit(worktree, "status", "--short"); err == nil {
-		msg.Status = strings.TrimRight(out, "\n")
-	}
-
-	// git diff HEAD --stat (unstaged + staged changes)
-	if out, err := runGit(worktree, "diff", "HEAD", "--stat"); err == nil {
-		msg.Diff = strings.TrimRight(out, "\n")
-	}
-
-	// git diff against merge-base with default branch (committed branch changes)
-	if base := findMergeBase(worktree); base != "" {
-		if out, err := runGit(worktree, "diff", "--stat", base+"..HEAD"); err == nil {
-			msg.BranchDiff = strings.TrimRight(out, "\n")
-		}
-		if out, err := runGit(worktree, "diff", "--name-status", base+"..HEAD"); err == nil {
-			msg.BranchFiles = strings.TrimRight(out, "\n")
-		}
-	}
-
-	return msg
-}
-
-// findMergeBase finds the merge-base between HEAD and the upstream or default branch.
-func findMergeBase(worktree string) string {
-	// Try upstream first
-	if base, err := runGit(worktree, "merge-base", "HEAD", "HEAD@{upstream}"); err == nil {
-		if b := strings.TrimSpace(base); b != "" {
-			return b
-		}
-	}
-	// Fallback: try common default branch names
-	for _, branch := range []string{"master", "main"} {
-		if base, err := runGit(worktree, "merge-base", "HEAD", branch); err == nil {
-			if b := strings.TrimSpace(base); b != "" {
-				return b
-			}
-		}
-	}
-	return ""
-}
-
-func runGit(dir string, args ...string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", append([]string{"--no-pager"}, args...)...)
-	cmd.Dir = dir
-	cmd.Env = append(cmd.Environ(),
-		"GIT_TERMINAL_PROMPT=0", // prevent credential prompts from blocking
-	)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &bytes.Buffer{}
-	err := cmd.Run()
-	return out.String(), err
-}

--- a/internal/ui/keybytes.go
+++ b/internal/ui/keybytes.go
@@ -1,0 +1,98 @@
+package ui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// keyByteMap maps Bubble Tea key types to their raw terminal byte sequences.
+var keyByteMap = map[tea.KeyType][]byte{
+	tea.KeySpace:     {' '},
+	tea.KeyEnter:     {'\r'},
+	tea.KeyBackspace: {0x7f},
+	tea.KeyTab:       {'\t'},
+	tea.KeyShiftTab:  []byte("\x1b[Z"),
+	tea.KeyEscape:    {0x1b},
+	tea.KeyHome:      []byte("\x1b[H"),
+	tea.KeyEnd:       []byte("\x1b[F"),
+	tea.KeyPgUp:      []byte("\x1b[5~"),
+	tea.KeyPgDown:    []byte("\x1b[6~"),
+	tea.KeyDelete:    []byte("\x1b[3~"),
+	tea.KeyCtrlA:     {0x01},
+	tea.KeyCtrlB:     {0x02},
+	tea.KeyCtrlC:     {0x03},
+	tea.KeyCtrlD:     {0x04},
+	tea.KeyCtrlE:     {0x05},
+	tea.KeyCtrlF:     {0x06},
+	tea.KeyCtrlG:     {0x07},
+	tea.KeyCtrlH:     {0x08},
+	tea.KeyCtrlK:     {0x0b},
+	tea.KeyCtrlL:     {0x0c},
+	tea.KeyCtrlN:     {0x0e},
+	tea.KeyCtrlO:     {0x0f},
+	tea.KeyCtrlP:     {0x10},
+	tea.KeyCtrlR:     {0x12},
+	tea.KeyCtrlS:     {0x13},
+	tea.KeyCtrlT:     {0x14},
+	tea.KeyCtrlU:     {0x15},
+	tea.KeyCtrlV:     {0x16},
+	tea.KeyCtrlW:     {0x17},
+	tea.KeyCtrlX:     {0x18},
+	tea.KeyCtrlY:     {0x19},
+	tea.KeyCtrlZ:     {0x1a},
+	tea.KeyF1:        []byte("\x1bOP"),
+	tea.KeyF2:        []byte("\x1bOQ"),
+	tea.KeyF3:        []byte("\x1bOR"),
+	tea.KeyF4:        []byte("\x1bOS"),
+	tea.KeyF5:        []byte("\x1b[15~"),
+	tea.KeyF6:        []byte("\x1b[17~"),
+	tea.KeyF7:        []byte("\x1b[18~"),
+	tea.KeyF8:        []byte("\x1b[19~"),
+	tea.KeyF9:        []byte("\x1b[20~"),
+	tea.KeyF10:       []byte("\x1b[21~"),
+	tea.KeyF11:       []byte("\x1b[23~"),
+	tea.KeyF12:       []byte("\x1b[24~"),
+}
+
+// altArrowMap maps arrow key types to their Alt-modified escape sequences.
+var altArrowMap = map[tea.KeyType][]byte{
+	tea.KeyUp:    []byte("\x1b[1;3A"),
+	tea.KeyDown:  []byte("\x1b[1;3B"),
+	tea.KeyRight: []byte("\x1b[1;3C"),
+	tea.KeyLeft:  []byte("\x1b[1;3D"),
+}
+
+// arrowMap maps arrow key types to their standard escape sequences.
+var arrowMap = map[tea.KeyType][]byte{
+	tea.KeyUp:    []byte("\x1b[A"),
+	tea.KeyDown:  []byte("\x1b[B"),
+	tea.KeyRight: []byte("\x1b[C"),
+	tea.KeyLeft:  []byte("\x1b[D"),
+}
+
+// keyMsgToBytes converts a Bubble Tea key message to raw terminal bytes.
+func keyMsgToBytes(msg tea.KeyMsg) []byte {
+	if msg.Type == tea.KeyRunes {
+		b := []byte(string(msg.Runes))
+		if msg.Alt {
+			return append([]byte{0x1b}, b...)
+		}
+		return b
+	}
+
+	if msg.Alt {
+		if b, ok := altArrowMap[msg.Type]; ok {
+			return b
+		}
+	}
+
+	if b, ok := arrowMap[msg.Type]; ok {
+		return b
+	}
+
+	if b, ok := keyByteMap[msg.Type]; ok {
+		return b
+	}
+
+	if s := msg.String(); s != "" {
+		return []byte(s)
+	}
+	return nil
+}

--- a/internal/ui/preview.go
+++ b/internal/ui/preview.go
@@ -1,23 +1,11 @@
 package ui
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/drn/argus/internal/agent"
-	"github.com/hinshun/vt10x"
-)
-
-// vt10x attribute bit flags (unexported in the library)
-const (
-	vtAttrReverse   = 1 << 0
-	vtAttrUnderline = 1 << 1
-	vtAttrBold      = 1 << 2
-	// attrGfx      = 1 << 3
-	vtAttrItalic = 1 << 4
-	// attrBlink    = 1 << 5
 )
 
 // Preview renders the agent output for the selected task.
@@ -74,9 +62,6 @@ func (p Preview) formatOutput(raw []byte, ptyCols, ptyRows int) string {
 		return ""
 	}
 
-	// Use the actual PTY dimensions so the vt10x interpretation matches
-	// what the child process was rendering for. Fall back to wide defaults
-	// if dimensions are unknown.
 	vtCols := ptyCols
 	vtRows := ptyRows
 	if vtCols < 40 {
@@ -85,33 +70,15 @@ func (p Preview) formatOutput(raw []byte, ptyCols, ptyRows int) string {
 	if vtRows < 10 {
 		vtRows = 500
 	}
-	vt := vt10x.New(vt10x.WithSize(vtCols, vtRows))
-	vt.Write(raw)
 
-	// Read the screen content from the virtual terminal with color info
-	vt.Lock()
-	defer vt.Unlock()
-
-	var lines []string
-	for y := 0; y < vtRows; y++ {
-		line := renderLine(vt, y, vtCols, -1)
-		lines = append(lines, line)
-	}
-
-	// Trim trailing empty lines (check stripped version for emptiness)
-	for len(lines) > 0 && stripANSI(lines[len(lines)-1]) == "" {
-		lines = lines[:len(lines)-1]
-	}
-
+	lines := replayVT10X(raw, vtCols, vtRows, false)
 	if len(lines) == 0 {
 		return ""
 	}
 
-	// Available display area inside the border
 	dispW := max(p.width-4, 10)
 	dispH := max(p.height-4, 3)
 
-	// Take the tail (most recent output) and truncate lines to fit
 	if len(lines) > dispH {
 		lines = lines[len(lines)-dispH:]
 	}
@@ -120,152 +87,4 @@ func (p Preview) formatOutput(raw []byte, ptyCols, ptyRows int) string {
 	}
 
 	return strings.Join(lines, "\n")
-}
-
-// renderLine builds a single line from the vt10x screen with ANSI colors.
-// cursorX is the column to render a cursor at (-1 for no cursor on this line).
-func renderLine(vt vt10x.Terminal, y, cols int, cursorX int) string {
-	var b strings.Builder
-	var curFG, curBG vt10x.Color
-	var curMode int16
-	active := false // whether we have an active SGR state
-
-	// Find the last non-empty column to trim trailing spaces
-	// (extend to cursor position if cursor is on this line)
-	lastCol := -1
-	for x := cols - 1; x >= 0; x-- {
-		cell := vt.Cell(x, y)
-		ch := cell.Char
-		if ch == 0 {
-			ch = ' '
-		}
-		if ch != ' ' || cell.FG != vt10x.DefaultFG || cell.BG != vt10x.DefaultBG || cell.Mode != 0 {
-			lastCol = x
-			break
-		}
-	}
-	if cursorX > lastCol {
-		lastCol = cursorX
-	}
-
-	for x := 0; x <= lastCol; x++ {
-		cell := vt.Cell(x, y)
-		ch := cell.Char
-		if ch == 0 {
-			ch = ' '
-		}
-
-		if x == cursorX {
-			// Render cursor cell with reverse video, preserving cell colors
-			b.WriteString(buildSGR(cell.FG, cell.BG, cell.Mode|vtAttrReverse))
-			b.WriteRune(ch)
-			b.WriteString("\x1b[0m")
-			// Force SGR re-emit on next cell
-			active = false
-		} else {
-			// Emit SGR sequence if attributes changed
-			if cell.FG != curFG || cell.BG != curBG || cell.Mode != curMode || !active {
-				b.WriteString(buildSGR(cell.FG, cell.BG, cell.Mode))
-				curFG = cell.FG
-				curBG = cell.BG
-				curMode = cell.Mode
-				active = true
-			}
-			b.WriteRune(ch)
-		}
-	}
-
-	// Reset at end of line if we emitted any SGR
-	if active {
-		b.WriteString("\x1b[0m")
-	}
-
-	return b.String()
-}
-
-// buildSGR builds an ANSI SGR escape sequence for the given attributes.
-func buildSGR(fg, bg vt10x.Color, mode int16) string {
-	var params []string
-
-	// Reset first, then apply attributes
-	params = append(params, "0")
-
-	if mode&vtAttrBold != 0 {
-		params = append(params, "1")
-	}
-	if mode&vtAttrItalic != 0 {
-		params = append(params, "3")
-	}
-	if mode&vtAttrUnderline != 0 {
-		params = append(params, "4")
-	}
-	if mode&vtAttrReverse != 0 {
-		params = append(params, "7")
-	}
-
-	if fg != vt10x.DefaultFG {
-		params = append(params, fgColor(fg))
-	}
-	if bg != vt10x.DefaultBG {
-		params = append(params, bgColor(bg))
-	}
-
-	return "\x1b[" + strings.Join(params, ";") + "m"
-}
-
-// fgColor returns the SGR parameter string for a foreground color.
-func fgColor(c vt10x.Color) string {
-	n := uint32(c)
-	switch {
-	case n < 8:
-		return fmt.Sprintf("%d", 30+n)
-	case n < 16:
-		return fmt.Sprintf("%d", 90+n-8)
-	case n < 256:
-		return fmt.Sprintf("38;5;%d", n)
-	default:
-		// vt10x stores RGB as r<<16 | g<<8 | b
-		r, g, b := (n>>16)&0xFF, (n>>8)&0xFF, n&0xFF
-		return fmt.Sprintf("38;2;%d;%d;%d", r, g, b)
-	}
-}
-
-// bgColor returns the SGR parameter string for a background color.
-func bgColor(c vt10x.Color) string {
-	n := uint32(c)
-	switch {
-	case n < 8:
-		return fmt.Sprintf("%d", 40+n)
-	case n < 16:
-		return fmt.Sprintf("%d", 100+n-8)
-	case n < 256:
-		return fmt.Sprintf("48;5;%d", n)
-	default:
-		// vt10x stores RGB as r<<16 | g<<8 | b
-		r, g, b := (n>>16)&0xFF, (n>>8)&0xFF, n&0xFF
-		return fmt.Sprintf("48;2;%d;%d;%d", r, g, b)
-	}
-}
-
-// stripANSI removes ANSI escape sequences and trims whitespace for emptiness check.
-func stripANSI(s string) string {
-	var b strings.Builder
-	i := 0
-	for i < len(s) {
-		if s[i] == '\x1b' && i+1 < len(s) && s[i+1] == '[' {
-			// Skip CSI sequence
-			j := i + 2
-			for j < len(s) && !((s[j] >= 'A' && s[j] <= 'Z') || (s[j] >= 'a' && s[j] <= 'z')) {
-				j++
-			}
-			if j < len(s) {
-				j++ // skip final byte
-			}
-			i = j
-		} else {
-			b.WriteByte(s[i])
-			i++
-		}
-	}
-	return strings.TrimSpace(b.String())
 }

--- a/internal/ui/preview_test.go
+++ b/internal/ui/preview_test.go
@@ -145,73 +145,69 @@ func TestBuildSGR_WithBGColor(t *testing.T) {
 	}
 }
 
-func TestFgColor_Standard(t *testing.T) {
-	// Colors 0-7: 30+n
-	result := fgColor(vt10x.Color(0))
+func TestSgrColor_FG_Standard(t *testing.T) {
+	result := sgrColor(vt10x.Color(0), 30)
 	if result != "30" {
-		t.Errorf("fgColor(0) = %q, want '30'", result)
+		t.Errorf("sgrColor(0, 30) = %q, want '30'", result)
 	}
-	result = fgColor(vt10x.Color(7))
+	result = sgrColor(vt10x.Color(7), 30)
 	if result != "37" {
-		t.Errorf("fgColor(7) = %q, want '37'", result)
+		t.Errorf("sgrColor(7, 30) = %q, want '37'", result)
 	}
 }
 
-func TestFgColor_Bright(t *testing.T) {
-	// Colors 8-15: 90+n-8
-	result := fgColor(vt10x.Color(8))
+func TestSgrColor_FG_Bright(t *testing.T) {
+	result := sgrColor(vt10x.Color(8), 30)
 	if result != "90" {
-		t.Errorf("fgColor(8) = %q, want '90'", result)
+		t.Errorf("sgrColor(8, 30) = %q, want '90'", result)
 	}
-	result = fgColor(vt10x.Color(15))
+	result = sgrColor(vt10x.Color(15), 30)
 	if result != "97" {
-		t.Errorf("fgColor(15) = %q, want '97'", result)
+		t.Errorf("sgrColor(15, 30) = %q, want '97'", result)
 	}
 }
 
-func TestFgColor_256(t *testing.T) {
-	// Colors 16-255: 38;5;n
-	result := fgColor(vt10x.Color(100))
+func TestSgrColor_FG_256(t *testing.T) {
+	result := sgrColor(vt10x.Color(100), 30)
 	if result != "38;5;100" {
-		t.Errorf("fgColor(100) = %q, want '38;5;100'", result)
+		t.Errorf("sgrColor(100, 30) = %q, want '38;5;100'", result)
 	}
 }
 
-func TestFgColor_RGB(t *testing.T) {
-	// Colors > 255: RGB r<<16|g<<8|b
-	rgb := vt10x.Color(0xFF8000) // r=255 g=128 b=0
-	result := fgColor(rgb)
+func TestSgrColor_FG_RGB(t *testing.T) {
+	rgb := vt10x.Color(0xFF8000)
+	result := sgrColor(rgb, 30)
 	if result != "38;2;255;128;0" {
-		t.Errorf("fgColor(RGB) = %q, want '38;2;255;128;0'", result)
+		t.Errorf("sgrColor(RGB, 30) = %q, want '38;2;255;128;0'", result)
 	}
 }
 
-func TestBgColor_Standard(t *testing.T) {
-	result := bgColor(vt10x.Color(0))
+func TestSgrColor_BG_Standard(t *testing.T) {
+	result := sgrColor(vt10x.Color(0), 40)
 	if result != "40" {
-		t.Errorf("bgColor(0) = %q, want '40'", result)
+		t.Errorf("sgrColor(0, 40) = %q, want '40'", result)
 	}
 }
 
-func TestBgColor_Bright(t *testing.T) {
-	result := bgColor(vt10x.Color(8))
+func TestSgrColor_BG_Bright(t *testing.T) {
+	result := sgrColor(vt10x.Color(8), 40)
 	if result != "100" {
-		t.Errorf("bgColor(8) = %q, want '100'", result)
+		t.Errorf("sgrColor(8, 40) = %q, want '100'", result)
 	}
 }
 
-func TestBgColor_256(t *testing.T) {
-	result := bgColor(vt10x.Color(200))
+func TestSgrColor_BG_256(t *testing.T) {
+	result := sgrColor(vt10x.Color(200), 40)
 	if result != "48;5;200" {
-		t.Errorf("bgColor(200) = %q, want '48;5;200'", result)
+		t.Errorf("sgrColor(200, 40) = %q, want '48;5;200'", result)
 	}
 }
 
-func TestBgColor_RGB(t *testing.T) {
-	rgb := vt10x.Color(0x102030) // r=16 g=32 b=48
-	result := bgColor(rgb)
+func TestSgrColor_BG_RGB(t *testing.T) {
+	rgb := vt10x.Color(0x102030)
+	result := sgrColor(rgb, 40)
 	if result != "48;2;16;32;48" {
-		t.Errorf("bgColor(RGB) = %q, want '48;2;16;32;48'", result)
+		t.Errorf("sgrColor(RGB, 40) = %q, want '48;2;16;32;48'", result)
 	}
 }
 

--- a/internal/ui/projectlist.go
+++ b/internal/ui/projectlist.go
@@ -12,11 +12,10 @@ import (
 // ProjectList renders the project list view.
 type ProjectList struct {
 	projects []projectEntry
-	cursor   int
+	scroll   ScrollState
 	theme    Theme
 	width    int
 	height   int
-	offset   int
 }
 
 // projectEntry is a flattened project for display.
@@ -36,9 +35,7 @@ func (pl *ProjectList) SetProjects(projects map[string]config.Project) {
 	}
 	// Sort alphabetically for stable ordering
 	sortProjects(pl.projects)
-	if pl.cursor >= len(pl.projects) {
-		pl.cursor = max(0, len(pl.projects)-1)
-	}
+	pl.scroll.ClampCursor(len(pl.projects))
 }
 
 func sortProjects(entries []projectEntry) {
@@ -53,30 +50,20 @@ func (pl *ProjectList) SetSize(w, h int) {
 }
 
 func (pl *ProjectList) CursorUp() {
-	if pl.cursor > 0 {
-		pl.cursor--
-		if pl.cursor < pl.offset {
-			pl.offset = pl.cursor
-		}
-	}
+	pl.scroll.CursorUp()
 }
 
 func (pl *ProjectList) CursorDown() {
-	if pl.cursor < len(pl.projects)-1 {
-		pl.cursor++
-		visible := pl.visibleRows()
-		if pl.cursor >= pl.offset+visible {
-			pl.offset = pl.cursor - visible + 1
-		}
-	}
+	pl.scroll.CursorDown(len(pl.projects), pl.visibleRows())
 }
 
 func (pl *ProjectList) Selected() *projectEntry {
 	if len(pl.projects) == 0 {
 		return nil
 	}
-	if pl.cursor >= 0 && pl.cursor < len(pl.projects) {
-		return &pl.projects[pl.cursor]
+	c := pl.scroll.Cursor()
+	if c >= 0 && c < len(pl.projects) {
+		return &pl.projects[c]
 	}
 	return nil
 }
@@ -97,14 +84,16 @@ func (pl ProjectList) View() string {
 
 	var b strings.Builder
 	visible := pl.visibleRows()
-	end := pl.offset + visible
+	offset := pl.scroll.Offset()
+	cursor := pl.scroll.Cursor()
+	end := offset + visible
 	if end > len(pl.projects) {
 		end = len(pl.projects)
 	}
 
-	for i := pl.offset; i < end; i++ {
+	for i := offset; i < end; i++ {
 		entry := pl.projects[i]
-		selected := i == pl.cursor
+		selected := i == cursor
 
 		// Project name
 		nameStyle := pl.theme.Normal

--- a/internal/ui/projectlist_test.go
+++ b/internal/ui/projectlist_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestNewProjectList(t *testing.T) {
 	pl := NewProjectList(DefaultTheme())
-	if pl.cursor != 0 {
-		t.Errorf("initial cursor = %d, want 0", pl.cursor)
+	if pl.scroll.Cursor() != 0 {
+		t.Errorf("initial cursor = %d, want 0", pl.scroll.Cursor())
 	}
 	if pl.Selected() != nil {
 		t.Error("selected should be nil with no projects")
@@ -76,40 +76,40 @@ func TestProjectList_CursorUpDown(t *testing.T) {
 		"c": {Path: "/c"},
 	})
 
-	if pl.cursor != 0 {
-		t.Fatalf("initial cursor = %d", pl.cursor)
+	if pl.scroll.Cursor() != 0 {
+		t.Fatalf("initial cursor = %d", pl.scroll.Cursor())
 	}
 
 	pl.CursorDown()
-	if pl.cursor != 1 {
-		t.Errorf("cursor after down = %d, want 1", pl.cursor)
+	if pl.scroll.Cursor() != 1 {
+		t.Errorf("cursor after down = %d, want 1", pl.scroll.Cursor())
 	}
 
 	pl.CursorDown()
-	if pl.cursor != 2 {
-		t.Errorf("cursor after down x2 = %d, want 2", pl.cursor)
+	if pl.scroll.Cursor() != 2 {
+		t.Errorf("cursor after down x2 = %d, want 2", pl.scroll.Cursor())
 	}
 
 	// Past end
 	pl.CursorDown()
-	if pl.cursor != 2 {
-		t.Errorf("cursor after down at end = %d, want 2", pl.cursor)
+	if pl.scroll.Cursor() != 2 {
+		t.Errorf("cursor after down at end = %d, want 2", pl.scroll.Cursor())
 	}
 
 	pl.CursorUp()
-	if pl.cursor != 1 {
-		t.Errorf("cursor after up = %d, want 1", pl.cursor)
+	if pl.scroll.Cursor() != 1 {
+		t.Errorf("cursor after up = %d, want 1", pl.scroll.Cursor())
 	}
 
 	pl.CursorUp()
-	if pl.cursor != 0 {
-		t.Errorf("cursor after up x2 = %d, want 0", pl.cursor)
+	if pl.scroll.Cursor() != 0 {
+		t.Errorf("cursor after up x2 = %d, want 0", pl.scroll.Cursor())
 	}
 
 	// Before start
 	pl.CursorUp()
-	if pl.cursor != 0 {
-		t.Errorf("cursor after up at start = %d, want 0", pl.cursor)
+	if pl.scroll.Cursor() != 0 {
+		t.Errorf("cursor after up at start = %d, want 0", pl.scroll.Cursor())
 	}
 }
 
@@ -190,13 +190,13 @@ func TestProjectList_SetProjectsClampsClursor(t *testing.T) {
 	pl.SetProjects(map[string]config.Project{
 		"a": {}, "b": {}, "c": {},
 	})
-	pl.cursor = 2
+	pl.scroll.cursor = 2
 
 	// Set fewer projects
 	pl.SetProjects(map[string]config.Project{
 		"a": {},
 	})
-	if pl.cursor != 0 {
-		t.Errorf("cursor should be clamped to 0, got %d", pl.cursor)
+	if pl.scroll.Cursor() != 0 {
+		t.Errorf("cursor should be clamped to 0, got %d", pl.scroll.Cursor())
 	}
 }

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -2,12 +2,10 @@ package ui
 
 import (
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/drn/argus/internal/agent"
 	"github.com/drn/argus/internal/db"
 	"github.com/drn/argus/internal/model"
@@ -484,46 +482,42 @@ func (m Model) startOrAttach(t *model.Task) (tea.Model, tea.Cmd) {
 	})
 }
 
+// determinePostExitStatus decides what status a task should have after its
+// agent process exits. Returns the new status and whether it was a quick exit
+// (error/too-fast) that should keep the agent view open.
+func determinePostExitStatus(msg AgentFinishedMsg, t *model.Task) (newStatus model.Status, clearSession bool, quickExit bool) {
+	if msg.Stopped {
+		return model.StatusInReview, false, false
+	}
+	if msg.Err != nil {
+		return t.Status, true, true
+	}
+	if !t.StartedAt.IsZero() && time.Since(t.StartedAt) < minAgentRunTime {
+		return t.Status, true, true
+	}
+	if t.Worktree != "" && !dirExists(t.Worktree) {
+		return model.StatusComplete, false, false
+	}
+	return model.StatusComplete, false, false
+}
+
 func (m Model) handleAgentFinished(msg AgentFinishedMsg) (tea.Model, tea.Cmd) {
 	t, err := m.db.Get(msg.TaskID)
 	if err != nil {
-		// Task was deleted while agent was running — silently ignore
 		return m, nil
 	}
 
 	t.AgentPID = 0
-
-	quickExit := false
-
-	if msg.Stopped {
-		// Explicitly stopped via Runner.Stop — mark for review
-		t.SetStatus(model.StatusInReview)
-	} else if msg.Err != nil {
-		// Process exited with an error (e.g. failed resume, crash) —
-		// keep the task in progress so the user can retry.
+	newStatus, clearSession, quickExit := determinePostExitStatus(msg, t)
+	t.SetStatus(newStatus)
+	if clearSession {
 		t.SessionID = ""
-		quickExit = true
-	} else if !t.StartedAt.IsZero() && time.Since(t.StartedAt) < minAgentRunTime {
-		// Agent exited too quickly — likely a startup or config error.
-		// Keep in progress so the user can retry.
-		t.SessionID = ""
-		quickExit = true
-	} else if t.Worktree != "" && !dirExists(t.Worktree) {
-		// Worktree removed — auto-complete
-		t.SetStatus(model.StatusComplete)
-	} else {
-		// Agent session exited on its own — task is complete
-		t.SetStatus(model.StatusComplete)
 	}
 
-	// Preserve last output so the agent view can display it after session cleanup.
 	if m.current == viewAgent && m.agentview.taskID == msg.TaskID {
 		m.agentview.SetLastOutput(msg.LastOutput)
 	}
 
-	// On normal completion or explicit stop, return to task list.
-	// On quick exit or error, stay on agent view so the user can see
-	// the terminal output (error messages, stack traces, etc.).
 	if m.current == viewAgent && m.agentview.taskID == msg.TaskID && !quickExit {
 		m.current = viewTaskList
 	}
@@ -572,18 +566,16 @@ func (m Model) handleNewTaskKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-func (m Model) handleConfirmDeleteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+// handleConfirmAction handles enter/esc for confirmation dialogs.
+// The cleanup function is called with the selected task on confirmation.
+func (m Model) handleConfirmAction(msg tea.KeyMsg, cleanup func(*model.Task)) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyEnter:
 		if t := m.tasklist.Selected(); t != nil {
-			// Stop the agent session if running
 			if m.runner.HasSession(t.ID) {
 				_ = m.runner.Stop(t.ID)
 			}
-			// Clean up worktree if configured
-			if t.Worktree != "" && m.db.Config().UI.ShouldCleanupWorktrees() {
-				removeWorktree(t.Worktree)
-			}
+			cleanup(t)
 			_ = m.db.Delete(t.ID)
 			m.refreshTasks()
 		}
@@ -593,42 +585,30 @@ func (m Model) handleConfirmDeleteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.current = viewTaskList
 		return m, nil
 	default:
-		// Only enter confirms, only esc cancels — ignore other keys
 		return m, nil
 	}
 }
 
-func (m Model) handleConfirmDestroyKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.Type {
-	case tea.KeyEnter:
-		if t := m.tasklist.Selected(); t != nil {
-			// Stop the agent session if running
-			if m.runner.HasSession(t.ID) {
-				_ = m.runner.Stop(t.ID)
-			}
-			// Remove worktree and delete branch
-			cfg := m.db.Config()
-			if t.Worktree != "" {
-				repoDir := agent.ResolveDir(t, cfg)
-				removeWorktreeAndBranch(t.Worktree, t.Branch, repoDir)
-			} else if t.Branch != "" {
-				// No worktree but has a branch — try to delete it from project dir
-				if repoDir := agent.ResolveDir(t, cfg); repoDir != "" {
-					deleteBranch(repoDir, t.Branch)
-				}
-			}
-			_ = m.db.Delete(t.ID)
-			m.refreshTasks()
+func (m Model) handleConfirmDeleteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	return m.handleConfirmAction(msg, func(t *model.Task) {
+		if t.Worktree != "" && m.db.Config().UI.ShouldCleanupWorktrees() {
+			removeWorktree(t.Worktree)
 		}
-		m.current = viewTaskList
-		return m, nil
-	case tea.KeyEsc:
-		m.current = viewTaskList
-		return m, nil
-	default:
-		// Only enter confirms, only esc cancels — ignore other keys
-		return m, nil
-	}
+	})
+}
+
+func (m Model) handleConfirmDestroyKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	return m.handleConfirmAction(msg, func(t *model.Task) {
+		cfg := m.db.Config()
+		if t.Worktree != "" {
+			repoDir := agent.ResolveDir(t, cfg)
+			removeWorktreeAndBranch(t.Worktree, t.Branch, repoDir)
+		} else if t.Branch != "" {
+			if repoDir := agent.ResolveDir(t, cfg); repoDir != "" {
+				deleteBranch(repoDir, t.Branch)
+			}
+		}
+	})
 }
 
 func (m Model) handleProjectListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -814,295 +794,4 @@ func (m *Model) refreshTasks() {
 	m.statusbar.SetRunning(running)
 }
 
-func (m Model) View() string {
-	if m.quitting {
-		return ""
-	}
-
-	// Status bar at the bottom
-	m.statusbar.SetProjectTab(m.activeTab == tabProjects)
-	bar := m.statusbar.View()
-
-	// Agent view: full-screen three-panel layout
-	if m.current == viewAgent {
-		return m.agentview.View()
-	}
-
-	// Modals are fully placed (centered), render directly with status bar
-	switch m.current {
-	case viewConfirmDeleteProject:
-		return m.confirmDeleteProjectView() + "\n" + bar
-	case viewConfirmDelete:
-		return m.confirmDeleteView() + "\n" + bar
-	case viewConfirmDestroy:
-		return m.confirmDestroyView() + "\n" + bar
-	}
-
-	// For overlay views, show them without the banner
-	switch m.current {
-	case viewHelp, viewPrompt:
-		var content string
-		switch m.current {
-		case viewHelp:
-			content = m.helpview.View()
-		case viewPrompt:
-			content = m.promptView()
-		}
-		return m.padToBottom(content, bar)
-	}
-
-	// Overlay modals
-	if m.current == viewNewTask {
-		return m.newtask.View() + "\n" + bar
-	}
-	if m.current == viewNewProject {
-		return m.newproject.View() + "\n" + bar
-	}
-
-	// Tab header
-	tabHeader := m.renderTabHeader()
-
-	switch m.activeTab {
-	case tabProjects:
-		return m.renderProjectsView(tabHeader, bar)
-	default:
-		return m.renderTasksView(tabHeader, bar)
-	}
-}
-
-func (m Model) padToBottom(content, bar string) string {
-	barHeight := lipgloss.Height(bar)
-	contentHeight := m.height - barHeight
-	if contentHeight < 0 {
-		contentHeight = 0
-	}
-	contentLines := lipgloss.Height(content)
-	padding := ""
-	if contentLines < contentHeight {
-		padding = strings.Repeat("\n", contentHeight-contentLines)
-	}
-	return content + padding + "\n" + bar
-}
-
-// splitRightHeights returns the git status and preview pane heights.
-// Git status gets ~30% of the right pane, preview gets the rest.
-func (m Model) splitRightHeights(total int) (int, int) {
-	gitH := total * 3 / 10
-	if gitH < 5 {
-		gitH = 5
-	}
-	if gitH > 15 {
-		gitH = 15
-	}
-	previewH := total - gitH
-	if previewH < 5 {
-		previewH = 5
-	}
-	return gitH, previewH
-}
-
-// splitWidths returns the left (task list) and right (preview) pane widths.
-func (m Model) splitWidths() (int, int) {
-	// Give ~40% to task list, rest to preview. Minimum 30 for tasks.
-	left := m.width * 2 / 5
-	if left < 30 {
-		left = 30
-	}
-	if left > m.width-20 {
-		left = m.width - 20
-	}
-	right := m.width - left
-	return left, right
-}
-
-func (m Model) renderTabHeader() string {
-	activeStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("87")).
-		Underline(false)
-	inactiveStyle := m.theme.Dimmed
-
-	tabs := []struct {
-		label string
-		key   string
-		t     tab
-	}{
-		{"TASKS", "1", tabTasks},
-		{"PROJECTS", "2", tabProjects},
-	}
-
-	var parts []string
-	for _, t := range tabs {
-		style := inactiveStyle
-		if t.t == m.activeTab {
-			style = activeStyle
-		}
-		parts = append(parts, style.Render("  "+t.label+" "))
-	}
-	header := strings.Join(parts, "  ")
-	return lipgloss.PlaceHorizontal(m.width, lipgloss.Center, header)
-}
-
-func (m Model) renderTasksView(tabHeader, bar string) string {
-	// Empty state: show banner centered on page
-	if len(m.db.Tasks()) == 0 {
-		content := m.emptyStateView()
-		return m.padToBottom(content, bar)
-	}
-
-	// Split layout: task list on left, agent preview on right
-	tasks := m.tasklist.View()
-	leftContent := tasks
-
-	// Git status + Preview pane for selected task
-	var taskID string
-	if t := m.tasklist.Selected(); t != nil {
-		taskID = t.ID
-	}
-	gitView := m.gitstatus.View()
-	previewView := m.preview.View(taskID)
-	rightContent := lipgloss.JoinVertical(lipgloss.Left, gitView, previewView)
-
-	// Join horizontally
-	body := lipgloss.JoinHorizontal(lipgloss.Top, leftContent, rightContent)
-	content := tabHeader + "\n" + body
-
-	return m.padToBottom(content, bar)
-}
-
-func (m Model) renderProjectsView(tabHeader, bar string) string {
-	projects := m.projectlist.View()
-	leftContent := projects
-
-	// Right pane: project details for selected project
-	rightContent := m.renderProjectDetail()
-
-	body := lipgloss.JoinHorizontal(lipgloss.Top, leftContent, rightContent)
-	content := tabHeader + "\n" + body
-	return m.padToBottom(content, bar)
-}
-
-func (m Model) renderProjectDetail() string {
-	entry := m.projectlist.Selected()
-	_, rightWidth := m.splitWidths()
-	contentHeight := m.height - 3
-
-	if entry == nil {
-		empty := m.theme.Dimmed.Render("  No project selected")
-		return lipgloss.NewStyle().Width(rightWidth).Height(contentHeight).Render(empty)
-	}
-
-	var b strings.Builder
-	b.WriteString(m.theme.Title.Render("  "+entry.Name) + "\n\n")
-
-	fields := []struct{ label, value string }{
-		{"Path", entry.Project.Path},
-		{"Branch", entry.Project.Branch},
-		{"Backend", entry.Project.Backend},
-	}
-	for _, f := range fields {
-		val := f.value
-		if val == "" {
-			val = "(default)"
-		}
-		b.WriteString("  " + m.theme.Dimmed.Render(f.label+": ") + m.theme.Normal.Render(val) + "\n")
-	}
-
-	return lipgloss.NewStyle().Width(rightWidth).Height(contentHeight).Render(b.String())
-}
-
-func (m Model) emptyStateView() string {
-	banner := renderBanner(m.width)
-	hint := m.theme.Dimmed.Render("Press [n] to create your first task")
-	hint = lipgloss.PlaceHorizontal(m.width, lipgloss.Center, hint)
-	block := banner + "\n\n" + hint
-
-	// Center vertically in the available content area
-	barHeight := 1
-	contentHeight := m.height - barHeight - 1
-	blockHeight := lipgloss.Height(block)
-	topPad := (contentHeight - blockHeight) / 2
-	if topPad < 0 {
-		topPad = 0
-	}
-
-	return strings.Repeat("\n", topPad) + block
-}
-
-func (m Model) promptView() string {
-	t := m.tasklist.Selected()
-	if t == nil {
-		return ""
-	}
-
-	title := m.theme.Title.Render("Prompt: " + t.Name)
-	prompt := t.Prompt
-	if prompt == "" {
-		prompt = m.theme.Dimmed.Render("(no prompt set)")
-	}
-
-	return title + "\n\n  " + prompt + "\n\n" +
-		m.theme.Help.Render("  Press any key to close")
-}
-
-// renderCenteredModal renders a bordered modal centered on screen.
-func (m Model) renderCenteredModal(body string, preferredWidth int) string {
-	w := preferredWidth
-	if m.width > 0 && w > m.width-4 {
-		w = m.width - 4
-	}
-	modal := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("238")).
-		Padding(1, 2).
-		Width(w).
-		Render(body)
-	return lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, modal)
-}
-
-func (m Model) confirmDeleteProjectView() string {
-	entry := m.projectlist.Selected()
-	if entry == nil {
-		return ""
-	}
-	title := m.theme.Title.Render("Delete project?")
-	name := "  " + m.theme.Normal.Render(entry.Name)
-	path := "  " + m.theme.Dimmed.Render(entry.Project.Path)
-	hint := m.theme.Help.Render("  [enter] confirm  [esc] cancel")
-	body := title + "\n\n" + name + "\n" + path + "\n\n" + hint
-	return m.renderCenteredModal(body, 50)
-}
-
-func (m Model) confirmDeleteView() string {
-	t := m.tasklist.Selected()
-	if t == nil {
-		return ""
-	}
-	title := m.theme.Title.Render("Delete task?")
-	name := "  " + m.theme.Normal.Render(t.Name)
-	hint := m.theme.Help.Render("  [enter] confirm  [esc] cancel")
-	body := title + "\n\n" + name + "\n\n" + hint
-	return m.renderCenteredModal(body, 50)
-}
-
-func (m Model) confirmDestroyView() string {
-	t := m.tasklist.Selected()
-	if t == nil {
-		return ""
-	}
-	var details []string
-	details = append(details, "  "+m.theme.Normal.Render(t.Name))
-	if t.Worktree != "" {
-		details = append(details, "  "+m.theme.Dimmed.Render("worktree: "+t.Worktree))
-	}
-	if t.Branch != "" {
-		details = append(details, "  "+m.theme.Dimmed.Render("branch: "+t.Branch))
-	}
-	title := m.theme.Title.Render("Destroy task?")
-	subtitle := m.theme.Help.Render("  This will terminate the agent, remove the worktree and branch, and delete the task.")
-	hint := m.theme.Help.Render("  [enter] confirm  [esc] cancel")
-	body := title + "\n" + subtitle + "\n\n" +
-		strings.Join(details, "\n") + "\n\n" + hint
-	return m.renderCenteredModal(body, 60)
-}
 

--- a/internal/ui/root_views.go
+++ b/internal/ui/root_views.go
@@ -1,0 +1,263 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func (m Model) View() string {
+	if m.quitting {
+		return ""
+	}
+
+	m.statusbar.SetProjectTab(m.activeTab == tabProjects)
+	bar := m.statusbar.View()
+
+	if m.current == viewAgent {
+		return m.agentview.View()
+	}
+
+	switch m.current {
+	case viewConfirmDeleteProject:
+		return m.confirmDeleteProjectView() + "\n" + bar
+	case viewConfirmDelete:
+		return m.confirmDeleteView() + "\n" + bar
+	case viewConfirmDestroy:
+		return m.confirmDestroyView() + "\n" + bar
+	case viewHelp:
+		return m.padToBottom(m.helpview.View(), bar)
+	case viewPrompt:
+		return m.padToBottom(m.promptView(), bar)
+	case viewNewTask:
+		return m.newtask.View() + "\n" + bar
+	case viewNewProject:
+		return m.newproject.View() + "\n" + bar
+	}
+
+	tabHeader := m.renderTabHeader()
+	switch m.activeTab {
+	case tabProjects:
+		return m.renderProjectsView(tabHeader, bar)
+	default:
+		return m.renderTasksView(tabHeader, bar)
+	}
+}
+
+func (m Model) padToBottom(content, bar string) string {
+	barHeight := lipgloss.Height(bar)
+	contentHeight := m.height - barHeight
+	if contentHeight < 0 {
+		contentHeight = 0
+	}
+	contentLines := lipgloss.Height(content)
+	padding := ""
+	if contentLines < contentHeight {
+		padding = strings.Repeat("\n", contentHeight-contentLines)
+	}
+	return content + padding + "\n" + bar
+}
+
+func (m Model) splitRightHeights(total int) (int, int) {
+	gitH := total * 3 / 10
+	if gitH < 5 {
+		gitH = 5
+	}
+	if gitH > 15 {
+		gitH = 15
+	}
+	previewH := total - gitH
+	if previewH < 5 {
+		previewH = 5
+	}
+	return gitH, previewH
+}
+
+func (m Model) splitWidths() (int, int) {
+	left := m.width * 2 / 5
+	if left < 30 {
+		left = 30
+	}
+	if left > m.width-20 {
+		left = m.width - 20
+	}
+	right := m.width - left
+	return left, right
+}
+
+func (m Model) renderTabHeader() string {
+	activeStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("87")).
+		Underline(false)
+	inactiveStyle := m.theme.Dimmed
+
+	tabs := []struct {
+		label string
+		key   string
+		t     tab
+	}{
+		{"TASKS", "1", tabTasks},
+		{"PROJECTS", "2", tabProjects},
+	}
+
+	var parts []string
+	for _, t := range tabs {
+		style := inactiveStyle
+		if t.t == m.activeTab {
+			style = activeStyle
+		}
+		parts = append(parts, style.Render("  "+t.label+" "))
+	}
+	header := strings.Join(parts, "  ")
+	return lipgloss.PlaceHorizontal(m.width, lipgloss.Center, header)
+}
+
+func (m Model) renderTasksView(tabHeader, bar string) string {
+	if len(m.db.Tasks()) == 0 {
+		content := m.emptyStateView()
+		return m.padToBottom(content, bar)
+	}
+
+	tasks := m.tasklist.View()
+	var taskID string
+	if t := m.tasklist.Selected(); t != nil {
+		taskID = t.ID
+	}
+	gitView := m.gitstatus.View()
+	previewView := m.preview.View(taskID)
+	rightContent := lipgloss.JoinVertical(lipgloss.Left, gitView, previewView)
+	body := lipgloss.JoinHorizontal(lipgloss.Top, tasks, rightContent)
+	content := tabHeader + "\n" + body
+	return m.padToBottom(content, bar)
+}
+
+func (m Model) renderProjectsView(tabHeader, bar string) string {
+	projects := m.projectlist.View()
+	rightContent := m.renderProjectDetail()
+	body := lipgloss.JoinHorizontal(lipgloss.Top, projects, rightContent)
+	content := tabHeader + "\n" + body
+	return m.padToBottom(content, bar)
+}
+
+func (m Model) renderProjectDetail() string {
+	entry := m.projectlist.Selected()
+	_, rightWidth := m.splitWidths()
+	contentHeight := m.height - 3
+
+	if entry == nil {
+		empty := m.theme.Dimmed.Render("  No project selected")
+		return lipgloss.NewStyle().Width(rightWidth).Height(contentHeight).Render(empty)
+	}
+
+	var b strings.Builder
+	b.WriteString(m.theme.Title.Render("  "+entry.Name) + "\n\n")
+
+	fields := []struct{ label, value string }{
+		{"Path", entry.Project.Path},
+		{"Branch", entry.Project.Branch},
+		{"Backend", entry.Project.Backend},
+	}
+	for _, f := range fields {
+		val := f.value
+		if val == "" {
+			val = "(default)"
+		}
+		b.WriteString("  " + m.theme.Dimmed.Render(f.label+": ") + m.theme.Normal.Render(val) + "\n")
+	}
+
+	return lipgloss.NewStyle().Width(rightWidth).Height(contentHeight).Render(b.String())
+}
+
+func (m Model) emptyStateView() string {
+	banner := renderBanner(m.width)
+	hint := m.theme.Dimmed.Render("Press [n] to create your first task")
+	hint = lipgloss.PlaceHorizontal(m.width, lipgloss.Center, hint)
+	block := banner + "\n\n" + hint
+
+	barHeight := 1
+	contentHeight := m.height - barHeight - 1
+	blockHeight := lipgloss.Height(block)
+	topPad := (contentHeight - blockHeight) / 2
+	if topPad < 0 {
+		topPad = 0
+	}
+
+	return strings.Repeat("\n", topPad) + block
+}
+
+func (m Model) promptView() string {
+	t := m.tasklist.Selected()
+	if t == nil {
+		return ""
+	}
+
+	title := m.theme.Title.Render("Prompt: " + t.Name)
+	prompt := t.Prompt
+	if prompt == "" {
+		prompt = m.theme.Dimmed.Render("(no prompt set)")
+	}
+
+	return title + "\n\n  " + prompt + "\n\n" +
+		m.theme.Help.Render("  Press any key to close")
+}
+
+func (m Model) renderCenteredModal(body string, preferredWidth int) string {
+	w := preferredWidth
+	if m.width > 0 && w > m.width-4 {
+		w = m.width - 4
+	}
+	modal := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("238")).
+		Padding(1, 2).
+		Width(w).
+		Render(body)
+	return lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, modal)
+}
+
+func (m Model) confirmDeleteProjectView() string {
+	entry := m.projectlist.Selected()
+	if entry == nil {
+		return ""
+	}
+	title := m.theme.Title.Render("Delete project?")
+	name := "  " + m.theme.Normal.Render(entry.Name)
+	path := "  " + m.theme.Dimmed.Render(entry.Project.Path)
+	hint := m.theme.Help.Render("  [enter] confirm  [esc] cancel")
+	body := title + "\n\n" + name + "\n" + path + "\n\n" + hint
+	return m.renderCenteredModal(body, 50)
+}
+
+func (m Model) confirmDeleteView() string {
+	t := m.tasklist.Selected()
+	if t == nil {
+		return ""
+	}
+	title := m.theme.Title.Render("Delete task?")
+	name := "  " + m.theme.Normal.Render(t.Name)
+	hint := m.theme.Help.Render("  [enter] confirm  [esc] cancel")
+	body := title + "\n\n" + name + "\n\n" + hint
+	return m.renderCenteredModal(body, 50)
+}
+
+func (m Model) confirmDestroyView() string {
+	t := m.tasklist.Selected()
+	if t == nil {
+		return ""
+	}
+	var details []string
+	details = append(details, "  "+m.theme.Normal.Render(t.Name))
+	if t.Worktree != "" {
+		details = append(details, "  "+m.theme.Dimmed.Render("worktree: "+t.Worktree))
+	}
+	if t.Branch != "" {
+		details = append(details, "  "+m.theme.Dimmed.Render("branch: "+t.Branch))
+	}
+	title := m.theme.Title.Render("Destroy task?")
+	subtitle := m.theme.Help.Render("  This will terminate the agent, remove the worktree and branch, and delete the task.")
+	hint := m.theme.Help.Render("  [enter] confirm  [esc] cancel")
+	body := title + "\n" + subtitle + "\n\n" +
+		strings.Join(details, "\n") + "\n\n" + hint
+	return m.renderCenteredModal(body, 60)
+}

--- a/internal/ui/scrollstate.go
+++ b/internal/ui/scrollstate.go
@@ -1,0 +1,46 @@
+package ui
+
+// ScrollState tracks cursor position and scroll offset for scrollable lists.
+type ScrollState struct {
+	cursor int
+	offset int
+}
+
+// CursorUp moves the cursor up one position, adjusting scroll offset if needed.
+func (s *ScrollState) CursorUp() {
+	if s.cursor > 0 {
+		s.cursor--
+		if s.cursor < s.offset {
+			s.offset = s.cursor
+		}
+	}
+}
+
+// CursorDown moves the cursor down one position, adjusting scroll offset if needed.
+func (s *ScrollState) CursorDown(total, visible int) {
+	if s.cursor < total-1 {
+		s.cursor++
+		if s.cursor >= s.offset+visible {
+			s.offset = s.cursor - visible + 1
+		}
+	}
+}
+
+// ClampCursor ensures the cursor is within bounds after the item count changes.
+func (s *ScrollState) ClampCursor(total int) {
+	if s.cursor >= total {
+		s.cursor = max(0, total-1)
+	}
+}
+
+// Cursor returns the current cursor position.
+func (s *ScrollState) Cursor() int { return s.cursor }
+
+// Offset returns the current scroll offset.
+func (s *ScrollState) Offset() int { return s.offset }
+
+// Reset sets cursor and offset to zero.
+func (s *ScrollState) Reset() {
+	s.cursor = 0
+	s.offset = 0
+}

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -31,10 +31,7 @@ func (sb *StatusBar) SetTasks(tasks []*model.Task) {
 }
 
 func (sb *StatusBar) SetRunning(ids []string) {
-	sb.running = make(map[string]bool, len(ids))
-	for _, id := range ids {
-		sb.running[id] = true
-	}
+	sb.running = toStringSet(ids)
 }
 
 func (sb *StatusBar) SetProjectTab(active bool) {

--- a/internal/ui/tasklist.go
+++ b/internal/ui/tasklist.go
@@ -11,11 +11,10 @@ import (
 // TaskList renders the task list view.
 type TaskList struct {
 	tasks    []*model.Task
-	cursor   int
+	scroll   ScrollState
 	theme    Theme
 	width    int
 	height   int
-	offset   int // scroll offset
 	filter   string
 	filtered []*model.Task
 	running  map[string]bool // task IDs with active agent sessions
@@ -27,25 +26,17 @@ func NewTaskList(theme Theme) TaskList {
 }
 
 func (tl *TaskList) SetRunning(ids []string) {
-	tl.running = make(map[string]bool, len(ids))
-	for _, id := range ids {
-		tl.running[id] = true
-	}
+	tl.running = toStringSet(ids)
 }
 
 func (tl *TaskList) SetIdle(ids []string) {
-	tl.idle = make(map[string]bool, len(ids))
-	for _, id := range ids {
-		tl.idle[id] = true
-	}
+	tl.idle = toStringSet(ids)
 }
 
 func (tl *TaskList) SetTasks(tasks []*model.Task) {
 	tl.tasks = tasks
 	tl.applyFilter()
-	if tl.cursor >= len(tl.filtered) {
-		tl.cursor = max(0, len(tl.filtered)-1)
-	}
+	tl.scroll.ClampCursor(len(tl.filtered))
 }
 
 func (tl *TaskList) SetSize(w, h int) {
@@ -54,30 +45,20 @@ func (tl *TaskList) SetSize(w, h int) {
 }
 
 func (tl *TaskList) CursorUp() {
-	if tl.cursor > 0 {
-		tl.cursor--
-		if tl.cursor < tl.offset {
-			tl.offset = tl.cursor
-		}
-	}
+	tl.scroll.CursorUp()
 }
 
 func (tl *TaskList) CursorDown() {
-	if tl.cursor < len(tl.filtered)-1 {
-		tl.cursor++
-		visible := tl.visibleRows()
-		if tl.cursor >= tl.offset+visible {
-			tl.offset = tl.cursor - visible + 1
-		}
-	}
+	tl.scroll.CursorDown(len(tl.filtered), tl.visibleRows())
 }
 
 func (tl *TaskList) Selected() *model.Task {
 	if len(tl.filtered) == 0 {
 		return nil
 	}
-	if tl.cursor >= 0 && tl.cursor < len(tl.filtered) {
-		return tl.filtered[tl.cursor]
+	c := tl.scroll.Cursor()
+	if c >= 0 && c < len(tl.filtered) {
+		return tl.filtered[c]
 	}
 	return nil
 }
@@ -85,8 +66,7 @@ func (tl *TaskList) Selected() *model.Task {
 func (tl *TaskList) SetFilter(f string) {
 	tl.filter = f
 	tl.applyFilter()
-	tl.cursor = 0
-	tl.offset = 0
+	tl.scroll.Reset()
 }
 
 func (tl *TaskList) applyFilter() {
@@ -120,14 +100,16 @@ func (tl TaskList) View() string {
 
 	var b strings.Builder
 	visible := tl.visibleRows()
-	end := tl.offset + visible
+	offset := tl.scroll.Offset()
+	cursor := tl.scroll.Cursor()
+	end := offset + visible
 	if end > len(tl.filtered) {
 		end = len(tl.filtered)
 	}
 
-	for i := tl.offset; i < end; i++ {
+	for i := offset; i < end; i++ {
 		t := tl.filtered[i]
-		selected := i == tl.cursor
+		selected := i == cursor
 
 		statusStyle := tl.statusStyle(t.Status)
 		badge := statusStyle.Render(t.Status.Badge())

--- a/internal/ui/tasklist_test.go
+++ b/internal/ui/tasklist_test.go
@@ -124,7 +124,7 @@ func TestTaskList_ClearFilter(t *testing.T) {
 		}
 		count++
 		tl.CursorDown()
-		if tl.Selected() == nil || tl.cursor >= len(tl.filtered)-1 {
+		if tl.Selected() == nil || tl.scroll.Cursor() >= len(tl.filtered)-1 {
 			count++
 			break
 		}
@@ -144,8 +144,8 @@ func TestTaskList_SetTasks_ClampsCursor(t *testing.T) {
 
 	// Shrink to 1 task
 	tl.SetTasks([]*model.Task{{Name: "only one"}})
-	if tl.cursor != 0 {
-		t.Errorf("cursor should be clamped to 0, got %d", tl.cursor)
+	if tl.scroll.Cursor() != 0 {
+		t.Errorf("cursor should be clamped to 0, got %d", tl.scroll.Cursor())
 	}
 }
 

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -39,6 +39,30 @@ func clampModalWidth(totalWidth int) int {
 	return w
 }
 
+// toStringSet converts a string slice to a lookup map.
+func toStringSet(ids []string) map[string]bool {
+	m := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m
+}
+
+// borderedPanel creates a rounded-border panel with focus-aware border color.
+func borderedPanel(w, h int, focused bool, content string) string {
+	borderColor := "238"
+	if focused {
+		borderColor = "87"
+	}
+	innerH := max(h-2, 1)
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(borderColor)).
+		Width(w - 2).
+		Height(innerH).
+		Render(content)
+}
+
 func DefaultTheme() Theme {
 	return Theme{
 		Title: lipgloss.NewStyle().

--- a/internal/ui/vtrender.go
+++ b/internal/ui/vtrender.go
@@ -1,0 +1,198 @@
+package ui
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/hinshun/vt10x"
+)
+
+// vt10x attribute bit flags (unexported in the library)
+const (
+	vtAttrReverse   = 1 << 0
+	vtAttrUnderline = 1 << 1
+	vtAttrBold      = 1 << 2
+	// attrGfx      = 1 << 3
+	vtAttrItalic = 1 << 4
+	// attrBlink    = 1 << 5
+)
+
+// replayVT10X replays raw terminal output through a virtual terminal and
+// returns the rendered lines with ANSI colors. cursorVisible controls whether
+// the cursor position is rendered with reverse video.
+func replayVT10X(raw []byte, vtCols, vtRows int, cursorVisible bool) []string {
+	vt := vt10x.New(vt10x.WithSize(vtCols, vtRows))
+	vt.Write(raw)
+
+	vt.Lock()
+	defer vt.Unlock()
+
+	cur := vt.Cursor()
+	showCursor := cursorVisible && vt.CursorVisible()
+
+	var lines []string
+	for y := 0; y < vtRows; y++ {
+		cursorX := -1
+		if showCursor && y == cur.Y {
+			cursorX = cur.X
+		}
+		line := renderLine(vt, y, vtCols, cursorX)
+		lines = append(lines, line)
+	}
+
+	// Trim trailing empty lines
+	for len(lines) > 0 && stripANSI(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	return lines
+}
+
+// estimateVTRows estimates the number of virtual terminal rows needed to
+// capture all output, given the raw bytes and display dimensions.
+func estimateVTRows(raw []byte, vtCols, dispH int) int {
+	vtRows := dispH
+	if n := bytes.Count(raw, []byte{'\n'}); n > vtRows {
+		vtRows = n + dispH
+	}
+	if vtCols > 0 {
+		wrappedEstimate := len(raw)/vtCols + dispH
+		if wrappedEstimate > vtRows {
+			vtRows = wrappedEstimate
+		}
+	}
+	return vtRows
+}
+
+// renderLine builds a single line from the vt10x screen with ANSI colors.
+// cursorX is the column to render a cursor at (-1 for no cursor on this line).
+func renderLine(vt vt10x.Terminal, y, cols int, cursorX int) string {
+	var b strings.Builder
+	var curFG, curBG vt10x.Color
+	var curMode int16
+	active := false
+
+	lastCol := -1
+	for x := cols - 1; x >= 0; x-- {
+		cell := vt.Cell(x, y)
+		ch := cell.Char
+		if ch == 0 {
+			ch = ' '
+		}
+		if ch != ' ' || cell.FG != vt10x.DefaultFG || cell.BG != vt10x.DefaultBG || cell.Mode != 0 {
+			lastCol = x
+			break
+		}
+	}
+	if cursorX > lastCol {
+		lastCol = cursorX
+	}
+
+	for x := 0; x <= lastCol; x++ {
+		cell := vt.Cell(x, y)
+		ch := cell.Char
+		if ch == 0 {
+			ch = ' '
+		}
+
+		if x == cursorX {
+			// Render cursor cell with reverse video, preserving cell colors
+			b.WriteString(buildSGR(cell.FG, cell.BG, cell.Mode|vtAttrReverse))
+			b.WriteRune(ch)
+			b.WriteString("\x1b[0m")
+			active = false
+		} else {
+			if cell.FG != curFG || cell.BG != curBG || cell.Mode != curMode || !active {
+				b.WriteString(buildSGR(cell.FG, cell.BG, cell.Mode))
+				curFG = cell.FG
+				curBG = cell.BG
+				curMode = cell.Mode
+				active = true
+			}
+			b.WriteRune(ch)
+		}
+	}
+
+	if active {
+		b.WriteString("\x1b[0m")
+	}
+
+	return b.String()
+}
+
+// buildSGR builds an ANSI SGR escape sequence for the given attributes.
+func buildSGR(fg, bg vt10x.Color, mode int16) string {
+	var params []string
+
+	params = append(params, "0")
+
+	if mode&vtAttrBold != 0 {
+		params = append(params, "1")
+	}
+	if mode&vtAttrItalic != 0 {
+		params = append(params, "3")
+	}
+	if mode&vtAttrUnderline != 0 {
+		params = append(params, "4")
+	}
+	if mode&vtAttrReverse != 0 {
+		params = append(params, "7")
+	}
+
+	if fg != vt10x.DefaultFG {
+		params = append(params, sgrColor(fg, 30))
+	}
+	if bg != vt10x.DefaultBG {
+		params = append(params, sgrColor(bg, 40))
+	}
+
+	return "\x1b[" + strings.Join(params, ";") + "m"
+}
+
+// sgrColor returns the SGR parameter string for a color.
+// base is 30 for foreground, 40 for background.
+func sgrColor(c vt10x.Color, base int) string {
+	n := uint32(c)
+	switch {
+	case n < 8:
+		return fmt.Sprintf("%d", base+int(n))
+	case n < 16:
+		return fmt.Sprintf("%d", base+60+int(n)-8)
+	case n < 256:
+		prefix := 38
+		if base == 40 {
+			prefix = 48
+		}
+		return fmt.Sprintf("%d;5;%d", prefix, n)
+	default:
+		prefix := 38
+		if base == 40 {
+			prefix = 48
+		}
+		r, g, b := (n>>16)&0xFF, (n>>8)&0xFF, n&0xFF
+		return fmt.Sprintf("%d;2;%d;%d;%d", prefix, r, g, b)
+	}
+}
+
+// stripANSI removes ANSI escape sequences and trims whitespace for emptiness check.
+func stripANSI(s string) string {
+	var b strings.Builder
+	i := 0
+	for i < len(s) {
+		if s[i] == '\x1b' && i+1 < len(s) && s[i+1] == '[' {
+			j := i + 2
+			for j < len(s) && !((s[j] >= 'A' && s[j] <= 'Z') || (s[j] >= 'a' && s[j] <= 'z')) {
+				j++
+			}
+			if j < len(s) {
+				j++
+			}
+			i = j
+		} else {
+			b.WriteByte(s[i])
+			i++
+		}
+	}
+	return strings.TrimSpace(b.String())
+}


### PR DESCRIPTION
## Summary
- Extract `ScrollState` struct from 3 list components with identical cursor/scroll logic
- Consolidate duplicate vt10x terminal rendering into shared `vtrender.go` with `replayVT10X`
- Merge `fgColor`/`bgColor` into parameterized `sgrColor(c, base)`
- Split `root.go` views into `root_views.go` (1107→797 lines)
- Extract key byte maps into `keybytes.go`, git commands into `gitcmd.go`
- Add `borderedPanel`, `toStringSet` helpers; use `errors.Is` idiomatically
- Extract `determinePostExitStatus` pure function and `handleConfirmAction` shared handler
- Net reduction: **-738 lines** across 23 files

## Test plan
- [x] `go test ./...` — all 7 packages pass
- [x] `go vet ./...` — clean
- [x] 3-reviewer independent fresh-eyes re-review: unanimous APPROVE, 0 blocking issues
- [x] All behavior changes verified equivalent (math checked for sgrColor, ordering verified for DetectLanguage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)