### PR TITLE
Enrich Projects tab with task status summaries and progress bar

### DIFF
--- a/internal/ui/projectlist.go
+++ b/internal/ui/projectlist.go
@@ -7,15 +7,29 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/model"
 )
 
 // ProjectList renders the project list view.
 type ProjectList struct {
-	projects []projectEntry
-	scroll   ScrollState
-	theme    Theme
-	width    int
-	height   int
+	projects   []projectEntry
+	taskCounts map[string]statusCounts // project name → task status counts
+	scroll     ScrollState
+	theme      Theme
+	width      int
+	height     int
+}
+
+// statusCounts tracks task counts per status for a project.
+type statusCounts struct {
+	Pending    int
+	InProgress int
+	InReview   int
+	Complete   int
+}
+
+func (sc statusCounts) Total() int {
+	return sc.Pending + sc.InProgress + sc.InReview + sc.Complete
 }
 
 // projectEntry is a flattened project for display.
@@ -25,7 +39,7 @@ type projectEntry struct {
 }
 
 func NewProjectList(theme Theme) ProjectList {
-	return ProjectList{theme: theme}
+	return ProjectList{theme: theme, taskCounts: make(map[string]statusCounts)}
 }
 
 func (pl *ProjectList) SetProjects(projects map[string]config.Project) {
@@ -36,6 +50,26 @@ func (pl *ProjectList) SetProjects(projects map[string]config.Project) {
 	// Sort alphabetically for stable ordering
 	sortProjects(pl.projects)
 	pl.scroll.ClampCursor(len(pl.projects))
+}
+
+// SetTasks computes per-project task status counts.
+func (pl *ProjectList) SetTasks(tasks []*model.Task) {
+	counts := make(map[string]statusCounts, len(pl.projects))
+	for _, t := range tasks {
+		sc := counts[t.Project]
+		switch t.Status {
+		case model.StatusPending:
+			sc.Pending++
+		case model.StatusInProgress:
+			sc.InProgress++
+		case model.StatusInReview:
+			sc.InReview++
+		case model.StatusComplete:
+			sc.Complete++
+		}
+		counts[t.Project] = sc
+	}
+	pl.taskCounts = counts
 }
 
 func sortProjects(entries []projectEntry) {
@@ -68,9 +102,14 @@ func (pl *ProjectList) Selected() *projectEntry {
 	return nil
 }
 
+// TaskCounts returns the task status counts for the named project.
+func (pl *ProjectList) TaskCounts(name string) statusCounts {
+	return pl.taskCounts[name]
+}
+
 func (pl *ProjectList) visibleRows() int {
-	// Each project takes 2 lines (name + path)
-	rows := pl.height / 2
+	// Each project takes 3 lines (name, path, status summary)
+	rows := pl.height / 3
 	if rows < 1 {
 		rows = 1
 	}
@@ -103,28 +142,30 @@ func (pl ProjectList) View() string {
 		name := nameStyle.Render(entry.Name)
 
 		// Cursor indicator
-		cursor := "  "
+		cur := "  "
 		if selected {
-			cursor = pl.theme.Selected.Render(" >")
+			cur = pl.theme.Selected.Render(">")  + " "
 		}
 
-		// Backend label (right-aligned)
-		backend := entry.Project.Backend
-		if backend == "" {
-			backend = "default"
+		// Task count badge
+		sc := pl.taskCounts[entry.Name]
+		total := sc.Total()
+		var badge string
+		if total > 0 {
+			badge = pl.theme.Dimmed.Render(fmt.Sprintf(" %d tasks", total))
 		}
-		right := pl.theme.Dimmed.Render(backend)
 
-		// Build first line
-		left := fmt.Sprintf("%s  %s", cursor, name)
-		gap := pl.width - lipgloss.Width(left) - lipgloss.Width(right) - 2
+		// Build first line: cursor + name + badge (right-aligned)
+		left := fmt.Sprintf(" %s %s", cur, name)
+		right := badge
+		gap := pl.width - lipgloss.Width(left) - lipgloss.Width(right) - 1
 		if gap < 1 {
 			gap = 1
 		}
 		b.WriteString(left + strings.Repeat(" ", gap) + right + "\n")
 
 		// Second line: path + branch
-		detail := "      "
+		detail := "     "
 		if entry.Project.Path != "" {
 			detail += pl.theme.Dimmed.Render(entry.Project.Path)
 		}
@@ -132,7 +173,32 @@ func (pl ProjectList) View() string {
 			detail += pl.theme.Dimmed.Render(" (" + entry.Project.Branch + ")")
 		}
 		b.WriteString(detail + "\n")
+
+		// Third line: mini status indicators
+		if total > 0 {
+			b.WriteString("     " + pl.renderMiniStatus(sc) + "\n")
+		} else {
+			b.WriteString("     " + pl.theme.Dimmed.Render("no tasks") + "\n")
+		}
 	}
 
 	return b.String()
+}
+
+// renderMiniStatus renders compact colored status counts (e.g., "2 pending  1 active  3 done").
+func (pl ProjectList) renderMiniStatus(sc statusCounts) string {
+	var parts []string
+	if sc.Pending > 0 {
+		parts = append(parts, pl.theme.Pending.Render(fmt.Sprintf("○ %d", sc.Pending)))
+	}
+	if sc.InProgress > 0 {
+		parts = append(parts, pl.theme.InProgress.Render(fmt.Sprintf("● %d", sc.InProgress)))
+	}
+	if sc.InReview > 0 {
+		parts = append(parts, pl.theme.InReview.Render(fmt.Sprintf("● %d", sc.InReview)))
+	}
+	if sc.Complete > 0 {
+		parts = append(parts, pl.theme.Complete.Render(fmt.Sprintf("✓ %d", sc.Complete)))
+	}
+	return strings.Join(parts, "  ")
 }

--- a/internal/ui/projectlist_test.go
+++ b/internal/ui/projectlist_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/model"
 )
 
 func TestNewProjectList(t *testing.T) {
@@ -161,18 +162,37 @@ func TestProjectList_ViewWithEntries(t *testing.T) {
 	if !strings.Contains(view, "myproject") {
 		t.Error("view should contain project name")
 	}
-	if !strings.Contains(view, "claude") {
-		t.Error("view should contain backend name")
-	}
 	if !strings.Contains(view, "/home/user/myproject") {
 		t.Error("view should contain project path")
 	}
 	if !strings.Contains(view, "main") {
 		t.Error("view should contain branch name")
 	}
+	// Should show "no tasks" since no tasks were set
+	if !strings.Contains(view, "no tasks") {
+		t.Error("view should show 'no tasks' when project has no tasks")
+	}
 }
 
-func TestProjectList_ViewDefaultBackend(t *testing.T) {
+func TestProjectList_ViewWithTaskCounts(t *testing.T) {
+	pl := NewProjectList(DefaultTheme())
+	pl.SetSize(80, 40)
+	pl.SetProjects(map[string]config.Project{
+		"myproject": {Path: "/tmp/proj"},
+	})
+	pl.SetTasks([]*model.Task{
+		{Project: "myproject", Status: model.StatusPending},
+		{Project: "myproject", Status: model.StatusInProgress},
+		{Project: "myproject", Status: model.StatusComplete},
+	})
+
+	view := pl.View()
+	if !strings.Contains(view, "3 tasks") {
+		t.Error("view should show task count badge")
+	}
+}
+
+func TestProjectList_ViewNoTasksLabel(t *testing.T) {
 	pl := NewProjectList(DefaultTheme())
 	pl.SetSize(80, 40)
 	pl.SetProjects(map[string]config.Project{
@@ -180,8 +200,8 @@ func TestProjectList_ViewDefaultBackend(t *testing.T) {
 	})
 
 	view := pl.View()
-	if !strings.Contains(view, "default") {
-		t.Error("view should show 'default' when backend is empty")
+	if !strings.Contains(view, "no tasks") {
+		t.Error("view should show 'no tasks' when project has no tasks")
 	}
 }
 
@@ -198,5 +218,73 @@ func TestProjectList_SetProjectsClampsClursor(t *testing.T) {
 	})
 	if pl.scroll.Cursor() != 0 {
 		t.Errorf("cursor should be clamped to 0, got %d", pl.scroll.Cursor())
+	}
+}
+
+func TestProjectList_SetTasks(t *testing.T) {
+	pl := NewProjectList(DefaultTheme())
+	pl.SetProjects(map[string]config.Project{
+		"alpha": {Path: "/a"},
+		"bravo": {Path: "/b"},
+	})
+
+	tasks := []*model.Task{
+		{Project: "alpha", Status: model.StatusPending},
+		{Project: "alpha", Status: model.StatusInProgress},
+		{Project: "alpha", Status: model.StatusComplete},
+		{Project: "bravo", Status: model.StatusInReview},
+	}
+	pl.SetTasks(tasks)
+
+	ac := pl.TaskCounts("alpha")
+	if ac.Pending != 1 || ac.InProgress != 1 || ac.Complete != 1 || ac.Total() != 3 {
+		t.Errorf("alpha counts = %+v, want 1/1/0/1", ac)
+	}
+
+	bc := pl.TaskCounts("bravo")
+	if bc.InReview != 1 || bc.Total() != 1 {
+		t.Errorf("bravo counts = %+v, want 0/0/1/0", bc)
+	}
+
+	// Unknown project should return zero counts
+	uc := pl.TaskCounts("unknown")
+	if uc.Total() != 0 {
+		t.Errorf("unknown project should have 0 tasks, got %d", uc.Total())
+	}
+}
+
+func TestProjectList_MiniStatus(t *testing.T) {
+	pl := NewProjectList(DefaultTheme())
+	pl.SetSize(80, 40)
+	pl.SetProjects(map[string]config.Project{
+		"proj": {Path: "/tmp"},
+	})
+	pl.SetTasks([]*model.Task{
+		{Project: "proj", Status: model.StatusPending},
+		{Project: "proj", Status: model.StatusPending},
+		{Project: "proj", Status: model.StatusInProgress},
+	})
+
+	view := pl.View()
+	// Should contain status indicators (○ for pending, ● for in-progress)
+	if !strings.Contains(view, "○") {
+		t.Error("view should contain pending status indicator")
+	}
+	if !strings.Contains(view, "●") {
+		t.Error("view should contain in-progress status indicator")
+	}
+}
+
+func TestStatusCounts_Total(t *testing.T) {
+	sc := statusCounts{Pending: 2, InProgress: 1, InReview: 3, Complete: 4}
+	if sc.Total() != 10 {
+		t.Errorf("Total() = %d, want 10", sc.Total())
+	}
+}
+
+func TestStatusCounts_Total_Zero(t *testing.T) {
+	sc := statusCounts{}
+	if sc.Total() != 0 {
+		t.Errorf("Total() = %d, want 0", sc.Total())
 	}
 }

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -229,6 +229,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.current != viewAgent {
 			m.refreshTasks()
 			m.tasklist.Tick()
+			if m.activeTab == tabProjects {
+				m.projectlist.SetTasks(m.db.Tasks())
+			}
 		}
 		if cmd := m.scheduleGitRefresh(); cmd != nil {
 			cmds = append(cmds, cmd)
@@ -819,6 +822,7 @@ func (m Model) handleConfirmDeleteProjectKey(msg tea.KeyMsg) (tea.Model, tea.Cmd
 
 func (m *Model) refreshProjects() {
 	m.projectlist.SetProjects(m.db.Projects())
+	m.projectlist.SetTasks(m.db.Tasks())
 }
 
 // selectedTaskForGit returns the task whose git status should be refreshed.

--- a/internal/ui/root_views.go
+++ b/internal/ui/root_views.go
@@ -170,13 +170,24 @@ func (m Model) renderProjectDetail() string {
 	contentHeight := m.height - 2
 
 	if entry == nil {
-		empty := m.theme.Dimmed.Render("  No project selected")
-		return lipgloss.NewStyle().Width(rightWidth).Height(contentHeight).Render(empty)
+		return borderedPanel(rightWidth, contentHeight, false,
+			m.theme.Dimmed.Render(" No project selected"))
 	}
 
-	var b strings.Builder
-	b.WriteString(m.theme.Title.Render("  "+entry.Name) + "\n\n")
+	innerW := max(rightWidth-4, 10)
+	innerH := max(contentHeight-2, 1)
 
+	var b strings.Builder
+
+	// Title
+	name := entry.Name
+	if len(name) > innerW-2 {
+		name = name[:innerW-5] + "..."
+	}
+	b.WriteString(m.theme.Title.Render(" "+name) + "\n\n")
+
+	// Configuration section
+	b.WriteString(m.theme.Section.Render("  CONFIG") + "\n")
 	fields := []struct{ label, value string }{
 		{"Path", entry.Project.Path},
 		{"Branch", entry.Project.Branch},
@@ -190,7 +201,110 @@ func (m Model) renderProjectDetail() string {
 		b.WriteString("  " + m.theme.Dimmed.Render(f.label+": ") + m.theme.Normal.Render(val) + "\n")
 	}
 
-	return lipgloss.NewStyle().Width(rightWidth).Height(contentHeight).Render(b.String())
+	// Task summary section
+	sc := m.projectlist.TaskCounts(entry.Name)
+	total := sc.Total()
+
+	b.WriteString("\n" + m.theme.Section.Render("  TASKS") + "\n")
+
+	if total == 0 {
+		b.WriteString("  " + m.theme.Dimmed.Render("No tasks yet. Press [1] to switch to tasks.") + "\n")
+	} else {
+		// Status breakdown
+		statuses := []struct {
+			label string
+			count int
+			style lipgloss.Style
+		}{
+			{"Pending", sc.Pending, m.theme.Pending},
+			{"In Progress", sc.InProgress, m.theme.InProgress},
+			{"In Review", sc.InReview, m.theme.InReview},
+			{"Complete", sc.Complete, m.theme.Complete},
+		}
+		for _, s := range statuses {
+			if s.count > 0 {
+				b.WriteString(fmt.Sprintf("  %s  %s\n",
+					s.style.Render(fmt.Sprintf("%2d", s.count)),
+					m.theme.Normal.Render(s.label)))
+			}
+		}
+
+		// Visual progress bar
+		barWidth := innerW - 4
+		if barWidth > 0 && total > 0 {
+			b.WriteString("\n")
+			bar := m.renderStatusBar(sc, barWidth)
+			b.WriteString("  " + bar + "\n")
+			// Progress percentage
+			pct := 0
+			if total > 0 {
+				pct = sc.Complete * 100 / total
+			}
+			b.WriteString("  " + m.theme.Dimmed.Render(fmt.Sprintf("%d%% complete", pct)) + "\n")
+		}
+	}
+
+	content := strings.TrimRight(b.String(), "\n")
+	lines := strings.Split(content, "\n")
+	if len(lines) > innerH {
+		lines = lines[:innerH]
+		content = strings.Join(lines, "\n")
+	}
+
+	return borderedPanel(rightWidth, contentHeight, false, content)
+}
+
+// renderStatusBar renders a horizontal progress bar with colored segments.
+func (m Model) renderStatusBar(sc statusCounts, width int) string {
+	total := sc.Total()
+	if total == 0 || width <= 0 {
+		return ""
+	}
+
+	// Calculate proportional widths
+	segments := []struct {
+		count int
+		ch    string
+		color string
+	}{
+		{sc.Complete, "█", "78"},   // green
+		{sc.InReview, "█", "81"},   // blue
+		{sc.InProgress, "█", "214"}, // orange
+		{sc.Pending, "░", "245"},   // gray
+	}
+
+	// Find the last non-zero segment index for remainder assignment
+	lastNonZero := -1
+	for i, seg := range segments {
+		if seg.count > 0 {
+			lastNonZero = i
+		}
+	}
+
+	var bar strings.Builder
+	remaining := width
+	for i, seg := range segments {
+		if seg.count == 0 {
+			continue
+		}
+		w := seg.count * width / total
+		if w < 1 {
+			w = 1
+		}
+		// Last non-zero segment gets any remaining width to avoid gaps
+		if i == lastNonZero {
+			w = remaining
+		}
+		if w <= 0 {
+			continue
+		}
+		remaining -= w
+		bar.WriteString(lipgloss.NewStyle().
+			Foreground(lipgloss.Color(seg.color)).
+			Render(strings.Repeat(seg.ch, w)))
+	}
+
+	return bar.String()
 }
 
 func (m Model) emptyStateView() string {


### PR DESCRIPTION
The Projects tab was sparse — just name/path/backend fields. Now shows per-project task count badges, mini colored status indicators, a bordered detail panel with CONFIG and TASKS sections, a visual progress bar with colored segments per status, and completion percentage.

Co-Authored-By: Claude <noreply@anthropic.com>