### PR TITLE
Display human-readable status names in task detail panel

### DIFF
--- a/internal/model/status.go
+++ b/internal/model/status.go
@@ -19,6 +19,13 @@ var statusNames = [...]string{
 	"complete",
 }
 
+var statusDisplayNames = [...]string{
+	"Pending",
+	"In Progress",
+	"In Review",
+	"Complete",
+}
+
 var statusDisplay = [...]string{
 	"\uF10C",
 	"\uF10C",
@@ -46,6 +53,14 @@ var statusDisplayAlt = [...]string{
 	"\uF192", // dot-circle-o: alternate frame for in_progress
 	"\uF06E",
 	"\uF00C",
+}
+
+// DisplayName returns a human-readable name like "In Progress".
+func (s Status) DisplayName() string {
+	if int(s) < len(statusDisplayNames) {
+		return statusDisplayNames[s]
+	}
+	return s.String()
 }
 
 func (s Status) Display() string {

--- a/internal/model/status_test.go
+++ b/internal/model/status_test.go
@@ -23,6 +23,24 @@ func TestStatus_String(t *testing.T) {
 	}
 }
 
+func TestStatus_DisplayName(t *testing.T) {
+	tests := []struct {
+		s    Status
+		want string
+	}{
+		{StatusPending, "Pending"},
+		{StatusInProgress, "In Progress"},
+		{StatusInReview, "In Review"},
+		{StatusComplete, "Complete"},
+		{Status(99), "unknown(99)"},
+	}
+	for _, tt := range tests {
+		if got := tt.s.DisplayName(); got != tt.want {
+			t.Errorf("Status(%d).DisplayName() = %q, want %q", tt.s, got, tt.want)
+		}
+	}
+}
+
 func TestStatus_Display(t *testing.T) {
 	if got := StatusPending.Display(); got != "\uF10C" {
 		t.Errorf("Pending.Display() = %q", got)

--- a/internal/ui/taskdetail.go
+++ b/internal/ui/taskdetail.go
@@ -45,7 +45,7 @@ func (d TaskDetail) View(t *model.Task, running bool) string {
 
 	// Status with running/idle indicator
 	statusStyle := d.statusStyle(t.Status)
-	statusLabel := t.Status.String()
+	statusLabel := t.Status.DisplayName()
 	if t.Status == model.StatusInProgress {
 		if running {
 			statusLabel += " (running)"

--- a/internal/ui/taskdetail_test.go
+++ b/internal/ui/taskdetail_test.go
@@ -27,7 +27,7 @@ func TestTaskDetailView(t *testing.T) {
 
 	checks := []string{
 		"fix-login-bug",
-		"in_progress",
+		"In Progress",
 		"running",
 		"myapp",
 		"argus/fix-login-bug",


### PR DESCRIPTION
Add DisplayName() method to Status returning clean names ("In Progress" instead of "in_progress"). Used in the right pane TaskDetail view for better readability.

Co-Authored-By: Claude <noreply@anthropic.com>