### PR TITLE
Add file-open shortcuts to agent view files pane

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"fmt"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -245,6 +247,12 @@ func (av *AgentView) HandleKey(msg tea.KeyMsg) (detach bool, cmd tea.Cmd) {
 			av.files.CursorDown()
 		case "enter":
 			return false, av.openFileDiff()
+		case "o":
+			return false, av.openInFinder()
+		case "e":
+			return false, av.openInEditor()
+		case "t":
+			return false, av.openTerminal()
 		}
 	}
 	return false, nil
@@ -283,6 +291,44 @@ func (av *AgentView) openFileDiff() tea.Cmd {
 	path := f.Path
 	return func() tea.Msg {
 		return FetchFileDiff(taskID, dir, path)
+	}
+}
+
+// openInFinder opens Finder to the selected file's location.
+func (av *AgentView) openInFinder() tea.Cmd {
+	f := av.files.SelectedFile()
+	if f == nil || av.worktreeDir == "" {
+		return nil
+	}
+	fullPath := filepath.Join(av.worktreeDir, f.Path)
+	return func() tea.Msg {
+		exec.Command("open", "-R", fullPath).Start()
+		return nil
+	}
+}
+
+// openInEditor opens a new tmux tab with nvim editing the selected file.
+func (av *AgentView) openInEditor() tea.Cmd {
+	f := av.files.SelectedFile()
+	if f == nil || av.worktreeDir == "" {
+		return nil
+	}
+	fullPath := filepath.Join(av.worktreeDir, f.Path)
+	return func() tea.Msg {
+		exec.Command("tmux", "new-window", "nvim", fullPath).Start()
+		return nil
+	}
+}
+
+// openTerminal opens a new tmux tab cd'd to the worktree directory.
+func (av *AgentView) openTerminal() tea.Cmd {
+	if av.worktreeDir == "" {
+		return nil
+	}
+	dir := av.worktreeDir
+	return func() tea.Msg {
+		exec.Command("tmux", "new-window", "-c", dir).Start()
+		return nil
 	}
 }
 

--- a/internal/ui/agentview_test.go
+++ b/internal/ui/agentview_test.go
@@ -948,6 +948,77 @@ func TestAgentView_FilesPanelEscRefocusesAgent(t *testing.T) {
 	}
 }
 
+func TestAgentView_FilesPanelOpenKeys(t *testing.T) {
+	av := newTestAgentView()
+	av.focus = panelFiles
+	av.worktreeDir = "/tmp/test-worktree"
+	av.files.SetFiles([]ChangedFile{
+		{Status: "M", Path: "main.go"},
+	})
+
+	// "o" returns a command (open in finder)
+	_, cmd := av.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	if cmd == nil {
+		t.Error("expected non-nil cmd for 'o' key")
+	}
+
+	// "e" returns a command (open in editor)
+	_, cmd = av.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	if cmd == nil {
+		t.Error("expected non-nil cmd for 'e' key")
+	}
+
+	// "t" returns a command (open terminal)
+	_, cmd = av.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	if cmd == nil {
+		t.Error("expected non-nil cmd for 't' key")
+	}
+}
+
+func TestAgentView_FilesPanelOpenKeys_NilWithoutWorktree(t *testing.T) {
+	av := newTestAgentView()
+	av.focus = panelFiles
+	av.worktreeDir = ""
+	av.files.SetFiles([]ChangedFile{
+		{Status: "M", Path: "main.go"},
+	})
+
+	// All keys return nil when no worktree dir
+	_, cmd := av.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	if cmd != nil {
+		t.Error("expected nil cmd for 'o' with no worktree dir")
+	}
+	_, cmd = av.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	if cmd != nil {
+		t.Error("expected nil cmd for 'e' with no worktree dir")
+	}
+	_, cmd = av.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	if cmd != nil {
+		t.Error("expected nil cmd for 't' with no worktree dir")
+	}
+}
+
+func TestAgentView_FilesPanelOpenKeys_NilWithNoFile(t *testing.T) {
+	av := newTestAgentView()
+	av.focus = panelFiles
+	av.worktreeDir = "/tmp/test-worktree"
+	// No files set
+
+	_, cmd := av.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	if cmd != nil {
+		t.Error("expected nil cmd for 'o' with no files")
+	}
+	_, cmd = av.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	if cmd != nil {
+		t.Error("expected nil cmd for 'e' with no files")
+	}
+	// "t" should still work — it only needs worktreeDir, not a selected file
+	_, cmd = av.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	if cmd == nil {
+		t.Error("expected non-nil cmd for 't' even with no files")
+	}
+}
+
 func TestAgentView_DiffMode_CtrlQExitsDiff(t *testing.T) {
 	av := newTestAgentView()
 	av.diffMode = true


### PR DESCRIPTION
Add keybindings in the files changed panel: 'o' opens Finder, 'e' opens nvim in a tmux tab, 't' opens a terminal in the worktree directory.

Co-Authored-By: Claude <noreply@anthropic.com>