### PR TITLE
Add collapsible project folders to task list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ go test ./internal/store/   # run tests for a single package
 - `cmd/argus/main.go` — Entry point. Opens SQLite database, creates agent runner, starts `tea.Program` with alt screen.
 - `internal/ui/root.go` — **Top-level Bubble Tea model**. Owns all sub-views and routes key events based on current view state (`viewTaskList`, `viewNewTask`, `viewHelp`, `viewPrompt`, `viewConfirmDelete`). This is the orchestration hub.
 - `internal/ui/worktree.go` — Git worktree discovery, cleanup, and process management helpers. Extracted from root.go to separate infrastructure concerns from UI logic.
-- `internal/ui/tasklist.go` — Task list with cursor, scrolling, filtering. Not a `tea.Model` itself — it's a plain struct that `root.Model` drives.
+- `internal/ui/tasklist.go` — Task list with collapsible project folders, cursor, scrolling, filtering. Tasks are grouped by project name into a flattened row list (project headers + task rows). Only one project is expanded at a time — auto-expands when the cursor enters a project, auto-collapses others. Not a `tea.Model` itself — it's a plain struct that `root.Model` drives.
 - `internal/ui/newtask.go` — New task form using `bubbles/textinput`. Has its own `Update` method but is called by root.
 - `internal/model/` — Core domain types. `Task` struct and `Status` enum with `pending → in_progress → in_review → complete` workflow. Status implements `encoding.TextMarshaler` for JSON serialization.
 - `internal/db/` — SQLite-backed persistence at `~/.argus/data.sql`. Stores tasks, projects, backends, and config in a single database. Thread-safe with mutex. Auto-migrates from legacy JSON/TOML files on first run.

--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -40,6 +40,15 @@
 - Fixed by changing `gitstatus GitStatus` to `gitstatus *GitStatus`, matching the existing `agentview *AgentView` pattern.
 - **Rule:** Any sub-view struct mutated outside the direct `Update` body must be a pointer. Value types only work for read-only or directly-mutated-in-Update fields.
 
+### Collapsible Project Folders in TaskList (2026-03-14)
+- Flat task list replaced with grouped project folders. Tasks grouped by `task.Project` into a flattened `[]row` slice where each row is either `rowProject` (header) or `rowTask`.
+- Only one project expanded at a time. `autoExpand()` called on every cursor move — if the cursor enters a different project, it sets `expanded`, rebuilds rows, and `restoreCursor()` repositions to the same logical item.
+- `Selected()` on a project header returns the first task in that project (next row). Preserves the `*model.Task` return type contract so root.go needed zero changes.
+- Projects sorted by activity tier (in-progress > pending > complete), alphabetical within tier, "Uncategorized" last.
+- `SetFilter()` must reset `expanded` if the expanded project disappears from filtered results — otherwise the first visible project stays collapsed.
+- `ScrollState` gained `SetCursor(int)` and `SetOffset(int)` for cursor repositioning after row list rebuilds.
+- Existing root_test.go tests needed updates: tasks must have a `Project` field set to control grouping, and cursor-down count must account for project header rows.
+
 ### Deferred Items for Future Sessions
 - Add error handling for silently ignored `_ = m.db.Update()` calls (~15 instances in root.go)
 - Handle `os.UserHomeDir()` errors in db.go and config.go

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -959,8 +959,9 @@ func TestModel_ViewTaskList_EmptyState(t *testing.T) {
 func TestModel_ViewTaskList_WithTasks(t *testing.T) {
 	task := &model.Task{ID: "t1", Name: "my-task", Status: model.StatusPending}
 	m := testModel(t, task)
-	m.width = 120
-	m.height = 40
+	// Send WindowSizeMsg so tasklist gets proper dimensions for rendering.
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
 	view := m.View()
 	if !strings.Contains(view, "my-task") {
 		t.Error("task list view should contain task name")
@@ -1061,22 +1062,31 @@ func TestModel_StatusRevert(t *testing.T) {
 
 func TestModel_CursorNavigation(t *testing.T) {
 	tasks := []*model.Task{
-		{ID: "t1", Name: "first", Status: model.StatusPending},
-		{ID: "t2", Name: "second", Status: model.StatusPending},
+		{ID: "t1", Name: "first", Status: model.StatusPending, Project: "proj"},
+		{ID: "t2", Name: "second", Status: model.StatusPending, Project: "proj"},
 	}
 	m := testModel(t, tasks...)
-	m.width = 120
-	m.height = 40
+	// Send WindowSizeMsg so tasklist gets proper dimensions.
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
 
-	// Down
+	// Rows: [proj header, first, second]. Cursor starts on header.
+	// Down once → first task
 	msg := tea.KeyMsg{Type: tea.KeyDown}
-	updated, _ := m.Update(msg)
+	updated, _ = m.Update(msg)
 	um := updated.(Model)
-	if sel := um.tasklist.Selected(); sel == nil || sel.Name != "second" {
-		t.Error("expected 'second' selected after down")
+	if sel := um.tasklist.Selected(); sel == nil || sel.Name != "first" {
+		t.Error("expected 'first' selected after first down")
 	}
 
-	// Up
+	// Down again → second task
+	updated, _ = um.Update(msg)
+	um = updated.(Model)
+	if sel := um.tasklist.Selected(); sel == nil || sel.Name != "second" {
+		t.Error("expected 'second' selected after second down")
+	}
+
+	// Up → back to first
 	msg = tea.KeyMsg{Type: tea.KeyUp}
 	updated, _ = um.Update(msg)
 	um = updated.(Model)
@@ -1318,15 +1328,18 @@ func TestScheduleGitRefresh_NoTaskReturnsNil(t *testing.T) {
 
 func TestCursorChange_TriggersGitRefresh(t *testing.T) {
 	tasks := []*model.Task{
-		{ID: "t1", Name: "first", Status: model.StatusPending},
-		{ID: "t2", Name: "second", Status: model.StatusPending},
+		{ID: "t1", Name: "first", Status: model.StatusPending, Project: "proj"},
+		{ID: "t2", Name: "second", Status: model.StatusPending, Project: "proj"},
 	}
 	m := testModel(t, tasks...)
+	// Send WindowSizeMsg so tasklist gets proper dimensions.
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
 
-	// Pre-populate cache for second task
-	m.resolvedDirs["t2"] = "/tmp/second-worktree"
+	// Pre-populate cache for first task (cursor lands on it after one down from header)
+	m.resolvedDirs["t1"] = "/tmp/first-worktree"
 
-	// Move cursor down
+	// Move cursor down (from project header to first task)
 	msg := tea.KeyMsg{Type: tea.KeyDown}
 	_, cmd := m.Update(msg)
 

--- a/internal/ui/scrollstate.go
+++ b/internal/ui/scrollstate.go
@@ -39,6 +39,16 @@ func (s *ScrollState) Cursor() int { return s.cursor }
 // Offset returns the current scroll offset.
 func (s *ScrollState) Offset() int { return s.offset }
 
+// SetCursor sets the cursor to a specific position.
+func (s *ScrollState) SetCursor(pos int) {
+	s.cursor = pos
+}
+
+// SetOffset sets the scroll offset directly.
+func (s *ScrollState) SetOffset(off int) {
+	s.offset = off
+}
+
 // Reset sets cursor and offset to zero.
 func (s *ScrollState) Reset() {
 	s.cursor = 0

--- a/internal/ui/tasklist.go
+++ b/internal/ui/tasklist.go
@@ -2,13 +2,32 @@ package ui
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/drn/argus/internal/model"
 )
 
-// TaskList renders the task list view.
+// rowKind distinguishes project header rows from task rows in the flattened list.
+type rowKind int
+
+const (
+	rowProject rowKind = iota
+	rowTask
+)
+
+// row represents a single navigable row in the task list — either a project
+// header or a task nested under it.
+type row struct {
+	kind    rowKind
+	project string
+	task    *model.Task // nil for project headers
+}
+
+const uncategorized = "Uncategorized"
+
+// TaskList renders the task list view with collapsible project folders.
 type TaskList struct {
 	tasks    []*model.Task
 	scroll   ScrollState
@@ -19,6 +38,8 @@ type TaskList struct {
 	filtered []*model.Task
 	running  map[string]bool // task IDs with active agent sessions
 	idle     map[string]bool // task IDs with sessions waiting for input
+	rows     []row           // flattened display rows (headers + tasks)
+	expanded string          // currently expanded project name
 }
 
 func NewTaskList(theme Theme) TaskList {
@@ -36,7 +57,8 @@ func (tl *TaskList) SetIdle(ids []string) {
 func (tl *TaskList) SetTasks(tasks []*model.Task) {
 	tl.tasks = tasks
 	tl.applyFilter()
-	tl.scroll.ClampCursor(len(tl.filtered))
+	tl.buildRows()
+	tl.scroll.ClampCursor(len(tl.rows))
 }
 
 func (tl *TaskList) SetSize(w, h int) {
@@ -46,19 +68,29 @@ func (tl *TaskList) SetSize(w, h int) {
 
 func (tl *TaskList) CursorUp() {
 	tl.scroll.CursorUp()
+	tl.autoExpand()
 }
 
 func (tl *TaskList) CursorDown() {
-	tl.scroll.CursorDown(len(tl.filtered), tl.visibleRows())
+	tl.scroll.CursorDown(len(tl.rows), tl.visibleRows())
+	tl.autoExpand()
 }
 
 func (tl *TaskList) Selected() *model.Task {
-	if len(tl.filtered) == 0 {
+	if len(tl.rows) == 0 {
 		return nil
 	}
 	c := tl.scroll.Cursor()
-	if c >= 0 && c < len(tl.filtered) {
-		return tl.filtered[c]
+	if c < 0 || c >= len(tl.rows) {
+		return nil
+	}
+	r := tl.rows[c]
+	if r.kind == rowTask {
+		return r.task
+	}
+	// On a project header — return the first task in the expanded project.
+	if c+1 < len(tl.rows) && tl.rows[c+1].kind == rowTask {
+		return tl.rows[c+1].task
 	}
 	return nil
 }
@@ -66,6 +98,24 @@ func (tl *TaskList) Selected() *model.Task {
 func (tl *TaskList) SetFilter(f string) {
 	tl.filter = f
 	tl.applyFilter()
+	// Reset expanded if the currently expanded project has no tasks after filtering.
+	if tl.expanded != "" {
+		found := false
+		for _, t := range tl.filtered {
+			p := t.Project
+			if p == "" {
+				p = uncategorized
+			}
+			if p == tl.expanded {
+				found = true
+				break
+			}
+		}
+		if !found {
+			tl.expanded = ""
+		}
+	}
+	tl.buildRows()
 	tl.scroll.Reset()
 }
 
@@ -84,17 +134,134 @@ func (tl *TaskList) applyFilter() {
 	}
 }
 
-func (tl *TaskList) visibleRows() int {
-	// Each task takes 2 lines (name + details)
-	rows := tl.height / 2
-	if rows < 1 {
-		rows = 1
+// projectGroup holds tasks belonging to a single project along with a
+// priority used for sort ordering.
+type projectGroup struct {
+	name     string
+	tasks    []*model.Task
+	priority int // lower = higher in the list
+}
+
+// buildRows groups filtered tasks by project and builds the flattened row list.
+func (tl *TaskList) buildRows() {
+	// Group tasks by project.
+	groupMap := make(map[string][]*model.Task)
+	var order []string
+	for _, t := range tl.filtered {
+		proj := t.Project
+		if proj == "" {
+			proj = uncategorized
+		}
+		if _, exists := groupMap[proj]; !exists {
+			order = append(order, proj)
+		}
+		groupMap[proj] = append(groupMap[proj], t)
 	}
-	return rows
+
+	// Build sortable groups with priority.
+	groups := make([]projectGroup, 0, len(order))
+	for _, name := range order {
+		tasks := groupMap[name]
+		pri := projectPriority(tasks)
+		if name == uncategorized {
+			pri += 100 // push to bottom within its tier
+		}
+		groups = append(groups, projectGroup{name: name, tasks: tasks, priority: pri})
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].priority != groups[j].priority {
+			return groups[i].priority < groups[j].priority
+		}
+		return groups[i].name < groups[j].name
+	})
+
+	// If nothing is expanded yet, expand the first project.
+	if tl.expanded == "" && len(groups) > 0 {
+		tl.expanded = groups[0].name
+	}
+
+	tl.rows = nil
+	for _, g := range groups {
+		tl.rows = append(tl.rows, row{kind: rowProject, project: g.name})
+		if g.name == tl.expanded {
+			for _, t := range g.tasks {
+				tl.rows = append(tl.rows, row{kind: rowTask, project: g.name, task: t})
+			}
+		}
+	}
+}
+
+// projectPriority returns a sort key: 0 for in-progress, 1 for pending, 2 for all-complete.
+func projectPriority(tasks []*model.Task) int {
+	hasInProgress := false
+	hasPending := false
+	for _, t := range tasks {
+		switch t.Status {
+		case model.StatusInProgress:
+			hasInProgress = true
+		case model.StatusPending:
+			hasPending = true
+		}
+	}
+	if hasInProgress {
+		return 0
+	}
+	if hasPending {
+		return 1
+	}
+	return 2
+}
+
+// autoExpand checks if the cursor moved to a different project and rebuilds
+// the row list with that project expanded.
+func (tl *TaskList) autoExpand() {
+	if len(tl.rows) == 0 {
+		return
+	}
+	c := tl.scroll.Cursor()
+	if c < 0 || c >= len(tl.rows) {
+		return
+	}
+	target := tl.rows[c].project
+	if target == tl.expanded {
+		return
+	}
+
+	// Remember what the cursor is pointing at so we can restore it.
+	currentRow := tl.rows[c]
+	tl.expanded = target
+	tl.buildRows()
+	tl.restoreCursor(currentRow)
+}
+
+// restoreCursor finds the row matching currentRow in the rebuilt rows slice
+// and positions the cursor there.
+func (tl *TaskList) restoreCursor(target row) {
+	for i, r := range tl.rows {
+		if r.kind == target.kind && r.project == target.project {
+			if r.kind == rowProject || r.task == target.task {
+				tl.scroll.SetCursor(i)
+				// Ensure offset is reasonable after cursor jump.
+				visible := tl.visibleRows()
+				if i < tl.scroll.Offset() {
+					tl.scroll.SetOffset(i)
+				} else if i >= tl.scroll.Offset()+visible {
+					tl.scroll.SetOffset(i - visible + 1)
+				}
+				return
+			}
+		}
+	}
+	tl.scroll.ClampCursor(len(tl.rows))
+}
+
+func (tl *TaskList) visibleRows() int {
+	// Each row takes 1-2 lines; use 2 as upper bound for scroll calculations.
+	return max(tl.height/2, 1)
 }
 
 func (tl TaskList) View() string {
-	if len(tl.filtered) == 0 {
+	if len(tl.rows) == 0 {
 		return "\n" + tl.theme.Dimmed.Render("    No tasks yet. Press [n] to create one.")
 	}
 
@@ -102,68 +269,94 @@ func (tl TaskList) View() string {
 	visible := tl.visibleRows()
 	offset := tl.scroll.Offset()
 	cursor := tl.scroll.Cursor()
-	end := offset + visible
-	if end > len(tl.filtered) {
-		end = len(tl.filtered)
-	}
+	end := min(offset+visible, len(tl.rows))
 
 	for i := offset; i < end; i++ {
-		t := tl.filtered[i]
+		r := tl.rows[i]
 		selected := i == cursor
 
-		statusStyle := tl.statusStyle(t.Status)
-		badge := statusStyle.Render(t.Status.Badge())
-
-		// Task name
-		nameStyle := tl.theme.Normal
-		if selected {
-			nameStyle = tl.theme.Selected
+		if r.kind == rowProject {
+			tl.renderProjectHeader(&b, r.project, selected)
+		} else {
+			tl.renderTaskRow(&b, r.task, selected)
 		}
-		if t.Status == model.StatusComplete {
-			nameStyle = tl.theme.Dimmed
-		}
-		name := nameStyle.Render(t.Name)
-
-		// Cursor indicator
-		cursor := "  "
-		if selected {
-			cursor = tl.theme.Selected.Render(" >")
-		}
-
-		// Status label (right-aligned)
-		displayText := t.Status.Display()
-		if t.Status == model.StatusInProgress && (!tl.running[t.ID] || tl.idle[t.ID]) {
-			displayText = "● idle"
-		}
-		statusLabel := statusStyle.Render(displayText)
-		elapsed := ""
-		if e := t.ElapsedString(); e != "" {
-			elapsed = "  " + tl.theme.Elapsed.Render(e)
-		}
-		right := statusLabel + elapsed
-
-		// Build first line with padding between name and status
-		left := fmt.Sprintf("%s %s  %s", cursor, badge, name)
-		gap := tl.width - lipgloss.Width(left) - lipgloss.Width(right) - 2
-		if gap < 1 {
-			gap = 1
-		}
-		b.WriteString(left + strings.Repeat(" ", gap) + right + "\n")
-
-		// Second line: project + branch (subtle)
-		detail := "      "
-		if t.Project != "" {
-			detail += tl.theme.ProjectName.Render(t.Project)
-			if t.Branch != "" {
-				detail += tl.theme.Dimmed.Render(" / " + t.Branch)
-			}
-		} else if t.Branch != "" {
-			detail += tl.theme.Dimmed.Render(t.Branch)
-		}
-		b.WriteString(detail + "\n")
 	}
 
 	return b.String()
+}
+
+func (tl TaskList) renderProjectHeader(b *strings.Builder, project string, selected bool) {
+	chevron := "▸"
+	if project == tl.expanded {
+		chevron = "▾"
+	}
+
+	// Count tasks in this project.
+	count := 0
+	for _, t := range tl.filtered {
+		p := t.Project
+		if p == "" {
+			p = uncategorized
+		}
+		if p == project {
+			count++
+		}
+	}
+
+	nameStyle := tl.theme.Section
+	chevronStyle := tl.theme.Dimmed
+	cursorStr := "  "
+	if selected {
+		nameStyle = tl.theme.Selected
+		chevronStyle = tl.theme.Selected
+		cursorStr = tl.theme.Selected.Render(" >")
+	}
+
+	countStr := tl.theme.Dimmed.Render(fmt.Sprintf(" (%d)", count))
+	line := fmt.Sprintf("%s %s %s%s", cursorStr, chevronStyle.Render(chevron), nameStyle.Render(project), countStr)
+	b.WriteString(line + "\n")
+}
+
+func (tl TaskList) renderTaskRow(b *strings.Builder, t *model.Task, selected bool) {
+	statusStyle := tl.statusStyle(t.Status)
+	badge := statusStyle.Render(t.Status.Badge())
+
+	nameStyle := tl.theme.Normal
+	if selected {
+		nameStyle = tl.theme.Selected
+	}
+	if t.Status == model.StatusComplete {
+		nameStyle = tl.theme.Dimmed
+	}
+	name := nameStyle.Render(t.Name)
+
+	cursorStr := "    "
+	if selected {
+		cursorStr = tl.theme.Selected.Render("   >")
+	}
+
+	// Status label (right-aligned)
+	displayText := t.Status.Display()
+	if t.Status == model.StatusInProgress && (!tl.running[t.ID] || tl.idle[t.ID]) {
+		displayText = "● idle"
+	}
+	statusLabel := statusStyle.Render(displayText)
+	elapsed := ""
+	if e := t.ElapsedString(); e != "" {
+		elapsed = "  " + tl.theme.Elapsed.Render(e)
+	}
+	right := statusLabel + elapsed
+
+	left := fmt.Sprintf("%s %s  %s", cursorStr, badge, name)
+	gap := max(tl.width-lipgloss.Width(left)-lipgloss.Width(right)-2, 1)
+	b.WriteString(left + strings.Repeat(" ", gap) + right + "\n")
+
+	// Second line: branch only (project shown in header)
+	detail := "        "
+	if t.Branch != "" {
+		detail += tl.theme.Dimmed.Render(t.Branch)
+	}
+	b.WriteString(detail + "\n")
 }
 
 func (tl TaskList) statusStyle(s model.Status) lipgloss.Style {

--- a/internal/ui/tasklist_test.go
+++ b/internal/ui/tasklist_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/drn/argus/internal/model"
@@ -23,73 +24,212 @@ func TestTaskList_Selected_Empty(t *testing.T) {
 
 func TestTaskList_Selected(t *testing.T) {
 	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 20)
 	tasks := testTasks()
 	tl.SetTasks(tasks)
 
+	// Cursor starts on the first project header; Selected returns first task in that project.
 	got := tl.Selected()
-	if got == nil || got.Name != "Fix login bug" {
-		t.Error("expected first task selected")
+	if got == nil {
+		t.Fatal("expected non-nil selected task")
+	}
+	// First project should be "webapp" (both projects have pending status, alphabetical: backend < webapp,
+	// but order depends on input order within same priority tier — they both have pending tasks).
+	// The first project header's Selected() returns its first task.
+	if got.Project != tl.rows[0].project {
+		t.Errorf("expected task from first project %q, got project %q", tl.rows[0].project, got.Project)
 	}
 }
 
 func TestTaskList_CursorNavigation(t *testing.T) {
 	tl := NewTaskList(DefaultTheme())
-	tl.SetSize(80, 20)
+	tl.SetSize(80, 40)
 	tl.SetTasks(testTasks())
 
+	// Cursor starts at row 0 (first project header).
+	// Moving down should enter the expanded project's tasks.
 	tl.CursorDown()
-	if got := tl.Selected(); got.Name != "Add API endpoint" {
-		t.Errorf("after down: got %q", got.Name)
+	got := tl.Selected()
+	if got == nil {
+		t.Fatal("expected task after cursor down")
+	}
+	// Should be on a task row now.
+	c := tl.scroll.Cursor()
+	if tl.rows[c].kind != rowTask {
+		t.Error("expected cursor on a task row after one down")
+	}
+}
+
+func TestTaskList_AutoExpand(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
+	tasks := []*model.Task{
+		{Name: "Task A1", Project: "alpha"},
+		{Name: "Task A2", Project: "alpha"},
+		{Name: "Task B1", Project: "beta"},
+	}
+	tl.SetTasks(tasks)
+
+	// Initially the first project is expanded.
+	firstProject := tl.expanded
+	if firstProject == "" {
+		t.Fatal("expected a project to be expanded")
 	}
 
-	tl.CursorDown()
-	if got := tl.Selected(); got.Name != "Update docs" {
-		t.Errorf("after 2nd down: got %q", got.Name)
+	// Navigate down past the first project's tasks to the next project header.
+	for i := 0; i < 20; i++ {
+		tl.CursorDown()
+		c := tl.scroll.Cursor()
+		if c < len(tl.rows) && tl.rows[c].kind == rowProject && tl.rows[c].project != firstProject {
+			break
+		}
 	}
 
-	// Should not go past end
-	tl.CursorDown()
-	if got := tl.Selected(); got.Name != "Update docs" {
-		t.Error("should stay at end")
+	// Now the expanded project should have changed.
+	if tl.expanded == firstProject {
+		t.Error("expected expanded project to change after navigating to a different project")
 	}
 
-	tl.CursorUp()
-	if got := tl.Selected(); got.Name != "Add API endpoint" {
-		t.Errorf("after up: got %q", got.Name)
+	// The new project's tasks should be visible in the rows.
+	found := false
+	for _, r := range tl.rows {
+		if r.kind == rowTask && r.project == tl.expanded {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected tasks from newly expanded project to be in rows")
 	}
 
-	// Should not go past beginning
-	tl.CursorUp()
-	tl.CursorUp()
-	if got := tl.Selected(); got.Name != "Fix login bug" {
-		t.Error("should stay at beginning")
+	// The old project's tasks should NOT be visible.
+	for _, r := range tl.rows {
+		if r.kind == rowTask && r.project == firstProject {
+			t.Error("expected old project's tasks to be collapsed")
+			break
+		}
+	}
+}
+
+func TestTaskList_SelectedOnHeader(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
+	tasks := []*model.Task{
+		{Name: "Task 1", Project: "proj"},
+	}
+	tl.SetTasks(tasks)
+
+	// Cursor is on the project header.
+	if tl.rows[0].kind != rowProject {
+		t.Fatal("expected first row to be project header")
+	}
+	got := tl.Selected()
+	if got == nil || got.Name != "Task 1" {
+		t.Error("Selected() on header should return first task in project")
+	}
+}
+
+func TestTaskList_UncategorizedGroup(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
+	tasks := []*model.Task{
+		{Name: "Orphan task", Project: ""},
+		{Name: "Project task", Project: "myproj"},
+	}
+	tl.SetTasks(tasks)
+
+	// Find the uncategorized header.
+	hasUncategorized := false
+	for _, r := range tl.rows {
+		if r.kind == rowProject && r.project == uncategorized {
+			hasUncategorized = true
+			break
+		}
+	}
+	if !hasUncategorized {
+		t.Error("expected Uncategorized group for tasks with empty project")
+	}
+}
+
+func TestTaskList_FilterWithGroups(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
+	tl.SetTasks(testTasks())
+
+	tl.SetFilter("webapp")
+
+	// Only webapp tasks should be in the rows.
+	for _, r := range tl.rows {
+		if r.kind == rowTask && r.task.Project != "webapp" {
+			t.Errorf("expected only webapp tasks, got project %q", r.task.Project)
+		}
+	}
+
+	// Should have exactly one project header (webapp).
+	headerCount := 0
+	for _, r := range tl.rows {
+		if r.kind == rowProject {
+			headerCount++
+			if r.project != "webapp" {
+				t.Errorf("expected webapp header, got %q", r.project)
+			}
+		}
+	}
+	if headerCount != 1 {
+		t.Errorf("expected 1 project header, got %d", headerCount)
+	}
+}
+
+func TestTaskList_SingleProject(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
+	tasks := []*model.Task{
+		{Name: "Task 1", Project: "solo"},
+		{Name: "Task 2", Project: "solo"},
+	}
+	tl.SetTasks(tasks)
+
+	// Single project should be expanded with all tasks visible.
+	taskRows := 0
+	for _, r := range tl.rows {
+		if r.kind == rowTask {
+			taskRows++
+		}
+	}
+	if taskRows != 2 {
+		t.Errorf("expected 2 task rows for single project, got %d", taskRows)
+	}
+}
+
+func TestTaskList_ViewRendersHeaders(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
+	tl.SetTasks(testTasks())
+
+	v := tl.View()
+	if !strings.Contains(v, "▾") && !strings.Contains(v, "▸") {
+		t.Error("expected chevron indicators in view output")
 	}
 }
 
 func TestTaskList_Filter(t *testing.T) {
 	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
 	tl.SetTasks(testTasks())
 
 	tl.SetFilter("webapp")
-	if got := tl.Selected(); got == nil || got.Name != "Fix login bug" {
-		t.Error("filter should show webapp tasks")
+	got := tl.Selected()
+	if got == nil {
+		t.Fatal("expected selected task after filter")
 	}
-
-	// Should have 2 results (both webapp tasks)
-	tl.CursorDown()
-	if got := tl.Selected(); got == nil || got.Name != "Update docs" {
-		t.Error("should have 2nd webapp task")
-	}
-
-	// Past end
-	tl.CursorDown()
-	if got := tl.Selected(); got.Name != "Update docs" {
-		t.Error("should not go past filtered end")
+	if got.Project != "webapp" {
+		t.Errorf("expected webapp task, got %q", got.Project)
 	}
 }
 
 func TestTaskList_FilterCaseInsensitive(t *testing.T) {
 	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
 	tl.SetTasks(testTasks())
 
 	tl.SetFilter("API")
@@ -111,41 +251,38 @@ func TestTaskList_FilterNoMatch(t *testing.T) {
 
 func TestTaskList_ClearFilter(t *testing.T) {
 	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
 	tl.SetTasks(testTasks())
 
 	tl.SetFilter("webapp")
 	tl.SetFilter("")
 
-	// Should show all tasks again
-	count := 0
-	for {
-		if tl.Selected() == nil {
-			break
-		}
-		count++
-		tl.CursorDown()
-		if tl.Selected() == nil || tl.scroll.Cursor() >= len(tl.filtered)-1 {
-			count++
-			break
+	// Should show all projects again.
+	projectCount := 0
+	for _, r := range tl.rows {
+		if r.kind == rowProject {
+			projectCount++
 		}
 	}
-	if count != 3 {
-		t.Errorf("expected 3 tasks after clearing filter, navigated %d", count)
+	if projectCount < 2 {
+		t.Errorf("expected at least 2 project headers after clearing filter, got %d", projectCount)
 	}
 }
 
 func TestTaskList_SetTasks_ClampsCursor(t *testing.T) {
 	tl := NewTaskList(DefaultTheme())
-	tl.SetSize(80, 20)
+	tl.SetSize(80, 40)
 	tl.SetTasks(testTasks())
 
-	tl.CursorDown()
-	tl.CursorDown() // cursor at 2
+	// Move cursor down several times.
+	for i := 0; i < 5; i++ {
+		tl.CursorDown()
+	}
 
-	// Shrink to 1 task
-	tl.SetTasks([]*model.Task{{Name: "only one"}})
-	if tl.scroll.Cursor() != 0 {
-		t.Errorf("cursor should be clamped to 0, got %d", tl.scroll.Cursor())
+	// Shrink to 1 task.
+	tl.SetTasks([]*model.Task{{Name: "only one", Project: "solo"}})
+	if tl.scroll.Cursor() >= len(tl.rows) {
+		t.Errorf("cursor should be clamped, got %d with %d rows", tl.scroll.Cursor(), len(tl.rows))
 	}
 }
 


### PR DESCRIPTION
Group tasks by project name into expandable/collapsible folders that auto-expand when the cursor enters and auto-collapse when leaving. Projects sorted by activity tier (in-progress > pending > complete), alphabetical within tier, Uncategorized last.

Co-Authored-By: Claude <noreply@anthropic.com>