### PR TITLE
Show iterative progress during worktree cleanup

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/drn/argus/internal/agent"
+	"github.com/drn/argus/internal/config"
 	"github.com/drn/argus/internal/db"
 	"github.com/drn/argus/internal/model"
 )
@@ -68,6 +69,14 @@ type SessionResumedMsg struct {
 	Err    error
 }
 
+// PruneProgressMsg signals that one worktree was cleaned; remaining work follows.
+type PruneProgressMsg struct {
+	Current   int           // 1-based index of the one just completed
+	Total     int           // total worktrees to clean
+	Remaining []*model.Task // tasks still to clean
+	Cfg       config.Config // config snapshot for resolving dirs
+}
+
 // PruneDoneMsg signals that all prune cleanup is finished.
 type PruneDoneMsg struct {
 	Count int
@@ -100,7 +109,8 @@ type Model struct {
 	resolvedDirs       map[string]string // taskID → resolved worktree dir (cache)
 
 	// Prune progress state (shown in viewPruning modal)
-	pruneTotal int // total worktrees being cleaned up
+	pruneTotal   int // total worktrees being cleaned up
+	pruneCurrent int // number completed so far (0 = starting)
 }
 
 // NewModel creates the top-level model. Set daemonConnected to true when the
@@ -306,6 +316,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case AgentFinishedMsg:
 		return m.handleAgentFinished(msg)
 
+	case PruneProgressMsg:
+		m.pruneCurrent = msg.Current
+		if len(msg.Remaining) == 0 {
+			// All done.
+			m.current = viewTaskList
+			m.refreshTasks()
+			return m, nil
+		}
+		// Clean next worktree.
+		return m, pruneNextCmd(msg.Current, msg.Total, msg.Remaining, msg.Cfg)
+
 	case PruneDoneMsg:
 		m.current = viewTaskList
 		m.refreshTasks()
@@ -505,20 +526,30 @@ func (m Model) handleTaskListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		// Show progress modal and run cleanup async.
+		// Show progress modal and run cleanup iteratively.
 		m.pruneTotal = len(toClean)
+		m.pruneCurrent = 0
 		m.current = viewPruning
 
-		return m, func() tea.Msg {
-			for _, t := range toClean {
-				repoDir := agent.ResolveDir(t, cfg)
-				removeWorktreeAndBranch(t.Worktree, t.Branch, repoDir)
-			}
-			return PruneDoneMsg{Count: len(toClean)}
-		}
+		return m, pruneNextCmd(0, len(toClean), toClean, cfg)
 	}
 
 	return m, nil
+}
+
+// pruneNextCmd cleans one worktree and returns a PruneProgressMsg with the remainder.
+func pruneNextCmd(done, total int, remaining []*model.Task, cfg config.Config) tea.Cmd {
+	return func() tea.Msg {
+		t := remaining[0]
+		repoDir := agent.ResolveDir(t, cfg)
+		removeWorktreeAndBranch(t.Worktree, t.Branch, repoDir)
+		return PruneProgressMsg{
+			Current:   done + 1,
+			Total:     total,
+			Remaining: remaining[1:],
+			Cfg:       cfg,
+		}
+	}
 }
 
 func (m Model) attachAgent() (tea.Model, tea.Cmd) {

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -140,8 +140,29 @@ func TestPruneCompleted_WithWorktrees_ShowsModal(t *testing.T) {
 		t.Error("expected non-nil cmd for async cleanup")
 	}
 
-	// Simulate PruneDoneMsg
-	updated, _ = um.Update(PruneDoneMsg{Count: 2})
+	// Simulate iterative progress — first worktree done, one remaining
+	updated, cmd = um.Update(PruneProgressMsg{
+		Current:   1,
+		Total:     2,
+		Remaining: []*model.Task{{ID: "t3", Name: "done2", Status: model.StatusComplete, Worktree: "/tmp/fake-wt-2"}},
+	})
+	um = updated.(Model)
+	if um.current != viewPruning {
+		t.Errorf("expected viewPruning during progress, got %d", um.current)
+	}
+	if um.pruneCurrent != 1 {
+		t.Errorf("expected pruneCurrent=1, got %d", um.pruneCurrent)
+	}
+	if cmd == nil {
+		t.Error("expected non-nil cmd for next cleanup step")
+	}
+
+	// Simulate final progress — all done
+	updated, _ = um.Update(PruneProgressMsg{
+		Current:   2,
+		Total:     2,
+		Remaining: nil,
+	})
 	um = updated.(Model)
 	if um.current != viewTaskList {
 		t.Errorf("expected viewTaskList after prune done, got %d", um.current)
@@ -164,6 +185,14 @@ func TestPruneView_Renders(t *testing.T) {
 	}
 	if !strings.Contains(v, "3") {
 		t.Error("pruneView should show the worktree count")
+	}
+
+	// With progress, should show "(2/5)" format
+	m.pruneCurrent = 2
+	m.pruneTotal = 5
+	v = m.View()
+	if !strings.Contains(v, "2/5") {
+		t.Error("pruneView with progress should show '2/5'")
 	}
 }
 

--- a/internal/ui/root_views.go
+++ b/internal/ui/root_views.go
@@ -269,9 +269,13 @@ func (m Model) pruneView() string {
 	// Spinner-like dots that animate with the 1s tick
 	dots := []string{".", "..", "..."}
 	dotIdx := int(time.Now().UnixMilli()/500) % len(dots)
-	status := "  " + m.theme.Normal.Render(
-		fmt.Sprintf("Cleaning up %d worktree(s)%s", m.pruneTotal, dots[dotIdx]),
-	)
+	var statusText string
+	if m.pruneCurrent == 0 {
+		statusText = fmt.Sprintf("Cleaning up %d worktree(s)%s", m.pruneTotal, dots[dotIdx])
+	} else {
+		statusText = fmt.Sprintf("Cleaning up worktrees (%d/%d)%s", m.pruneCurrent, m.pruneTotal, dots[dotIdx])
+	}
+	status := "  " + m.theme.Normal.Render(statusText)
 	hint := m.theme.Help.Render("  Removing worktrees and branches")
 	body := title + "\n\n" + status + "\n\n" + hint
 	return m.renderCenteredModal(body, 50)


### PR DESCRIPTION
Instead of a static count, the prune modal now displays incremental progress (e.g. "2/7") as each worktree is removed. Cleanup processes one worktree per tea.Cmd cycle via PruneProgressMsg chaining.

Co-Authored-By: Claude <noreply@anthropic.com>