### PR TITLE
Add split/unified toggle to diff viewer

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -61,7 +61,10 @@ type AgentView struct {
 
 	// Diff viewer state
 	diffMode      bool              // true when viewing a file's diff
-	diffRows      []SideBySideLine  // parsed side-by-side rows
+	diffSplit     bool              // true = side-by-side, false = unified
+	diffParsed    ParsedDiff        // parsed diff structure (for both views)
+	diffRows      []SideBySideLine  // side-by-side rows (computed from diffParsed)
+	diffUnified   []string          // unified view lines (highlighted, computed from diffParsed)
 	diffScrollOff int               // scroll offset within diff
 	worktreeDir   string            // resolved worktree directory for git commands
 	diffFileName  string            // current file being diffed (for highlighting)
@@ -72,6 +75,7 @@ func NewAgentView(theme Theme, runner *agent.Runner) AgentView {
 		theme:     theme,
 		runner:    runner,
 		focus:     panelAgent,
+		diffSplit: true,
 		gitstatus: NewGitStatus(theme),
 		files:     NewFileExplorer(theme),
 	}
@@ -92,7 +96,10 @@ func (av *AgentView) Enter(taskID, taskName string) {
 	av.vtTerm = nil
 	av.vtFedTotal = 0
 	av.diffMode = false
+	av.diffSplit = true
+	av.diffParsed = ParsedDiff{}
 	av.diffRows = nil
+	av.diffUnified = nil
 	av.diffScrollOff = 0
 	av.worktreeDir = ""
 	av.diffFileName = ""
@@ -283,10 +290,13 @@ func (av *AgentView) UpdateFileDiff(msg FileDiffMsg) {
 	av.diffScrollOff = 0
 	av.diffFileName = msg.FilePath
 	if msg.Diff == "" {
+		av.diffParsed = ParsedDiff{}
 		av.diffRows = nil
+		av.diffUnified = nil
 	} else {
-		pd := ParseUnifiedDiff(msg.Diff)
-		av.diffRows = BuildSideBySide(pd)
+		av.diffParsed = ParseUnifiedDiff(msg.Diff)
+		av.diffRows = BuildSideBySide(av.diffParsed)
+		av.diffUnified = RenderUnifiedLines(av.diffParsed, msg.FilePath)
 	}
 }
 
@@ -297,7 +307,9 @@ func (av *AgentView) SetWorktreeDir(dir string) {
 
 func (av *AgentView) exitDiffMode() {
 	av.diffMode = false
+	av.diffParsed = ParsedDiff{}
 	av.diffRows = nil
+	av.diffUnified = nil
 	av.diffScrollOff = 0
 	av.diffFileName = ""
 }
@@ -320,6 +332,9 @@ func (av *AgentView) handleDiffKey(msg tea.KeyMsg) tea.Cmd {
 		av.diffScrollUp(av.diffVisibleRows())
 	case "shift+down", "pgdown":
 		av.diffScrollDown(av.diffVisibleRows())
+	case "s":
+		av.diffSplit = !av.diffSplit
+		av.diffScrollOff = 0
 	}
 	return nil
 }
@@ -340,8 +355,15 @@ func (av *AgentView) diffScrollUp(n int) {
 	}
 }
 
+func (av *AgentView) diffLineCount() int {
+	if av.diffSplit {
+		return len(av.diffRows)
+	}
+	return len(av.diffUnified)
+}
+
 func (av *AgentView) diffScrollDown(n int) {
-	maxOff := len(av.diffRows) - av.diffVisibleRows()
+	maxOff := av.diffLineCount() - av.diffVisibleRows()
 	if maxOff < 0 {
 		maxOff = 0
 	}
@@ -463,7 +485,8 @@ func (av *AgentView) renderDiffPanel(w, h int) string {
 		Width(w - 2).
 		Height(innerH)
 
-	if len(av.diffRows) == 0 {
+	lineCount := av.diffLineCount()
+	if lineCount == 0 {
 		empty := av.theme.Dimmed.
 			Width(w - 4).
 			Height(innerH).
@@ -480,7 +503,11 @@ func (av *AgentView) renderDiffPanel(w, h int) string {
 	if f := av.files.SelectedFile(); f != nil {
 		fileName = f.Path
 	}
-	header := RenderSideBySideHeader(fileName, av.files.scroll.Cursor(), av.files.FileCount(), av.theme)
+	modeLabel := "split"
+	if !av.diffSplit {
+		modeLabel = "unified"
+	}
+	header := RenderDiffHeader(fileName, av.files.scroll.Cursor(), av.files.FileCount(), modeLabel, av.theme)
 
 	// Visible diff rows (minus header)
 	visibleH := dispH - 1
@@ -488,7 +515,12 @@ func (av *AgentView) renderDiffPanel(w, h int) string {
 		visibleH = 1
 	}
 
-	content := RenderSideBySide(av.diffRows, fileName, dispW, visibleH, av.diffScrollOff, av.theme)
+	var content string
+	if av.diffSplit {
+		content = RenderSideBySide(av.diffRows, fileName, dispW, visibleH, av.diffScrollOff, av.theme)
+	} else {
+		content = RenderUnified(av.diffUnified, dispW, visibleH, av.diffScrollOff)
+	}
 
 	return border.Render(header + "\n" + content)
 }
@@ -606,6 +638,7 @@ func (av AgentView) renderStatusBar() string {
 		keys = []struct{ key, label string }{
 			{"↑/↓", "file"},
 			{"scroll", "navigate"},
+			{"s", "split/unified"},
 			{"esc", "close"},
 		}
 	} else {
@@ -625,7 +658,11 @@ func (av AgentView) renderStatusBar() string {
 	// Focus indicator — truly centered on the bar
 	var focusLabel string
 	if av.diffMode {
-		focusLabel = "DIFF"
+		if av.diffSplit {
+			focusLabel = "DIFF SPLIT"
+		} else {
+			focusLabel = "DIFF UNIFIED"
+		}
 	} else {
 		switch av.focus {
 		case panelAgent:

--- a/internal/ui/sidebyside.go
+++ b/internal/ui/sidebyside.go
@@ -162,9 +162,117 @@ func truncatePlain(s string, maxW int) string {
 	return string(runes[:maxW])
 }
 
-// RenderSideBySideHeader renders the header line for the diff panel.
-func RenderSideBySideHeader(filename string, fileIdx, fileCount int, theme Theme) string {
+// RenderDiffHeader renders the header line for the diff panel with mode indicator.
+func RenderDiffHeader(filename string, fileIdx, fileCount int, mode string, theme Theme) string {
 	return theme.Section.Render("  DIFF") +
 		theme.Dimmed.Render(" "+filename) +
-		theme.Dimmed.Render(fmt.Sprintf("  [%d/%d]", fileIdx+1, fileCount))
+		theme.Dimmed.Render(fmt.Sprintf("  [%d/%d]", fileIdx+1, fileCount)) +
+		theme.Dimmed.Render("  "+mode)
+}
+
+// RenderUnifiedLines builds syntax-highlighted unified diff lines from a ParsedDiff.
+// Each line includes the +/- prefix and line numbers. Returns pre-rendered ANSI strings.
+func RenderUnifiedLines(pd ParsedDiff, filename string) []string {
+	if len(pd.Hunks) == 0 {
+		return nil
+	}
+
+	removedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
+	addedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("78"))
+	lineNumStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("239"))
+	hunkHeaderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Italic(true)
+	dividerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("236"))
+
+	// Collect all line contents for batch highlighting
+	var allContents []string
+	type lineRef struct {
+		hunkIdx int
+		lineIdx int
+		isHunk  bool // true = hunk header or separator
+	}
+	var refs []lineRef
+
+	for hi, hunk := range pd.Hunks {
+		if hi > 0 {
+			refs = append(refs, lineRef{isHunk: true})
+			allContents = append(allContents, "───")
+		}
+		refs = append(refs, lineRef{isHunk: true})
+		allContents = append(allContents, hunk.Header)
+		for li := range hunk.Lines {
+			refs = append(refs, lineRef{hunkIdx: hi, lineIdx: li})
+			allContents = append(allContents, hunk.Lines[li].Content)
+		}
+	}
+
+	highlighted := HighlightLines(allContents, filename)
+
+	var result []string
+	for i, ref := range refs {
+		hl := highlighted[i]
+
+		if ref.isHunk {
+			if allContents[i] == "───" {
+				result = append(result, dividerStyle.Render("───"))
+			} else {
+				result = append(result, hunkHeaderStyle.Render(allContents[i]))
+			}
+			continue
+		}
+
+		dl := pd.Hunks[ref.hunkIdx].Lines[ref.lineIdx]
+		oldNum := FormatLineNum(dl.OldNum, lineNumWidth)
+		newNum := FormatLineNum(dl.NewNum, lineNumWidth)
+		nums := lineNumStyle.Render(oldNum) + " " + lineNumStyle.Render(newNum)
+
+		switch dl.Type {
+		case DiffRemoved:
+			prefix := removedStyle.Render("-")
+			var content string
+			if hl == dl.Content {
+				content = removedStyle.Render(dl.Content)
+			} else {
+				content = hl
+			}
+			result = append(result, nums+" "+prefix+content)
+		case DiffAdded:
+			prefix := addedStyle.Render("+")
+			var content string
+			if hl == dl.Content {
+				content = addedStyle.Render(dl.Content)
+			} else {
+				content = hl
+			}
+			result = append(result, nums+" "+prefix+content)
+		default:
+			result = append(result, nums+"  "+hl)
+		}
+	}
+
+	return result
+}
+
+// RenderUnified renders the unified diff view for the given visible window.
+func RenderUnified(lines []string, dispW, visibleH, scrollOff int) string {
+	if len(lines) == 0 {
+		return "(no diff)"
+	}
+
+	end := scrollOff + visibleH
+	if end > len(lines) {
+		end = len(lines)
+	}
+	start := scrollOff
+	if start > end {
+		start = end
+	}
+
+	var b strings.Builder
+	for i := start; i < end; i++ {
+		b.WriteString(ansi.Truncate(lines[i], dispW, "\x1b[0m"))
+		if i < end-1 {
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
 }

--- a/internal/ui/sidebyside_test.go
+++ b/internal/ui/sidebyside_test.go
@@ -86,9 +86,9 @@ func TestRenderSideBySide_Separator(t *testing.T) {
 	}
 }
 
-func TestRenderSideBySideHeader(t *testing.T) {
+func TestRenderDiffHeader(t *testing.T) {
 	theme := DefaultTheme()
-	header := RenderSideBySideHeader("main.go", 0, 5, theme)
+	header := RenderDiffHeader("main.go", 0, 5, "split", theme)
 	if !strings.Contains(header, "DIFF") {
 		t.Error("expected 'DIFF' in header")
 	}
@@ -97,6 +97,9 @@ func TestRenderSideBySideHeader(t *testing.T) {
 	}
 	if !strings.Contains(header, "[1/5]") {
 		t.Error("expected file count in header")
+	}
+	if !strings.Contains(header, "split") {
+		t.Error("expected mode label in header")
 	}
 }
 


### PR DESCRIPTION
Press 's' in diff mode to toggle between side-by-side and unified views. Both use chroma syntax highlighting. Mode shown in status bar and header. Stores ParsedDiff for both views without refetching.

Co-Authored-By: Claude <noreply@anthropic.com>