### PR TITLE
Add file diff viewer to agent view files panel

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -58,6 +58,13 @@ type AgentView struct {
 	vtFedTotal uint64 // monotonic byte count fed to vtTerm
 	vtCols     int    // vtTerm column count
 	vtRows     int    // vtTerm row count
+
+	// Diff viewer state
+	diffMode       bool     // true when viewing a file's diff
+	diffContent    string   // raw colorized diff output
+	diffLines      []string // split lines for scrolling
+	diffScrollOff  int      // scroll offset within diff
+	worktreeDir    string   // resolved worktree directory for git commands
 }
 
 func NewAgentView(theme Theme, runner *agent.Runner) AgentView {
@@ -84,6 +91,11 @@ func (av *AgentView) Enter(taskID, taskName string) {
 	av.cachedLines = nil
 	av.vtTerm = nil
 	av.vtFedTotal = 0
+	av.diffMode = false
+	av.diffContent = ""
+	av.diffLines = nil
+	av.diffScrollOff = 0
+	av.worktreeDir = ""
 }
 
 // SetLastOutput stores the final ring buffer from a finished session
@@ -149,14 +161,25 @@ func (av *AgentView) FocusRight() {
 	}
 }
 
-// HandleKey processes a key event. Returns true if the user wants to detach.
-func (av *AgentView) HandleKey(msg tea.KeyMsg) (detach bool) {
+// HandleKey processes a key event. Returns detach=true if the user wants to
+// detach, and optionally a tea.Cmd (e.g. to fetch a file diff).
+func (av *AgentView) HandleKey(msg tea.KeyMsg) (detach bool, cmd tea.Cmd) {
 	keyStr := msg.String()
 
 	// Global agent view keys (regardless of focus)
 	if keyStr == "ctrl+q" {
-		return true
+		if av.diffMode {
+			av.exitDiffMode()
+			return false, nil
+		}
+		return true, nil
 	}
+
+	// In diff mode, handle keys for scrolling / navigation
+	if av.diffMode {
+		return false, av.handleDiffKey(msg)
+	}
+
 	// Panel switching: ctrl+left/right only.
 	// Use type-based matching to handle terminals that set the Alt flag on
 	// ctrl+arrow sequences (urxvt sends \x1b[Od which parses as
@@ -164,10 +187,10 @@ func (av *AgentView) HandleKey(msg tea.KeyMsg) (detach bool) {
 	switch msg.Type {
 	case tea.KeyCtrlLeft:
 		av.FocusLeft()
-		return false
+		return false, nil
 	case tea.KeyCtrlRight:
 		av.FocusRight()
-		return false
+		return false, nil
 	}
 
 	// Panel-specific key handling
@@ -178,19 +201,19 @@ func (av *AgentView) HandleKey(msg tea.KeyMsg) (detach bool) {
 		switch keyStr {
 		case "shift+up":
 			av.scrollUp(1)
-			return false
+			return false, nil
 		case "shift+down":
 			av.scrollDown(1)
-			return false
+			return false, nil
 		case "shift+pgup":
 			av.scrollUp(dispH)
-			return false
+			return false, nil
 		case "shift+pgdown":
 			av.scrollDown(dispH)
-			return false
+			return false, nil
 		case "shift+end":
 			av.scrollOffset = 0
-			return false
+			return false, nil
 		}
 		// Any other key sent to PTY resets scroll to follow tail
 		av.scrollOffset = 0
@@ -208,9 +231,112 @@ func (av *AgentView) HandleKey(msg tea.KeyMsg) (detach bool) {
 			av.files.CursorUp()
 		case "down", "j":
 			av.files.CursorDown()
+		case "enter":
+			return false, av.openFileDiff()
 		}
 	}
-	return false
+	return false, nil
+}
+
+// HandleMouse processes mouse events (scroll wheel).
+func (av *AgentView) HandleMouse(msg tea.MouseMsg) {
+	if av.diffMode {
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			av.diffScrollUp(3)
+		case tea.MouseButtonWheelDown:
+			av.diffScrollDown(3)
+		}
+	}
+}
+
+// openFileDiff starts an async fetch of the selected file's diff.
+func (av *AgentView) openFileDiff() tea.Cmd {
+	f := av.files.SelectedFile()
+	if f == nil || av.worktreeDir == "" {
+		return nil
+	}
+	taskID := av.taskID
+	dir := av.worktreeDir
+	path := f.Path
+	return func() tea.Msg {
+		return FetchFileDiff(taskID, dir, path)
+	}
+}
+
+// UpdateFileDiff handles the result of an async file diff fetch.
+func (av *AgentView) UpdateFileDiff(msg FileDiffMsg) {
+	if msg.TaskID != av.taskID {
+		return
+	}
+	av.diffMode = true
+	av.diffContent = msg.Diff
+	av.diffScrollOff = 0
+	if msg.Diff == "" {
+		av.diffLines = []string{"(no diff)"}
+	} else {
+		av.diffLines = strings.Split(msg.Diff, "\n")
+	}
+}
+
+// SetWorktreeDir sets the resolved worktree directory for git commands.
+func (av *AgentView) SetWorktreeDir(dir string) {
+	av.worktreeDir = dir
+}
+
+func (av *AgentView) exitDiffMode() {
+	av.diffMode = false
+	av.diffContent = ""
+	av.diffLines = nil
+	av.diffScrollOff = 0
+}
+
+func (av *AgentView) handleDiffKey(msg tea.KeyMsg) tea.Cmd {
+	keyStr := msg.String()
+	switch keyStr {
+	case "esc", "q":
+		av.exitDiffMode()
+	case "up", "k":
+		// Move to previous file and show its diff
+		av.files.CursorUp()
+		return av.openFileDiff()
+	case "down", "j":
+		// Move to next file and show its diff
+		av.files.CursorDown()
+		return av.openFileDiff()
+	case "shift+up", "pgup":
+		av.diffScrollUp(av.diffVisibleRows())
+	case "shift+down", "pgdown":
+		av.diffScrollDown(av.diffVisibleRows())
+	}
+	return nil
+}
+
+func (av *AgentView) diffVisibleRows() int {
+	contentH := av.height - 1
+	rows := contentH - 4
+	if rows < 3 {
+		rows = 3
+	}
+	return rows
+}
+
+func (av *AgentView) diffScrollUp(n int) {
+	av.diffScrollOff -= n
+	if av.diffScrollOff < 0 {
+		av.diffScrollOff = 0
+	}
+}
+
+func (av *AgentView) diffScrollDown(n int) {
+	maxOff := len(av.diffLines) - av.diffVisibleRows()
+	if maxOff < 0 {
+		maxOff = 0
+	}
+	av.diffScrollOff += n
+	if av.diffScrollOff > maxOff {
+		av.diffScrollOff = maxOff
+	}
 }
 
 // View renders the three-panel layout.
@@ -222,8 +348,13 @@ func (av *AgentView) View() string {
 	av.gitstatus.SetFocused(av.focus == panelGit)
 	leftView := av.gitstatus.View()
 
-	// Center panel: agent terminal
-	centerView := av.renderTerminal(centerW, contentH)
+	// Center panel: diff viewer or agent terminal
+	var centerView string
+	if av.diffMode {
+		centerView = av.renderDiffPanel(centerW, contentH)
+	} else {
+		centerView = av.renderTerminal(centerW, contentH)
+	}
 
 	// Right panel: file explorer
 	rightView := av.files.View(av.focus == panelFiles)
@@ -309,6 +440,67 @@ func (av *AgentView) renderTerminal(w, h int) string {
 	av.cachedScrollOff = av.scrollOffset
 	av.cachedTerminal = content
 	return border.Render(content)
+}
+
+func (av *AgentView) renderDiffPanel(w, h int) string {
+	borderColor := "87" // always focused when viewing diff
+	innerH := max(h-2, 1)
+	border := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(borderColor)).
+		Width(w - 2).
+		Height(innerH)
+
+	if len(av.diffLines) == 0 {
+		empty := av.theme.Dimmed.
+			Width(w - 4).
+			Height(innerH).
+			AlignHorizontal(lipgloss.Center).
+			AlignVertical(lipgloss.Center)
+		return border.Render(empty.Render("No diff available"))
+	}
+
+	dispW := max(w-4, 10)
+	dispH := max(h-4, 3)
+
+	// Header
+	fileName := ""
+	if f := av.files.SelectedFile(); f != nil {
+		fileName = f.Path
+	}
+	header := av.theme.Section.Render("  DIFF") +
+		av.theme.Dimmed.Render(" " + fileName) +
+		av.theme.Dimmed.Render(fmt.Sprintf("  [%d/%d]", av.files.scroll.Cursor()+1, av.files.FileCount()))
+	headerLines := 1
+
+	// Visible diff lines
+	visibleH := dispH - headerLines
+	if visibleH < 1 {
+		visibleH = 1
+	}
+
+	end := av.diffScrollOff + visibleH
+	if end > len(av.diffLines) {
+		end = len(av.diffLines)
+	}
+	start := av.diffScrollOff
+	if start > end {
+		start = end
+	}
+
+	var b strings.Builder
+	b.WriteString(header + "\n")
+	for i := start; i < end; i++ {
+		line := av.diffLines[i]
+		// Truncate to panel width (ANSI-aware)
+		line = ansi.Truncate(line, dispW, "\x1b[0m")
+		b.WriteString(line)
+		if i < end-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	return border.Render(b.String())
 }
 
 // renderIncremental feeds only new bytes to a persistent vt10x terminal,
@@ -419,11 +611,20 @@ func (av AgentView) renderStatusBar() string {
 	left := " " + av.theme.Normal.Render(av.taskName) + status
 
 	// Right: keybinding hints
-	keys := []struct{ key, label string }{
-		{"⌘↑/↓", "task"},
-		{"⇧↑/↓", "scroll"},
-		{"ctrl+←/→", "panel"},
-		{"ctrl+q", "detach"},
+	var keys []struct{ key, label string }
+	if av.diffMode {
+		keys = []struct{ key, label string }{
+			{"↑/↓", "file"},
+			{"scroll", "navigate"},
+			{"esc", "close"},
+		}
+	} else {
+		keys = []struct{ key, label string }{
+			{"⌘↑/↓", "task"},
+			{"⇧↑/↓", "scroll"},
+			{"ctrl+←/→", "panel"},
+			{"ctrl+q", "detach"},
+		}
 	}
 	var parts []string
 	for _, k := range keys {
@@ -433,13 +634,17 @@ func (av AgentView) renderStatusBar() string {
 
 	// Focus indicator — truly centered on the bar
 	var focusLabel string
-	switch av.focus {
-	case panelGit:
-		focusLabel = "GIT STATUS"
-	case panelAgent:
-		focusLabel = "TERMINAL"
-	case panelFiles:
-		focusLabel = "FILES"
+	if av.diffMode {
+		focusLabel = "DIFF"
+	} else {
+		switch av.focus {
+		case panelGit:
+			focusLabel = "GIT STATUS"
+		case panelAgent:
+			focusLabel = "TERMINAL"
+		case panelFiles:
+			focusLabel = "FILES"
+		}
 	}
 	center := av.theme.Section.Render(" [" + focusLabel + "] ")
 

--- a/internal/ui/agentview_test.go
+++ b/internal/ui/agentview_test.go
@@ -81,7 +81,7 @@ func TestAgentView_ShiftUpKeyScrolls(t *testing.T) {
 	}
 
 	msg := tea.KeyMsg{Type: tea.KeyShiftUp}
-	detach := av.HandleKey(msg)
+	detach, _ := av.HandleKey(msg)
 	if detach {
 		t.Fatal("shift+up should not trigger detach")
 	}
@@ -295,7 +295,7 @@ func TestAgentView_FocusLeftRight(t *testing.T) {
 func TestAgentView_HandleKey_CtrlQ_Detach(t *testing.T) {
 	av := newTestAgentView()
 	msg := tea.KeyMsg{Type: tea.KeyCtrlQ}
-	if !av.HandleKey(msg) {
+	if detach, _ := av.HandleKey(msg); !detach {
 		t.Error("ctrl+q should trigger detach")
 	}
 }
@@ -304,7 +304,7 @@ func TestAgentView_HandleKey_CtrlLeft(t *testing.T) {
 	av := newTestAgentView()
 	// Start at center
 	msg := tea.KeyMsg{Type: tea.KeyCtrlLeft}
-	detach := av.HandleKey(msg)
+	detach, _ := av.HandleKey(msg)
 	if detach {
 		t.Error("ctrl+left should not trigger detach")
 	}
@@ -316,7 +316,7 @@ func TestAgentView_HandleKey_CtrlLeft(t *testing.T) {
 func TestAgentView_HandleKey_CtrlRight(t *testing.T) {
 	av := newTestAgentView()
 	msg := tea.KeyMsg{Type: tea.KeyCtrlRight}
-	detach := av.HandleKey(msg)
+	detach, _ := av.HandleKey(msg)
 	if detach {
 		t.Error("ctrl+right should not trigger detach")
 	}
@@ -894,5 +894,218 @@ func TestKeyMsgToBytes_AltArrows(t *testing.T) {
 	want = []byte("\x1b[D")
 	if string(got) != string(want) {
 		t.Errorf("plain Left: got %q, want %q", got, want)
+	}
+}
+
+func TestAgentView_DiffMode_EnterOpensAndEscCloses(t *testing.T) {
+	av := newTestAgentView()
+	av.focus = panelFiles
+	av.worktreeDir = "/tmp/test-worktree"
+	av.files.SetFiles([]ChangedFile{
+		{Status: "M", Path: "a.go"},
+		{Status: "A", Path: "b.go"},
+	})
+
+	// Enter should return a cmd (we can't execute it without a real git repo)
+	_, cmd := av.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("enter on file should return a non-nil cmd")
+	}
+
+	// Simulate diff result
+	av.UpdateFileDiff(FileDiffMsg{
+		TaskID:   "task-1",
+		FilePath: "a.go",
+		Diff:     "+added line\n-removed line\n context",
+	})
+	if !av.diffMode {
+		t.Fatal("expected diffMode to be true after UpdateFileDiff")
+	}
+	if len(av.diffLines) != 3 {
+		t.Errorf("expected 3 diff lines, got %d", len(av.diffLines))
+	}
+
+	// Escape exits diff mode
+	av.HandleKey(tea.KeyMsg{Type: tea.KeyEscape})
+	if av.diffMode {
+		t.Fatal("expected diffMode to be false after escape")
+	}
+}
+
+func TestAgentView_DiffMode_CtrlQExitsDiff(t *testing.T) {
+	av := newTestAgentView()
+	av.diffMode = true
+	av.diffLines = []string{"line1"}
+
+	// ctrl+q in diff mode should exit diff, not detach
+	detach, _ := av.HandleKey(tea.KeyMsg{Type: tea.KeyCtrlQ})
+	if detach {
+		t.Fatal("ctrl+q in diff mode should exit diff, not detach")
+	}
+	if av.diffMode {
+		t.Fatal("expected diffMode to be false after ctrl+q")
+	}
+}
+
+func TestAgentView_DiffMode_UpDownSwitchFiles(t *testing.T) {
+	av := newTestAgentView()
+	av.focus = panelFiles
+	av.worktreeDir = "/tmp/test-worktree"
+	av.files.SetFiles([]ChangedFile{
+		{Status: "M", Path: "a.go"},
+		{Status: "M", Path: "b.go"},
+		{Status: "M", Path: "c.go"},
+	})
+	av.diffMode = true
+	av.diffLines = []string{"old diff"}
+
+	// Down arrow should move cursor and return a cmd
+	_, cmd := av.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+	if cmd == nil {
+		t.Fatal("down in diff mode should return a cmd to fetch next file's diff")
+	}
+	if av.files.scroll.Cursor() != 1 {
+		t.Errorf("cursor should be 1, got %d", av.files.scroll.Cursor())
+	}
+
+	// Up arrow
+	_, cmd = av.HandleKey(tea.KeyMsg{Type: tea.KeyUp})
+	if cmd == nil {
+		t.Fatal("up in diff mode should return a cmd")
+	}
+	if av.files.scroll.Cursor() != 0 {
+		t.Errorf("cursor should be 0, got %d", av.files.scroll.Cursor())
+	}
+}
+
+func TestAgentView_DiffMode_ScrollUpDown(t *testing.T) {
+	av := newTestAgentView()
+	av.diffMode = true
+	// Create many lines
+	lines := make([]string, 100)
+	for i := range lines {
+		lines[i] = "line"
+	}
+	av.diffLines = lines
+
+	av.diffScrollDown(5)
+	if av.diffScrollOff != 5 {
+		t.Errorf("diffScrollOff after down(5) = %d, want 5", av.diffScrollOff)
+	}
+
+	av.diffScrollUp(3)
+	if av.diffScrollOff != 2 {
+		t.Errorf("diffScrollOff after up(3) = %d, want 2", av.diffScrollOff)
+	}
+
+	// Scroll up past top
+	av.diffScrollUp(100)
+	if av.diffScrollOff != 0 {
+		t.Errorf("diffScrollOff should clamp to 0, got %d", av.diffScrollOff)
+	}
+}
+
+func TestAgentView_DiffMode_MouseWheel(t *testing.T) {
+	av := newTestAgentView()
+	av.diffMode = true
+	lines := make([]string, 100)
+	for i := range lines {
+		lines[i] = "line"
+	}
+	av.diffLines = lines
+
+	// Wheel down
+	av.HandleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	if av.diffScrollOff != 3 {
+		t.Errorf("diffScrollOff after wheel down = %d, want 3", av.diffScrollOff)
+	}
+
+	// Wheel up
+	av.HandleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+	if av.diffScrollOff != 0 {
+		t.Errorf("diffScrollOff after wheel up = %d, want 0", av.diffScrollOff)
+	}
+}
+
+func TestAgentView_DiffMode_MouseWheel_NotInDiffMode(t *testing.T) {
+	av := newTestAgentView()
+	av.diffMode = false
+
+	// Mouse wheel should be no-op when not in diff mode
+	av.HandleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	// No crash = pass
+}
+
+func TestAgentView_DiffMode_RenderDiffPanel(t *testing.T) {
+	av := newTestAgentView()
+	av.diffMode = true
+	av.files.SetFiles([]ChangedFile{
+		{Status: "M", Path: "test.go"},
+	})
+	av.diffLines = []string{"+added", "-removed", " context"}
+
+	view := av.View()
+	if view == "" {
+		t.Fatal("expected non-empty view in diff mode")
+	}
+	if !strings.Contains(view, "DIFF") {
+		t.Error("expected DIFF header in diff panel")
+	}
+}
+
+func TestAgentView_DiffMode_EmptyDiff(t *testing.T) {
+	av := newTestAgentView()
+	av.UpdateFileDiff(FileDiffMsg{
+		TaskID:   "task-1",
+		FilePath: "empty.go",
+		Diff:     "",
+	})
+	if !av.diffMode {
+		t.Fatal("expected diffMode even for empty diff")
+	}
+	if len(av.diffLines) != 1 || av.diffLines[0] != "(no diff)" {
+		t.Errorf("expected '(no diff)' placeholder, got %v", av.diffLines)
+	}
+}
+
+func TestAgentView_Enter_ResetsDiffMode(t *testing.T) {
+	av := newTestAgentView()
+	av.diffMode = true
+	av.diffLines = []string{"old"}
+
+	av.Enter("task-2", "new task")
+	if av.diffMode {
+		t.Fatal("Enter should reset diffMode")
+	}
+	if av.diffLines != nil {
+		t.Fatal("Enter should clear diffLines")
+	}
+}
+
+func TestFileExplorer_SelectedFile(t *testing.T) {
+	fe := NewFileExplorer(DefaultTheme())
+
+	// No files → nil
+	if fe.SelectedFile() != nil {
+		t.Error("expected nil with no files")
+	}
+
+	fe.SetFiles([]ChangedFile{
+		{Status: "M", Path: "a.go"},
+		{Status: "A", Path: "b.go"},
+	})
+
+	f := fe.SelectedFile()
+	if f == nil {
+		t.Fatal("expected non-nil selected file")
+	}
+	if f.Path != "a.go" {
+		t.Errorf("expected a.go, got %s", f.Path)
+	}
+
+	fe.CursorDown()
+	f = fe.SelectedFile()
+	if f == nil || f.Path != "b.go" {
+		t.Errorf("expected b.go after CursorDown, got %v", f)
 	}
 }

--- a/internal/ui/ctrl_arrow_test.go
+++ b/internal/ui/ctrl_arrow_test.go
@@ -16,7 +16,7 @@ func TestAgentView_CtrlLeftRight(t *testing.T) {
 
 	// Ctrl+left should move to panelGit
 	msg := tea.KeyMsg{Type: tea.KeyCtrlLeft}
-	detach := av.HandleKey(msg)
+	detach, _ := av.HandleKey(msg)
 	if detach {
 		t.Fatal("ctrl+left should not trigger detach")
 	}
@@ -29,7 +29,7 @@ func TestAgentView_CtrlLeftRight(t *testing.T) {
 
 	// Ctrl+right should move to panelFiles
 	msg2 := tea.KeyMsg{Type: tea.KeyCtrlRight}
-	detach = av.HandleKey(msg2)
+	detach, _ = av.HandleKey(msg2)
 	if detach {
 		t.Fatal("ctrl+right should not trigger detach")
 	}
@@ -43,7 +43,7 @@ func TestAgentView_CtrlLeftRightWithAlt(t *testing.T) {
 
 	// Ctrl+left with Alt flag (urxvt sends \x1b[Od → KeyCtrlLeft + Alt)
 	msg := tea.KeyMsg{Type: tea.KeyCtrlLeft, Alt: true}
-	detach := av.HandleKey(msg)
+	detach, _ := av.HandleKey(msg)
 	if detach {
 		t.Fatal("alt+ctrl+left should not trigger detach")
 	}
@@ -56,7 +56,7 @@ func TestAgentView_CtrlLeftRightWithAlt(t *testing.T) {
 
 	// Ctrl+right with Alt flag
 	msg2 := tea.KeyMsg{Type: tea.KeyCtrlRight, Alt: true}
-	detach = av.HandleKey(msg2)
+	detach, _ = av.HandleKey(msg2)
 	if detach {
 		t.Fatal("alt+ctrl+right should not trigger detach")
 	}
@@ -70,7 +70,7 @@ func TestAgentView_AltLeftRight_NoSwitch(t *testing.T) {
 
 	// Alt+left should NOT switch panels (only ctrl+left does)
 	msg := tea.KeyMsg{Type: tea.KeyLeft, Alt: true}
-	detach := av.HandleKey(msg)
+	detach, _ := av.HandleKey(msg)
 	if detach {
 		t.Fatal("alt+left should not trigger detach")
 	}
@@ -80,7 +80,7 @@ func TestAgentView_AltLeftRight_NoSwitch(t *testing.T) {
 
 	// Alt+right should NOT switch panels
 	msg2 := tea.KeyMsg{Type: tea.KeyRight, Alt: true}
-	detach = av.HandleKey(msg2)
+	detach, _ = av.HandleKey(msg2)
 	if detach {
 		t.Fatal("alt+right should not trigger detach")
 	}
@@ -94,7 +94,7 @@ func TestAgentView_PlainLeftRight_NoSwitch(t *testing.T) {
 
 	// Plain left arrow should NOT switch panels (only ctrl+left does)
 	msg := tea.KeyMsg{Type: tea.KeyLeft}
-	detach := av.HandleKey(msg)
+	detach, _ := av.HandleKey(msg)
 	if detach {
 		t.Fatal("plain left should not trigger detach")
 	}
@@ -104,7 +104,7 @@ func TestAgentView_PlainLeftRight_NoSwitch(t *testing.T) {
 
 	// Plain right arrow should NOT switch panels
 	msg2 := tea.KeyMsg{Type: tea.KeyRight}
-	detach = av.HandleKey(msg2)
+	detach, _ = av.HandleKey(msg2)
 	if detach {
 		t.Fatal("plain right should not trigger detach")
 	}

--- a/internal/ui/fileexplorer.go
+++ b/internal/ui/fileexplorer.go
@@ -44,6 +44,20 @@ func (fe *FileExplorer) CursorDown() {
 	fe.scroll.CursorDown(len(fe.files), fe.visibleRows())
 }
 
+// SelectedFile returns the currently selected file, or nil if none.
+func (fe *FileExplorer) SelectedFile() *ChangedFile {
+	c := fe.scroll.Cursor()
+	if c < 0 || c >= len(fe.files) {
+		return nil
+	}
+	return &fe.files[c]
+}
+
+// FileCount returns the number of files.
+func (fe *FileExplorer) FileCount() int {
+	return len(fe.files)
+}
+
 func (fe *FileExplorer) visibleRows() int {
 	// Reserve 3 for border + header
 	rows := fe.height - 3

--- a/internal/ui/gitcmd.go
+++ b/internal/ui/gitcmd.go
@@ -55,6 +55,43 @@ func findMergeBase(worktree string) string {
 	return ""
 }
 
+// FileDiffMsg carries the result of an async file diff fetch.
+type FileDiffMsg struct {
+	TaskID   string
+	FilePath string
+	Diff     string
+}
+
+// FetchFileDiff runs git diff for a specific file and returns colorized output.
+func FetchFileDiff(taskID, worktree, filePath string) FileDiffMsg {
+	msg := FileDiffMsg{TaskID: taskID, FilePath: filePath}
+	if worktree == "" || filePath == "" {
+		return msg
+	}
+
+	// Try uncommitted diff first (staged + unstaged)
+	if out, err := runGit(worktree, "diff", "--color=always", "HEAD", "--", filePath); err == nil && out != "" {
+		msg.Diff = out
+		return msg
+	}
+
+	// Fall back to branch diff (committed changes vs merge-base)
+	if base := findMergeBase(worktree); base != "" {
+		if out, err := runGit(worktree, "diff", "--color=always", base+"..HEAD", "--", filePath); err == nil {
+			msg.Diff = out
+		}
+	}
+
+	// For untracked files, show the file contents as an "added" diff
+	if msg.Diff == "" {
+		if out, err := runGit(worktree, "diff", "--color=always", "--no-index", "/dev/null", filePath); err == nil || out != "" {
+			msg.Diff = out
+		}
+	}
+
+	return msg
+}
+
 func runGit(dir string, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -222,6 +222,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				t.Worktree = msg.Dir
 				_ = m.db.Update(t)
 			}
+			// Set worktree dir on agent view immediately.
+			if m.current == viewAgent && m.agentview.taskID == msg.TaskID {
+				m.agentview.SetWorktreeDir(msg.Dir)
+			}
 		}
 		// Now that we have the dir, kick off git status fetch
 		if t := m.selectedTaskForGit(); t != nil && t.ID == msg.TaskID && msg.Dir != "" {
@@ -248,6 +252,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case GitStatusRefreshMsg:
 		m.gitstatus.Update(msg)
 		m.agentview.UpdateGitStatus(msg)
+		return m, nil
+
+	case FileDiffMsg:
+		m.agentview.UpdateFileDiff(msg)
+		return m, nil
+
+	case tea.MouseMsg:
+		if m.current == viewAgent {
+			m.agentview.HandleMouse(msg)
+		}
 		return m, nil
 
 	case SessionResumedMsg:
@@ -335,11 +349,13 @@ func (m Model) handleAgentViewKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	if detach := m.agentview.HandleKey(msg); detach {
+	detach, cmd := m.agentview.HandleKey(msg)
+	if detach {
 		m.current = viewTaskList
 		m.refreshTasks()
+		return m, nil
 	}
-	return m, nil
+	return m, cmd
 }
 
 // switchAgentTask navigates to the adjacent task's agent view (dir: -1=prev, +1=next).
@@ -454,6 +470,9 @@ func (m Model) startOrAttach(t *model.Task) (tea.Model, tea.Cmd) {
 	if m.runner.Get(t.ID) != nil {
 		m.agentview.Enter(t.ID, t.Name)
 		m.agentview.SetSize(m.width, m.height)
+		if dir, ok := m.resolvedDirs[t.ID]; ok && dir != "" {
+			m.agentview.SetWorktreeDir(dir)
+		}
 		m.current = viewAgent
 		return m, tea.Tick(100*time.Millisecond, func(_ time.Time) tea.Msg {
 			return AgentViewTickMsg{}
@@ -506,6 +525,9 @@ func (m Model) startOrAttach(t *model.Task) (tea.Model, tea.Cmd) {
 
 	m.agentview.Enter(t.ID, t.Name)
 	m.agentview.SetSize(m.width, m.height)
+	if dir, ok := m.resolvedDirs[t.ID]; ok && dir != "" {
+		m.agentview.SetWorktreeDir(dir)
+	}
 	m.current = viewAgent
 	return m, tea.Tick(100*time.Millisecond, func(_ time.Time) tea.Msg {
 		return AgentViewTickMsg{}
@@ -741,6 +763,9 @@ func (m Model) scheduleGitRefresh() tea.Cmd {
 	// Fast path: dir already cached.
 	if dir, ok := m.resolvedDirs[t.ID]; ok && dir != "" {
 		m.gitstatus.SetTask(t.ID)
+		if m.current == viewAgent && m.agentview.taskID == t.ID {
+			m.agentview.SetWorktreeDir(dir)
+		}
 		needsMain := m.gitstatus.NeedsRefresh()
 		needsAgent := m.current == viewAgent && m.agentview.NeedsGitRefresh()
 		if needsMain || needsAgent {


### PR DESCRIPTION
Enter on a file in the files changed panel opens a colorized git diff. Up/down arrows navigate between files, mouse scroll works for long diffs. Fixes worktreeDir timing bug that prevented diffs from loading.

Co-Authored-By: Claude <noreply@anthropic.com>