### PR TITLE
Titleize tab labels and match tmux status bar style

### DIFF
--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -111,6 +111,12 @@
 - Fix: add `strings.Count(s, "⌘")` to the computed width. Applied in `renderStatusBar()` for the `right` hints string.
 - **Pattern:** When adding Unicode symbols to TUI layouts, verify `runewidth.RuneWidth(r)` against actual terminal rendering. Common offenders: miscellaneous symbols block (U+2300–U+23FF), dingbats, and emoji.
 
+### Tmux-Matched Tab Header (2026-03-14)
+- Tab header restyled to blend with the user's tmux status bar. Colors sourced from `~/.dots/cmd/tmux-status/color/root.go`.
+- **Key color mapping:** base background `colour236` (tmux C3), active tab `fg=236 bg=103` (tmux C1 — purple/lavender), inactive text `colour244` (tmux C3 fg).
+- **Powerline separators:** `\ue0b0` (right-facing full chevron) for smooth active tab transitions. Defined in `~/.dots/cmd/tmux-status/separator/root.go`.
+- **Pattern:** When styling Argus UI elements that sit adjacent to tmux chrome, use the tmux C1/C2/C3 palette to maintain visual continuity. The color constants are in `~/.dots/cmd/tmux-status/color/root.go`.
+
 ### Deferred Items for Future Sessions
 - Add error handling for silently ignored `_ = m.db.Update()` calls (~15 instances in root.go)
 - Handle `os.UserHomeDir()` errors in db.go and config.go

--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -4,7 +4,7 @@ Structured knowledge for cross-session persistence. Each file covers a topic/dom
 
 | File | Topic | Key Entities | Last Updated |
 |------|-------|-------------|-------------|
-| code-quality.md | Refactoring patterns and deferred items | ScrollState, vtrender.go, sgrColor, borderedPanel, file splits, GitStatus pointer bug, cursor skip-header, Alt modifier keyMsgToBytes, textarea zero-value trap, textarea viewport scroll bug, worktree removal safety guard, self-managed worktrees, scroll-offset chicken-and-egg, diff panel line wrapping, ⌘ runewidth mismatch, deferred items | 2026-03-14 |
+| code-quality.md | Refactoring patterns and deferred items | ScrollState, vtrender.go, sgrColor, borderedPanel, file splits, GitStatus pointer bug, cursor skip-header, Alt modifier keyMsgToBytes, textarea zero-value trap, textarea viewport scroll bug, worktree removal safety guard, self-managed worktrees, scroll-offset chicken-and-egg, diff panel line wrapping, ⌘ runewidth mismatch, tmux color palette, deferred items | 2026-03-14 |
 
 ## Coverage Map
 

--- a/internal/ui/root_views.go
+++ b/internal/ui/root_views.go
@@ -123,31 +123,45 @@ func (m Model) splitThreeWidths() (int, int, int) {
 }
 
 func (m Model) renderTabHeader() string {
-	activeStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("87")).
-		Underline(false)
-	inactiveStyle := m.theme.Dimmed
+	const (
+		baseBg   = "236" // tmux C3 background
+		activeFg = "236" // dark text on active tab
+		activeBg = "103" // tmux C1 purple/lavender
+		inFg     = "244" // tmux C3 text
+		chevron  = "\ue0b0"
+	)
+
+	bg := lipgloss.Color(baseBg)
+	abg := lipgloss.Color(activeBg)
+
+	activeText := lipgloss.NewStyle().Foreground(lipgloss.Color(activeFg)).Background(abg)
+	inactiveText := lipgloss.NewStyle().Foreground(lipgloss.Color(inFg)).Background(bg)
 
 	tabs := []struct {
 		label string
-		key   string
 		t     tab
 	}{
-		{"TASKS", "1", tabTasks},
-		{"PROJECTS", "2", tabProjects},
+		{"Tasks", tabTasks},
+		{"Projects", tabProjects},
 	}
 
-	var parts []string
+	var b strings.Builder
 	for _, t := range tabs {
-		style := inactiveStyle
 		if t.t == m.activeTab {
-			style = activeStyle
+			// transition: base → active
+			b.WriteString(lipgloss.NewStyle().Foreground(bg).Background(abg).Render(chevron))
+			b.WriteString(activeText.Render(" " + t.label + " "))
+			// transition: active → base
+			b.WriteString(lipgloss.NewStyle().Foreground(abg).Background(bg).Render(chevron))
+		} else {
+			b.WriteString(inactiveText.Render("  " + t.label + " "))
 		}
-		parts = append(parts, style.Render("  "+t.label+" "))
 	}
-	header := strings.Join(parts, "  ")
-	return lipgloss.PlaceHorizontal(m.width, lipgloss.Center, header)
+
+	return lipgloss.NewStyle().
+		Background(bg).
+		Width(m.width).
+		Render(b.String())
 }
 
 func (m Model) renderTasksView(tabHeader, bar string) string {


### PR DESCRIPTION
Tabs changed from uppercase to titlecase. Header restyled with tmux C1/C3 palette (bg=236, active bg=103) and powerline chevron separators for visual continuity with the tmux status bar.

Co-Authored-By: Claude <noreply@anthropic.com>