### PR TITLE
Embellish ARGUS banner with minimal decorative accents

### DIFF
--- a/internal/ui/banner.go
+++ b/internal/ui/banner.go
@@ -24,6 +24,13 @@ var bannerGradient = [...]lipgloss.Color{
 
 const bannerWidth = 41
 
+// Accent colors matching gradient endpoints.
+var (
+	accentCyan = lipgloss.Color("87")  // cyan (top of gradient)
+	accentPink = lipgloss.Color("212") // pink (bottom of gradient)
+	dimColor   = lipgloss.Color("241") // muted gray
+)
+
 func renderBanner(width int) string {
 	if width < bannerWidth+4 {
 		// Terminal too narrow for banner — use compact title
@@ -32,27 +39,121 @@ func renderBanner(width int) string {
 			Foreground(lipgloss.Color("87")).
 			Render("ARGUS")
 		sub := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("241")).
+			Foreground(dimColor).
 			Render("CODE ORCHESTRATOR")
 		block := lipgloss.JoinVertical(lipgloss.Center, title, sub)
 		return lipgloss.PlaceHorizontal(width, lipgloss.Center, block)
 	}
 
 	var b strings.Builder
+
+	// Top accent: fading lines from center with hexagon
+	b.WriteString(renderFadingAccent(width, accentCyan, accentPink))
+	b.WriteByte('\n')
+	b.WriteByte('\n')
+
+	// Main banner text with per-line gradient
 	for i, line := range bannerLines {
-		styled := lipgloss.NewStyle().Foreground(bannerGradient[i]).Render(line)
+		styled := lipgloss.NewStyle().
+			Bold(true).
+			Foreground(bannerGradient[i]).
+			Render(line)
 		centered := lipgloss.PlaceHorizontal(width, lipgloss.Center, styled)
 		b.WriteString(centered)
-		if i < len(bannerLines)-1 {
-			b.WriteByte('\n')
-		}
+		b.WriteByte('\n')
 	}
 
-	sub := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("241")).
-		Render("C O D E   O R C H E S T R A T O R")
+	// Gradient underline beneath banner
+	underlineLen := bannerWidth
+	b.WriteString(renderGradientUnderline(width, underlineLen))
 	b.WriteByte('\n')
+	b.WriteByte('\n')
+
+	// Subtitle — clean and airy
+	sub := lipgloss.NewStyle().
+		Foreground(dimColor).
+		Render("C O D E   O R C H E S T R A T O R")
 	b.WriteString(lipgloss.PlaceHorizontal(width, lipgloss.Center, sub))
+	b.WriteByte('\n')
+	b.WriteByte('\n')
+
+	// Bottom accent: fading lines with hexagon
+	b.WriteString(renderFadingAccent(width, accentCyan, accentPink))
 
 	return b.String()
+}
+
+// renderFadingAccent draws two fading dashes from center with a hexagon accent.
+// The left side fades in the left color, the right side in the right color.
+func renderFadingAccent(width int, left, right lipgloss.Color) string {
+	sideLen := max((width-bannerWidth)/2-2, 3)
+
+	// Build fading dashes: sparse near edges, dense near center
+	leftDashes := fadeDashes(sideLen, false)
+	rightDashes := fadeDashes(sideLen, true)
+
+	leftStyled := lipgloss.NewStyle().Foreground(left).Render(leftDashes)
+	rightStyled := lipgloss.NewStyle().Foreground(right).Render(rightDashes)
+	hex := lipgloss.NewStyle().Foreground(left).Render("⬡")
+
+	line := leftStyled + " " + hex + " " + rightStyled
+	return lipgloss.PlaceHorizontal(width, lipgloss.Center, line)
+}
+
+// fadeDashes generates a string of dashes that fade from sparse to dense.
+// If reverse is true, the dense end is on the left (fading out to the right).
+func fadeDashes(length int, reverse bool) string {
+	if length <= 0 {
+		return ""
+	}
+	buf := make([]byte, length)
+	for i := range buf {
+		// density increases toward the center
+		pos := i
+		if reverse {
+			pos = length - 1 - i
+		}
+		// first third: sparse (every 3rd char), middle: every 2nd, last: solid
+		third := length / 3
+		if third == 0 {
+			third = 1
+		}
+		if pos < third {
+			if pos%3 == 2 {
+				buf[i] = '-'
+			} else {
+				buf[i] = ' '
+			}
+		} else if pos < 2*third {
+			if pos%2 == 1 {
+				buf[i] = '-'
+			} else {
+				buf[i] = ' '
+			}
+		} else {
+			buf[i] = '-'
+		}
+	}
+	return string(buf)
+}
+
+// renderGradientUnderline renders a centered underline using the gradient colors.
+func renderGradientUnderline(width, lineLen int) string {
+	if lineLen <= 0 {
+		return ""
+	}
+	// Split the underline into segments matching the gradient
+	segLen := max(lineLen/len(bannerGradient), 1)
+	var parts []string
+	for i, c := range bannerGradient {
+		n := segLen
+		if i == len(bannerGradient)-1 {
+			n = lineLen - segLen*(len(bannerGradient)-1) // remainder
+		}
+		if n > 0 {
+			parts = append(parts, lipgloss.NewStyle().Foreground(c).Render(strings.Repeat("─", n)))
+		}
+	}
+	line := strings.Join(parts, "")
+	return lipgloss.PlaceHorizontal(width, lipgloss.Center, line)
 }

--- a/internal/ui/banner_test.go
+++ b/internal/ui/banner_test.go
@@ -7,12 +7,17 @@ import (
 
 func TestRenderBanner_WideWidth(t *testing.T) {
 	result := renderBanner(100)
-	// Wide banner uses block art characters (e.g. "███████") not the word "ARGUS"
 	if !strings.Contains(result, "██") {
 		t.Error("wide banner should contain block art characters")
 	}
 	if !strings.Contains(result, "O R C H E S T R A T O R") {
 		t.Error("wide banner should contain spaced subtitle")
+	}
+	if !strings.Contains(result, "⬡") {
+		t.Error("wide banner should contain hexagon accent")
+	}
+	if !strings.Contains(result, "─") {
+		t.Error("wide banner should contain gradient underline")
 	}
 }
 
@@ -27,7 +32,6 @@ func TestRenderBanner_NarrowWidth(t *testing.T) {
 }
 
 func TestRenderBanner_ExactBoundary(t *testing.T) {
-	// bannerWidth+4 = 45, so 44 should be narrow and 45 should be wide
 	narrow := renderBanner(bannerWidth + 3)
 	if !strings.Contains(narrow, "CODE ORCHESTRATOR") {
 		t.Error("width bannerWidth+3 should use compact format")
@@ -40,9 +44,51 @@ func TestRenderBanner_ExactBoundary(t *testing.T) {
 }
 
 func TestRenderBanner_ZeroWidth(t *testing.T) {
-	// Should not panic
 	result := renderBanner(0)
 	if result == "" {
 		t.Error("banner with zero width should still produce output")
+	}
+}
+
+func TestFadeDashes(t *testing.T) {
+	tests := []struct {
+		length  int
+		reverse bool
+	}{
+		{0, false},
+		{1, false},
+		{10, false},
+		{10, true},
+		{30, false},
+	}
+	for _, tt := range tests {
+		result := fadeDashes(tt.length, tt.reverse)
+		if len(result) != tt.length {
+			t.Errorf("fadeDashes(%d, %v) length = %d, want %d", tt.length, tt.reverse, len(result), tt.length)
+		}
+	}
+}
+
+func TestRenderGradientUnderline(t *testing.T) {
+	result := renderGradientUnderline(80, 41)
+	if !strings.Contains(result, "─") {
+		t.Error("gradient underline should contain dash characters")
+	}
+	if result == "" {
+		t.Error("gradient underline should not be empty")
+	}
+}
+
+func TestRenderGradientUnderline_ZeroLen(t *testing.T) {
+	result := renderGradientUnderline(80, 0)
+	if result != "" {
+		t.Error("gradient underline with zero length should be empty")
+	}
+}
+
+func TestRenderFadingAccent(t *testing.T) {
+	result := renderFadingAccent(80, accentCyan, accentPink)
+	if !strings.Contains(result, "⬡") {
+		t.Error("fading accent should contain hexagon")
 	}
 }


### PR DESCRIPTION
Add fading accent lines with hexagon glyphs, a gradient underline beneath the block letters, and bold text weight. Subtle upgrade inspired by the AI-RON terminal banner aesthetic.

Co-Authored-By: Claude <noreply@anthropic.com>