### PR TITLE
Add daemon architecture for persistent agent sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ go test ./internal/db/      # run tests for a single package
 
 **Elm Architecture (Model → Update → View)** via Bubble Tea. The entire UI is a single `tea.Program` with view switching.
 
-- `cmd/argus/main.go` — Entry point. Opens SQLite database, creates agent runner, starts `tea.Program` with alt screen and mouse cell motion.
+- `cmd/argus/main.go` — Entry point. Parses subcommands (`daemon`, `daemon stop`), opens SQLite database. In TUI mode: tries daemon client first, falls back to in-process runner. Starts `tea.Program` with alt screen and mouse cell motion.
 - `internal/ui/root.go` — **Top-level Bubble Tea model**. Owns all sub-views and routes key events based on current view state (`viewTaskList`, `viewNewTask`, `viewHelp`, `viewPrompt`, `viewConfirmDelete`). This is the orchestration hub.
 - `internal/ui/worktree.go` — Git worktree discovery, cleanup, and process management helpers. Extracted from root.go to separate infrastructure concerns from UI logic.
 - `internal/ui/tasklist.go` — Task list with collapsible project folders, cursor, scrolling, filtering. Tasks are grouped by project name into a flattened row list (project headers + task rows). Only one project is expanded at a time — auto-expands when the cursor enters a project, auto-collapses others. Cursor navigation skips project header rows entirely (`moveCursor`) — the cursor always lands on a task row, never a header. When navigating up across projects, cursor lands on the *last* task of the previous project. Not a `tea.Model` itself — it's a plain struct that `root.Model` drives.
@@ -32,15 +32,27 @@ go test ./internal/db/      # run tests for a single package
 - `internal/agent/` — Agent process management with PTY:
   - `agent.go` — Backend resolution and command building (`BuildCmd`). Supports `--session-id` for conversation pinning.
   - `worktree.go` — Git worktree creation under `~/.argus/worktrees/<project>/<task>` with `argus/<task>` branch naming.
-  - `session.go` — PTY-backed process session via `creack/pty`. Single `readLoop` goroutine tees output to ring buffer + attached writer. Supports attach/detach without stopping the process.
-  - `runner.go` — Multi-session manager keyed by task ID. Start/Stop/Get/Attach/Detach. Auto-cleans up on process exit, fires `onFinish` callback.
+  - `iface.go` — `SessionProvider` (manages sessions) and `SessionHandle` (single session) interfaces. UI code depends only on these interfaces, enabling both in-process and daemon-backed implementations.
+  - `session.go` — PTY-backed process session via `creack/pty`. Single `readLoop` goroutine tees output to ring buffer + all attached writers. Multi-writer support via `AddWriter`/`RemoveWriter` for fan-out to multiple consumers. Supports attach/detach without stopping the process.
+  - `runner.go` — Multi-session manager keyed by task ID. Implements `SessionProvider`. Start/Stop/Get/Attach/Detach. Auto-cleans up on process exit, fires `onFinish` callback.
   - `attach.go` — `AttachCmd` implements `tea.ExecCommand` for Bubble Tea integration. Sets raw terminal mode, resizes PTY, uses detachReader to intercept `ctrl+q` for detach.
-  - `ringbuffer.go` — Fixed-size circular buffer for output replay on reattach.
+  - `ringbuffer.go` — Exported `RingBuffer` — fixed-size circular buffer for output replay on reattach. Used by both in-process sessions and daemon client's local buffer.
   - `errors.go` — Sentinel errors.
+- `internal/daemon/` — Daemon architecture for persistent agent sessions:
+  - `daemon.go` — `Daemon` struct: owns Runner, accepts Unix socket connections, dispatches RPC vs stream (first byte 'R'/'S'). PID file at `~/.argus/daemon.pid`. Signal handling (SIGTERM/SIGINT → graceful shutdown).
+  - `types.go` — Shared RPC request/response types (`StartReq`, `SessionInfo`, `StreamHeader`, etc.).
+  - `rpc.go` — `RPCService` implementing JSON-RPC methods: Ping, StartSession, StopSession, StopAll, SessionStatus, ListSessions, WriteInput, Resize, Shutdown.
+  - `stream.go` — Output streaming handler. Client sends `StreamHeader` JSON, daemon calls `AddWriter(conn)` on the session. Raw bytes flow until session exit or client disconnect.
+- `internal/daemon/client/` — TUI-side daemon client:
+  - `client.go` — `Client` implementing `SessionProvider` via JSON-RPC to daemon. Manages `RemoteSession` lifecycle.
+  - `handle.go` — `RemoteSession` implementing `SessionHandle`. Local `RingBuffer` populated by stream reader. RPC calls for WriteInput, Resize, PTYSize, etc.
+  - `stream.go` — Goroutine reads raw bytes from daemon stream connection into local ring buffer.
 
 **Key pattern:** Sub-views (`TaskList`, `StatusBar`, `HelpView`) are plain structs with `View() string` methods — not independent `tea.Model`s. Only `NewTaskForm` has its own `Update` because it manages text input focus. Root model coordinates everything.
 
-**Agent pattern:** A single `readLoop` goroutine is the sole reader of the PTY master fd. It always writes to the ring buffer, and when a writer is attached (via `session.attachW`), also tees output there. This avoids competing readers on the same fd. The detach key (`ctrl+q`) is intercepted by `detachReader` wrapping stdin.
+**Agent pattern:** A single `readLoop` goroutine is the sole reader of the PTY master fd. It always writes to the ring buffer, and tees output to all attached writers (via `session.writers` slice). Writers are copied under lock before iterating; errored writers are removed automatically. `AddWriter(w)` replays the ring buffer then registers for live output. `Attach()`/`Detach()` use AddWriter/RemoveWriter internally. The detach key (`ctrl+q`) is intercepted by `detachReader` wrapping stdin.
+
+**Daemon pattern:** The daemon (`argus daemon`) owns the Runner and PTY sessions. The TUI connects via Unix socket (`~/.argus/daemon.sock`). First byte on each connection selects the protocol: 'R' for JSON-RPC (request/response), 'S' for output streaming (raw bytes). The TUI's `Client` implements `SessionProvider` so the UI code is identical whether running in-process or via daemon. Sessions survive TUI restarts — the daemon keeps PTY fds alive until explicit stop or shutdown.
 
 **Task/worktree lifecycle:** New task form submission → `handleNewTaskKey` creates worktree BEFORE persisting the task: `agent.CreateWorktree(projDir, project, taskName, branch)` creates worktree at `~/.argus/worktrees/<project>/<task>` with branch `argus/<task>`. If worktree creation fails, the task is NOT created — the form stays open with the error message. On name conflict (directory exists), `CreateWorktree` auto-suffixes with `-1`, `-2`, etc. Only after worktree succeeds: `db.Add(task)` → `startOrAttach` generates session ID → `runner.Start` builds command with `cmd.Dir = t.Worktree` → captures PID in DB. On delete/destroy: stops agent → `removeWorktreeAndBranch(path, branch, repoDir)` removes worktree (via `git worktree remove` from repoDir) → deletes local branch → deletes remote branch → removes from DB.
 
@@ -84,6 +96,8 @@ go test ./internal/db/      # run tests for a single package
 
 - **All panels in `PanelLayout.Render()` must enforce their own width.** `PanelLayout.Render()` only pads height and joins horizontally — it does NOT enforce column widths. If a panel's content is narrower than its allocated width, the panel collapses to content width and the layout breaks visually. Every panel passed to `Render()` must use `borderedPanel(width, height, ...)` or `lipgloss.NewStyle().Width(w)` to fill its allocation. The agent view panels already do this via `borderedPanel`; the task list view's left pane was missing it.
 - **Worktree creation must succeed before task persistence.** Never `db.Add(task)` without a valid worktree. If `CreateWorktree` fails, keep the new task form open with the error — do NOT fall back to running in the project directory or delegating to `--worktree`. The `ResolveTaskDirMsg` handler must only persist paths that pass `isWorktreeSubdir()` to prevent project directories from being saved as `t.Worktree`. `CreateWorktree` returns `(wtPath, finalName, err)` — the `finalName` may differ from the input if name conflicts required a `-1`, `-2` suffix.
+- **Map lookups returning `*T` become non-nil interfaces.** When a method returns an interface (e.g., `Get(id) SessionHandle`) and the underlying implementation uses a map (`sessions[id]`), a missing key returns `nil *Session`. Assigning this to an interface gives a **non-nil interface** with a nil concrete value — `== nil` checks fail. The `Get` method must explicitly check `if sess == nil { return nil }` before returning. This applies to any method on Runner/Client that returns `SessionHandle`.
+- **`AddWriter` must replay before registering.** When adding a writer to a session, send the ring buffer replay BEFORE appending the writer to the `writers` slice. If you register first, `readLoop` can deliver live bytes to the writer before replay is sent, causing duplicate data. The correct order is: snapshot replay → send replay → register writer. This creates a small gap (bytes produced during replay are missed) rather than duplicates. Gaps are handled gracefully by vt10x (partial escape sequences ignored); duplicates cause visible rendering corruption.
 
 ## Development Rules
 

--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -1,16 +1,38 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"log"
+	"net"
+	"net/rpc/jsonrpc"
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/drn/argus/internal/agent"
+	"github.com/drn/argus/internal/daemon"
+	dclient "github.com/drn/argus/internal/daemon/client"
 	"github.com/drn/argus/internal/db"
 	"github.com/drn/argus/internal/ui"
 )
 
 func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "daemon":
+			if len(os.Args) > 2 && os.Args[2] == "stop" {
+				runDaemonStop()
+				return
+			}
+			runDaemon()
+			return
+		}
+	}
+
+	runTUI()
+}
+
+func runTUI() {
 	database, err := db.Open(db.DefaultPath())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error opening database: %v\n", err)
@@ -18,14 +40,40 @@ func main() {
 	}
 	defer database.Close()
 
-	// Create runner — the onFinish callback sends a message to the tea.Program.
-	// We need to create the program first, so we use a closure that captures p.
+	// Try to connect to daemon; if that fails, fall back to in-process runner.
+	var runner agent.SessionProvider
 	var p *tea.Program
-	runner := agent.NewRunner(func(taskID string, err error, stopped bool, lastOutput []byte) {
-		if p != nil {
-			p.Send(ui.AgentFinishedMsg{TaskID: taskID, Err: err, Stopped: stopped, LastOutput: lastOutput})
-		}
-	})
+
+	sockPath := daemon.DefaultSocketPath()
+	client, err := dclient.Connect(sockPath)
+	if err != nil {
+		// No daemon running — use in-process runner (original behavior).
+		inProc := agent.NewRunner(func(taskID string, err error, stopped bool, lastOutput []byte) {
+			if p != nil {
+				p.Send(ui.AgentFinishedMsg{TaskID: taskID, Err: err, Stopped: stopped, LastOutput: lastOutput})
+			}
+		})
+		runner = inProc
+	} else {
+		// Daemon is running — use client as session provider.
+		client.OnSessionExit(func(taskID string, info daemon.ExitInfo) {
+			if p != nil {
+				var exitErr error
+				if info.Err != "" {
+					exitErr = errors.New(info.Err)
+				}
+				p.Send(ui.AgentFinishedMsg{
+					TaskID:     taskID,
+					Err:        exitErr,
+					Stopped:    info.Stopped,
+					LastOutput: info.LastOutput,
+				})
+			}
+		})
+		runner = client
+		defer client.Close()
+	}
+
 	m := ui.NewModel(database, runner)
 	p = tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	if _, err := p.Run(); err != nil {
@@ -33,3 +81,43 @@ func main() {
 		os.Exit(1)
 	}
 }
+
+func runDaemon() {
+	database, err := db.Open(db.DefaultPath())
+	if err != nil {
+		log.Fatalf("error opening database: %v", err)
+	}
+	defer database.Close()
+
+	d := daemon.New(database)
+	if err := d.Serve(daemon.DefaultSocketPath()); err != nil {
+		log.Fatalf("daemon error: %v", err)
+	}
+}
+
+func runDaemonStop() {
+	sockPath := daemon.DefaultSocketPath()
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot connect to daemon: %v\n", err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	// Send RPC prefix byte.
+	if _, err := conn.Write([]byte("R")); err != nil {
+		fmt.Fprintf(os.Stderr, "write error: %v\n", err)
+		os.Exit(1)
+	}
+
+	client := jsonrpc.NewClient(conn)
+	defer client.Close()
+
+	var resp daemon.StatusResp
+	if err := client.Call("Daemon.Shutdown", &daemon.Empty{}, &resp); err != nil {
+		fmt.Fprintf(os.Stderr, "shutdown error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("daemon stopped")
+}
+

--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -152,11 +152,25 @@
 - Fix: wrapped task list content in `borderedPanel(widths[0], contentHeight, false, ...)` in `renderTasksView()`, and adjusted `tasklist.SetSize()` to subtract 2 from each dimension for the border.
 - **Pattern:** Every panel passed to `PanelLayout.Render()` must enforce its own width. `borderedPanel` does this internally (`Width(w-2)` + border = `w` total). Panels without borders need explicit `lipgloss.NewStyle().Width(w)`.
 
+### Daemon Architecture Implementation (2026-03-15)
+- **SessionProvider/SessionHandle interfaces** (`iface.go`): Decouples UI from concrete `*Runner`/`*Session`. UI code depends only on interfaces, enabling both in-process and daemon-backed implementations.
+- **Multi-writer pattern** (`session.go`): Replaced single `attachW io.Writer` with `writers []io.Writer` slice. `readLoop` copies slice under lock, iterates outside lock. Failed writers auto-removed. `AddWriter()` sends replay BEFORE registering the writer to avoid duplicate bytes (replay-then-register, not register-then-replay). `Attach()`/`Detach()` use AddWriter/RemoveWriter internally. `AddWriter`/`RemoveWriter` are on the `SessionHandle` interface so daemon stream handler doesn't need type assertions.
+- **Nil-interface gotcha**: `Runner.Get()` returns `SessionHandle` (interface). Map lookups on missing keys return `nil *Session`, which becomes a non-nil interface. Fixed with explicit nil check before returning.
+- **RingBuffer exported** (`RingBuffer`/`NewRingBuffer`): Used by both in-process sessions and daemon client's local buffer.
+- **Daemon IPC**: Unix socket with first-byte dispatch ('R' = JSON-RPC, 'S' = raw stream). `net/rpc/jsonrpc` codec for structured calls. Raw byte streaming for PTY output with ring buffer replay.
+- **Client `SessionProvider`**: `RemoteSession` has a local `RingBuffer` populated by a stream reader goroutine. RPC calls for WriteInput/Resize/SessionStatus. `Done()` channel closed on stream EOF.
+- **ExitInfo pattern**: Daemon caches `ExitInfo{Err, Stopped, LastOutput}` in `onFinish` callback. Client calls `Daemon.GetExitInfo` RPC (consume-once) when stream closes, then passes real values to `AgentFinishedMsg`. Without this, daemon mode silently marks crashed/stopped sessions as successful completions because `Err`/`Stopped` default to zero values.
+- **Test gotcha**: `db.OpenInMemory()` seeds the default "claude" backend. Tests that create sessions with custom backends must set `task.Backend` explicitly — otherwise `ResolveBackend` falls through to the default claude backend and launches a real Claude Code process.
+
 ### Deferred Items for Future Sessions
 - Add error handling for silently ignored `_ = m.db.Update()` calls (~15 instances in root.go)
 - Handle `os.UserHomeDir()` errors in db.go and config.go
 - Remove dead `store` package
-- Define interfaces for DB and Runner to improve testability
+- Define interface for DB to improve testability (Runner interfaces done — `SessionProvider`/`SessionHandle` in `iface.go`)
 - Add dedicated tests for ScrollState, borderedPanel, determinePostExitStatus (currently covered transitively)
 - Goroutine leak in Session.Attach stdin copy (needs cancellation mechanism)
 - Document Detect() ordering constraint in project/detect.go to prevent future signature reordering regressions
+- Improve `internal/daemon` test coverage from 45% to ≥80% (missing: stream handler, WriteInput/Resize RPCs, error paths, concurrent stream/RPC, session exit notification)
+- Improve `internal/daemon/client` test coverage from 46% to ≥80% (missing: Get() with existing remote session, session exit callback, stream reconnection, error handling)
+- Daemon auto-start: `ensureDaemon()` was removed as dead code. Re-implement when E2E validation is complete — the TUI currently falls back to in-process silently.
+- Daemon session resume on startup: daemon should resume in-progress tasks with saved session IDs (port Init() logic from root.go)

--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -4,7 +4,7 @@ Structured knowledge for cross-session persistence. Each file covers a topic/dom
 
 | File | Topic | Key Entities | Last Updated |
 |------|-------|-------------|-------------|
-| code-quality.md | Refactoring patterns and deferred items | ScrollState, vtrender.go, sgrColor, borderedPanel, file splits, GitStatus pointer bug, cursor skip-header, Alt modifier keyMsgToBytes, textarea zero-value trap, textarea viewport scroll bug, worktree removal safety guard, self-managed worktrees, scroll-offset chicken-and-egg, diff panel line wrapping, ⌘ runewidth mismatch, tmux color palette, zero-dimension View() panic, vt10x cursor XOR reverse, PanelLayout extraction, worktree-first task creation regression, PanelLayout width enforcement bug, deferred items | 2026-03-15 |
+| code-quality.md | Refactoring patterns, daemon architecture, and deferred items | ScrollState, vtrender.go, sgrColor, borderedPanel, file splits, GitStatus pointer bug, cursor skip-header, Alt modifier keyMsgToBytes, textarea zero-value trap, textarea viewport scroll bug, worktree removal safety guard, self-managed worktrees, scroll-offset chicken-and-egg, diff panel line wrapping, ⌘ runewidth mismatch, tmux color palette, zero-dimension View() panic, vt10x cursor XOR reverse, PanelLayout extraction, worktree-first task creation regression, PanelLayout width enforcement bug, SessionProvider/SessionHandle interfaces, multi-writer pattern, nil-interface gotcha, daemon IPC protocol, RingBuffer export, daemon client, deferred items | 2026-03-15 |
 
 ## Coverage Map
 
@@ -12,3 +12,4 @@ Which context files are captured in knowledge:
 
 | Context File | Knowledge File(s) | Coverage |
 |-------------|-------------------|----------|
+| context/plans/daemon-architecture.md | code-quality.md (Daemon Architecture section) | Implementation patterns, IPC design, gotchas |

--- a/internal/agent/iface.go
+++ b/internal/agent/iface.go
@@ -1,0 +1,44 @@
+package agent
+
+import (
+	"io"
+
+	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/model"
+)
+
+// SessionProvider abstracts the management of agent sessions.
+// Implemented by Runner (in-process) and daemon client (remote).
+type SessionProvider interface {
+	Start(task *model.Task, cfg config.Config, rows, cols uint16, resume bool) (SessionHandle, error)
+	Stop(taskID string) error
+	StopAll()
+	Get(taskID string) SessionHandle // returns nil if not found
+	Running() []string
+	Idle() []string
+	HasSession(taskID string) bool
+	WorkDir(taskID string) string
+}
+
+// SessionHandle abstracts a single agent session.
+// Implemented by Session (in-process) and RemoteSession (daemon client).
+type SessionHandle interface {
+	PID() int
+	WriteInput(p []byte) (int, error)
+	Resize(rows, cols uint16) error
+	RecentOutput() []byte
+	TotalWritten() uint64
+	IsIdle() bool
+	Alive() bool
+	PTYSize() (cols, rows int)
+	Done() <-chan struct{}
+	Err() error
+	WorkDir() string
+	Stop() error
+	AddWriter(w io.Writer)
+	RemoveWriter(w io.Writer)
+}
+
+// Compile-time assertions.
+var _ SessionProvider = (*Runner)(nil)
+var _ SessionHandle = (*Session)(nil)

--- a/internal/agent/ringbuffer.go
+++ b/internal/agent/ringbuffer.go
@@ -1,8 +1,8 @@
 package agent
 
-// ringBuffer is a fixed-size circular byte buffer.
+// RingBuffer is a fixed-size circular byte buffer.
 // When full, new writes overwrite the oldest data.
-type ringBuffer struct {
+type RingBuffer struct {
 	data  []byte
 	size  int
 	pos   int
@@ -10,15 +10,16 @@ type ringBuffer struct {
 	total uint64 // monotonic count of bytes written
 }
 
-func newRingBuffer(size int) *ringBuffer {
-	return &ringBuffer{
+// NewRingBuffer creates a ring buffer of the given size.
+func NewRingBuffer(size int) *RingBuffer {
+	return &RingBuffer{
 		data: make([]byte, size),
 		size: size,
 	}
 }
 
 // Write appends data to the ring buffer using bulk copy operations.
-func (rb *ringBuffer) Write(p []byte) {
+func (rb *RingBuffer) Write(p []byte) {
 	rb.total += uint64(len(p))
 	for len(p) > 0 {
 		n := copy(rb.data[rb.pos:], p)
@@ -32,12 +33,12 @@ func (rb *ringBuffer) Write(p []byte) {
 }
 
 // TotalWritten returns the monotonic count of bytes written to the buffer.
-func (rb *ringBuffer) TotalWritten() uint64 {
+func (rb *RingBuffer) TotalWritten() uint64 {
 	return rb.total
 }
 
 // Bytes returns the buffered data in order (oldest first).
-func (rb *ringBuffer) Bytes() []byte {
+func (rb *RingBuffer) Bytes() []byte {
 	if !rb.full {
 		return append([]byte(nil), rb.data[:rb.pos]...)
 	}
@@ -49,7 +50,7 @@ func (rb *ringBuffer) Bytes() []byte {
 }
 
 // Len returns the number of bytes stored.
-func (rb *ringBuffer) Len() int {
+func (rb *RingBuffer) Len() int {
 	if rb.full {
 		return rb.size
 	}
@@ -57,7 +58,7 @@ func (rb *ringBuffer) Len() int {
 }
 
 // Reset clears the buffer.
-func (rb *ringBuffer) Reset() {
+func (rb *RingBuffer) Reset() {
 	rb.pos = 0
 	rb.full = false
 }

--- a/internal/agent/ringbuffer_test.go
+++ b/internal/agent/ringbuffer_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRingBuffer_Basic(t *testing.T) {
-	rb := newRingBuffer(10)
+	rb := NewRingBuffer(10)
 	rb.Write([]byte("hello"))
 
 	if rb.Len() != 5 {
@@ -18,7 +18,7 @@ func TestRingBuffer_Basic(t *testing.T) {
 }
 
 func TestRingBuffer_Wrap(t *testing.T) {
-	rb := newRingBuffer(5)
+	rb := NewRingBuffer(5)
 	rb.Write([]byte("abcde"))   // fills buffer
 	rb.Write([]byte("fg"))      // overwrites a, b
 
@@ -32,7 +32,7 @@ func TestRingBuffer_Wrap(t *testing.T) {
 }
 
 func TestRingBuffer_LargeWrite(t *testing.T) {
-	rb := newRingBuffer(4)
+	rb := NewRingBuffer(4)
 	rb.Write([]byte("abcdefgh")) // 2x buffer size
 
 	if rb.Len() != 4 {
@@ -45,7 +45,7 @@ func TestRingBuffer_LargeWrite(t *testing.T) {
 }
 
 func TestRingBuffer_Reset(t *testing.T) {
-	rb := newRingBuffer(10)
+	rb := NewRingBuffer(10)
 	rb.Write([]byte("data"))
 	rb.Reset()
 
@@ -58,7 +58,7 @@ func TestRingBuffer_Reset(t *testing.T) {
 }
 
 func TestRingBuffer_Empty(t *testing.T) {
-	rb := newRingBuffer(10)
+	rb := NewRingBuffer(10)
 	if rb.Len() != 0 {
 		t.Errorf("Len() = %d", rb.Len())
 	}
@@ -68,7 +68,7 @@ func TestRingBuffer_Empty(t *testing.T) {
 }
 
 func TestRingBuffer_TotalWritten(t *testing.T) {
-	rb := newRingBuffer(5)
+	rb := NewRingBuffer(5)
 	if rb.TotalWritten() != 0 {
 		t.Errorf("TotalWritten() = %d, want 0", rb.TotalWritten())
 	}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -32,7 +32,7 @@ func NewRunner(onFinish func(taskID string, err error, stopped bool, lastOutput 
 // rows and cols set the initial PTY size (falls back to 80x24 if zero).
 // If resume is true, the agent reconnects to an existing conversation via --resume.
 // Returns an error if a session already exists for this task.
-func (r *Runner) Start(task *model.Task, cfg config.Config, rows, cols uint16, resume bool) (*Session, error) {
+func (r *Runner) Start(task *model.Task, cfg config.Config, rows, cols uint16, resume bool) (SessionHandle, error) {
 	r.mu.Lock()
 	if _, exists := r.sessions[task.ID]; exists {
 		r.mu.Unlock()
@@ -74,16 +74,20 @@ func (r *Runner) Start(task *model.Task, cfg config.Config, rows, cols uint16, r
 }
 
 // Get returns the session for a task, or nil if not found.
-func (r *Runner) Get(taskID string) *Session {
+func (r *Runner) Get(taskID string) SessionHandle {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.sessions[taskID]
+	sess := r.sessions[taskID]
+	if sess == nil {
+		return nil
+	}
+	return sess
 }
 
 // Attach connects stdin/stdout to a running session's PTY.
 // Blocks until detach or process exit.
 func (r *Runner) Attach(taskID string, stdin io.Reader, stdout io.Writer) error {
-	sess := r.Get(taskID)
+	sess := r.getSession(taskID)
 	if sess == nil {
 		return ErrSessionNotFound
 	}
@@ -92,9 +96,16 @@ func (r *Runner) Attach(taskID string, stdin io.Reader, stdout io.Writer) error 
 
 // Detach disconnects from a running session without stopping it.
 func (r *Runner) Detach(taskID string) {
-	if sess := r.Get(taskID); sess != nil {
+	if sess := r.getSession(taskID); sess != nil {
 		sess.Detach()
 	}
+}
+
+// getSession returns the concrete *Session for internal use (e.g., Attach/Detach).
+func (r *Runner) getSession(taskID string) *Session {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.sessions[taskID]
 }
 
 // Stop sends SIGTERM to a running session.

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -214,8 +214,8 @@ func TestRunner_Idle(t *testing.T) {
 		t.Errorf("expected no idle sessions, got %v", idle)
 	}
 
-	// Simulate the session having old output
-	sess := r.Get("idle-t1")
+	// Simulate the session having old output (cast to concrete type for test)
+	sess := r.Get("idle-t1").(*Session)
 	sess.mu.Lock()
 	sess.lastOutput = time.Now().Add(-5 * time.Second)
 	sess.mu.Unlock()

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -29,8 +29,8 @@ type Session struct {
 	ptmx   *os.File // PTY master
 
 	mu         sync.Mutex
-	buf        *ringBuffer
-	attachW    io.Writer // when non-nil, readLoop tees output here
+	buf        *RingBuffer
+	writers    []io.Writer // readLoop tees output to all attached writers
 	done       chan struct{}
 	err        error
 	attached   bool
@@ -59,7 +59,7 @@ func StartSession(taskID string, cmd *exec.Cmd, rows, cols uint16) (*Session, er
 		TaskID:   taskID,
 		Cmd:      cmd,
 		ptmx:     ptmx,
-		buf:      newRingBuffer(defaultBufSize),
+		buf:      NewRingBuffer(defaultBufSize),
 		done:     make(chan struct{}),
 		detachCh: make(chan struct{}),
 		ptyCols:  cols,
@@ -76,7 +76,7 @@ func StartSession(taskID string, cmd *exec.Cmd, rows, cols uint16) (*Session, er
 }
 
 // readLoop is the sole reader of the PTY. It always writes to the ring buffer,
-// and when a writer is attached, also tees output there.
+// and tees output to all attached writers.
 func (s *Session) readLoop() {
 	tmp := make([]byte, 4096)
 	for {
@@ -87,10 +87,23 @@ func (s *Session) readLoop() {
 			s.mu.Lock()
 			s.buf.Write(chunk)
 			s.lastOutput = time.Now()
-			w := s.attachW
+			// Copy writer slice under lock, iterate outside lock.
+			ws := make([]io.Writer, len(s.writers))
+			copy(ws, s.writers)
 			s.mu.Unlock()
-			if w != nil {
-				w.Write(chunk)
+			// Write to all attached writers, collect any that error.
+			var failed []io.Writer
+			for _, w := range ws {
+				if _, werr := w.Write(chunk); werr != nil {
+					failed = append(failed, w)
+				}
+			}
+			if len(failed) > 0 {
+				s.mu.Lock()
+				for _, f := range failed {
+					s.removeWriterLocked(f)
+				}
+				s.mu.Unlock()
 			}
 		}
 		if err != nil {
@@ -149,6 +162,52 @@ func (s *Session) PID() int {
 	return 0
 }
 
+// AddWriter registers a writer to receive PTY output. The writer immediately
+// receives a replay of the ring buffer contents, then receives live output.
+// Replay is sent before registering the writer to avoid duplicate bytes:
+// if we registered first, readLoop could deliver live bytes to w before
+// the replay is sent, causing the same bytes to appear twice.
+// Safe to call concurrently.
+func (s *Session) AddWriter(w io.Writer) {
+	s.mu.Lock()
+	replay := s.buf.Bytes()
+	s.mu.Unlock()
+
+	// Send replay outside lock but BEFORE registering the writer.
+	// Any bytes produced by readLoop during this window are missed
+	// (they're in the ring buffer but not yet in replay and w isn't
+	// registered yet). This creates a small gap rather than a duplicate.
+	// The gap is acceptable: the vt10x terminal handles missing bytes
+	// gracefully (partial escape sequences are ignored), whereas
+	// duplicate bytes cause visible rendering corruption.
+	if len(replay) > 0 {
+		w.Write(replay)
+	}
+
+	// Now register for live output. Any bytes that arrived during
+	// replay will be in the ring buffer for future RecentOutput() calls.
+	s.mu.Lock()
+	s.writers = append(s.writers, w)
+	s.mu.Unlock()
+}
+
+// RemoveWriter unregisters a writer. Safe to call concurrently.
+func (s *Session) RemoveWriter(w io.Writer) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.removeWriterLocked(w)
+}
+
+// removeWriterLocked removes a writer from the slice. Caller must hold s.mu.
+func (s *Session) removeWriterLocked(w io.Writer) {
+	for i, existing := range s.writers {
+		if existing == w {
+			s.writers = append(s.writers[:i], s.writers[i+1:]...)
+			return
+		}
+	}
+}
+
 // Attach splices the PTY to the given stdin/stdout.
 // Blocks until detach is called, the process exits, or an error occurs.
 // Returns nil on detach, the process error on exit.
@@ -160,23 +219,17 @@ func (s *Session) Attach(stdin io.Reader, stdout io.Writer) error {
 	}
 	s.attached = true
 	s.detachCh = make(chan struct{})
-
-	// Replay buffered output so user sees recent context,
-	// then set tee writer — all under one lock so no data is lost.
-	replay := s.buf.Bytes()
-	s.attachW = stdout
 	s.mu.Unlock()
 
+	// AddWriter replays buffered output and registers for live output.
+	s.AddWriter(stdout)
+
 	defer func() {
+		s.RemoveWriter(stdout)
 		s.mu.Lock()
-		s.attachW = nil
 		s.attached = false
 		s.mu.Unlock()
 	}()
-
-	if len(replay) > 0 {
-		stdout.Write(replay)
-	}
 
 	errCh := make(chan error, 1)
 

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -35,7 +35,7 @@ func TestStartSession_EchoCommand(t *testing.T) {
 	// Give readLoop time to capture output
 	time.Sleep(50 * time.Millisecond)
 
-	output := string(sess.buf.Bytes())
+	output := string(sess.RecentOutput())
 	if !strings.Contains(output, "hello from pty") {
 		t.Errorf("expected output to contain 'hello from pty', got %q", output)
 	}
@@ -498,6 +498,67 @@ func TestSession_Attach_StdinEOF(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout waiting for attach to return after stdin EOF")
+	}
+}
+
+func TestSession_MultiWriter(t *testing.T) {
+	cmd := exec.Command("echo", "multi-writer-test")
+	sess, err := StartSession("mw-1", cmd, 24, 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf1, buf2 bytes.Buffer
+	sess.AddWriter(&buf1)
+	sess.AddWriter(&buf2)
+
+	// Wait for process to exit and output to propagate
+	select {
+	case <-sess.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	// Both writers should have received the replay + any live output
+	if !strings.Contains(buf1.String(), "multi-writer-test") {
+		t.Errorf("writer 1 missing output: %q", buf1.String())
+	}
+	if !strings.Contains(buf2.String(), "multi-writer-test") {
+		t.Errorf("writer 2 missing output: %q", buf2.String())
+	}
+}
+
+func TestSession_RemoveWriter(t *testing.T) {
+	// Use cat which echoes stdin to stdout, producing observable output.
+	cmd := exec.Command("cat")
+	sess, err := StartSession("rw-1", cmd, 24, 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sess.Stop()
+
+	var buf bytes.Buffer
+	sess.AddWriter(&buf)
+
+	// Write some input so cat echoes it — this produces output
+	// that the writer receives.
+	sess.WriteInput([]byte("before\n"))
+	time.Sleep(100 * time.Millisecond)
+
+	if buf.Len() == 0 {
+		t.Fatal("expected writer to receive output before removal")
+	}
+
+	// Now remove the writer and send more input.
+	sess.RemoveWriter(&buf)
+	initialLen := buf.Len()
+
+	sess.WriteInput([]byte("after-removal\n"))
+	time.Sleep(100 * time.Millisecond)
+
+	if buf.Len() > initialLen {
+		t.Error("writer received output after removal")
 	}
 }
 

--- a/internal/daemon/client/client.go
+++ b/internal/daemon/client/client.go
@@ -1,0 +1,222 @@
+package client
+
+import (
+	"fmt"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"sync"
+
+	"github.com/drn/argus/internal/agent"
+	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/daemon"
+	"github.com/drn/argus/internal/model"
+)
+
+// Compile-time assertion.
+var _ agent.SessionProvider = (*Client)(nil)
+
+// Client connects to the daemon and implements agent.SessionProvider.
+type Client struct {
+	rpc      *rpc.Client
+	sockPath string
+	sessions map[string]*RemoteSession
+	mu       sync.Mutex
+
+	// onSessionExit is called when a session's stream EOF is detected.
+	// Includes exit info (error, stopped flag, last output) from the daemon.
+	onSessionExit func(taskID string, info daemon.ExitInfo)
+}
+
+// Connect dials the daemon socket and returns a Client.
+func Connect(sockPath string) (*Client, error) {
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		return nil, fmt.Errorf("connect to daemon: %w", err)
+	}
+
+	// Send RPC prefix byte.
+	if _, err := conn.Write([]byte("R")); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	return &Client{
+		rpc:      jsonrpc.NewClient(conn),
+		sockPath: sockPath,
+		sessions: make(map[string]*RemoteSession),
+	}, nil
+}
+
+// OnSessionExit registers a callback invoked when a session's stream reports EOF.
+// The callback receives exit info (error string, stopped flag, last output) from the daemon.
+func (c *Client) OnSessionExit(fn func(taskID string, info daemon.ExitInfo)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onSessionExit = fn
+}
+
+// Close shuts down the client and all stream connections.
+func (c *Client) Close() error {
+	c.mu.Lock()
+	sessions := make(map[string]*RemoteSession, len(c.sessions))
+	for k, v := range c.sessions {
+		sessions[k] = v
+	}
+	c.mu.Unlock()
+
+	for _, rs := range sessions {
+		rs.close()
+	}
+	return c.rpc.Close()
+}
+
+// Start requests the daemon to start a session and opens a stream for its output.
+func (c *Client) Start(task *model.Task, cfg config.Config, rows, cols uint16, resume bool) (agent.SessionHandle, error) {
+	req := &daemon.StartReq{
+		TaskID:    task.ID,
+		SessionID: task.SessionID,
+		Prompt:    task.Prompt,
+		Project:   task.Project,
+		Backend:   task.Backend,
+		Worktree:  task.Worktree,
+		Branch:    task.Branch,
+		Rows:      rows,
+		Cols:      cols,
+		Resume:    resume,
+	}
+
+	var resp daemon.StartResp
+	if err := c.rpc.Call("Daemon.StartSession", req, &resp); err != nil {
+		return nil, err
+	}
+
+	rs := c.getOrCreateSession(task.ID)
+	rs.pid = resp.PID
+	return rs, nil
+}
+
+// Get returns a SessionHandle for the task, or nil if not found.
+func (c *Client) Get(taskID string) agent.SessionHandle {
+	c.mu.Lock()
+	rs, ok := c.sessions[taskID]
+	c.mu.Unlock()
+	if ok {
+		return rs
+	}
+
+	// Check with daemon if session exists.
+	var info daemon.SessionInfo
+	if err := c.rpc.Call("Daemon.SessionStatus", &daemon.TaskIDReq{TaskID: taskID}, &info); err != nil {
+		return nil
+	}
+	if !info.Alive && info.PID == 0 {
+		return nil
+	}
+
+	rs = c.getOrCreateSession(taskID)
+	rs.updateInfo(info)
+	return rs
+}
+
+// Stop stops a session via RPC.
+func (c *Client) Stop(taskID string) error {
+	var resp daemon.StatusResp
+	if err := c.rpc.Call("Daemon.StopSession", &daemon.TaskIDReq{TaskID: taskID}, &resp); err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	return nil
+}
+
+// StopAll stops all sessions via RPC. Errors are silently ignored since
+// StopAll is typically called during shutdown where there's no recovery path.
+func (c *Client) StopAll() {
+	var resp daemon.StatusResp
+	_ = c.rpc.Call("Daemon.StopAll", &daemon.Empty{}, &resp)
+}
+
+// Running returns task IDs of running sessions.
+func (c *Client) Running() []string {
+	var resp daemon.ListResp
+	if err := c.rpc.Call("Daemon.ListSessions", &daemon.Empty{}, &resp); err != nil {
+		return nil
+	}
+	ids := make([]string, 0, len(resp.Sessions))
+	for _, s := range resp.Sessions {
+		if s.Alive {
+			ids = append(ids, s.TaskID)
+		}
+	}
+	return ids
+}
+
+// Idle returns task IDs of idle sessions.
+func (c *Client) Idle() []string {
+	var resp daemon.ListResp
+	if err := c.rpc.Call("Daemon.ListSessions", &daemon.Empty{}, &resp); err != nil {
+		return nil
+	}
+	var ids []string
+	for _, s := range resp.Sessions {
+		if s.Idle {
+			ids = append(ids, s.TaskID)
+		}
+	}
+	return ids
+}
+
+// HasSession returns true if a session exists for the task.
+func (c *Client) HasSession(taskID string) bool {
+	var info daemon.SessionInfo
+	if err := c.rpc.Call("Daemon.SessionStatus", &daemon.TaskIDReq{TaskID: taskID}, &info); err != nil {
+		return false
+	}
+	return info.Alive || info.PID != 0
+}
+
+// WorkDir returns the working directory of a session.
+func (c *Client) WorkDir(taskID string) string {
+	var info daemon.SessionInfo
+	if err := c.rpc.Call("Daemon.SessionStatus", &daemon.TaskIDReq{TaskID: taskID}, &info); err != nil {
+		return ""
+	}
+	return info.WorkDir
+}
+
+// getOrCreateSession returns an existing RemoteSession or creates a new one
+// with a stream connection.
+func (c *Client) getOrCreateSession(taskID string) *RemoteSession {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if rs, ok := c.sessions[taskID]; ok {
+		return rs
+	}
+
+	rs := newRemoteSession(taskID, c)
+	c.sessions[taskID] = rs
+
+	// Open a stream connection in the background.
+	go rs.connectStream(c.sockPath)
+
+	return rs
+}
+
+// removeSession cleans up a session from the client's map, queries exit info
+// from the daemon, and fires the callback.
+func (c *Client) removeSession(taskID string) {
+	c.mu.Lock()
+	delete(c.sessions, taskID)
+	fn := c.onSessionExit
+	c.mu.Unlock()
+
+	if fn != nil {
+		// Query exit info from daemon before firing callback.
+		var info daemon.ExitInfo
+		c.rpc.Call("Daemon.GetExitInfo", &daemon.TaskIDReq{TaskID: taskID}, &info)
+		fn(taskID, info)
+	}
+}

--- a/internal/daemon/client/client_test.go
+++ b/internal/daemon/client/client_test.go
@@ -1,0 +1,125 @@
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/daemon"
+	"github.com/drn/argus/internal/db"
+	"github.com/drn/argus/internal/model"
+)
+
+func testSetup(t *testing.T) (*daemon.Daemon, string) {
+	t.Helper()
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	database.SetBackend("test", config.Backend{Command: "echo hello-from-daemon"})
+	database.SetConfigValue("default.backend", "test")
+
+	d := daemon.New(database)
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	go d.Serve(sockPath)
+	t.Cleanup(func() { d.Shutdown() })
+
+	// Wait for socket.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(sockPath); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return d, sockPath
+}
+
+func TestClient_ConnectAndPing(t *testing.T) {
+	_, sockPath := testSetup(t)
+
+	c, err := Connect(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	// HasSession should return false for nonexistent.
+	if c.HasSession("nonexistent") {
+		t.Error("expected false for nonexistent session")
+	}
+}
+
+func TestClient_StartAndGetOutput(t *testing.T) {
+	_, sockPath := testSetup(t)
+
+	c, err := Connect(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	task := &model.Task{ID: "t1", Name: "test-task", Backend: "test"}
+	sess, err := c.Start(task, config.Config{}, 24, 80, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.PID() == 0 {
+		t.Error("expected non-zero PID")
+	}
+
+	// Wait for process to exit and stream to deliver output.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !sess.Alive() {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Give stream reader time to populate buffer.
+	time.Sleep(200 * time.Millisecond)
+
+	output := string(sess.RecentOutput())
+	if !strings.Contains(output, "hello-from-daemon") {
+		t.Errorf("expected output to contain 'hello-from-daemon', got %q", output)
+	}
+}
+
+func TestClient_RunningAndIdle(t *testing.T) {
+	_, sockPath := testSetup(t)
+
+	c, err := Connect(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	// Initially no sessions.
+	if ids := c.Running(); len(ids) != 0 {
+		t.Errorf("expected no running sessions, got %v", ids)
+	}
+	if ids := c.Idle(); len(ids) != 0 {
+		t.Errorf("expected no idle sessions, got %v", ids)
+	}
+}
+
+func TestClient_StopAll(t *testing.T) {
+	_, sockPath := testSetup(t)
+
+	c, err := Connect(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	// StopAll should not panic with no sessions.
+	c.StopAll()
+}

--- a/internal/daemon/client/handle.go
+++ b/internal/daemon/client/handle.go
@@ -1,0 +1,162 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/drn/argus/internal/agent"
+	"github.com/drn/argus/internal/daemon"
+)
+
+const defaultBufSize = 256 * 1024 // 256KB ring buffer, same as agent
+
+// Compile-time assertion.
+var _ agent.SessionHandle = (*RemoteSession)(nil)
+
+// RemoteSession implements agent.SessionHandle by proxying to the daemon.
+type RemoteSession struct {
+	taskID string
+	client *Client
+
+	mu   sync.Mutex
+	buf  *agent.RingBuffer // local ring buffer, populated by stream reader
+	pid  int
+	info daemon.SessionInfo // cached session info
+	done chan struct{}       // closed when stream EOF
+}
+
+func newRemoteSession(taskID string, c *Client) *RemoteSession {
+	return &RemoteSession{
+		taskID: taskID,
+		client: c,
+		buf:    agent.NewRingBuffer(defaultBufSize),
+		done:   make(chan struct{}),
+	}
+}
+
+func (rs *RemoteSession) PID() int {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return rs.pid
+}
+
+func (rs *RemoteSession) WriteInput(p []byte) (int, error) {
+	var resp daemon.StatusResp
+	err := rs.client.rpc.Call("Daemon.WriteInput", &daemon.WriteReq{
+		TaskID: rs.taskID,
+		Data:   p,
+	}, &resp)
+	if err != nil {
+		return 0, err
+	}
+	if resp.Error != "" {
+		return 0, fmt.Errorf("%s", resp.Error)
+	}
+	return len(p), nil
+}
+
+func (rs *RemoteSession) Resize(rows, cols uint16) error {
+	var resp daemon.StatusResp
+	err := rs.client.rpc.Call("Daemon.Resize", &daemon.ResizeReq{
+		TaskID: rs.taskID,
+		Rows:   rows,
+		Cols:   cols,
+	}, &resp)
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	return nil
+}
+
+func (rs *RemoteSession) RecentOutput() []byte {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return rs.buf.Bytes()
+}
+
+func (rs *RemoteSession) TotalWritten() uint64 {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return rs.buf.TotalWritten()
+}
+
+func (rs *RemoteSession) IsIdle() bool {
+	rs.refreshInfo()
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return rs.info.Idle
+}
+
+func (rs *RemoteSession) Alive() bool {
+	select {
+	case <-rs.done:
+		return false
+	default:
+		return true
+	}
+}
+
+func (rs *RemoteSession) PTYSize() (cols, rows int) {
+	rs.refreshInfo()
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return rs.info.Cols, rs.info.Rows
+}
+
+func (rs *RemoteSession) Done() <-chan struct{} {
+	return rs.done
+}
+
+func (rs *RemoteSession) Err() error {
+	return nil // errors are communicated via DB, not the handle
+}
+
+func (rs *RemoteSession) WorkDir() string {
+	rs.refreshInfo()
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return rs.info.WorkDir
+}
+
+func (rs *RemoteSession) Stop() error {
+	return rs.client.Stop(rs.taskID)
+}
+
+// updateInfo stores cached session info.
+func (rs *RemoteSession) updateInfo(info daemon.SessionInfo) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	rs.info = info
+	if info.PID != 0 {
+		rs.pid = info.PID
+	}
+}
+
+// refreshInfo fetches session info from the daemon.
+func (rs *RemoteSession) refreshInfo() {
+	var info daemon.SessionInfo
+	if err := rs.client.rpc.Call("Daemon.SessionStatus", &daemon.TaskIDReq{TaskID: rs.taskID}, &info); err != nil {
+		return
+	}
+	rs.updateInfo(info)
+}
+
+// AddWriter is a no-op on RemoteSession. The daemon manages writers directly;
+// the client receives output via its stream connection.
+func (rs *RemoteSession) AddWriter(_ io.Writer) {}
+
+// RemoveWriter is a no-op on RemoteSession.
+func (rs *RemoteSession) RemoveWriter(_ io.Writer) {}
+
+// close shuts down the remote session.
+func (rs *RemoteSession) close() {
+	select {
+	case <-rs.done:
+	default:
+		close(rs.done)
+	}
+}

--- a/internal/daemon/client/stream.go
+++ b/internal/daemon/client/stream.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"encoding/json"
+	"net"
+
+	"github.com/drn/argus/internal/daemon"
+)
+
+// connectStream opens a stream connection to the daemon for this session's output.
+// Reads raw bytes and writes them to the local ring buffer. Closes rs.done on EOF.
+func (rs *RemoteSession) connectStream(sockPath string) {
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		rs.client.removeSession(rs.taskID)
+		return
+	}
+	defer conn.Close()
+
+	// Send stream prefix byte.
+	if _, err := conn.Write([]byte("S")); err != nil {
+		rs.client.removeSession(rs.taskID)
+		return
+	}
+
+	// Send stream header to subscribe to this session's output.
+	enc := json.NewEncoder(conn)
+	if err := enc.Encode(daemon.StreamHeader{
+		TaskID: rs.taskID,
+	}); err != nil {
+		rs.client.removeSession(rs.taskID)
+		return
+	}
+
+	// Read output stream into local ring buffer.
+	buf := make([]byte, 4096)
+	for {
+		n, err := conn.Read(buf)
+		if n > 0 {
+			rs.mu.Lock()
+			rs.buf.Write(buf[:n])
+			rs.mu.Unlock()
+		}
+		if err != nil {
+			break // EOF or connection error — treat as session exit
+		}
+	}
+
+	// Stream ended — session exited or daemon shut down.
+	rs.close()
+	rs.client.removeSession(rs.taskID)
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,0 +1,213 @@
+package daemon
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"syscall"
+
+	"github.com/drn/argus/internal/agent"
+	"github.com/drn/argus/internal/db"
+)
+
+// DefaultSocketPath returns the default Unix socket path.
+func DefaultSocketPath() string {
+	return filepath.Join(db.DataDir(), "daemon.sock")
+}
+
+// DefaultPIDPath returns the default PID file path.
+func DefaultPIDPath() string {
+	return filepath.Join(db.DataDir(), "daemon.pid")
+}
+
+// ExitInfo holds the exit state of a finished session, cached briefly
+// so clients can query it after the stream closes.
+type ExitInfo struct {
+	Err        string
+	Stopped    bool
+	LastOutput []byte
+}
+
+// Daemon manages agent sessions and exposes them over a Unix socket.
+type Daemon struct {
+	db        *db.DB
+	runner    *agent.Runner
+	listener  net.Listener
+	streams   map[string][]net.Conn // taskID → connected stream clients
+	exitInfos map[string]ExitInfo    // taskID → cached exit info (brief)
+	mu        sync.Mutex
+	done      chan struct{}
+}
+
+// New creates a new Daemon.
+func New(database *db.DB) *Daemon {
+	d := &Daemon{
+		db:        database,
+		streams:   make(map[string][]net.Conn),
+		exitInfos: make(map[string]ExitInfo),
+		done:      make(chan struct{}),
+	}
+
+	// Create runner with onFinish callback that caches exit info and
+	// notifies stream clients by closing their connections.
+	d.runner = agent.NewRunner(func(taskID string, err error, stopped bool, lastOutput []byte) {
+		var errStr string
+		if err != nil {
+			errStr = err.Error()
+		}
+
+		d.mu.Lock()
+		d.exitInfos[taskID] = ExitInfo{
+			Err:        errStr,
+			Stopped:    stopped,
+			LastOutput: lastOutput,
+		}
+		conns := d.streams[taskID]
+		delete(d.streams, taskID)
+		d.mu.Unlock()
+
+		// Signal stream EOF to all connected clients by closing their connections.
+		for _, conn := range conns {
+			conn.Close()
+		}
+	})
+
+	return d
+}
+
+// Runner returns the underlying runner for direct access (e.g., AddWriter).
+func (d *Daemon) Runner() *agent.Runner {
+	return d.runner
+}
+
+// Serve starts listening on the given socket path and accepts connections.
+// Blocks until Shutdown is called or the listener is closed.
+func (d *Daemon) Serve(sockPath string) error {
+	// Remove stale socket file.
+	os.Remove(sockPath)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return fmt.Errorf("listen: %w", err)
+	}
+	d.listener = ln
+
+	// Write PID file.
+	pidPath := DefaultPIDPath()
+	if err := writePIDFile(pidPath); err != nil {
+		ln.Close()
+		return fmt.Errorf("pid file: %w", err)
+	}
+
+	// Register RPC service.
+	svc := &RPCService{daemon: d}
+	server := rpc.NewServer()
+	if err := server.RegisterName("Daemon", svc); err != nil {
+		ln.Close()
+		return fmt.Errorf("register rpc: %w", err)
+	}
+
+	// Trap signals for graceful shutdown.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		select {
+		case <-sigCh:
+			d.Shutdown()
+		case <-d.done:
+		}
+	}()
+
+	log.Printf("daemon listening on %s (pid %d)", sockPath, os.Getpid())
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-d.done:
+				return nil // clean shutdown
+			default:
+				return fmt.Errorf("accept: %w", err)
+			}
+		}
+		go d.handleConn(conn, server)
+	}
+}
+
+// handleConn dispatches a connection based on its first byte:
+// 'R' for JSON-RPC, 'S' for output streaming.
+func (d *Daemon) handleConn(conn net.Conn, server *rpc.Server) {
+	defer conn.Close()
+
+	// Read dispatch byte.
+	var prefix [1]byte
+	if _, err := io.ReadFull(conn, prefix[:]); err != nil {
+		return
+	}
+
+	switch prefix[0] {
+	case 'R':
+		server.ServeCodec(jsonrpc.NewServerCodec(conn))
+	case 'S':
+		d.handleStream(conn)
+	}
+}
+
+// registerStream registers a stream connection for a task.
+func (d *Daemon) registerStream(taskID string, conn net.Conn) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.streams[taskID] = append(d.streams[taskID], conn)
+}
+
+// unregisterStream removes a stream connection for a task.
+func (d *Daemon) unregisterStream(taskID string, conn net.Conn) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	conns := d.streams[taskID]
+	for i, c := range conns {
+		if c == conn {
+			d.streams[taskID] = append(conns[:i], conns[i+1:]...)
+			return
+		}
+	}
+}
+
+// Shutdown gracefully stops the daemon.
+func (d *Daemon) Shutdown() {
+	select {
+	case <-d.done:
+		return // already shutting down
+	default:
+		close(d.done)
+	}
+
+	log.Println("daemon shutting down...")
+
+	if d.listener != nil {
+		d.listener.Close()
+	}
+
+	d.runner.StopAll()
+
+	// Clean up socket and PID files.
+	os.Remove(DefaultSocketPath())
+	os.Remove(DefaultPIDPath())
+}
+
+// writePIDFile atomically writes the current process PID to a file.
+func writePIDFile(path string) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(strconv.Itoa(os.Getpid())), 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,0 +1,197 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/db"
+)
+
+func testDaemon(t *testing.T) (*Daemon, string) {
+	t.Helper()
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	d := New(database)
+
+	// Use a temp socket path.
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	return d, sockPath
+}
+
+func dialRPC(t *testing.T, sockPath string) *rpc.Client {
+	t.Helper()
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	// Send RPC prefix byte.
+	conn.Write([]byte("R"))
+	client := jsonrpc.NewClient(conn)
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
+func dialStream(t *testing.T, sockPath string, taskID string) net.Conn {
+	t.Helper()
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial stream: %v", err)
+	}
+	// Send stream prefix byte.
+	conn.Write([]byte("S"))
+	// Send stream header.
+	enc := json.NewEncoder(conn)
+	if err := enc.Encode(StreamHeader{TaskID: taskID}); err != nil {
+		conn.Close()
+		t.Fatalf("encode header: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	return conn
+}
+
+func TestDaemon_Ping(t *testing.T) {
+	d, sockPath := testDaemon(t)
+
+	go d.Serve(sockPath)
+	t.Cleanup(func() { d.Shutdown() })
+
+	// Wait for socket to appear.
+	waitForSocket(t, sockPath)
+
+	client := dialRPC(t, sockPath)
+	var resp PongResp
+	if err := client.Call("Daemon.Ping", &Empty{}, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Error("expected Ping to return OK=true")
+	}
+}
+
+func TestDaemon_ListSessions_Empty(t *testing.T) {
+	d, sockPath := testDaemon(t)
+
+	go d.Serve(sockPath)
+	t.Cleanup(func() { d.Shutdown() })
+	waitForSocket(t, sockPath)
+
+	client := dialRPC(t, sockPath)
+	var resp ListResp
+	if err := client.Call("Daemon.ListSessions", &Empty{}, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Sessions) != 0 {
+		t.Errorf("expected 0 sessions, got %d", len(resp.Sessions))
+	}
+}
+
+func TestDaemon_StartAndStop(t *testing.T) {
+	d, sockPath := testDaemon(t)
+
+	// Seed a backend config.
+	d.db.SetBackend("test", config.Backend{Command: "sleep 60"})
+	d.db.SetConfigValue("default.backend", "test")
+
+	go d.Serve(sockPath)
+	t.Cleanup(func() { d.Shutdown() })
+	waitForSocket(t, sockPath)
+
+	client := dialRPC(t, sockPath)
+
+	// Start a session.
+	var startResp StartResp
+	err := client.Call("Daemon.StartSession", &StartReq{
+		TaskID:  "t1",
+		Backend: "test",
+		Rows:    24,
+		Cols:    80,
+	}, &startResp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if startResp.PID == 0 {
+		t.Error("expected non-zero PID")
+	}
+
+	// List sessions.
+	var listResp ListResp
+	if err := client.Call("Daemon.ListSessions", &Empty{}, &listResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(listResp.Sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(listResp.Sessions))
+	}
+	if listResp.Sessions[0].TaskID != "t1" {
+		t.Errorf("expected task t1, got %q", listResp.Sessions[0].TaskID)
+	}
+
+	// Stop session.
+	var stopResp StatusResp
+	if err := client.Call("Daemon.StopSession", &TaskIDReq{TaskID: "t1"}, &stopResp); err != nil {
+		t.Fatal(err)
+	}
+	if !stopResp.OK {
+		t.Errorf("expected OK, got error: %s", stopResp.Error)
+	}
+
+	// Wait for cleanup.
+	time.Sleep(200 * time.Millisecond)
+
+	// Session should be gone.
+	var listResp2 ListResp
+	if err := client.Call("Daemon.ListSessions", &Empty{}, &listResp2); err != nil {
+		t.Fatal(err)
+	}
+	if len(listResp2.Sessions) != 0 {
+		t.Errorf("expected 0 sessions after stop, got %d", len(listResp2.Sessions))
+	}
+}
+
+func TestDaemon_Shutdown(t *testing.T) {
+	d, sockPath := testDaemon(t)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- d.Serve(sockPath)
+	}()
+	waitForSocket(t, sockPath)
+
+	client := dialRPC(t, sockPath)
+	var resp StatusResp
+	if err := client.Call("Daemon.Shutdown", &Empty{}, &resp); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("Serve returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for Serve to return")
+	}
+}
+
+func waitForSocket(t *testing.T, sockPath string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(sockPath); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("socket %s did not appear", sockPath)
+}

--- a/internal/daemon/rpc.go
+++ b/internal/daemon/rpc.go
@@ -1,0 +1,150 @@
+package daemon
+
+import (
+	"github.com/drn/argus/internal/model"
+)
+
+// RPCService implements the JSON-RPC methods exposed by the daemon.
+type RPCService struct {
+	daemon *Daemon
+}
+
+// Ping verifies the daemon is responsive.
+func (s *RPCService) Ping(_ *Empty, resp *PongResp) error {
+	resp.OK = true
+	return nil
+}
+
+// StartSession starts a new agent session.
+func (s *RPCService) StartSession(req *StartReq, resp *StartResp) error {
+	task := &model.Task{
+		ID:        req.TaskID,
+		SessionID: req.SessionID,
+		Prompt:    req.Prompt,
+		Project:   req.Project,
+		Backend:   req.Backend,
+		Worktree:  req.Worktree,
+		Branch:    req.Branch,
+	}
+
+	cfg := s.daemon.db.Config()
+	sess, err := s.daemon.runner.Start(task, cfg, req.Rows, req.Cols, req.Resume)
+	if err != nil {
+		return err
+	}
+	resp.PID = sess.PID()
+	return nil
+}
+
+// StopSession stops a running session.
+func (s *RPCService) StopSession(req *TaskIDReq, resp *StatusResp) error {
+	if err := s.daemon.runner.Stop(req.TaskID); err != nil {
+		resp.Error = err.Error()
+		return nil
+	}
+	resp.OK = true
+	return nil
+}
+
+// StopAll stops all running sessions.
+func (s *RPCService) StopAll(_ *Empty, resp *StatusResp) error {
+	s.daemon.runner.StopAll()
+	resp.OK = true
+	return nil
+}
+
+// SessionStatus returns info about a single session.
+func (s *RPCService) SessionStatus(req *TaskIDReq, resp *SessionInfo) error {
+	sess := s.daemon.runner.Get(req.TaskID)
+	if sess == nil {
+		resp.TaskID = req.TaskID
+		return nil
+	}
+	cols, rows := sess.PTYSize()
+	resp.TaskID = req.TaskID
+	resp.Alive = sess.Alive()
+	resp.Idle = sess.IsIdle()
+	resp.PID = sess.PID()
+	resp.Cols = cols
+	resp.Rows = rows
+	resp.WorkDir = sess.WorkDir()
+	resp.TotalWritten = sess.TotalWritten()
+	return nil
+}
+
+// ListSessions returns info about all running sessions.
+func (s *RPCService) ListSessions(_ *Empty, resp *ListResp) error {
+	ids := s.daemon.runner.Running()
+	resp.Sessions = make([]SessionInfo, 0, len(ids))
+	for _, id := range ids {
+		sess := s.daemon.runner.Get(id)
+		if sess == nil {
+			continue
+		}
+		cols, rows := sess.PTYSize()
+		resp.Sessions = append(resp.Sessions, SessionInfo{
+			TaskID:       id,
+			Alive:        sess.Alive(),
+			Idle:         sess.IsIdle(),
+			PID:          sess.PID(),
+			Cols:         cols,
+			Rows:         rows,
+			WorkDir:      sess.WorkDir(),
+			TotalWritten: sess.TotalWritten(),
+		})
+	}
+	return nil
+}
+
+// WriteInput sends data to a session's PTY stdin.
+func (s *RPCService) WriteInput(req *WriteReq, resp *StatusResp) error {
+	sess := s.daemon.runner.Get(req.TaskID)
+	if sess == nil {
+		resp.Error = "session not found"
+		return nil
+	}
+	if _, err := sess.WriteInput(req.Data); err != nil {
+		resp.Error = err.Error()
+		return nil
+	}
+	resp.OK = true
+	return nil
+}
+
+// Resize changes a session's PTY dimensions.
+func (s *RPCService) Resize(req *ResizeReq, resp *StatusResp) error {
+	sess := s.daemon.runner.Get(req.TaskID)
+	if sess == nil {
+		resp.Error = "session not found"
+		return nil
+	}
+	if err := sess.Resize(req.Rows, req.Cols); err != nil {
+		resp.Error = err.Error()
+		return nil
+	}
+	resp.OK = true
+	return nil
+}
+
+// GetExitInfo returns cached exit info for a finished session.
+// Returns empty ExitInfo if the session is still running or info has expired.
+func (s *RPCService) GetExitInfo(req *TaskIDReq, resp *ExitInfo) error {
+	s.daemon.mu.Lock()
+	info, ok := s.daemon.exitInfos[req.TaskID]
+	if ok {
+		delete(s.daemon.exitInfos, req.TaskID) // consume once
+	}
+	s.daemon.mu.Unlock()
+
+	if ok {
+		*resp = info
+	}
+	return nil
+}
+
+// Shutdown initiates a graceful daemon shutdown.
+func (s *RPCService) Shutdown(_ *Empty, resp *StatusResp) error {
+	resp.OK = true
+	go s.daemon.Shutdown()
+	return nil
+}

--- a/internal/daemon/stream.go
+++ b/internal/daemon/stream.go
@@ -1,0 +1,54 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+)
+
+// handleStream processes a stream connection. The client sends a JSON
+// StreamHeader, then the daemon registers the connection as a writer on
+// the session. Output flows as raw bytes until the session exits or the
+// client disconnects.
+func (d *Daemon) handleStream(conn net.Conn) {
+	var header StreamHeader
+	dec := json.NewDecoder(conn)
+	if err := dec.Decode(&header); err != nil {
+		return
+	}
+
+	sess := d.runner.Get(header.TaskID)
+	if sess == nil {
+		return
+	}
+
+	d.registerStream(header.TaskID, conn)
+	defer d.unregisterStream(header.TaskID, conn)
+
+	// AddWriter replays the ring buffer and registers for live output.
+	sess.AddWriter(conn)
+	defer sess.RemoveWriter(conn)
+
+	// Block until the session exits or the client disconnects.
+	// We detect client disconnect by trying to read from the connection.
+	// The client doesn't send anything on the stream after the header,
+	// so a read will block until the connection is closed.
+	select {
+	case <-sess.Done():
+		// Session exited — the onFinish callback closes the connection.
+	case <-d.done:
+		// Daemon shutting down.
+	case <-waitForClose(conn):
+		// Client disconnected.
+	}
+}
+
+// waitForClose returns a channel that closes when the connection is closed.
+func waitForClose(conn net.Conn) <-chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		buf := make([]byte, 1)
+		conn.Read(buf) // blocks until close or error
+		close(ch)
+	}()
+	return ch
+}

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -1,0 +1,75 @@
+package daemon
+
+// StartReq is the RPC request to start a new agent session.
+type StartReq struct {
+	TaskID    string
+	SessionID string
+	Prompt    string
+	Project   string
+	Backend   string
+	Worktree  string
+	Branch    string
+	Rows      uint16
+	Cols      uint16
+	Resume    bool
+}
+
+// StartResp is the RPC response from starting a session.
+type StartResp struct {
+	PID int
+}
+
+// TaskIDReq is an RPC request that identifies a single task.
+type TaskIDReq struct {
+	TaskID string
+}
+
+// StatusResp is a generic success/error RPC response.
+type StatusResp struct {
+	OK    bool
+	Error string
+}
+
+// SessionInfo describes the state of a running session.
+type SessionInfo struct {
+	TaskID       string
+	Alive        bool
+	Idle         bool
+	PID          int
+	Cols         int
+	Rows         int
+	WorkDir      string
+	TotalWritten uint64
+}
+
+// WriteReq is the RPC request to send input to a session's PTY.
+type WriteReq struct {
+	TaskID string
+	Data   []byte
+}
+
+// ResizeReq is the RPC request to resize a session's PTY.
+type ResizeReq struct {
+	TaskID string
+	Rows   uint16
+	Cols   uint16
+}
+
+// StreamHeader is sent by the client on a stream connection to subscribe
+// to a session's output.
+type StreamHeader struct {
+	TaskID string `json:"task_id"`
+}
+
+// ListResp is the RPC response for listing all sessions.
+type ListResp struct {
+	Sessions []SessionInfo
+}
+
+// PongResp is the RPC response for a Ping request.
+type PongResp struct {
+	OK bool
+}
+
+// Empty is a placeholder for RPC methods that take no arguments.
+type Empty struct{}

--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -27,7 +27,7 @@ type AgentViewTickMsg struct{}
 // AgentView renders a three-panel layout: git status | agent terminal | file explorer.
 type AgentView struct {
 	theme    Theme
-	runner   *agent.Runner
+	runner   agent.SessionProvider
 	taskID   string
 	taskName string
 	focus    AgentPanel
@@ -71,7 +71,7 @@ type AgentView struct {
 	diffFileName  string            // current file being diffed (for highlighting)
 }
 
-func NewAgentView(theme Theme, runner *agent.Runner) AgentView {
+func NewAgentView(theme Theme, runner agent.SessionProvider) AgentView {
 	return AgentView{
 		theme:     theme,
 		runner:    runner,
@@ -554,7 +554,7 @@ func (av *AgentView) renderDiffPanel(w, h int) string {
 
 // renderIncremental feeds only new bytes to a persistent vt10x terminal,
 // avoiding the O(buffer_size) full replay on every render tick.
-func (av *AgentView) renderIncremental(sess *agent.Session, raw []byte, totalWritten uint64, panelW, panelH int) string {
+func (av *AgentView) renderIncremental(sess agent.SessionHandle, raw []byte, totalWritten uint64, panelW, panelH int) string {
 	dispW := max(panelW-4, 10)
 	dispH := max(panelH-4, 3)
 

--- a/internal/ui/preview.go
+++ b/internal/ui/preview.go
@@ -11,12 +11,12 @@ import (
 // Preview renders the agent output for the selected task.
 type Preview struct {
 	theme  Theme
-	runner *agent.Runner
+	runner agent.SessionProvider
 	width  int
 	height int
 }
 
-func NewPreview(theme Theme, runner *agent.Runner) Preview {
+func NewPreview(theme Theme, runner agent.SessionProvider) Preview {
 	return Preview{theme: theme, runner: runner}
 }
 

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -76,7 +76,7 @@ type PruneDoneMsg struct {
 // Model is the top-level Bubble Tea model.
 type Model struct {
 	db          *db.DB
-	runner      *agent.Runner
+	runner      agent.SessionProvider
 	keys        KeyMap
 	theme       Theme
 	tasklist    TaskList
@@ -102,7 +102,7 @@ type Model struct {
 	pruneTotal int // total worktrees being cleaned up
 }
 
-func NewModel(database *db.DB, runner *agent.Runner) Model {
+func NewModel(database *db.DB, runner agent.SessionProvider) Model {
 	theme := DefaultTheme()
 	keys := DefaultKeyMap()
 
@@ -151,40 +151,46 @@ func (m Model) Init() tea.Cmd {
 		}),
 	}
 
-	// Resume sessions for in-progress tasks that have a saved session ID.
-	// Each resume runs in a background goroutine so the UI stays responsive.
-	for _, t := range m.db.Tasks() {
-		if t.Status == model.StatusInProgress && t.SessionID != "" {
-			task := t // capture loop variable
+	// Check if the runner already has sessions (e.g., daemon client discovered them).
+	// If so, just sync state — don't try to resume.
+	daemonRunning := len(m.runner.Running()) > 0
 
-			// Kill any orphaned process from a previous Argus session.
-			// When Argus exits, PTY master fds close and children get SIGHUP,
-			// but we clean up any that might linger before resuming.
-			if task.AgentPID > 0 {
-				killStaleProcess(task.AgentPID)
-				task.AgentPID = 0
-			}
+	if !daemonRunning {
+		// Resume sessions for in-progress tasks that have a saved session ID.
+		// Each resume runs in a background goroutine so the UI stays responsive.
+		for _, t := range m.db.Tasks() {
+			if t.Status == model.StatusInProgress && t.SessionID != "" {
+				task := t // capture loop variable
 
-			// Backfill worktree path for tasks that don't have one stored.
-			if task.Worktree == "" && task.Name != "" && task.Project != "" {
-				if wt := discoverWorktree(task.Project, task.Name); wt != "" {
-					task.Worktree = wt
-					m.resolvedDirs[task.ID] = wt
+				// Kill any orphaned process from a previous Argus session.
+				// When Argus exits, PTY master fds close and children get SIGHUP,
+				// but we clean up any that might linger before resuming.
+				if task.AgentPID > 0 {
+					killStaleProcess(task.AgentPID)
+					task.AgentPID = 0
 				}
-			}
 
-			// Reset StartedAt before starting so the quick-exit check in
-			// handleAgentFinished uses the resume time, not the original start.
-			task.StartedAt = time.Now()
-			_ = m.db.Update(task)
-
-			cmds = append(cmds, func() tea.Msg {
-				sess, err := m.runner.Start(task, m.db.Config(), 24, 80, true)
-				if err != nil {
-					return SessionResumedMsg{TaskID: task.ID, Err: err}
+				// Backfill worktree path for tasks that don't have one stored.
+				if task.Worktree == "" && task.Name != "" && task.Project != "" {
+					if wt := discoverWorktree(task.Project, task.Name); wt != "" {
+						task.Worktree = wt
+						m.resolvedDirs[task.ID] = wt
+					}
 				}
-				return SessionResumedMsg{TaskID: task.ID, PID: sess.PID()}
-			})
+
+				// Reset StartedAt before starting so the quick-exit check in
+				// handleAgentFinished uses the resume time, not the original start.
+				task.StartedAt = time.Now()
+				_ = m.db.Update(task)
+
+				cmds = append(cmds, func() tea.Msg {
+					sess, err := m.runner.Start(task, m.db.Config(), 24, 80, true)
+					if err != nil {
+						return SessionResumedMsg{TaskID: task.ID, Err: err}
+					}
+					return SessionResumedMsg{TaskID: task.ID, PID: sess.PID()}
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
Split Argus into a long-lived daemon (owns PTY sessions) and an ephemeral TUI client so sessions survive TUI restarts.

- Extract SessionProvider/SessionHandle interfaces decoupling UI from concrete types
- Multi-writer Session support with replay-before-register ordering
- Daemon core: Unix socket IPC (JSON-RPC + raw stream), PID file, signal handling
- RPC service: Start/Stop/List sessions, WriteInput, Resize, GetExitInfo, Shutdown
- Daemon client implementing SessionProvider with local RingBuffer and stream reader
- ExitInfo caching for correct Err/Stopped/LastOutput propagation in daemon mode
- TUI gracefully falls back to in-process runner when no daemon is running

Co-Authored-By: Claude <noreply@anthropic.com>