### PR TITLE
Fix empty screen after pruning all tasks in expanded project

### DIFF
--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -46,6 +46,7 @@
 - `Selected()` on a project header returns the first task in that project (next row). Preserves the `*model.Task` return type contract so root.go needed zero changes.
 - Projects sorted by activity tier (in-progress > pending > complete), alphabetical within tier, "Uncategorized" last.
 - `SetFilter()` must reset `expanded` if the expanded project disappears from filtered results — otherwise the first visible project stays collapsed.
+- `buildRows()` must reset `expanded` if the expanded project no longer exists in any group (e.g. all its tasks were pruned). Without this, the auto-expand-first-project logic (`if expanded == ""`) never fires, leaving all remaining projects collapsed and the screen appearing empty until a cursor move triggers `autoExpand()`.
 - `ScrollState` gained `SetCursor(int)` and `SetOffset(int)` for cursor repositioning after row list rebuilds.
 - Existing root_test.go tests needed updates: tasks must have a `Project` field set to control grouping, and cursor-down count must account for project header rows.
 

--- a/internal/ui/tasklist.go
+++ b/internal/ui/tasklist.go
@@ -246,7 +246,21 @@ func (tl *TaskList) buildRows() {
 		return groups[i].name < groups[j].name
 	})
 
-	// If nothing is expanded yet, expand the first project.
+	// Reset expanded if the project no longer exists (e.g. all its tasks were pruned).
+	if tl.expanded != "" {
+		found := false
+		for _, g := range groups {
+			if g.name == tl.expanded {
+				found = true
+				break
+			}
+		}
+		if !found {
+			tl.expanded = ""
+		}
+	}
+
+	// If nothing is expanded, expand the first project.
 	if tl.expanded == "" && len(groups) > 0 {
 		tl.expanded = groups[0].name
 	}

--- a/internal/ui/tasklist_test.go
+++ b/internal/ui/tasklist_test.go
@@ -344,6 +344,45 @@ func TestTaskList_CursorUpAcrossProjects(t *testing.T) {
 	}
 }
 
+func TestTaskList_ExpandedProjectRemoved(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
+
+	// Start with two projects. Force alpha expanded by setting it before SetTasks.
+	tl.expanded = "alpha"
+	tasks := []*model.Task{
+		{Name: "A1", Project: "alpha", Status: model.StatusComplete},
+		{Name: "A2", Project: "alpha", Status: model.StatusComplete},
+		{Name: "B1", Project: "beta", Status: model.StatusPending},
+	}
+	tl.SetTasks(tasks)
+
+	if tl.expanded != "alpha" {
+		t.Fatalf("expected alpha expanded, got %q", tl.expanded)
+	}
+
+	// Simulate pruning: remove all alpha tasks, only beta remains.
+	tl.SetTasks([]*model.Task{
+		{Name: "B1", Project: "beta", Status: model.StatusPending},
+	})
+
+	// The expanded project should switch to beta (the only remaining project).
+	if tl.expanded != "beta" {
+		t.Errorf("expected beta expanded after alpha removed, got %q", tl.expanded)
+	}
+
+	// Beta's tasks should be visible in rows.
+	taskRows := 0
+	for _, r := range tl.rows {
+		if r.kind == rowTask {
+			taskRows++
+		}
+	}
+	if taskRows != 1 {
+		t.Errorf("expected 1 visible task row, got %d", taskRows)
+	}
+}
+
 func TestTaskList_View_Empty(t *testing.T) {
 	tl := NewTaskList(DefaultTheme())
 	tl.SetTasks(nil)


### PR DESCRIPTION
When all tasks in the currently expanded project were pruned, the stale expanded state caused all remaining projects to render collapsed. The screen appeared empty until a cursor move triggered autoExpand(). buildRows() now resets expanded when the project no longer exists in any group.

Co-Authored-By: Claude <noreply@anthropic.com>