### PR TITLE
Replace task status icons with animated Nerd Font glyphs

### DIFF
--- a/internal/model/status.go
+++ b/internal/model/status.go
@@ -20,10 +20,10 @@ var statusNames = [...]string{
 }
 
 var statusDisplay = [...]string{
-	"◻ pending",
-	"⏳ progress",
-	"👀 review",
-	"✓ complete",
+	"\uF10C",
+	"\uF10C",
+	"\uF06E",
+	"\uF00C",
 }
 
 var statusBadges = [...]string{
@@ -40,9 +40,25 @@ func (s Status) String() string {
 	return fmt.Sprintf("unknown(%d)", int(s))
 }
 
+// statusDisplayAlt holds the alternate animation frame for statuses that animate.
+var statusDisplayAlt = [...]string{
+	"\uF10C",
+	"\uF192", // dot-circle-o: alternate frame for in_progress
+	"\uF06E",
+	"\uF00C",
+}
+
 func (s Status) Display() string {
 	if int(s) < len(statusDisplay) {
 		return statusDisplay[s]
+	}
+	return s.String()
+}
+
+// DisplayAlt returns the alternate animation frame for the status icon.
+func (s Status) DisplayAlt() string {
+	if int(s) < len(statusDisplayAlt) {
+		return statusDisplayAlt[s]
 	}
 	return s.String()
 }

--- a/internal/model/status_test.go
+++ b/internal/model/status_test.go
@@ -24,11 +24,27 @@ func TestStatus_String(t *testing.T) {
 }
 
 func TestStatus_Display(t *testing.T) {
-	if got := StatusPending.Display(); got != "◻ pending" {
+	if got := StatusPending.Display(); got != "\uF10C" {
 		t.Errorf("Pending.Display() = %q", got)
+	}
+	if got := StatusComplete.Display(); got != "\uF00C" {
+		t.Errorf("Complete.Display() = %q", got)
 	}
 	if got := Status(99).Display(); got != "unknown(99)" {
 		t.Errorf("out-of-range Display() = %q", got)
+	}
+}
+
+func TestStatus_DisplayAlt(t *testing.T) {
+	if got := StatusInProgress.DisplayAlt(); got != "\uF192" {
+		t.Errorf("InProgress.DisplayAlt() = %q, want dot-circle-o", got)
+	}
+	// Non-animated statuses return same as Display
+	if got := StatusPending.DisplayAlt(); got != "\uF10C" {
+		t.Errorf("Pending.DisplayAlt() = %q", got)
+	}
+	if got := Status(99).DisplayAlt(); got != "unknown(99)" {
+		t.Errorf("out-of-range DisplayAlt() = %q", got)
 	}
 }
 

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -199,6 +199,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case TickMsg:
 		// Keep running state fresh so idle tasks display correctly.
 		m.refreshTasks()
+		m.tasklist.Tick()
 		var cmds []tea.Cmd
 		cmds = append(cmds, tea.Tick(time.Second, func(_ time.Time) tea.Msg {
 			return TickMsg{}

--- a/internal/ui/tasklist.go
+++ b/internal/ui/tasklist.go
@@ -40,10 +40,15 @@ type TaskList struct {
 	idle     map[string]bool // task IDs with sessions waiting for input
 	rows     []row           // flattened display rows (headers + tasks)
 	expanded string          // currently expanded project name
+	tickEven bool            // toggles each tick for status icon animation
 }
 
 func NewTaskList(theme Theme) TaskList {
 	return TaskList{theme: theme, running: make(map[string]bool), idle: make(map[string]bool)}
+}
+
+func (tl *TaskList) Tick() {
+	tl.tickEven = !tl.tickEven
 }
 
 func (tl *TaskList) SetRunning(ids []string) {
@@ -446,8 +451,12 @@ func (tl TaskList) renderTaskRow(b *strings.Builder, t *model.Task, selected boo
 
 	// Status label (right-aligned)
 	displayText := t.Status.Display()
-	if t.Status == model.StatusInProgress && (!tl.running[t.ID] || tl.idle[t.ID]) {
-		displayText = "● idle"
+	if t.Status == model.StatusInProgress {
+		if !tl.running[t.ID] || tl.idle[t.ID] {
+			displayText = "\uF186" // moon: idle
+		} else if tl.tickEven {
+			displayText = t.Status.DisplayAlt() // animate between circle-o and dot-circle-o
+		}
 	}
 	statusLabel := statusStyle.Render(displayText)
 	elapsed := ""


### PR DESCRIPTION
Use Font Awesome Nerd Font icons for all task states. In-progress status animates between circle-o and dot-circle-o on each tick. Idle uses moon icon.

Co-Authored-By: Claude <noreply@anthropic.com>