### PR TITLE
Handle Cmd+arrow keys from terminals sending Super modifier

### DIFF
--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -27,7 +27,7 @@ func main() {
 		}
 	})
 	m := ui.NewModel(database, runner)
-	p = tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
+	p = tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion(), tea.WithFilter(ui.SuperToAltFilter))
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/internal/ui/filter.go
+++ b/internal/ui/filter.go
@@ -1,0 +1,39 @@
+package ui
+
+import (
+	"reflect"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// SuperToAltFilter converts Cmd+arrow keys (sent as CSI sequences with
+// Super/modifier 9 by modern terminals like Ghostty and kitty) into
+// Alt-modified KeyMsgs that the rest of the UI code expects.
+//
+// Bubbletea v1.3 doesn't recognise modifier 9 (Super), so sequences
+// like \x1b[1;9C arrive as unexported unknownCSISequenceMsg. This
+// filter intercepts them and re-emits standard Alt+arrow KeyMsgs.
+func SuperToAltFilter(_ tea.Model, msg tea.Msg) tea.Msg {
+	v := reflect.ValueOf(msg)
+	if v.Kind() != reflect.Slice || v.Type().Elem().Kind() != reflect.Uint8 {
+		return msg
+	}
+	raw := v.Bytes()
+
+	// Match CSI sequences with Super modifier: \x1b [ 1 ; 9 <letter>
+	if len(raw) == 6 &&
+		raw[0] == '\x1b' && raw[1] == '[' &&
+		raw[2] == '1' && raw[3] == ';' && raw[4] == '9' {
+		switch raw[5] {
+		case 'A':
+			return tea.KeyMsg{Type: tea.KeyUp, Alt: true}
+		case 'B':
+			return tea.KeyMsg{Type: tea.KeyDown, Alt: true}
+		case 'C':
+			return tea.KeyMsg{Type: tea.KeyRight, Alt: true}
+		case 'D':
+			return tea.KeyMsg{Type: tea.KeyLeft, Alt: true}
+		}
+	}
+	return msg
+}

--- a/internal/ui/filter_integration_test.go
+++ b/internal/ui/filter_integration_test.go
@@ -1,0 +1,75 @@
+package ui
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// captureModel is a minimal tea.Model that records KeyMsgs it receives.
+type captureModel struct {
+	keys []tea.KeyMsg
+	done bool
+}
+
+func (m captureModel) Init() tea.Cmd { return nil }
+
+func (m captureModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		m.keys = append(m.keys, msg)
+		// Quit after receiving the key so the program exits.
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m captureModel) View() string { return "" }
+
+// TestSuperToAltFilter_Integration feeds raw Cmd+Right bytes (\x1b[1;9C)
+// through a real tea.Program with the SuperToAltFilter and verifies the
+// model receives an Alt+Right KeyMsg.
+func TestSuperToAltFilter_Integration(t *testing.T) {
+	// Feed the raw CSI sequence for Cmd+Right (Super modifier = 9)
+	input := bytes.NewReader([]byte("\x1b[1;9C"))
+
+	m := captureModel{}
+	p := tea.NewProgram(m,
+		tea.WithInput(input),
+		tea.WithOutput(&bytes.Buffer{}), // suppress output
+		tea.WithFilter(SuperToAltFilter),
+	)
+
+	done := make(chan struct{})
+	var finalModel tea.Model
+	var runErr error
+	go func() {
+		finalModel, runErr = p.Run()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("tea.Program timed out")
+	}
+
+	if runErr != nil {
+		t.Fatalf("program error: %v", runErr)
+	}
+
+	cm := finalModel.(captureModel)
+	if len(cm.keys) == 0 {
+		t.Fatal("no KeyMsg received — filter did not convert the CSI sequence")
+	}
+
+	got := cm.keys[0]
+	if got.Type != tea.KeyRight {
+		t.Errorf("Type = %v, want KeyRight", got.Type)
+	}
+	if !got.Alt {
+		t.Error("Alt = false, want true")
+	}
+}

--- a/internal/ui/filter_test.go
+++ b/internal/ui/filter_test.go
@@ -1,0 +1,82 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestSuperToAltFilter_CmdArrows(t *testing.T) {
+	// Simulate unknownCSISequenceMsg ([]byte subtype) via reflect-compatible type.
+	// In practice bubbletea sends these as its unexported unknownCSISequenceMsg,
+	// which has underlying type []byte. We use a local alias to test the same
+	// reflect path.
+	type csiMsg []byte
+
+	tests := []struct {
+		name    string
+		input   csiMsg
+		wantKey tea.KeyType
+		wantAlt bool
+	}{
+		{"Cmd+Up", csiMsg("\x1b[1;9A"), tea.KeyUp, true},
+		{"Cmd+Down", csiMsg("\x1b[1;9B"), tea.KeyDown, true},
+		{"Cmd+Right", csiMsg("\x1b[1;9C"), tea.KeyRight, true},
+		{"Cmd+Left", csiMsg("\x1b[1;9D"), tea.KeyLeft, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SuperToAltFilter(nil, tt.input)
+			km, ok := result.(tea.KeyMsg)
+			if !ok {
+				t.Fatalf("expected tea.KeyMsg, got %T", result)
+			}
+			if km.Type != tt.wantKey {
+				t.Errorf("Type = %v, want %v", km.Type, tt.wantKey)
+			}
+			if km.Alt != tt.wantAlt {
+				t.Errorf("Alt = %v, want %v", km.Alt, tt.wantAlt)
+			}
+		})
+	}
+}
+
+func TestSuperToAltFilter_PassesThrough(t *testing.T) {
+	type csiMsg []byte
+
+	// KeyMsg is not comparable (contains Runes slice), so test it separately.
+	t.Run("normal KeyMsg", func(t *testing.T) {
+		input := tea.KeyMsg{Type: tea.KeyLeft}
+		result := SuperToAltFilter(nil, input)
+		if _, ok := result.(tea.KeyMsg); !ok {
+			t.Fatalf("expected tea.KeyMsg passthrough, got %T", result)
+		}
+		km := result.(tea.KeyMsg)
+		if km.Type != tea.KeyLeft || km.Alt {
+			t.Errorf("KeyMsg was modified: %+v", km)
+		}
+	})
+
+	// These are all comparable types.
+	t.Run("wrong length", func(t *testing.T) {
+		input := csiMsg("\x1b[1;9")
+		result := SuperToAltFilter(nil, input)
+		if _, ok := result.(tea.KeyMsg); ok {
+			t.Error("short sequence should not be converted")
+		}
+	})
+	t.Run("wrong modifier", func(t *testing.T) {
+		input := csiMsg("\x1b[1;3C")
+		result := SuperToAltFilter(nil, input)
+		if _, ok := result.(tea.KeyMsg); ok {
+			t.Error("modifier 3 should not be converted")
+		}
+	})
+	t.Run("WindowSizeMsg", func(t *testing.T) {
+		input := tea.WindowSizeMsg{Width: 80, Height: 24}
+		result := SuperToAltFilter(nil, input)
+		if result != input {
+			t.Errorf("expected passthrough, got %v", result)
+		}
+	})
+}


### PR DESCRIPTION
Modern macOS terminals (Ghostty, kitty) send Cmd+arrow as CSI sequences with modifier 9 (Super). Bubbletea v1.3 doesn't recognize modifier 9, so these are silently dropped. Adds a tea.WithFilter that converts Super-modified (;9) arrow sequences into Alt-modified KeyMsgs, making Cmd+Left/Right panel switching and Cmd+Up/Down task switching work on these terminals.

Co-Authored-By: Claude <noreply@anthropic.com>