### PR TITLE
Add three-panel layout to task list view

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -81,6 +81,7 @@ type Model struct {
 	newproject  NewProjectForm
 	preview     Preview
 	gitstatus   *GitStatus
+	detail      TaskDetail
 	agentview   *AgentView
 	current      view
 	activeTab    tab
@@ -102,6 +103,7 @@ func NewModel(database *db.DB, runner *agent.Runner) Model {
 
 	pv := NewPreview(theme, runner)
 	gs := NewGitStatus(theme)
+	dt := NewTaskDetail(theme)
 	avv := NewAgentView(theme, runner)
 	av := &avv
 
@@ -117,6 +119,7 @@ func NewModel(database *db.DB, runner *agent.Runner) Model {
 		helpview:    hv,
 		preview:     pv,
 		gitstatus:   &gs,
+		detail:      dt,
 		agentview:   av,
 		current:     viewTaskList,
 		activeTab:   tabTasks,
@@ -178,14 +181,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		leftWidth, rightWidth := m.splitWidths()
 		// Reserve space: section header(1) + gap(1) + statusbar(1)
 		contentHeight := msg.Height - 3
-		m.tasklist.SetSize(leftWidth, contentHeight)
-		m.projectlist.SetSize(leftWidth, contentHeight)
-		gitH, previewH := m.splitRightHeights(contentHeight)
-		m.gitstatus.SetSize(rightWidth, gitH)
-		m.preview.SetSize(rightWidth, previewH)
+
+		// Tasks tab: three-panel layout
+		leftW, centerW, rightW := m.splitThreeWidths()
+		m.tasklist.SetSize(leftW, contentHeight)
+		gitH, previewH := m.splitCenterHeights(contentHeight)
+		m.gitstatus.SetSize(centerW, gitH)
+		m.preview.SetSize(centerW, previewH)
+		m.detail.SetSize(rightW, contentHeight)
+
+		// Projects tab still uses two-panel split
+		m.projectlist.SetSize(leftW, contentHeight)
+
 		m.statusbar.SetWidth(msg.Width)
 		m.newtask.SetSize(msg.Width, msg.Height)
 		m.newproject.SetSize(msg.Width, msg.Height)

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -781,12 +781,12 @@ func TestModel_SplitWidths_NarrowTerminal(t *testing.T) {
 	}
 }
 
-func TestModel_SplitRightHeights(t *testing.T) {
+func TestModel_SplitCenterHeights(t *testing.T) {
 	m := testModel(t)
 
-	gitH, previewH := m.splitRightHeights(40)
+	gitH, previewH := m.splitCenterHeights(40)
 	if gitH+previewH < 40 {
-		t.Errorf("splitRightHeights total = %d, want >= 40", gitH+previewH)
+		t.Errorf("splitCenterHeights total = %d, want >= 40", gitH+previewH)
 	}
 	if gitH < 5 {
 		t.Errorf("gitH = %d, want >= 5", gitH)
@@ -799,9 +799,9 @@ func TestModel_SplitRightHeights(t *testing.T) {
 	}
 }
 
-func TestModel_SplitRightHeights_Small(t *testing.T) {
+func TestModel_SplitCenterHeights_Small(t *testing.T) {
 	m := testModel(t)
-	gitH, previewH := m.splitRightHeights(8)
+	gitH, previewH := m.splitCenterHeights(8)
 	if gitH < 5 {
 		t.Errorf("gitH = %d, want >= 5 (minimum)", gitH)
 	}

--- a/internal/ui/root_views.go
+++ b/internal/ui/root_views.go
@@ -58,7 +58,7 @@ func (m Model) padToBottom(content, bar string) string {
 	return content + padding + "\n" + bar
 }
 
-func (m Model) splitRightHeights(total int) (int, int) {
+func (m Model) splitCenterHeights(total int) (int, int) {
 	gitH := total * 3 / 10
 	if gitH < 5 {
 		gitH = 5
@@ -73,6 +73,7 @@ func (m Model) splitRightHeights(total int) (int, int) {
 	return gitH, previewH
 }
 
+// splitWidths returns a two-panel split for the projects tab.
 func (m Model) splitWidths() (int, int) {
 	left := m.width * 2 / 5
 	if left < 30 {
@@ -83,6 +84,42 @@ func (m Model) splitWidths() (int, int) {
 	}
 	right := m.width - left
 	return left, right
+}
+
+// splitThreeWidths returns widths for the three-panel task list layout.
+// Left: 30%, Center: 40%, Right: 30%.
+func (m Model) splitThreeWidths() (int, int, int) {
+	left := m.width * 30 / 100
+	if left < 25 {
+		left = 25
+	}
+	right := m.width * 30 / 100
+	if right < 20 {
+		right = 20
+	}
+	center := m.width - left - right
+	if center < 30 {
+		center = 30
+	}
+	// If total exceeds width, compress proportionally
+	total := left + center + right
+	if total > m.width {
+		// Give center priority, shrink right first
+		excess := total - m.width
+		if right-excess >= 10 {
+			right -= excess
+		} else {
+			right = 10
+			excess = left + center + right - m.width
+			if left-excess >= 15 {
+				left -= excess
+			} else {
+				left = 15
+				center = m.width - left - right
+			}
+		}
+	}
+	return left, center, right
 }
 
 func (m Model) renderTabHeader() string {
@@ -119,15 +156,24 @@ func (m Model) renderTasksView(tabHeader, bar string) string {
 		return m.padToBottom(content, bar)
 	}
 
+	contentHeight := m.height - 3
+
 	tasks := m.tasklist.View()
+	selected := m.tasklist.Selected()
 	var taskID string
-	if t := m.tasklist.Selected(); t != nil {
-		taskID = t.ID
+	if selected != nil {
+		taskID = selected.ID
 	}
 	gitView := m.gitstatus.View()
 	previewView := m.preview.View(taskID)
-	rightContent := lipgloss.JoinVertical(lipgloss.Left, gitView, previewView)
-	body := lipgloss.JoinHorizontal(lipgloss.Top, tasks, rightContent)
+	centerContent := lipgloss.JoinVertical(lipgloss.Left, gitView, previewView)
+	centerContent = padHeight(centerContent, contentHeight)
+
+	isRunning := selected != nil && m.runner.HasSession(selected.ID)
+	detailView := m.detail.View(selected, isRunning)
+	detailView = padHeight(detailView, contentHeight)
+
+	body := lipgloss.JoinHorizontal(lipgloss.Top, tasks, centerContent, detailView)
 	content := tabHeader + "\n" + body
 	return m.padToBottom(content, bar)
 }

--- a/internal/ui/taskdetail.go
+++ b/internal/ui/taskdetail.go
@@ -1,0 +1,160 @@
+package ui
+
+import (
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/drn/argus/internal/model"
+)
+
+// TaskDetail renders metadata for the selected task in a right-side panel.
+type TaskDetail struct {
+	theme  Theme
+	width  int
+	height int
+}
+
+func NewTaskDetail(theme Theme) TaskDetail {
+	return TaskDetail{theme: theme}
+}
+
+func (d *TaskDetail) SetSize(w, h int) {
+	d.width = w
+	d.height = h
+}
+
+// View renders the task detail panel. If t is nil, shows an empty state.
+func (d TaskDetail) View(t *model.Task, running bool) string {
+	if t == nil {
+		return borderedPanel(d.width, d.height, false,
+			d.theme.Dimmed.Render(" No task selected"))
+	}
+
+	innerW := max(d.width-4, 10)
+	innerH := max(d.height-2, 1)
+
+	var b strings.Builder
+
+	// Title
+	name := t.Name
+	if len(name) > innerW-2 {
+		name = name[:innerW-5] + "..."
+	}
+	b.WriteString(d.theme.Title.Render(" "+name) + "\n\n")
+
+	// Status with running/idle indicator
+	statusStyle := d.statusStyle(t.Status)
+	statusLabel := t.Status.String()
+	if t.Status == model.StatusInProgress {
+		if running {
+			statusLabel += " (running)"
+		} else {
+			statusLabel += " (idle)"
+		}
+	}
+	b.WriteString("  " + d.theme.Dimmed.Render("Status: ") + statusStyle.Render(statusLabel) + "\n")
+
+	// Project
+	if t.Project != "" {
+		b.WriteString("  " + d.theme.Dimmed.Render("Project: ") + d.theme.Normal.Render(t.Project) + "\n")
+	}
+
+	// Branch
+	if t.Branch != "" {
+		b.WriteString("  " + d.theme.Dimmed.Render("Branch: ") + d.theme.Normal.Render(t.Branch) + "\n")
+	}
+
+	// Backend (only if non-empty, i.e. non-default)
+	if t.Backend != "" {
+		b.WriteString("  " + d.theme.Dimmed.Render("Backend: ") + d.theme.Normal.Render(t.Backend) + "\n")
+	}
+
+	// Worktree path (truncated)
+	if t.Worktree != "" {
+		wt := t.Worktree
+		maxWtLen := innerW - 14 // "  Worktree: " + some margin
+		if maxWtLen > 0 && len(wt) > maxWtLen {
+			wt = "..." + wt[len(wt)-maxWtLen+3:]
+		}
+		b.WriteString("  " + d.theme.Dimmed.Render("Worktree: ") + d.theme.Normal.Render(wt) + "\n")
+	}
+
+	// Created date
+	if !t.CreatedAt.IsZero() {
+		b.WriteString("  " + d.theme.Dimmed.Render("Created: ") + d.theme.Normal.Render(t.CreatedAt.Format(time.DateOnly)) + "\n")
+	}
+
+	// Elapsed time
+	if elapsed := t.ElapsedString(); elapsed != "" {
+		b.WriteString("  " + d.theme.Dimmed.Render("Elapsed: ") + d.theme.Elapsed.Render(elapsed) + "\n")
+	}
+
+	// Prompt text (fills remaining space)
+	if t.Prompt != "" {
+		b.WriteString("\n" + d.theme.Section.Render("  PROMPT") + "\n")
+		prompt := d.wrapText(t.Prompt, innerW-2)
+		// Truncate to remaining height
+		headerLines := strings.Count(b.String(), "\n")
+		remaining := innerH - headerLines
+		if remaining > 0 {
+			promptLines := strings.Split(prompt, "\n")
+			if len(promptLines) > remaining {
+				promptLines = promptLines[:remaining]
+			}
+			for _, line := range promptLines {
+				b.WriteString("  " + d.theme.Normal.Render(line) + "\n")
+			}
+		}
+	}
+
+	content := strings.TrimRight(b.String(), "\n")
+	// Truncate to inner height
+	lines := strings.Split(content, "\n")
+	if len(lines) > innerH {
+		lines = lines[:innerH]
+		content = strings.Join(lines, "\n")
+	}
+
+	return borderedPanel(d.width, d.height, false, content)
+}
+
+// statusStyle returns the theme style for a given status.
+func (d TaskDetail) statusStyle(s model.Status) lipgloss.Style {
+	switch s {
+	case model.StatusPending:
+		return d.theme.Pending
+	case model.StatusInProgress:
+		return d.theme.InProgress
+	case model.StatusInReview:
+		return d.theme.InReview
+	case model.StatusComplete:
+		return d.theme.Complete
+	default:
+		return d.theme.Normal
+	}
+}
+
+// wrapText wraps text to fit within maxWidth, breaking at word boundaries.
+func (d TaskDetail) wrapText(text string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return text
+	}
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return ""
+	}
+	var lines []string
+	line := words[0]
+	for _, w := range words[1:] {
+		if len(line)+1+len(w) > maxWidth {
+			lines = append(lines, line)
+			line = w
+		} else {
+			line += " " + w
+		}
+	}
+	lines = append(lines, line)
+	return strings.Join(lines, "\n")
+}
+

--- a/internal/ui/taskdetail_test.go
+++ b/internal/ui/taskdetail_test.go
@@ -1,0 +1,199 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/drn/argus/internal/model"
+)
+
+func TestTaskDetailView(t *testing.T) {
+	d := NewTaskDetail(DefaultTheme())
+	d.SetSize(40, 30)
+
+	task := &model.Task{
+		ID:        "t1",
+		Name:      "fix-login-bug",
+		Status:    model.StatusInProgress,
+		Project:   "myapp",
+		Branch:    "argus/fix-login-bug",
+		Prompt:    "Fix the login bug in auth.go",
+		CreatedAt: time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
+		StartedAt: time.Now().Add(-5 * time.Minute),
+	}
+
+	view := d.View(task, true)
+
+	checks := []string{
+		"fix-login-bug",
+		"in_progress",
+		"running",
+		"myapp",
+		"argus/fix-login-bug",
+		"PROMPT",
+		"Fix the login bug",
+	}
+	for _, want := range checks {
+		if !strings.Contains(view, want) {
+			t.Errorf("view missing %q", want)
+		}
+	}
+}
+
+func TestTaskDetailView_Idle(t *testing.T) {
+	d := NewTaskDetail(DefaultTheme())
+	d.SetSize(40, 20)
+
+	task := &model.Task{
+		ID:     "t2",
+		Name:   "idle-task",
+		Status: model.StatusInProgress,
+	}
+
+	view := d.View(task, false)
+	if !strings.Contains(view, "idle") {
+		t.Error("expected 'idle' for non-running in_progress task")
+	}
+}
+
+func TestTaskDetailView_CompletedNoIndicator(t *testing.T) {
+	d := NewTaskDetail(DefaultTheme())
+	d.SetSize(40, 20)
+
+	task := &model.Task{
+		ID:     "t3",
+		Name:   "done-task",
+		Status: model.StatusComplete,
+	}
+
+	view := d.View(task, false)
+	if strings.Contains(view, "running") || strings.Contains(view, "idle") {
+		t.Error("completed task should not show running/idle indicator")
+	}
+}
+
+func TestTaskDetailViewNilTask(t *testing.T) {
+	d := NewTaskDetail(DefaultTheme())
+	d.SetSize(40, 20)
+
+	view := d.View(nil, false)
+	if view == "" {
+		t.Error("nil task should still render a panel")
+	}
+	if !strings.Contains(view, "No task selected") {
+		t.Error("nil task should show empty state message")
+	}
+}
+
+func TestTaskDetailSetSize(t *testing.T) {
+	d := NewTaskDetail(DefaultTheme())
+	d.SetSize(50, 25)
+
+	if d.width != 50 {
+		t.Errorf("width = %d, want 50", d.width)
+	}
+	if d.height != 25 {
+		t.Errorf("height = %d, want 25", d.height)
+	}
+}
+
+func TestTaskDetailView_Backend(t *testing.T) {
+	d := NewTaskDetail(DefaultTheme())
+	d.SetSize(50, 25)
+
+	task := &model.Task{
+		ID:      "t4",
+		Name:    "custom-backend",
+		Status:  model.StatusPending,
+		Backend: "codex",
+	}
+
+	view := d.View(task, false)
+	if !strings.Contains(view, "codex") {
+		t.Error("expected backend name in view")
+	}
+}
+
+func TestTaskDetailView_Worktree(t *testing.T) {
+	d := NewTaskDetail(DefaultTheme())
+	d.SetSize(50, 25)
+
+	task := &model.Task{
+		ID:       "t5",
+		Name:     "wt-task",
+		Status:   model.StatusInProgress,
+		Worktree: "/Users/test/.argus/worktrees/proj/wt-task",
+	}
+
+	view := d.View(task, false)
+	if !strings.Contains(view, "Worktree") {
+		t.Error("expected worktree label in view")
+	}
+}
+
+func TestTaskDetailWrapText(t *testing.T) {
+	d := NewTaskDetail(DefaultTheme())
+	text := "this is a long prompt that should wrap across multiple lines when rendered"
+	wrapped := d.wrapText(text, 20)
+	lines := strings.Split(wrapped, "\n")
+	if len(lines) < 2 {
+		t.Errorf("expected multiple lines, got %d", len(lines))
+	}
+	for _, line := range lines {
+		if len(line) > 20 {
+			t.Errorf("line exceeds maxWidth: %q (len=%d)", line, len(line))
+		}
+	}
+}
+
+func TestSplitThreeWidths(t *testing.T) {
+	tests := []struct {
+		name     string
+		width    int
+		wantLeft func(int) bool
+		wantMin  func(int, int, int) bool
+	}{
+		{
+			name:  "wide terminal",
+			width: 200,
+			wantLeft: func(left int) bool {
+				return left >= 25
+			},
+			wantMin: func(l, c, r int) bool {
+				return l+c+r == 200
+			},
+		},
+		{
+			name:  "medium terminal",
+			width: 120,
+			wantLeft: func(left int) bool {
+				return left >= 25
+			},
+			wantMin: func(l, c, r int) bool {
+				return l+c+r == 120
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := testModel(t)
+			m.width = tt.width
+			left, center, right := m.splitThreeWidths()
+			if !tt.wantLeft(left) {
+				t.Errorf("left = %d, failed check", left)
+			}
+			if center < 20 {
+				t.Errorf("center = %d, want >= 20", center)
+			}
+			if right < 10 {
+				t.Errorf("right = %d, want >= 10", right)
+			}
+			if !tt.wantMin(left, center, right) {
+				t.Errorf("total = %d, want %d (left=%d, center=%d, right=%d)",
+					left+center+right, tt.width, left, center, right)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Restructure task list from two-panel (tasks + git/preview) to three-panel (tasks + git/preview + task detail). The new right panel surfaces task metadata including prompt text, status, branch, and timing — previously hidden behind pressing `p`.

Co-Authored-By: Claude <noreply@anthropic.com>