### PR TITLE
Add side-by-side diff view with syntax highlighting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 )
 
 require (
+	github.com/alecthomas/chroma/v2 v2.23.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
@@ -22,6 +23,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
+	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/alecthomas/chroma/v2 v2.23.1 h1:nv2AVZdTyClGbVQkIzlDm/rnhk1E9bU9nXwmZ/Vk/iY=
+github.com/alecthomas/chroma/v2 v2.23.1/go.mod h1:NqVhfBR0lte5Ouh3DcthuUCTUpDC9cxBOfyMbMQPs3o=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -24,6 +26,8 @@ github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w
 github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
+github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=

--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -60,13 +60,11 @@ type AgentView struct {
 	vtRows     int    // vtTerm row count
 
 	// Diff viewer state
-	diffMode         bool     // true when viewing a file's diff
-	diffContent      string   // raw colorized diff output
-	diffLines        []string // split lines for scrolling
-	diffScrollOff    int      // scroll offset within diff
-	worktreeDir      string   // resolved worktree directory for git commands
-	diffWrappedLines []string // diffLines wrapped to panel width (visual lines)
-	diffWrapWidth    int      // width used to compute diffWrappedLines
+	diffMode      bool              // true when viewing a file's diff
+	diffRows      []SideBySideLine  // parsed side-by-side rows
+	diffScrollOff int               // scroll offset within diff
+	worktreeDir   string            // resolved worktree directory for git commands
+	diffFileName  string            // current file being diffed (for highlighting)
 }
 
 func NewAgentView(theme Theme, runner *agent.Runner) AgentView {
@@ -94,10 +92,10 @@ func (av *AgentView) Enter(taskID, taskName string) {
 	av.vtTerm = nil
 	av.vtFedTotal = 0
 	av.diffMode = false
-	av.diffContent = ""
-	av.diffLines = nil
+	av.diffRows = nil
 	av.diffScrollOff = 0
 	av.worktreeDir = ""
+	av.diffFileName = ""
 }
 
 // SetLastOutput stores the final ring buffer from a finished session
@@ -282,14 +280,13 @@ func (av *AgentView) UpdateFileDiff(msg FileDiffMsg) {
 		return
 	}
 	av.diffMode = true
-	av.diffContent = msg.Diff
 	av.diffScrollOff = 0
-	av.diffWrappedLines = nil
-	av.diffWrapWidth = 0
+	av.diffFileName = msg.FilePath
 	if msg.Diff == "" {
-		av.diffLines = []string{"(no diff)"}
+		av.diffRows = nil
 	} else {
-		av.diffLines = strings.Split(msg.Diff, "\n")
+		pd := ParseUnifiedDiff(msg.Diff)
+		av.diffRows = BuildSideBySide(pd)
 	}
 }
 
@@ -300,25 +297,9 @@ func (av *AgentView) SetWorktreeDir(dir string) {
 
 func (av *AgentView) exitDiffMode() {
 	av.diffMode = false
-	av.diffContent = ""
-	av.diffLines = nil
-	av.diffWrappedLines = nil
-	av.diffWrapWidth = 0
+	av.diffRows = nil
 	av.diffScrollOff = 0
-}
-
-// wrapDiffLines wraps diffLines to the given width, caching the result.
-func (av *AgentView) wrapDiffLines(width int) []string {
-	if width == av.diffWrapWidth && av.diffWrappedLines != nil {
-		return av.diffWrappedLines
-	}
-	av.diffWrapWidth = width
-	av.diffWrappedLines = nil
-	for _, line := range av.diffLines {
-		wrapped := ansi.Hardwrap(line, width, false)
-		av.diffWrappedLines = append(av.diffWrappedLines, strings.Split(wrapped, "\n")...)
-	}
-	return av.diffWrappedLines
+	av.diffFileName = ""
 }
 
 func (av *AgentView) handleDiffKey(msg tea.KeyMsg) tea.Cmd {
@@ -360,11 +341,7 @@ func (av *AgentView) diffScrollUp(n int) {
 }
 
 func (av *AgentView) diffScrollDown(n int) {
-	lines := av.diffWrappedLines
-	if lines == nil {
-		lines = av.diffLines
-	}
-	maxOff := len(lines) - av.diffVisibleRows()
+	maxOff := len(av.diffRows) - av.diffVisibleRows()
 	if maxOff < 0 {
 		maxOff = 0
 	}
@@ -486,7 +463,7 @@ func (av *AgentView) renderDiffPanel(w, h int) string {
 		Width(w - 2).
 		Height(innerH)
 
-	if len(av.diffLines) == 0 {
+	if len(av.diffRows) == 0 {
 		empty := av.theme.Dimmed.
 			Width(w - 4).
 			Height(innerH).
@@ -499,43 +476,21 @@ func (av *AgentView) renderDiffPanel(w, h int) string {
 	dispH := max(h-4, 3)
 
 	// Header
-	fileName := ""
+	fileName := av.diffFileName
 	if f := av.files.SelectedFile(); f != nil {
 		fileName = f.Path
 	}
-	header := av.theme.Section.Render("  DIFF") +
-		av.theme.Dimmed.Render(" " + fileName) +
-		av.theme.Dimmed.Render(fmt.Sprintf("  [%d/%d]", av.files.scroll.Cursor()+1, av.files.FileCount()))
-	headerLines := 1
+	header := RenderSideBySideHeader(fileName, av.files.scroll.Cursor(), av.files.FileCount(), av.theme)
 
-	// Visible diff lines
-	visibleH := dispH - headerLines
+	// Visible diff rows (minus header)
+	visibleH := dispH - 1
 	if visibleH < 1 {
 		visibleH = 1
 	}
 
-	// Use wrapped visual lines for rendering
-	wrapped := av.wrapDiffLines(dispW)
+	content := RenderSideBySide(av.diffRows, fileName, dispW, visibleH, av.diffScrollOff, av.theme)
 
-	end := av.diffScrollOff + visibleH
-	if end > len(wrapped) {
-		end = len(wrapped)
-	}
-	start := av.diffScrollOff
-	if start > end {
-		start = end
-	}
-
-	var b strings.Builder
-	b.WriteString(header + "\n")
-	for i := start; i < end; i++ {
-		b.WriteString(wrapped[i])
-		if i < end-1 {
-			b.WriteString("\n")
-		}
-	}
-
-	return border.Render(b.String())
+	return border.Render(header + "\n" + content)
 }
 
 // renderIncremental feeds only new bytes to a persistent vt10x terminal,

--- a/internal/ui/agentview_test.go
+++ b/internal/ui/agentview_test.go
@@ -916,17 +916,17 @@ func TestAgentView_DiffMode_EnterOpensAndEscCloses(t *testing.T) {
 		t.Fatal("enter on file should return a non-nil cmd")
 	}
 
-	// Simulate diff result
+	// Simulate diff result with a proper unified diff
 	av.UpdateFileDiff(FileDiffMsg{
 		TaskID:   "task-1",
 		FilePath: "a.go",
-		Diff:     "+added line\n-removed line\n context",
+		Diff:     "--- a/a.go\n+++ b/a.go\n@@ -1,3 +1,3 @@\n+added line\n-removed line\n context",
 	})
 	if !av.diffMode {
 		t.Fatal("expected diffMode to be true after UpdateFileDiff")
 	}
-	if len(av.diffLines) != 3 {
-		t.Errorf("expected 3 diff lines, got %d", len(av.diffLines))
+	if len(av.diffRows) == 0 {
+		t.Error("expected non-empty diffRows after UpdateFileDiff")
 	}
 
 	// Escape exits diff mode and refocuses on agent panel
@@ -952,7 +952,7 @@ func TestAgentView_FilesPanelEscRefocusesAgent(t *testing.T) {
 func TestAgentView_DiffMode_CtrlQExitsDiff(t *testing.T) {
 	av := newTestAgentView()
 	av.diffMode = true
-	av.diffLines = []string{"line1"}
+	av.diffRows = []SideBySideLine{{LeftNum: 1, LeftText: "line1", RightNum: 1, RightText: "line1"}}
 
 	// ctrl+q in diff mode should exit diff, not detach
 	detach, _ := av.HandleKey(tea.KeyMsg{Type: tea.KeyCtrlQ})
@@ -974,7 +974,7 @@ func TestAgentView_DiffMode_UpDownSwitchFiles(t *testing.T) {
 		{Status: "M", Path: "c.go"},
 	})
 	av.diffMode = true
-	av.diffLines = []string{"old diff"}
+	av.diffRows = []SideBySideLine{{LeftNum: 1, LeftText: "old diff"}}
 
 	// Down arrow should move cursor and return a cmd
 	_, cmd := av.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
@@ -998,12 +998,12 @@ func TestAgentView_DiffMode_UpDownSwitchFiles(t *testing.T) {
 func TestAgentView_DiffMode_ScrollUpDown(t *testing.T) {
 	av := newTestAgentView()
 	av.diffMode = true
-	// Create many lines
-	lines := make([]string, 100)
-	for i := range lines {
-		lines[i] = "line"
+	// Create many rows
+	rows := make([]SideBySideLine, 100)
+	for i := range rows {
+		rows[i] = SideBySideLine{LeftNum: i + 1, LeftText: "line", RightNum: i + 1, RightText: "line"}
 	}
-	av.diffLines = lines
+	av.diffRows = rows
 
 	av.diffScrollDown(5)
 	if av.diffScrollOff != 5 {
@@ -1025,11 +1025,11 @@ func TestAgentView_DiffMode_ScrollUpDown(t *testing.T) {
 func TestAgentView_DiffMode_MouseWheel(t *testing.T) {
 	av := newTestAgentView()
 	av.diffMode = true
-	lines := make([]string, 100)
-	for i := range lines {
-		lines[i] = "line"
+	rows := make([]SideBySideLine, 100)
+	for i := range rows {
+		rows[i] = SideBySideLine{LeftNum: i + 1, LeftText: "line", RightNum: i + 1, RightText: "line"}
 	}
-	av.diffLines = lines
+	av.diffRows = rows
 
 	// Wheel down
 	av.HandleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
@@ -1059,7 +1059,10 @@ func TestAgentView_DiffMode_RenderDiffPanel(t *testing.T) {
 	av.files.SetFiles([]ChangedFile{
 		{Status: "M", Path: "test.go"},
 	})
-	av.diffLines = []string{"+added", "-removed", " context"}
+	av.diffRows = []SideBySideLine{
+		{LeftNum: 1, LeftText: "removed", LeftType: DiffRemoved, RightNum: 1, RightText: "added", RightType: DiffAdded},
+		{LeftNum: 2, LeftText: "context", LeftType: DiffContext, RightNum: 2, RightText: "context", RightType: DiffContext},
+	}
 
 	view := av.View()
 	if view == "" {
@@ -1080,61 +1083,22 @@ func TestAgentView_DiffMode_EmptyDiff(t *testing.T) {
 	if !av.diffMode {
 		t.Fatal("expected diffMode even for empty diff")
 	}
-	if len(av.diffLines) != 1 || av.diffLines[0] != "(no diff)" {
-		t.Errorf("expected '(no diff)' placeholder, got %v", av.diffLines)
+	if len(av.diffRows) != 0 {
+		t.Errorf("expected empty diffRows for empty diff, got %d rows", len(av.diffRows))
 	}
 }
 
 func TestAgentView_Enter_ResetsDiffMode(t *testing.T) {
 	av := newTestAgentView()
 	av.diffMode = true
-	av.diffLines = []string{"old"}
+	av.diffRows = []SideBySideLine{{LeftNum: 1, LeftText: "old"}}
 
 	av.Enter("task-2", "new task")
 	if av.diffMode {
 		t.Fatal("Enter should reset diffMode")
 	}
-	if av.diffLines != nil {
-		t.Fatal("Enter should clear diffLines")
-	}
-}
-
-func TestAgentView_DiffMode_LongLinesWrap(t *testing.T) {
-	av := newTestAgentView()
-	av.diffMode = true
-	av.files.SetFiles([]ChangedFile{
-		{Status: "M", Path: "test.go"},
-	})
-
-	// Create a line longer than the panel width (120 - 4 border = 116 display)
-	longLine := "+" + strings.Repeat("x", 200)
-	av.diffLines = []string{longLine, " short"}
-
-	// Wrap to a narrow width to make the test deterministic
-	wrapped := av.wrapDiffLines(40)
-	if len(wrapped) < 3 {
-		t.Errorf("expected long line to wrap into multiple visual lines, got %d lines", len(wrapped))
-	}
-	// Verify the view renders without truncation
-	view := av.View()
-	if view == "" {
-		t.Fatal("expected non-empty view with wrapped lines")
-	}
-}
-
-func TestAgentView_DiffMode_WrapCacheInvalidation(t *testing.T) {
-	av := newTestAgentView()
-	av.diffLines = []string{strings.Repeat("a", 100)}
-
-	w1 := av.wrapDiffLines(50)
-	w2 := av.wrapDiffLines(50) // should return cached
-	if len(w1) != len(w2) {
-		t.Fatal("cache should return same result for same width")
-	}
-
-	w3 := av.wrapDiffLines(30) // different width → re-wrap
-	if len(w3) <= len(w1) {
-		t.Error("narrower width should produce more wrapped lines")
+	if av.diffRows != nil {
+		t.Fatal("Enter should clear diffRows")
 	}
 }
 

--- a/internal/ui/diffparse.go
+++ b/internal/ui/diffparse.go
@@ -1,0 +1,261 @@
+package ui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// DiffLineType categorizes a line in a unified diff.
+type DiffLineType int
+
+const (
+	DiffContext DiffLineType = iota
+	DiffAdded
+	DiffRemoved
+)
+
+// DiffLine is a single line from a parsed unified diff.
+type DiffLine struct {
+	Type    DiffLineType
+	Content string // line content without the +/- prefix
+	OldNum  int    // line number in old file (0 if added)
+	NewNum  int    // line number in new file (0 if removed)
+}
+
+// DiffHunk is a group of contiguous changes.
+type DiffHunk struct {
+	OldStart int
+	OldCount int
+	NewStart int
+	NewCount int
+	Header   string // the @@ line
+	Lines    []DiffLine
+}
+
+// ParsedDiff is the result of parsing a unified diff.
+type ParsedDiff struct {
+	OldFile string
+	NewFile string
+	Hunks   []DiffHunk
+}
+
+// SideBySideLine represents one row in a side-by-side diff view.
+type SideBySideLine struct {
+	LeftNum  int    // 0 = blank/padding
+	LeftText string // raw content (no ANSI yet)
+	LeftType DiffLineType
+	RightNum  int
+	RightText string
+	RightType DiffLineType
+}
+
+// ParseUnifiedDiff parses raw unified diff output into structured data.
+func ParseUnifiedDiff(raw string) ParsedDiff {
+	lines := strings.Split(raw, "\n")
+	var pd ParsedDiff
+	var currentHunk *DiffHunk
+	oldNum, newNum := 0, 0
+
+	for _, line := range lines {
+		// File headers
+		if strings.HasPrefix(line, "--- ") {
+			pd.OldFile = strings.TrimPrefix(line, "--- ")
+			pd.OldFile = strings.TrimPrefix(pd.OldFile, "a/")
+			continue
+		}
+		if strings.HasPrefix(line, "+++ ") {
+			pd.NewFile = strings.TrimPrefix(line, "+++ ")
+			pd.NewFile = strings.TrimPrefix(pd.NewFile, "b/")
+			continue
+		}
+
+		// Hunk header: @@ -old,count +new,count @@
+		if strings.HasPrefix(line, "@@") {
+			h := parseHunkHeader(line)
+			pd.Hunks = append(pd.Hunks, h)
+			currentHunk = &pd.Hunks[len(pd.Hunks)-1]
+			oldNum = h.OldStart
+			newNum = h.NewStart
+			continue
+		}
+
+		// Skip diff metadata lines (diff --git, index, etc.)
+		if currentHunk == nil {
+			continue
+		}
+
+		// Diff content lines
+		if strings.HasPrefix(line, "-") {
+			currentHunk.Lines = append(currentHunk.Lines, DiffLine{
+				Type:    DiffRemoved,
+				Content: line[1:],
+				OldNum:  oldNum,
+			})
+			oldNum++
+		} else if strings.HasPrefix(line, "+") {
+			currentHunk.Lines = append(currentHunk.Lines, DiffLine{
+				Type:    DiffAdded,
+				Content: line[1:],
+				NewNum:  newNum,
+			})
+			newNum++
+		} else if strings.HasPrefix(line, " ") {
+			currentHunk.Lines = append(currentHunk.Lines, DiffLine{
+				Type:    DiffContext,
+				Content: line[1:],
+				OldNum:  oldNum,
+				NewNum:  newNum,
+			})
+			oldNum++
+			newNum++
+		} else if line == `\ No newline at end of file` {
+			// Skip this marker
+			continue
+		} else if line == "" {
+			// Could be a context line that's just empty
+			if currentHunk != nil && oldNum > 0 {
+				currentHunk.Lines = append(currentHunk.Lines, DiffLine{
+					Type:    DiffContext,
+					Content: "",
+					OldNum:  oldNum,
+					NewNum:  newNum,
+				})
+				oldNum++
+				newNum++
+			}
+		}
+	}
+
+	return pd
+}
+
+// parseHunkHeader parses "@@ -old,count +new,count @@ optional context"
+func parseHunkHeader(line string) DiffHunk {
+	h := DiffHunk{Header: line, OldStart: 1, OldCount: 1, NewStart: 1, NewCount: 1}
+	// Find the range spec between @@ markers
+	if !strings.HasPrefix(line, "@@") {
+		return h
+	}
+	end := strings.Index(line[2:], "@@")
+	if end < 0 {
+		return h
+	}
+	spec := strings.TrimSpace(line[2 : 2+end])
+	parts := strings.Fields(spec)
+	for _, p := range parts {
+		if strings.HasPrefix(p, "-") {
+			h.OldStart, h.OldCount = parseRange(p[1:])
+		} else if strings.HasPrefix(p, "+") {
+			h.NewStart, h.NewCount = parseRange(p[1:])
+		}
+	}
+	return h
+}
+
+// parseRange parses "start,count" or just "start" (count defaults to 1).
+func parseRange(s string) (int, int) {
+	if idx := strings.Index(s, ","); idx >= 0 {
+		start, _ := strconv.Atoi(s[:idx])
+		count, _ := strconv.Atoi(s[idx+1:])
+		if start == 0 {
+			start = 1
+		}
+		return start, count
+	}
+	start, _ := strconv.Atoi(s)
+	if start == 0 {
+		start = 1
+	}
+	return start, 1
+}
+
+// BuildSideBySide converts parsed diff hunks into side-by-side line pairs.
+// Consecutive removed+added blocks are paired together.
+func BuildSideBySide(pd ParsedDiff) []SideBySideLine {
+	var result []SideBySideLine
+
+	for hi, hunk := range pd.Hunks {
+		// Add a separator between hunks (except first)
+		if hi > 0 {
+			result = append(result, SideBySideLine{
+				LeftText: "───", RightText: "───",
+			})
+		}
+		// Add hunk header as a separator
+		result = append(result, SideBySideLine{
+			LeftText:  hunk.Header,
+			RightText: hunk.Header,
+			LeftType:  DiffContext,
+			RightType: DiffContext,
+		})
+
+		lines := hunk.Lines
+		i := 0
+		for i < len(lines) {
+			dl := lines[i]
+			switch dl.Type {
+			case DiffContext:
+				result = append(result, SideBySideLine{
+					LeftNum: dl.OldNum, LeftText: dl.Content, LeftType: DiffContext,
+					RightNum: dl.NewNum, RightText: dl.Content, RightType: DiffContext,
+				})
+				i++
+			case DiffRemoved:
+				// Collect consecutive removed lines
+				removed := collectRun(lines, i, DiffRemoved)
+				j := i + len(removed)
+				// Collect consecutive added lines that follow
+				added := collectRun(lines, j, DiffAdded)
+
+				// Pair them up
+				maxLen := max(len(removed), len(added))
+				for k := 0; k < maxLen; k++ {
+					var row SideBySideLine
+					if k < len(removed) {
+						row.LeftNum = removed[k].OldNum
+						row.LeftText = removed[k].Content
+						row.LeftType = DiffRemoved
+					}
+					if k < len(added) {
+						row.RightNum = added[k].NewNum
+						row.RightText = added[k].Content
+						row.RightType = DiffAdded
+					}
+					result = append(result, row)
+				}
+				i = j + len(added)
+			case DiffAdded:
+				// Added lines without preceding removed lines
+				result = append(result, SideBySideLine{
+					RightNum: dl.NewNum, RightText: dl.Content, RightType: DiffAdded,
+				})
+				i++
+			}
+		}
+	}
+
+	return result
+}
+
+// collectRun collects consecutive lines of the given type starting at index i.
+func collectRun(lines []DiffLine, i int, t DiffLineType) []DiffLine {
+	var run []DiffLine
+	for i < len(lines) && lines[i].Type == t {
+		run = append(run, lines[i])
+		i++
+	}
+	return run
+}
+
+// FormatLineNum formats a line number for display, or blank if 0.
+func FormatLineNum(n, width int) string {
+	if n == 0 {
+		return strings.Repeat(" ", width)
+	}
+	s := strconv.Itoa(n)
+	if len(s) > width {
+		return s[len(s)-width:]
+	}
+	return fmt.Sprintf("%*d", width, n)
+}

--- a/internal/ui/diffparse_test.go
+++ b/internal/ui/diffparse_test.go
@@ -1,0 +1,284 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseUnifiedDiff_Basic(t *testing.T) {
+	raw := `diff --git a/main.go b/main.go
+index abc123..def456 100644
+--- a/main.go
++++ b/main.go
+@@ -1,5 +1,5 @@
+ package main
+
+-import "fmt"
++import "log"
+
+ func main() {`
+
+	pd := ParseUnifiedDiff(raw)
+	if pd.OldFile != "main.go" {
+		t.Errorf("OldFile = %q, want %q", pd.OldFile, "main.go")
+	}
+	if pd.NewFile != "main.go" {
+		t.Errorf("NewFile = %q, want %q", pd.NewFile, "main.go")
+	}
+	if len(pd.Hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(pd.Hunks))
+	}
+	h := pd.Hunks[0]
+	if h.OldStart != 1 || h.OldCount != 5 {
+		t.Errorf("old range = %d,%d, want 1,5", h.OldStart, h.OldCount)
+	}
+	if h.NewStart != 1 || h.NewCount != 5 {
+		t.Errorf("new range = %d,%d, want 1,5", h.NewStart, h.NewCount)
+	}
+
+	// Should have: context, context, removed, added, context, context
+	var removed, added, context int
+	for _, dl := range h.Lines {
+		switch dl.Type {
+		case DiffRemoved:
+			removed++
+		case DiffAdded:
+			added++
+		case DiffContext:
+			context++
+		}
+	}
+	if removed != 1 {
+		t.Errorf("removed lines = %d, want 1", removed)
+	}
+	if added != 1 {
+		t.Errorf("added lines = %d, want 1", added)
+	}
+	if context < 3 {
+		t.Errorf("context lines = %d, want >= 3", context)
+	}
+}
+
+func TestParseUnifiedDiff_MultipleHunks(t *testing.T) {
+	raw := `--- a/file.go
++++ b/file.go
+@@ -1,3 +1,3 @@
+ line1
+-old2
++new2
+ line3
+@@ -10,3 +10,4 @@
+ line10
++inserted
+ line11
+ line12`
+
+	pd := ParseUnifiedDiff(raw)
+	if len(pd.Hunks) != 2 {
+		t.Fatalf("expected 2 hunks, got %d", len(pd.Hunks))
+	}
+	if pd.Hunks[1].NewStart != 10 {
+		t.Errorf("hunk 2 NewStart = %d, want 10", pd.Hunks[1].NewStart)
+	}
+}
+
+func TestParseUnifiedDiff_Empty(t *testing.T) {
+	pd := ParseUnifiedDiff("")
+	if len(pd.Hunks) != 0 {
+		t.Errorf("expected 0 hunks for empty input, got %d", len(pd.Hunks))
+	}
+}
+
+func TestParseUnifiedDiff_NewFile(t *testing.T) {
+	raw := `diff --git a/new.go b/new.go
+new file mode 100644
+--- /dev/null
++++ b/new.go
+@@ -0,0 +1,3 @@
++package main
++
++func hello() {}`
+
+	pd := ParseUnifiedDiff(raw)
+	if pd.NewFile != "new.go" {
+		t.Errorf("NewFile = %q, want %q", pd.NewFile, "new.go")
+	}
+	if len(pd.Hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(pd.Hunks))
+	}
+	// All lines should be added
+	for _, dl := range pd.Hunks[0].Lines {
+		if dl.Type != DiffAdded {
+			t.Errorf("expected all lines to be Added, got %v for %q", dl.Type, dl.Content)
+		}
+	}
+}
+
+func TestParseHunkHeader(t *testing.T) {
+	tests := []struct {
+		input                            string
+		oldStart, oldCount, newStart, newCount int
+	}{
+		{"@@ -1,5 +1,5 @@", 1, 5, 1, 5},
+		{"@@ -10,3 +10,4 @@ func main()", 10, 3, 10, 4},
+		{"@@ -1 +1,2 @@", 1, 1, 1, 2},
+		{"@@ -0,0 +1,3 @@", 1, 0, 1, 3},
+	}
+	for _, tc := range tests {
+		h := parseHunkHeader(tc.input)
+		if h.OldStart != tc.oldStart || h.OldCount != tc.oldCount {
+			t.Errorf("parseHunkHeader(%q): old = %d,%d, want %d,%d",
+				tc.input, h.OldStart, h.OldCount, tc.oldStart, tc.oldCount)
+		}
+		if h.NewStart != tc.newStart || h.NewCount != tc.newCount {
+			t.Errorf("parseHunkHeader(%q): new = %d,%d, want %d,%d",
+				tc.input, h.NewStart, h.NewCount, tc.newStart, tc.newCount)
+		}
+	}
+}
+
+func TestBuildSideBySide_PairsRemovedAdded(t *testing.T) {
+	pd := ParsedDiff{
+		Hunks: []DiffHunk{
+			{
+				OldStart: 1, OldCount: 3, NewStart: 1, NewCount: 3,
+				Header: "@@ -1,3 +1,3 @@",
+				Lines: []DiffLine{
+					{Type: DiffContext, Content: "line1", OldNum: 1, NewNum: 1},
+					{Type: DiffRemoved, Content: "old2", OldNum: 2},
+					{Type: DiffAdded, Content: "new2", NewNum: 2},
+					{Type: DiffContext, Content: "line3", OldNum: 3, NewNum: 3},
+				},
+			},
+		},
+	}
+
+	rows := BuildSideBySide(pd)
+	// Should have: header + context + paired(removed,added) + context = 4 rows
+	if len(rows) < 4 {
+		t.Fatalf("expected at least 4 rows, got %d", len(rows))
+	}
+
+	// Find the paired row (removed on left, added on right)
+	found := false
+	for _, r := range rows {
+		if r.LeftType == DiffRemoved && r.RightType == DiffAdded {
+			if r.LeftText != "old2" || r.RightText != "new2" {
+				t.Errorf("paired row: left=%q right=%q, want old2/new2", r.LeftText, r.RightText)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected a row with removed left and added right (paired)")
+	}
+}
+
+func TestBuildSideBySide_AddedOnly(t *testing.T) {
+	pd := ParsedDiff{
+		Hunks: []DiffHunk{
+			{
+				Header: "@@ -1,2 +1,3 @@",
+				Lines: []DiffLine{
+					{Type: DiffContext, Content: "line1", OldNum: 1, NewNum: 1},
+					{Type: DiffAdded, Content: "inserted", NewNum: 2},
+					{Type: DiffContext, Content: "line2", OldNum: 2, NewNum: 3},
+				},
+			},
+		},
+	}
+
+	rows := BuildSideBySide(pd)
+	// Find the added-only row
+	found := false
+	for _, r := range rows {
+		if r.RightType == DiffAdded && r.RightText == "inserted" {
+			if r.LeftNum != 0 {
+				t.Errorf("added-only row should have LeftNum=0, got %d", r.LeftNum)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected an added-only row with 'inserted'")
+	}
+}
+
+func TestFormatLineNum(t *testing.T) {
+	tests := []struct {
+		n, w int
+		want string
+	}{
+		{0, 4, "    "},
+		{1, 4, "   1"},
+		{42, 4, "  42"},
+		{9999, 4, "9999"},
+		{12345, 4, "2345"}, // overflow: truncated
+	}
+	for _, tc := range tests {
+		got := FormatLineNum(tc.n, tc.w)
+		if got != tc.want {
+			t.Errorf("FormatLineNum(%d, %d) = %q, want %q", tc.n, tc.w, got, tc.want)
+		}
+	}
+}
+
+func TestParseRange(t *testing.T) {
+	tests := []struct {
+		input      string
+		wantStart  int
+		wantCount  int
+	}{
+		{"1,5", 1, 5},
+		{"10,3", 10, 3},
+		{"1", 1, 1},
+		{"0,0", 1, 0}, // 0 start normalized to 1
+	}
+	for _, tc := range tests {
+		start, count := parseRange(tc.input)
+		if start != tc.wantStart || count != tc.wantCount {
+			t.Errorf("parseRange(%q) = %d,%d, want %d,%d", tc.input, start, count, tc.wantStart, tc.wantCount)
+		}
+	}
+}
+
+func TestCollectRun(t *testing.T) {
+	lines := []DiffLine{
+		{Type: DiffRemoved, Content: "a"},
+		{Type: DiffRemoved, Content: "b"},
+		{Type: DiffAdded, Content: "c"},
+		{Type: DiffContext, Content: "d"},
+	}
+	run := collectRun(lines, 0, DiffRemoved)
+	if len(run) != 2 {
+		t.Errorf("collectRun removed: got %d, want 2", len(run))
+	}
+	run = collectRun(lines, 2, DiffAdded)
+	if len(run) != 1 {
+		t.Errorf("collectRun added: got %d, want 1", len(run))
+	}
+	run = collectRun(lines, 0, DiffAdded)
+	if len(run) != 0 {
+		t.Errorf("collectRun mismatch: got %d, want 0", len(run))
+	}
+}
+
+func TestParseUnifiedDiff_NoNewlineMarker(t *testing.T) {
+	raw := `--- a/file.txt
++++ b/file.txt
+@@ -1,2 +1,2 @@
+-old line
++new line
+\ No newline at end of file`
+
+	pd := ParseUnifiedDiff(raw)
+	if len(pd.Hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(pd.Hunks))
+	}
+	// The "no newline" marker should be skipped
+	for _, dl := range pd.Hunks[0].Lines {
+		if strings.Contains(dl.Content, "No newline") {
+			t.Error("should not include 'No newline' marker in parsed lines")
+		}
+	}
+}

--- a/internal/ui/gitcmd.go
+++ b/internal/ui/gitcmd.go
@@ -69,22 +69,22 @@ func FetchFileDiff(taskID, worktree, filePath string) FileDiffMsg {
 		return msg
 	}
 
-	// Try uncommitted diff first (staged + unstaged)
-	if out, err := runGit(worktree, "diff", "--color=always", "HEAD", "--", filePath); err == nil && out != "" {
+	// Try uncommitted diff first (staged + unstaged) — raw output for parsing
+	if out, err := runGit(worktree, "diff", "HEAD", "--", filePath); err == nil && out != "" {
 		msg.Diff = out
 		return msg
 	}
 
 	// Fall back to branch diff (committed changes vs merge-base)
 	if base := findMergeBase(worktree); base != "" {
-		if out, err := runGit(worktree, "diff", "--color=always", base+"..HEAD", "--", filePath); err == nil {
+		if out, err := runGit(worktree, "diff", base+"..HEAD", "--", filePath); err == nil {
 			msg.Diff = out
 		}
 	}
 
 	// For untracked files, show the file contents as an "added" diff
 	if msg.Diff == "" {
-		if out, err := runGit(worktree, "diff", "--color=always", "--no-index", "/dev/null", filePath); err == nil || out != "" {
+		if out, err := runGit(worktree, "diff", "--no-index", "/dev/null", filePath); err == nil || out != "" {
 			msg.Diff = out
 		}
 	}

--- a/internal/ui/highlight.go
+++ b/internal/ui/highlight.go
@@ -1,0 +1,70 @@
+package ui
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/formatters"
+	"github.com/alecthomas/chroma/v2/lexers"
+	"github.com/alecthomas/chroma/v2/styles"
+)
+
+// HighlightLines applies syntax highlighting to a slice of plain-text lines
+// based on the file extension. Returns ANSI-colored lines.
+func HighlightLines(lines []string, filename string) []string {
+	if len(lines) == 0 {
+		return lines
+	}
+	lexer := lexerForFile(filename)
+	if lexer == nil {
+		return lines
+	}
+	lexer = chroma.Coalesce(lexer)
+	formatter := formatters.Get("terminal256")
+	if formatter == nil {
+		return lines
+	}
+	style := styles.Get("monokai")
+	if style == nil {
+		style = styles.Fallback
+	}
+
+	result := make([]string, len(lines))
+	for i, line := range lines {
+		result[i] = highlightLine(lexer, formatter, style, line)
+	}
+	return result
+}
+
+// highlightLine highlights a single line of code and returns ANSI output.
+func highlightLine(lexer chroma.Lexer, formatter chroma.Formatter, style *chroma.Style, line string) string {
+	iterator, err := lexer.Tokenise(nil, line)
+	if err != nil {
+		return line
+	}
+	var b strings.Builder
+	err = formatter.Format(&b, style, iterator)
+	if err != nil {
+		return line
+	}
+	// The formatter appends a trailing newline — strip it
+	s := b.String()
+	s = strings.TrimRight(s, "\n")
+	return s
+}
+
+// lexerForFile returns a chroma lexer for the given filename, or nil if unknown.
+func lexerForFile(filename string) chroma.Lexer {
+	// Try by filename first (handles Makefile, Dockerfile, etc.)
+	lexer := lexers.Match(filename)
+	if lexer != nil {
+		return lexer
+	}
+	// Fall back to extension
+	ext := filepath.Ext(filename)
+	if ext == "" {
+		return nil
+	}
+	return lexers.Get(ext)
+}

--- a/internal/ui/highlight_test.go
+++ b/internal/ui/highlight_test.go
@@ -1,0 +1,83 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHighlightLines_GoFile(t *testing.T) {
+	lines := []string{
+		"package main",
+		"func hello() string {",
+		`	return "world"`,
+		"}",
+	}
+	result := HighlightLines(lines, "main.go")
+	if len(result) != len(lines) {
+		t.Fatalf("expected %d lines, got %d", len(lines), len(result))
+	}
+	// Highlighted lines should contain ANSI escape sequences
+	for i, line := range result {
+		if !strings.Contains(line, "\x1b[") {
+			t.Errorf("line %d should contain ANSI codes: %q", i, line)
+		}
+	}
+}
+
+func TestHighlightLines_UnknownExtension(t *testing.T) {
+	lines := []string{"just some text", "no highlighting"}
+	result := HighlightLines(lines, "file.unknownext")
+	// Should return lines unchanged
+	for i, line := range result {
+		if line != lines[i] {
+			t.Errorf("line %d changed: %q -> %q", i, lines[i], line)
+		}
+	}
+}
+
+func TestHighlightLines_Empty(t *testing.T) {
+	result := HighlightLines(nil, "test.go")
+	if len(result) != 0 {
+		t.Errorf("expected 0 lines, got %d", len(result))
+	}
+}
+
+func TestHighlightLines_PythonFile(t *testing.T) {
+	lines := []string{
+		"def hello():",
+		"    print('world')",
+	}
+	result := HighlightLines(lines, "script.py")
+	if len(result) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(result))
+	}
+	// Python keywords should be highlighted
+	for _, line := range result {
+		if !strings.Contains(line, "\x1b[") {
+			t.Errorf("expected ANSI in Python highlight: %q", line)
+		}
+	}
+}
+
+func TestLexerForFile(t *testing.T) {
+	tests := []struct {
+		filename string
+		wantNil  bool
+	}{
+		{"main.go", false},
+		{"script.py", false},
+		{"style.css", false},
+		{"Makefile", false},
+		{"Dockerfile", false},
+		{"noext", true},
+	}
+	for _, tc := range tests {
+		lexer := lexerForFile(tc.filename)
+		if tc.wantNil && lexer != nil {
+			t.Errorf("lexerForFile(%q) should be nil", tc.filename)
+		}
+		if !tc.wantNil && lexer == nil {
+			t.Errorf("lexerForFile(%q) should not be nil", tc.filename)
+		}
+	}
+}

--- a/internal/ui/sidebyside.go
+++ b/internal/ui/sidebyside.go
@@ -1,0 +1,170 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// lineNumWidth is the number of characters reserved for line numbers.
+const lineNumWidth = 4
+
+// RenderSideBySide renders a side-by-side diff view for the given width and
+// visible line range. Returns a string ready for display inside a bordered panel.
+func RenderSideBySide(rows []SideBySideLine, filename string, totalW, visibleH, scrollOff int, theme Theme) string {
+	if len(rows) == 0 {
+		return theme.Dimmed.Render("(no diff)")
+	}
+
+	// Each side: lineNumWidth + 1 (separator) + content + 1 (padding)
+	// Middle divider: 1 char ("│")
+	// Total: 2*(lineNumWidth + 2 + contentW) + 1 = totalW
+	sideW := (totalW - 1) / 2
+	contentW := sideW - lineNumWidth - 2
+	if contentW < 5 {
+		contentW = 5
+	}
+
+	// Syntax highlight all left and right text lines
+	leftTexts := make([]string, len(rows))
+	rightTexts := make([]string, len(rows))
+	for i, r := range rows {
+		leftTexts[i] = r.LeftText
+		rightTexts[i] = r.RightText
+	}
+	leftHL := HighlightLines(leftTexts, filename)
+	rightHL := HighlightLines(rightTexts, filename)
+
+	// Styles for diff line backgrounds
+	removedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
+	addedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("78"))
+	lineNumStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("239"))
+	dividerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("236"))
+	hunkHeaderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Italic(true)
+	divider := dividerStyle.Render("│")
+
+	// Window slice
+	end := scrollOff + visibleH
+	if end > len(rows) {
+		end = len(rows)
+	}
+	start := scrollOff
+	if start > end {
+		start = end
+	}
+
+	var b strings.Builder
+	for i := start; i < end; i++ {
+		row := rows[i]
+		leftH := leftHL[i]
+		rightH := rightHL[i]
+
+		// Hunk header rows (no line numbers)
+		if row.LeftNum == 0 && row.RightNum == 0 && strings.HasPrefix(row.LeftText, "@@") {
+			headerLine := hunkHeaderStyle.Render(ansi.Truncate(row.LeftText, totalW, "\x1b[0m"))
+			b.WriteString(headerLine)
+			if i < end-1 {
+				b.WriteString("\n")
+			}
+			continue
+		}
+
+		// Separator rows
+		if row.LeftNum == 0 && row.RightNum == 0 && row.LeftText == "───" {
+			sep := dividerStyle.Render(strings.Repeat("─", totalW))
+			b.WriteString(sep)
+			if i < end-1 {
+				b.WriteString("\n")
+			}
+			continue
+		}
+
+		// Left side
+		leftNumStr := lineNumStyle.Render(FormatLineNum(row.LeftNum, lineNumWidth))
+		leftContent := formatSideContent(leftH, row.LeftText, row.LeftType, contentW, removedStyle, addedStyle)
+
+		// Right side
+		rightNumStr := lineNumStyle.Render(FormatLineNum(row.RightNum, lineNumWidth))
+		rightContent := formatSideContent(rightH, row.RightText, row.RightType, contentW, removedStyle, addedStyle)
+
+		b.WriteString(leftNumStr)
+		b.WriteString(" ")
+		b.WriteString(leftContent)
+		b.WriteString(divider)
+		b.WriteString(rightNumStr)
+		b.WriteString(" ")
+		b.WriteString(rightContent)
+		if i < end-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}
+
+// formatSideContent renders one side of a diff line with appropriate coloring.
+func formatSideContent(highlighted, raw string, lineType DiffLineType, width int, removedStyle, addedStyle lipgloss.Style) string {
+	if raw == "" && lineType == DiffContext {
+		// Blank padding
+		return strings.Repeat(" ", width+1)
+	}
+
+	var prefix string
+	var content string
+
+	switch lineType {
+	case DiffRemoved:
+		prefix = removedStyle.Render("-")
+		if highlighted == raw {
+			// No highlighting — apply removal color to whole line
+			content = removedStyle.Render(truncatePlain(raw, width-1))
+		} else {
+			content = ansi.Truncate(highlighted, width-1, "\x1b[0m")
+		}
+	case DiffAdded:
+		prefix = addedStyle.Render("+")
+		if highlighted == raw {
+			content = addedStyle.Render(truncatePlain(raw, width-1))
+		} else {
+			content = ansi.Truncate(highlighted, width-1, "\x1b[0m")
+		}
+	default:
+		prefix = " "
+		if highlighted == raw {
+			content = truncatePlain(raw, width-1)
+		} else {
+			content = ansi.Truncate(highlighted, width-1, "\x1b[0m")
+		}
+	}
+
+	// Pad content to fill the column
+	visW := ansi.StringWidth(prefix + content)
+	pad := width + 1 - visW
+	if pad < 0 {
+		pad = 0
+	}
+
+	return prefix + content + strings.Repeat(" ", pad)
+}
+
+// truncatePlain truncates a plain (no ANSI) string to maxW visible characters.
+func truncatePlain(s string, maxW int) string {
+	if len(s) <= maxW {
+		return s
+	}
+	// Simple rune-based truncation
+	runes := []rune(s)
+	if len(runes) <= maxW {
+		return s
+	}
+	return string(runes[:maxW])
+}
+
+// RenderSideBySideHeader renders the header line for the diff panel.
+func RenderSideBySideHeader(filename string, fileIdx, fileCount int, theme Theme) string {
+	return theme.Section.Render("  DIFF") +
+		theme.Dimmed.Render(" "+filename) +
+		theme.Dimmed.Render(fmt.Sprintf("  [%d/%d]", fileIdx+1, fileCount))
+}

--- a/internal/ui/sidebyside_test.go
+++ b/internal/ui/sidebyside_test.go
@@ -1,0 +1,160 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderSideBySide_BasicOutput(t *testing.T) {
+	rows := []SideBySideLine{
+		{LeftNum: 1, LeftText: "old line", LeftType: DiffRemoved,
+			RightNum: 1, RightText: "new line", RightType: DiffAdded},
+		{LeftNum: 2, LeftText: "same", LeftType: DiffContext,
+			RightNum: 2, RightText: "same", RightType: DiffContext},
+	}
+
+	theme := DefaultTheme()
+	output := RenderSideBySide(rows, "test.go", 80, 10, 0, theme)
+
+	if output == "" {
+		t.Fatal("expected non-empty output")
+	}
+	// Should contain the divider character
+	if !strings.Contains(output, "│") {
+		t.Error("expected side-by-side divider '│'")
+	}
+}
+
+func TestRenderSideBySide_EmptyRows(t *testing.T) {
+	theme := DefaultTheme()
+	output := RenderSideBySide(nil, "test.go", 80, 10, 0, theme)
+	if !strings.Contains(output, "no diff") {
+		t.Errorf("expected 'no diff' for empty rows, got %q", output)
+	}
+}
+
+func TestRenderSideBySide_ScrollOffset(t *testing.T) {
+	rows := make([]SideBySideLine, 20)
+	for i := range rows {
+		rows[i] = SideBySideLine{
+			LeftNum: i + 1, LeftText: "left", LeftType: DiffContext,
+			RightNum: i + 1, RightText: "right", RightType: DiffContext,
+		}
+	}
+
+	theme := DefaultTheme()
+	// Scroll to offset 10, visible 5
+	output := RenderSideBySide(rows, "test.go", 80, 5, 10, theme)
+	if output == "" {
+		t.Fatal("expected non-empty output with scroll offset")
+	}
+	// Count rendered lines
+	lines := strings.Split(output, "\n")
+	if len(lines) > 5 {
+		t.Errorf("expected at most 5 visible lines, got %d", len(lines))
+	}
+}
+
+func TestRenderSideBySide_HunkHeader(t *testing.T) {
+	rows := []SideBySideLine{
+		{LeftText: "@@ -1,3 +1,3 @@", RightText: "@@ -1,3 +1,3 @@",
+			LeftType: DiffContext, RightType: DiffContext},
+		{LeftNum: 1, LeftText: "line", LeftType: DiffContext,
+			RightNum: 1, RightText: "line", RightType: DiffContext},
+	}
+
+	theme := DefaultTheme()
+	output := RenderSideBySide(rows, "test.go", 80, 10, 0, theme)
+	if !strings.Contains(output, "@@") {
+		t.Error("expected hunk header in output")
+	}
+}
+
+func TestRenderSideBySide_Separator(t *testing.T) {
+	rows := []SideBySideLine{
+		{LeftNum: 1, LeftText: "line", LeftType: DiffContext,
+			RightNum: 1, RightText: "line", RightType: DiffContext},
+		{LeftText: "───", RightText: "───"},
+		{LeftNum: 10, LeftText: "line10", LeftType: DiffContext,
+			RightNum: 10, RightText: "line10", RightType: DiffContext},
+	}
+
+	theme := DefaultTheme()
+	output := RenderSideBySide(rows, "test.go", 80, 10, 0, theme)
+	if !strings.Contains(output, "─") {
+		t.Error("expected separator in output")
+	}
+}
+
+func TestRenderSideBySideHeader(t *testing.T) {
+	theme := DefaultTheme()
+	header := RenderSideBySideHeader("main.go", 0, 5, theme)
+	if !strings.Contains(header, "DIFF") {
+		t.Error("expected 'DIFF' in header")
+	}
+	if !strings.Contains(header, "main.go") {
+		t.Error("expected filename in header")
+	}
+	if !strings.Contains(header, "[1/5]") {
+		t.Error("expected file count in header")
+	}
+}
+
+func TestFormatSideContent_Removed(t *testing.T) {
+	removedStyle := DefaultTheme().Error
+	addedStyle := DefaultTheme().Complete
+	result := formatSideContent("old code", "old code", DiffRemoved, 20, removedStyle, addedStyle)
+	if !strings.Contains(result, "-") {
+		t.Error("removed line should have '-' prefix")
+	}
+}
+
+func TestFormatSideContent_Added(t *testing.T) {
+	removedStyle := DefaultTheme().Error
+	addedStyle := DefaultTheme().Complete
+	result := formatSideContent("new code", "new code", DiffAdded, 20, removedStyle, addedStyle)
+	if !strings.Contains(result, "+") {
+		t.Error("added line should have '+' prefix")
+	}
+}
+
+func TestFormatSideContent_Context(t *testing.T) {
+	removedStyle := DefaultTheme().Error
+	addedStyle := DefaultTheme().Complete
+	result := formatSideContent("same", "same", DiffContext, 20, removedStyle, addedStyle)
+	if result == "" {
+		t.Error("context line should not be empty")
+	}
+}
+
+func TestTruncatePlain(t *testing.T) {
+	tests := []struct {
+		input string
+		maxW  int
+		want  string
+	}{
+		{"hello", 10, "hello"},
+		{"hello world", 5, "hello"},
+		{"", 5, ""},
+		{"abc", 3, "abc"},
+	}
+	for _, tc := range tests {
+		got := truncatePlain(tc.input, tc.maxW)
+		if got != tc.want {
+			t.Errorf("truncatePlain(%q, %d) = %q, want %q", tc.input, tc.maxW, got, tc.want)
+		}
+	}
+}
+
+func TestRenderSideBySide_NarrowWidth(t *testing.T) {
+	rows := []SideBySideLine{
+		{LeftNum: 1, LeftText: "short", LeftType: DiffContext,
+			RightNum: 1, RightText: "short", RightType: DiffContext},
+	}
+	theme := DefaultTheme()
+	// Very narrow width
+	output := RenderSideBySide(rows, "test.go", 20, 5, 0, theme)
+	if output == "" {
+		t.Fatal("should render even with narrow width")
+	}
+}


### PR DESCRIPTION
Replace raw git diff output with a parsed, structured side-by-side diff viewer. Unified diffs are parsed into left/right line pairs with consecutive removed+added blocks paired together. Per-language syntax highlighting via chroma based on file extension. Two-column rendering with line numbers and color-coded diff lines.

New: diffparse.go, highlight.go, sidebyside.go with full test coverage.

Co-Authored-By: Claude <noreply@anthropic.com>