### PR TITLE
Add right-aligned status summary icons to project headers

### DIFF
--- a/internal/ui/tasklist.go
+++ b/internal/ui/tasklist.go
@@ -399,23 +399,43 @@ func (tl TaskList) View() string {
 	return b.String()
 }
 
-func (tl TaskList) renderProjectHeader(b *strings.Builder, project string, selected bool) {
-	chevron := "▸"
-	if project == tl.expanded {
-		chevron = "▾"
-	}
-
-	// Count tasks in this project.
-	count := 0
+// projectTasks returns the filtered tasks belonging to the given project name.
+func (tl TaskList) projectTasks(project string) []*model.Task {
+	var tasks []*model.Task
 	for _, t := range tl.filtered {
 		p := t.Project
 		if p == "" {
 			p = uncategorized
 		}
 		if p == project {
-			count++
+			tasks = append(tasks, t)
 		}
 	}
+	return tasks
+}
+
+// taskStatusIcon returns the styled status icon for a task, including
+// animation logic for in-progress tasks (running/idle/tick).
+func (tl TaskList) taskStatusIcon(t *model.Task) string {
+	displayText := t.Status.Display()
+	if t.Status == model.StatusInProgress {
+		if !tl.running[t.ID] || tl.idle[t.ID] {
+			displayText = "\uF186" // moon: idle
+		} else if tl.tickEven {
+			displayText = t.Status.DisplayAlt()
+		}
+	}
+	return tl.statusStyle(t.Status).Render(displayText)
+}
+
+func (tl TaskList) renderProjectHeader(b *strings.Builder, project string, selected bool) {
+	chevron := "▸"
+	if project == tl.expanded {
+		chevron = "▾"
+	}
+
+	tasks := tl.projectTasks(project)
+	count := len(tasks)
 
 	nameStyle := tl.theme.Section
 	chevronStyle := tl.theme.Dimmed
@@ -427,23 +447,31 @@ func (tl TaskList) renderProjectHeader(b *strings.Builder, project string, selec
 	}
 
 	countStr := tl.theme.Dimmed.Render(fmt.Sprintf(" (%d)", count))
-	line := fmt.Sprintf("%s %s %s%s", cursorStr, chevronStyle.Render(chevron), nameStyle.Render(project), countStr)
-	b.WriteString(line + "\n")
+	left := fmt.Sprintf("%s %s %s%s", cursorStr, chevronStyle.Render(chevron), nameStyle.Render(project), countStr)
+
+	// Build right-aligned status icon summary.
+	var icons strings.Builder
+	if count > 8 {
+		for _, t := range tasks[:4] {
+			icons.WriteString(tl.taskStatusIcon(t))
+		}
+		icons.WriteString(tl.theme.Dimmed.Render("…"))
+		for _, t := range tasks[count-3:] {
+			icons.WriteString(tl.taskStatusIcon(t))
+		}
+	} else {
+		for _, t := range tasks {
+			icons.WriteString(tl.taskStatusIcon(t))
+		}
+	}
+	right := icons.String()
+
+	gap := max(tl.width-lipgloss.Width(left)-lipgloss.Width(right)-2, 1)
+	b.WriteString(left + strings.Repeat(" ", gap) + right + "\n")
 }
 
 func (tl TaskList) renderTaskRow(b *strings.Builder, t *model.Task, selected bool) {
-	statusStyle := tl.statusStyle(t.Status)
-
-	// Status icon (displayed to the left of the task name)
-	displayText := t.Status.Display()
-	if t.Status == model.StatusInProgress {
-		if !tl.running[t.ID] || tl.idle[t.ID] {
-			displayText = "\uF186" // moon: idle
-		} else if tl.tickEven {
-			displayText = t.Status.DisplayAlt() // animate between circle-o and dot-circle-o
-		}
-	}
-	icon := statusStyle.Render(displayText)
+	icon := tl.taskStatusIcon(t)
 
 	nameStyle := tl.theme.Normal
 	if selected {

--- a/internal/ui/tasklist_test.go
+++ b/internal/ui/tasklist_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -435,6 +436,133 @@ func TestTaskList_AdjacentTask_Empty(t *testing.T) {
 	tl.SetTasks(nil)
 	if tl.AdjacentTask("any", +1) != nil {
 		t.Error("expected nil for empty list")
+	}
+}
+
+func TestTaskList_projectTasks(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
+	tasks := []*model.Task{
+		{Name: "A1", Project: "alpha"},
+		{Name: "A2", Project: "alpha"},
+		{Name: "B1", Project: "beta"},
+		{Name: "No Project", Project: ""},
+	}
+	tl.SetTasks(tasks)
+
+	got := tl.projectTasks("alpha")
+	if len(got) != 2 {
+		t.Errorf("expected 2 alpha tasks, got %d", len(got))
+	}
+
+	got = tl.projectTasks("beta")
+	if len(got) != 1 {
+		t.Errorf("expected 1 beta task, got %d", len(got))
+	}
+
+	got = tl.projectTasks(uncategorized)
+	if len(got) != 1 {
+		t.Errorf("expected 1 uncategorized task, got %d", len(got))
+	}
+
+	got = tl.projectTasks("nonexistent")
+	if len(got) != 0 {
+		t.Errorf("expected 0 tasks for nonexistent project, got %d", len(got))
+	}
+}
+
+func TestTaskList_taskStatusIcon(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
+
+	statuses := []model.Status{
+		model.StatusPending,
+		model.StatusInProgress,
+		model.StatusInReview,
+		model.StatusComplete,
+	}
+	for _, s := range statuses {
+		task := &model.Task{ID: "t1", Status: s}
+		icon := tl.taskStatusIcon(task)
+		if icon == "" {
+			t.Errorf("expected non-empty icon for status %v", s)
+		}
+	}
+}
+
+func TestTaskList_taskStatusIcon_InProgressVariants(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+
+	// Not running → moon icon
+	task := &model.Task{ID: "t1", Status: model.StatusInProgress}
+	icon := tl.taskStatusIcon(task)
+	if !strings.Contains(icon, "\uF186") {
+		t.Error("expected moon icon for non-running in-progress task")
+	}
+
+	// Running but idle → moon icon
+	tl.SetRunning([]string{"t1"})
+	tl.SetIdle([]string{"t1"})
+	icon = tl.taskStatusIcon(task)
+	if !strings.Contains(icon, "\uF186") {
+		t.Error("expected moon icon for idle in-progress task")
+	}
+
+	// Running and active, tickEven=true → alternate icon
+	tl.SetIdle(nil)
+	tl.tickEven = true
+	icon = tl.taskStatusIcon(task)
+	if strings.Contains(icon, "\uF186") {
+		t.Error("expected alternate icon for active running task on even tick")
+	}
+}
+
+func TestTaskList_renderProjectHeader_StatusIcons(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
+	tasks := []*model.Task{
+		{ID: "t1", Name: "A1", Project: "alpha", Status: model.StatusPending},
+		{ID: "t2", Name: "A2", Project: "alpha", Status: model.StatusComplete},
+	}
+	tl.SetTasks(tasks)
+
+	var b strings.Builder
+	tl.renderProjectHeader(&b, "alpha", false)
+	output := b.String()
+
+	// Should contain the pending and complete display glyphs.
+	pendingGlyph := model.StatusPending.Display()
+	completeGlyph := model.StatusComplete.Display()
+	if !strings.Contains(output, pendingGlyph) {
+		t.Errorf("expected pending glyph %q in header output", pendingGlyph)
+	}
+	if !strings.Contains(output, completeGlyph) {
+		t.Errorf("expected complete glyph %q in header output", completeGlyph)
+	}
+}
+
+func TestTaskList_renderProjectHeader_Truncation(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(120, 60)
+
+	// Create 10 tasks (>8 triggers truncation).
+	tasks := make([]*model.Task, 10)
+	for i := range tasks {
+		tasks[i] = &model.Task{
+			ID:      fmt.Sprintf("t%d", i),
+			Name:    fmt.Sprintf("Task %d", i),
+			Project: "big",
+			Status:  model.StatusPending,
+		}
+	}
+	tl.SetTasks(tasks)
+
+	var b strings.Builder
+	tl.renderProjectHeader(&b, "big", false)
+	output := b.String()
+
+	if !strings.Contains(output, "…") {
+		t.Error("expected ellipsis in header for >8 tasks")
 	}
 }
 


### PR DESCRIPTION
Show one status icon per task on project header rows so aggregate status is visible without expanding. Reuses taskStatusIcon() helper extracted from renderTaskRow, with ellipsis truncation for >8 tasks.

Co-Authored-By: Claude <noreply@anthropic.com>