### PR TITLE
Add daemon logs viewer in Settings

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -32,6 +33,7 @@ const (
 	viewAgent
 	viewSandboxInstall
 	viewDaemonRestart
+	viewDaemonLogs
 )
 
 type tab int
@@ -101,6 +103,12 @@ type DaemonRestartedMsg struct {
 	Err    error
 }
 
+// DaemonLogsMsg carries the loaded daemon log lines.
+type DaemonLogsMsg struct {
+	Lines []string
+	Err   error
+}
+
 // Model is the top-level Bubble Tea model.
 type Model struct {
 	db          *db.DB
@@ -136,6 +144,10 @@ type Model struct {
 	sandboxInstallPending *model.Task // task to start after install completes
 	sandboxInstalling     bool        // true while npm install is running
 	sandboxInstallResult  string      // install output or error
+
+	// Daemon log viewer state
+	daemonLogLines  []string // lines of the daemon log file
+	daemonLogOffset int      // scroll offset for log viewer
 
 	// program is set by SetProgram so daemon restart can register
 	// OnSessionExit on the new client. Shared via pointer indirection
@@ -363,6 +375,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.current == viewAgent {
 			m.agentview.HandleMouse(msg)
 		}
+		if m.current == viewDaemonLogs {
+			m.handleDaemonLogsMouse(msg)
+		}
 		return m, nil
 
 	case SessionResumedMsg:
@@ -447,6 +462,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.refreshSettings()
 		return m, nil
 
+	case DaemonLogsMsg:
+		if msg.Err != nil {
+			m.statusbar.SetError("failed to read daemon log: " + msg.Err.Error())
+			return m, nil
+		}
+		m.daemonLogLines = msg.Lines
+		m.daemonLogOffset = max(0, len(msg.Lines)-m.daemonLogVisibleLines())
+		m.current = viewDaemonLogs
+		return m, nil
+
 	case AgentDetachedMsg:
 		// User detached — agent still running in background
 		m.refreshTasks()
@@ -478,6 +503,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleConfirmDestroyKey(msg)
 	case viewConfirmDeleteProject:
 		return m.handleConfirmDeleteProjectKey(msg)
+	case viewDaemonLogs:
+		return m.handleDaemonLogsKey(msg)
 	case viewPruning, viewDaemonRestart:
 		// Absorb all keys while pruning or restarting — no interaction allowed.
 		return m, nil
@@ -993,6 +1020,9 @@ func (m Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			agent.ResetSandboxCache()
 			m.refreshSettings()
 		}
+		if sel != nil && sel.kind == settingsRowDaemonLogs {
+			return m, m.loadDaemonLogsCmd()
+		}
 		return m, nil
 
 	case key.Matches(msg, m.keys.Delete):
@@ -1211,4 +1241,112 @@ func (m *Model) refreshTasks() {
 	m.statusbar.SetRunning(running)
 }
 
+// loadDaemonLogsCmd returns a tea.Cmd that reads the daemon log file.
+func (m Model) loadDaemonLogsCmd() tea.Cmd {
+	return func() tea.Msg {
+		logPath := filepath.Join(db.DataDir(), "daemon.log")
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			return DaemonLogsMsg{Err: err}
+		}
+		lines := strings.Split(string(data), "\n")
+		// Cap to last 1000 lines to keep memory reasonable.
+		if len(lines) > 1000 {
+			lines = lines[len(lines)-1000:]
+		}
+		return DaemonLogsMsg{Lines: lines}
+	}
+}
 
+// daemonLogVisibleLines returns the number of log lines visible in the modal.
+func (m Model) daemonLogVisibleLines() int {
+	// Modal height is ~80% of screen, minus borders/padding/title/hint.
+	h := m.height * 8 / 10
+	h -= 6 // title, hint, padding, borders
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+func (m Model) handleDaemonLogsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEscape, tea.KeyEnter:
+		m.daemonLogLines = nil
+		m.daemonLogOffset = 0
+		m.current = viewTaskList
+		m.activeTab = tabSettings
+		return m, nil
+	case tea.KeyUp:
+		if m.daemonLogOffset > 0 {
+			m.daemonLogOffset--
+		}
+		return m, nil
+	case tea.KeyDown:
+		maxOff := len(m.daemonLogLines) - m.daemonLogVisibleLines()
+		if maxOff < 0 {
+			maxOff = 0
+		}
+		if m.daemonLogOffset < maxOff {
+			m.daemonLogOffset++
+		}
+		return m, nil
+	case tea.KeyPgUp:
+		m.daemonLogOffset -= m.daemonLogVisibleLines()
+		if m.daemonLogOffset < 0 {
+			m.daemonLogOffset = 0
+		}
+		return m, nil
+	case tea.KeyPgDown:
+		m.daemonLogOffset += m.daemonLogVisibleLines()
+		maxOff := len(m.daemonLogLines) - m.daemonLogVisibleLines()
+		if maxOff < 0 {
+			maxOff = 0
+		}
+		if m.daemonLogOffset > maxOff {
+			m.daemonLogOffset = maxOff
+		}
+		return m, nil
+	case tea.KeyHome:
+		m.daemonLogOffset = 0
+		return m, nil
+	case tea.KeyEnd:
+		maxOff := len(m.daemonLogLines) - m.daemonLogVisibleLines()
+		if maxOff < 0 {
+			maxOff = 0
+		}
+		m.daemonLogOffset = maxOff
+		return m, nil
+	}
+
+	// q also closes
+	if msg.String() == "q" {
+		m.daemonLogLines = nil
+		m.daemonLogOffset = 0
+		m.current = viewTaskList
+		m.activeTab = tabSettings
+		return m, nil
+	}
+
+	return m, nil
+}
+
+func (m *Model) handleDaemonLogsMouse(msg tea.MouseMsg) {
+	visible := m.daemonLogVisibleLines()
+	maxOff := len(m.daemonLogLines) - visible
+	if maxOff < 0 {
+		maxOff = 0
+	}
+	switch msg.Button {
+	case tea.MouseButtonWheelUp:
+		m.daemonLogOffset -= 3
+		if m.daemonLogOffset < 0 {
+			m.daemonLogOffset = 0
+		}
+	case tea.MouseButtonWheelDown:
+		m.daemonLogOffset += 3
+		if m.daemonLogOffset > maxOff {
+			m.daemonLogOffset = maxOff
+		}
+	}
+}

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -752,6 +752,7 @@ func TestDeleteProject_EnterConfirms(t *testing.T) {
 	m := testModelWithProjects(t, projects)
 	m.activeTab = tabSettings
 	// Navigate cursor to the project row (past status and sandbox sections).
+	m.settings.CursorDown() // daemon logs
 	m.settings.CursorDown() // sandbox
 	m.settings.CursorDown() // project
 	m.current = viewConfirmDeleteProject
@@ -775,6 +776,7 @@ func TestDeleteProject_EscCancels(t *testing.T) {
 	}
 	m := testModelWithProjects(t, projects)
 	m.activeTab = tabSettings
+	m.settings.CursorDown() // daemon logs
 	m.settings.CursorDown() // sandbox
 	m.settings.CursorDown() // project
 	m.current = viewConfirmDeleteProject
@@ -798,6 +800,7 @@ func TestDeleteProject_YKeyNoLongerConfirms(t *testing.T) {
 	}
 	m := testModelWithProjects(t, projects)
 	m.activeTab = tabSettings
+	m.settings.CursorDown() // daemon logs
 	m.settings.CursorDown() // sandbox
 	m.settings.CursorDown() // project
 	m.current = viewConfirmDeleteProject
@@ -821,6 +824,7 @@ func TestDeleteProject_ModalView(t *testing.T) {
 	}
 	m := testModelWithProjects(t, projects)
 	m.activeTab = tabSettings
+	m.settings.CursorDown() // daemon logs
 	m.settings.CursorDown() // sandbox
 	m.settings.CursorDown() // project
 	m.current = viewConfirmDeleteProject
@@ -1239,6 +1243,7 @@ func TestModel_NewProjectKey(t *testing.T) {
 	m := testModel(t)
 	m.activeTab = tabSettings
 	// Navigate cursor to a project row so 'n' opens the new project form.
+	m.settings.CursorDown() // daemon logs
 	m.settings.CursorDown() // sandbox
 	m.settings.CursorDown() // project (or "(no projects)" placeholder)
 
@@ -1593,6 +1598,7 @@ func TestModel_ViewZeroDimensions(t *testing.T) {
 		{"sandboxInstalling", func(m *Model) { m.current = viewSandboxInstall; m.sandboxInstalling = true }},
 		{"sandboxInstallDone", func(m *Model) { m.current = viewSandboxInstall; m.sandboxInstallResult = "Installed" }},
 		{"daemonRestart", func(m *Model) { m.current = viewDaemonRestart; m.daemonRestarting = true }},
+		{"daemonLogs", func(m *Model) { m.current = viewDaemonLogs; m.daemonLogLines = []string{"test log line"} }},
 	}
 	for _, tc := range views {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/ui/root_views.go
+++ b/internal/ui/root_views.go
@@ -33,6 +33,8 @@ func (m Model) View() string {
 		return m.sandboxInstallView() + "\n" + bar
 	case viewDaemonRestart:
 		return m.daemonRestartView() + "\n" + bar
+	case viewDaemonLogs:
+		return m.daemonLogsView() + "\n" + bar
 	case viewHelp:
 		return m.padToBottom(m.helpview.View(), bar)
 	case viewPrompt:
@@ -293,6 +295,62 @@ func (m Model) daemonRestartView() string {
 	hint := m.theme.Help.Render("  Please wait")
 	body := title + "\n\n" + status + "\n\n" + hint
 	return m.renderCenteredModal(body, 50)
+}
+
+func (m Model) daemonLogsView() string {
+	visible := m.daemonLogVisibleLines()
+	totalLines := len(m.daemonLogLines)
+
+	title := m.theme.Title.Render("Daemon Logs")
+
+	// Scroll indicator
+	var scrollInfo string
+	if totalLines > visible {
+		end := m.daemonLogOffset + visible
+		if end > totalLines {
+			end = totalLines
+		}
+		scrollInfo = m.theme.Dimmed.Render(fmt.Sprintf("  lines %d-%d of %d", m.daemonLogOffset+1, end, totalLines))
+	}
+
+	// Build log content
+	var logContent strings.Builder
+	end := m.daemonLogOffset + visible
+	if end > totalLines {
+		end = totalLines
+	}
+	start := m.daemonLogOffset
+	if start < 0 {
+		start = 0
+	}
+	for i := start; i < end; i++ {
+		line := m.daemonLogLines[i]
+		logContent.WriteString("  " + m.theme.Dimmed.Render(line) + "\n")
+	}
+	// Pad remaining lines
+	rendered := end - start
+	for i := rendered; i < visible; i++ {
+		logContent.WriteString("\n")
+	}
+
+	hint := m.theme.Help.Render("  [esc/enter/q] close  [↑↓] scroll  [pgup/pgdn] page  [home/end] jump")
+
+	body := title + scrollInfo + "\n\n" + logContent.String() + "\n" + hint
+	w := m.width * 8 / 10
+	if w < 40 {
+		w = 40
+	}
+	if m.width > 0 && w > m.width-4 {
+		w = m.width - 4
+	}
+
+	modal := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("238")).
+		Padding(1, 2).
+		Width(w).
+		Render(body)
+	return lipgloss.Place(m.width, m.height-1, lipgloss.Center, lipgloss.Center, modal)
 }
 
 func (m Model) sandboxInstallView() string {

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -18,6 +18,7 @@ const (
 	settingsRowProject                         // project item
 	settingsRowBackend                         // backend item
 	settingsRowSandbox                         // sandbox config item
+	settingsRowDaemonLogs                      // daemon logs item
 )
 
 type settingsRow struct {
@@ -137,6 +138,9 @@ func (sv *SettingsView) rebuildRows() {
 			sv.rows = append(sv.rows, settingsRow{kind: settingsRowWarning, label: w, key: fmt.Sprintf("_warn_%d", i)})
 		}
 	}
+
+	// DAEMON LOGS row (in STATUS section)
+	sv.rows = append(sv.rows, settingsRow{kind: settingsRowDaemonLogs, label: "Daemon Logs", key: "_logs"})
 
 	// SANDBOX section
 	sv.rows = append(sv.rows, settingsRow{kind: settingsRowSection, label: "SANDBOX"})
@@ -336,6 +340,8 @@ func (sv SettingsView) View() string {
 				} else {
 					icon = "  "
 				}
+			case settingsRowDaemonLogs:
+				icon = "  "
 			case settingsRowProject:
 				icon = "  "
 			case settingsRowBackend:
@@ -366,6 +372,8 @@ func (sv SettingsView) RenderDetail(rightWidth, contentHeight int) string {
 		content = sv.renderWarningDetail(sel, innerW)
 	case settingsRowSandbox:
 		content = sv.renderSandboxDetail(innerW)
+	case settingsRowDaemonLogs:
+		content = sv.renderDaemonLogsDetail(innerW)
 	case settingsRowProject:
 		content = sv.renderProjectDetail(sel, innerW)
 	case settingsRowBackend:
@@ -381,6 +389,14 @@ func (sv SettingsView) RenderDetail(rightWidth, contentHeight int) string {
 	}
 
 	return borderedPanel(rightWidth, contentHeight, false, content)
+}
+
+func (sv SettingsView) renderDaemonLogsDetail(_ int) string {
+	var b strings.Builder
+	b.WriteString(sv.theme.Title.Render(" Daemon Logs") + "\n\n")
+	b.WriteString("  " + sv.theme.Dimmed.Render("View recent daemon log output.") + "\n\n")
+	b.WriteString("  " + sv.theme.Help.Render("Press [enter] to open log viewer") + "\n")
+	return b.String()
 }
 
 func (sv SettingsView) renderSandboxDetail(_ int) string {

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -87,21 +88,29 @@ func TestSettingsView_CursorNavigation(t *testing.T) {
 		t.Errorf("expected initial selection to be warning row, got kind %d", sel.kind)
 	}
 
+	// Move down — should land on daemon logs row
+	sv.CursorDown()
+	sel = sv.Selected()
+	if sel == nil || sel.kind != settingsRowDaemonLogs {
+		t.Errorf("expected cursor to be on daemon logs row after first down, got kind %d", sel.kind)
+	}
+
 	// Move down — should land on sandbox row (skipping section header)
 	sv.CursorDown()
 	sel = sv.Selected()
 	if sel == nil || sel.kind != settingsRowSandbox {
-		t.Errorf("expected cursor to be on sandbox row after first down, got kind %d", sel.kind)
+		t.Errorf("expected cursor to be on sandbox row after second down, got kind %d", sel.kind)
 	}
 
 	// Move down again — should land on a project row (skipping section header)
 	sv.CursorDown()
 	sel = sv.Selected()
 	if sel == nil || sel.kind != settingsRowProject {
-		t.Error("expected cursor to be on a project row after second down")
+		t.Error("expected cursor to be on a project row after third down")
 	}
 
-	// Move up twice — should go back to status row
+	// Move up three times — should go back to status row
+	sv.CursorUp()
 	sv.CursorUp()
 	sv.CursorUp()
 	sel = sv.Selected()
@@ -119,7 +128,8 @@ func TestSettingsView_SelectedProject(t *testing.T) {
 	})
 	sv.SetBackends(nil)
 
-	// Move past sandbox to project row
+	// Move past daemon logs and sandbox to project row
+	sv.CursorDown() // daemon logs
 	sv.CursorDown() // sandbox
 	sv.CursorDown() // project
 	proj := sv.SelectedProject()
@@ -140,7 +150,8 @@ func TestSettingsView_SelectedBackend(t *testing.T) {
 		"claude": {Command: "claude --skip"},
 	})
 
-	// Move past status, sandbox, and empty projects to backend row
+	// Move past status, daemon logs, sandbox, and empty projects to backend row
+	sv.CursorDown() // daemon logs
 	sv.CursorDown() // sandbox
 	sv.CursorDown() // (no projects) placeholder
 	sv.CursorDown() // claude backend
@@ -175,6 +186,7 @@ func TestSettingsView_RenderDetail_Project(t *testing.T) {
 	})
 	sv.SetBackends(nil)
 
+	sv.CursorDown() // daemon logs
 	sv.CursorDown() // sandbox
 	sv.CursorDown() // move to project
 	detail := sv.RenderDetail(60, 20)
@@ -195,6 +207,7 @@ func TestSettingsView_RenderDetail_Backend(t *testing.T) {
 		"claude": {Command: "claude --skip"},
 	})
 
+	sv.CursorDown() // daemon logs
 	sv.CursorDown() // sandbox
 	sv.CursorDown() // (no projects)
 	sv.CursorDown() // claude backend
@@ -261,6 +274,7 @@ func TestSettingsView_SandboxDetail(t *testing.T) {
 	sv.SetSandboxConfig(true, true, []string{"github.com"}, []string{"/secrets"}, []string{"~/.cache"})
 
 	// Navigate to sandbox row
+	sv.CursorDown() // daemon logs
 	sv.CursorDown() // sandbox row
 	detail := sv.RenderDetail(60, 20)
 	if !strings.Contains(detail, "Sandbox") {
@@ -284,6 +298,7 @@ func TestSettingsView_SandboxDetailUnavailable(t *testing.T) {
 	sv.SetSandboxConfig(true, false, nil, nil, nil)
 
 	// Navigate to sandbox row
+	sv.CursorDown() // daemon logs
 	sv.CursorDown()
 	detail := sv.RenderDetail(60, 20)
 	if !strings.Contains(detail, "srt not found") {
@@ -358,7 +373,8 @@ func TestModel_SandboxToggle(t *testing.T) {
 	m.refreshSettings()
 
 	// Navigate to sandbox row (down from initial "All systems nominal")
-	m.settings.CursorDown()
+	m.settings.CursorDown() // daemon logs
+	m.settings.CursorDown() // sandbox
 	sel := m.settings.Selected()
 	if sel == nil || sel.kind != settingsRowSandbox {
 		t.Fatalf("expected cursor on sandbox row, got %v", sel)
@@ -393,6 +409,279 @@ func TestModel_SandboxToggle(t *testing.T) {
 	cfg = m.db.Config()
 	if cfg.Sandbox.Enabled {
 		t.Error("expected sandbox disabled after second Enter toggle")
+	}
+}
+
+func TestSettingsView_DaemonLogsRow(t *testing.T) {
+	sv := NewSettingsView(DefaultTheme())
+	sv.SetSize(40, 30)
+	sv.SetWarnings(nil)
+	sv.SetProjects(nil)
+	sv.SetBackends(nil)
+
+	view := sv.View()
+	if !strings.Contains(view, "Daemon Logs") {
+		t.Error("expected 'Daemon Logs' row in settings view")
+	}
+}
+
+func TestSettingsView_DaemonLogsDetail(t *testing.T) {
+	sv := NewSettingsView(DefaultTheme())
+	sv.SetSize(40, 30)
+	sv.SetWarnings(nil)
+	sv.SetProjects(nil)
+	sv.SetBackends(nil)
+
+	// Navigate to daemon logs row (down from status "all good")
+	sv.CursorDown() // daemon logs row
+	sel := sv.Selected()
+	if sel == nil || sel.kind != settingsRowDaemonLogs {
+		t.Fatal("expected cursor on daemon logs row")
+	}
+
+	detail := sv.RenderDetail(60, 20)
+	if !strings.Contains(detail, "Daemon Logs") {
+		t.Error("expected 'Daemon Logs' in detail panel")
+	}
+	if !strings.Contains(detail, "enter") {
+		t.Error("expected enter hint in detail panel")
+	}
+}
+
+func TestModel_DaemonLogsView(t *testing.T) {
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	runner := agent.NewRunner(nil)
+	m := NewModel(database, runner, false)
+	m.current = viewDaemonLogs
+	m.width = 80
+	m.height = 24
+	m.daemonLogLines = []string{
+		"2026-03-15 daemon listening on /tmp/daemon.sock",
+		"2026-03-15 session started: task-1",
+		"2026-03-15 session finished: task-1",
+	}
+	m.daemonLogOffset = 0
+
+	view := m.View()
+	if !strings.Contains(view, "Daemon Logs") {
+		t.Error("expected 'Daemon Logs' title")
+	}
+	if !strings.Contains(view, "daemon listening") {
+		t.Error("expected log content in view")
+	}
+	if !strings.Contains(view, "esc") {
+		t.Error("expected close hint")
+	}
+}
+
+func TestModel_DaemonLogsScroll(t *testing.T) {
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	runner := agent.NewRunner(nil)
+	m := NewModel(database, runner, false)
+	m.current = viewDaemonLogs
+	m.width = 80
+	m.height = 24
+
+	// Generate enough lines to require scrolling
+	lines := make([]string, 100)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("log line %d", i)
+	}
+	m.daemonLogLines = lines
+	m.daemonLogOffset = 0
+
+	// Scroll down
+	downMsg := tea.KeyMsg{Type: tea.KeyDown}
+	updated, _ := m.handleDaemonLogsKey(downMsg)
+	m = updated.(Model)
+	if m.daemonLogOffset != 1 {
+		t.Errorf("expected offset 1 after down, got %d", m.daemonLogOffset)
+	}
+
+	// Scroll up
+	upMsg := tea.KeyMsg{Type: tea.KeyUp}
+	updated, _ = m.handleDaemonLogsKey(upMsg)
+	m = updated.(Model)
+	if m.daemonLogOffset != 0 {
+		t.Errorf("expected offset 0 after up, got %d", m.daemonLogOffset)
+	}
+
+	// Can't scroll past top
+	updated, _ = m.handleDaemonLogsKey(upMsg)
+	m = updated.(Model)
+	if m.daemonLogOffset != 0 {
+		t.Errorf("expected offset to stay 0, got %d", m.daemonLogOffset)
+	}
+
+	// Page down
+	pgDownMsg := tea.KeyMsg{Type: tea.KeyPgDown}
+	updated, _ = m.handleDaemonLogsKey(pgDownMsg)
+	m = updated.(Model)
+	if m.daemonLogOffset == 0 {
+		t.Error("expected offset > 0 after page down")
+	}
+}
+
+func TestModel_DaemonLogsMsg_Error(t *testing.T) {
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	runner := agent.NewRunner(nil)
+	m := NewModel(database, runner, false)
+	m.activeTab = tabSettings
+	m.width = 80
+	m.height = 24
+
+	// Simulate a failed log read (file not found)
+	updated, _ := m.Update(DaemonLogsMsg{Err: fmt.Errorf("open daemon.log: no such file or directory")})
+	m = updated.(Model)
+
+	// Should NOT switch to log viewer
+	if m.current == viewDaemonLogs {
+		t.Error("should not switch to viewDaemonLogs on error")
+	}
+}
+
+func TestModel_DaemonLogsClose_QKey(t *testing.T) {
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	runner := agent.NewRunner(nil)
+	m := NewModel(database, runner, false)
+	m.current = viewDaemonLogs
+	m.width = 80
+	m.height = 24
+	m.daemonLogLines = []string{"line 1"}
+
+	// q should close
+	qMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
+	updated, _ := m.handleDaemonLogsKey(qMsg)
+	m = updated.(Model)
+	if m.current != viewTaskList {
+		t.Errorf("expected viewTaskList after q, got %d", m.current)
+	}
+	if m.activeTab != tabSettings {
+		t.Error("expected settings tab after closing logs via q")
+	}
+}
+
+func TestModel_DaemonLogsScroll_AllKeys(t *testing.T) {
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	runner := agent.NewRunner(nil)
+	m := NewModel(database, runner, false)
+	m.current = viewDaemonLogs
+	m.width = 80
+	m.height = 24
+
+	lines := make([]string, 200)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("log line %d", i)
+	}
+	m.daemonLogLines = lines
+	visible := m.daemonLogVisibleLines()
+
+	// End key — jump to bottom
+	updated, _ := m.handleDaemonLogsKey(tea.KeyMsg{Type: tea.KeyEnd})
+	m = updated.(Model)
+	expectedEnd := len(lines) - visible
+	if m.daemonLogOffset != expectedEnd {
+		t.Errorf("expected offset %d after End, got %d", expectedEnd, m.daemonLogOffset)
+	}
+
+	// Home key — jump to top
+	updated, _ = m.handleDaemonLogsKey(tea.KeyMsg{Type: tea.KeyHome})
+	m = updated.(Model)
+	if m.daemonLogOffset != 0 {
+		t.Errorf("expected offset 0 after Home, got %d", m.daemonLogOffset)
+	}
+
+	// PgDown then PgUp
+	updated, _ = m.handleDaemonLogsKey(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = updated.(Model)
+	afterPgDown := m.daemonLogOffset
+	if afterPgDown != visible {
+		t.Errorf("expected offset %d after PgDown, got %d", visible, afterPgDown)
+	}
+	updated, _ = m.handleDaemonLogsKey(tea.KeyMsg{Type: tea.KeyPgUp})
+	m = updated.(Model)
+	if m.daemonLogOffset != 0 {
+		t.Errorf("expected offset 0 after PgUp, got %d", m.daemonLogOffset)
+	}
+}
+
+func TestModel_DaemonLogsClose(t *testing.T) {
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	runner := agent.NewRunner(nil)
+	m := NewModel(database, runner, false)
+	m.current = viewDaemonLogs
+	m.width = 80
+	m.height = 24
+	m.daemonLogLines = []string{"line 1"}
+
+	// Escape should close
+	escMsg := tea.KeyMsg{Type: tea.KeyEscape}
+	updated, _ := m.handleDaemonLogsKey(escMsg)
+	m = updated.(Model)
+	if m.current != viewTaskList {
+		t.Errorf("expected viewTaskList after esc, got %d", m.current)
+	}
+	if m.activeTab != tabSettings {
+		t.Error("expected settings tab after closing logs")
+	}
+	if m.daemonLogLines != nil {
+		t.Error("expected daemonLogLines to be nil after close")
+	}
+}
+
+func TestModel_DaemonLogsMouseScroll(t *testing.T) {
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	runner := agent.NewRunner(nil)
+	m := NewModel(database, runner, false)
+	m.current = viewDaemonLogs
+	m.width = 80
+	m.height = 24
+
+	lines := make([]string, 100)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("log line %d", i)
+	}
+	m.daemonLogLines = lines
+	m.daemonLogOffset = 10
+
+	// Mouse wheel down
+	m.handleDaemonLogsMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	if m.daemonLogOffset != 13 {
+		t.Errorf("expected offset 13 after wheel down, got %d", m.daemonLogOffset)
+	}
+
+	// Mouse wheel up
+	m.handleDaemonLogsMouse(tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+	if m.daemonLogOffset != 10 {
+		t.Errorf("expected offset 10 after wheel up, got %d", m.daemonLogOffset)
 	}
 }
 


### PR DESCRIPTION
New 'Daemon Logs' row in the Settings STATUS section. Pressing Enter/Space loads ~/.argus/daemon.log and opens a scrollable modal with keyboard (arrows, pgup/pgdn, home/end) and mouse-wheel support. Starts scrolled to the most recent entries, capped at 1000 lines.

Co-Authored-By: Claude <noreply@anthropic.com>