### PR TITLE
Add escape key to refocus agent panel from files view

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -227,6 +227,8 @@ func (av *AgentView) HandleKey(msg tea.KeyMsg) (detach bool, cmd tea.Cmd) {
 		// Sidebar navigation (no-op for now, git status is read-only)
 	case panelFiles:
 		switch keyStr {
+		case "esc":
+			av.focus = panelAgent
 		case "up", "k":
 			av.files.CursorUp()
 		case "down", "j":
@@ -306,6 +308,7 @@ func (av *AgentView) handleDiffKey(msg tea.KeyMsg) tea.Cmd {
 	switch keyStr {
 	case "esc", "q":
 		av.exitDiffMode()
+		av.focus = panelAgent
 	case "up", "k":
 		// Move to previous file and show its diff
 		av.files.CursorUp()

--- a/internal/ui/agentview_test.go
+++ b/internal/ui/agentview_test.go
@@ -935,10 +935,23 @@ func TestAgentView_DiffMode_EnterOpensAndEscCloses(t *testing.T) {
 		t.Errorf("expected 3 diff lines, got %d", len(av.diffLines))
 	}
 
-	// Escape exits diff mode
+	// Escape exits diff mode and refocuses on agent panel
 	av.HandleKey(tea.KeyMsg{Type: tea.KeyEscape})
 	if av.diffMode {
 		t.Fatal("expected diffMode to be false after escape")
+	}
+	if av.focus != panelAgent {
+		t.Errorf("expected focus on panelAgent after escape, got %d", av.focus)
+	}
+}
+
+func TestAgentView_FilesPanelEscRefocusesAgent(t *testing.T) {
+	av := newTestAgentView()
+	av.focus = panelFiles
+
+	av.HandleKey(tea.KeyMsg{Type: tea.KeyEscape})
+	if av.focus != panelAgent {
+		t.Errorf("expected focus on panelAgent after escape from files panel, got %d", av.focus)
 	}
 }
 


### PR DESCRIPTION
Pressing escape in the diff viewer or files panel now returns focus to the agent terminal panel. Adds tests for both escape paths.

Co-Authored-By: Claude <noreply@anthropic.com>