### PR TITLE
Fix srt v1.0.0 schema and add sandbox config UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,45 @@ argus
 | `ctrl+q` | Detach from agent |
 | `ctrl+←` / `ctrl+→` | Switch panels |
 
+## Sandbox
+
+Argus can run agent processes inside [`@anthropic-ai/sandbox-runtime`](https://www.npmjs.com/package/@anthropic-ai/sandbox-runtime) (srt) for OS-level filesystem and network isolation. When enabled, each agent session gets a temporary config file that restricts what the process can read, write, and access over the network.
+
+### Requirements
+
+Install the sandbox runtime globally:
+
+```bash
+npm i -g @anthropic-ai/sandbox-runtime
+```
+
+### Configuration
+
+All sandbox settings are managed in the **Settings tab** (`2` key). Navigate to the **Sandbox** row and press `Enter` to open the configuration form:
+
+| Setting | Description |
+|---------|-------------|
+| Enabled | Master toggle (`ctrl+e` in the form) |
+| Allowed Domains | Extra network domains to permit (comma-separated, e.g. `github.com,registry.npmjs.org`) |
+| Deny Read | Extra paths to block reads from (comma-separated, e.g. `/secrets,~/.private`) |
+| Extra Write | Extra paths to allow writes to (comma-separated, e.g. `~/.npm,/var/cache`) |
+
+### Built-in defaults
+
+These are always applied and don't need to be configured:
+
+**Network (always allowed):**
+- `api.anthropic.com`, `statsig.anthropic.com`, `sentry.io`
+
+**Filesystem (always denied read):**
+- `~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.kube`, `~/.config/gcloud`
+
+**Filesystem (always allowed write):**
+- The task's worktree directory
+- `/tmp`
+
+Settings are persisted in `~/.argus/data.sql`.
+
 ## Data
 
 All state (tasks, projects, backends, keybindings, UI settings) is persisted in SQLite at `~/.argus/data.sql`.

--- a/internal/agent/sandbox.go
+++ b/internal/agent/sandbox.go
@@ -39,24 +39,22 @@ var defaultAllowedDomains = []string{
 	"sentry.io",
 }
 
-// srtSettings mirrors the JSON structure expected by @anthropic-ai/sandbox-runtime.
+// srtSettings mirrors the JSON structure expected by @anthropic-ai/sandbox-runtime v1.0.0.
+// Fields are top-level (not nested under "sandbox").
 type srtSettings struct {
-	Sandbox srtSandbox `json:"sandbox"`
-}
-
-type srtSandbox struct {
-	Enabled    bool          `json:"enabled"`
-	Filesystem srtFilesystem `json:"filesystem"`
 	Network    srtNetwork    `json:"network"`
+	Filesystem srtFilesystem `json:"filesystem"`
 }
 
 type srtFilesystem struct {
 	AllowWrite []string `json:"allowWrite"`
 	DenyRead   []string `json:"denyRead"`
+	DenyWrite  []string `json:"denyWrite"`
 }
 
 type srtNetwork struct {
 	AllowedDomains []string `json:"allowedDomains"`
+	DeniedDomains  []string `json:"deniedDomains"`
 }
 
 // IsSandboxAvailable checks whether the sandbox-runtime (srt) binary is installed.
@@ -122,15 +120,14 @@ func GenerateSandboxConfig(worktreePath string, cfg config.Config) (string, func
 	}
 
 	settings := srtSettings{
-		Sandbox: srtSandbox{
-			Enabled: true,
-			Filesystem: srtFilesystem{
-				AllowWrite: allowWrite,
-				DenyRead:   denyRead,
-			},
-			Network: srtNetwork{
-				AllowedDomains: domains,
-			},
+		Filesystem: srtFilesystem{
+			AllowWrite: allowWrite,
+			DenyRead:   denyRead,
+			DenyWrite:  []string{},
+		},
+		Network: srtNetwork{
+			AllowedDomains: domains,
+			DeniedDomains:  []string{},
 		},
 	}
 

--- a/internal/agent/sandbox_test.go
+++ b/internal/agent/sandbox_test.go
@@ -34,12 +34,8 @@ func TestGenerateSandboxConfig_BasicPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !settings.Sandbox.Enabled {
-		t.Error("expected sandbox.enabled=true")
-	}
-
 	// Check allowWrite contains worktree and /tmp
-	aw := settings.Sandbox.Filesystem.AllowWrite
+	aw := settings.Filesystem.AllowWrite
 	if !containsString(aw, "//home/user/.argus/worktrees/myapp/fix-bug") {
 		t.Errorf("allowWrite missing worktree path, got %v", aw)
 	}
@@ -48,7 +44,7 @@ func TestGenerateSandboxConfig_BasicPaths(t *testing.T) {
 	}
 
 	// Check denyRead contains credential dirs
-	dr := settings.Sandbox.Filesystem.DenyRead
+	dr := settings.Filesystem.DenyRead
 	for _, expected := range []string{"~/.ssh", "~/.gnupg", "~/.aws", "~/.kube"} {
 		if !containsString(dr, expected) {
 			t.Errorf("denyRead missing %q, got %v", expected, dr)
@@ -56,7 +52,7 @@ func TestGenerateSandboxConfig_BasicPaths(t *testing.T) {
 	}
 
 	// Check default allowed domains
-	ad := settings.Sandbox.Network.AllowedDomains
+	ad := settings.Network.AllowedDomains
 	for _, expected := range []string{"api.anthropic.com", "statsig.anthropic.com", "sentry.io"} {
 		if !containsString(ad, expected) {
 			t.Errorf("allowedDomains missing %q, got %v", expected, ad)
@@ -91,7 +87,7 @@ func TestGenerateSandboxConfig_CustomConfig(t *testing.T) {
 	}
 
 	// Custom domains should be merged with defaults
-	ad := settings.Sandbox.Network.AllowedDomains
+	ad := settings.Network.AllowedDomains
 	if !containsString(ad, "github.com") {
 		t.Errorf("allowedDomains missing github.com, got %v", ad)
 	}
@@ -100,13 +96,13 @@ func TestGenerateSandboxConfig_CustomConfig(t *testing.T) {
 	}
 
 	// Custom deny read paths
-	dr := settings.Sandbox.Filesystem.DenyRead
+	dr := settings.Filesystem.DenyRead
 	if !containsString(dr, "//secrets") {
 		t.Errorf("denyRead missing /secrets, got %v", dr)
 	}
 
 	// Custom extra write paths
-	aw := settings.Sandbox.Filesystem.AllowWrite
+	aw := settings.Filesystem.AllowWrite
 	if !containsString(aw, "~/.npm") {
 		t.Errorf("allowWrite missing ~/.npm, got %v", aw)
 	}
@@ -160,14 +156,14 @@ func TestGenerateSandboxConfig_NoDuplicateDomains(t *testing.T) {
 
 	// Count occurrences of api.anthropic.com
 	count := 0
-	for _, d := range settings.Sandbox.Network.AllowedDomains {
+	for _, d := range settings.Network.AllowedDomains {
 		if d == "api.anthropic.com" {
 			count++
 		}
 	}
 	if count != 1 {
 		t.Errorf("api.anthropic.com should appear once, got %d times in %v",
-			count, settings.Sandbox.Network.AllowedDomains)
+			count, settings.Network.AllowedDomains)
 	}
 }
 

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -32,6 +32,7 @@ const (
 	viewPruning
 	viewAgent
 	viewSandboxInstall
+	viewSandboxConfig
 	viewDaemonRestart
 	viewDaemonLogs
 )
@@ -120,7 +121,8 @@ type Model struct {
 	statusbar   StatusBar
 	helpview    HelpView
 	newtask     NewTaskForm
-	newproject  NewProjectForm
+	newproject    NewProjectForm
+	sandboxconfig SandboxConfigForm // sandbox settings editor
 	preview     Preview
 	gitstatus   *GitStatus
 	detail      TaskDetail
@@ -300,6 +302,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusbar.SetWidth(msg.Width)
 		m.newtask.SetSize(msg.Width, msg.Height)
 		m.newproject.SetSize(msg.Width, msg.Height)
+		m.sandboxconfig.SetSize(msg.Width, msg.Height)
 		m.agentview.SetSize(msg.Width, msg.Height)
 		return m, nil
 
@@ -510,6 +513,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case viewSandboxInstall:
 		return m.handleSandboxInstallKey(msg)
+	case viewSandboxConfig:
+		return m.handleSandboxConfigKey(msg)
 	case viewAgent:
 		return m.handleAgentViewKey(msg)
 	default:
@@ -987,6 +992,41 @@ func (m Model) handleSandboxInstallKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 }
 
+func (m Model) handleSandboxConfigKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	cmd := m.sandboxconfig.Update(msg)
+
+	if m.sandboxconfig.Canceled() {
+		m.current = viewTaskList
+		return m, nil
+	}
+
+	if m.sandboxconfig.Done() {
+		enabled, domains, denyRead, extraWrite := m.sandboxconfig.Result()
+		var saveErr error
+		if err := m.db.SetSandboxEnabled(enabled); err != nil {
+			saveErr = err
+		}
+		if err := m.db.SetConfigValue("sandbox.allowed_domains", domains); err != nil {
+			saveErr = err
+		}
+		if err := m.db.SetConfigValue("sandbox.deny_read", denyRead); err != nil {
+			saveErr = err
+		}
+		if err := m.db.SetConfigValue("sandbox.extra_write", extraWrite); err != nil {
+			saveErr = err
+		}
+		if saveErr != nil {
+			m.statusbar.SetError("failed to save sandbox config")
+		}
+		agent.ResetSandboxCache()
+		m.refreshSettings()
+		m.current = viewTaskList
+		return m, nil
+	}
+
+	return m, cmd
+}
+
 func (m Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch {
 	case key.Matches(msg, m.keys.Quit):
@@ -1016,9 +1056,16 @@ func (m Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		sel := m.settings.Selected()
 		if sel != nil && sel.kind == settingsRowSandbox {
 			cfg := m.db.Config()
-			_ = m.db.SetSandboxEnabled(!cfg.Sandbox.Enabled)
-			agent.ResetSandboxCache()
-			m.refreshSettings()
+			m.sandboxconfig = NewSandboxConfigForm(
+				m.theme,
+				cfg.Sandbox.Enabled,
+				cfg.Sandbox.AllowedDomains,
+				cfg.Sandbox.DenyRead,
+				cfg.Sandbox.ExtraWrite,
+			)
+			m.sandboxconfig.SetSize(m.width, m.height)
+			m.current = viewSandboxConfig
+			return m, m.sandboxconfig.FocusFirst()
 		}
 		if sel != nil && sel.kind == settingsRowDaemonLogs {
 			return m, m.loadDaemonLogsCmd()

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -1598,6 +1598,10 @@ func TestModel_ViewZeroDimensions(t *testing.T) {
 		{"sandboxInstalling", func(m *Model) { m.current = viewSandboxInstall; m.sandboxInstalling = true }},
 		{"sandboxInstallDone", func(m *Model) { m.current = viewSandboxInstall; m.sandboxInstallResult = "Installed" }},
 		{"daemonRestart", func(m *Model) { m.current = viewDaemonRestart; m.daemonRestarting = true }},
+		{"sandboxConfig", func(m *Model) {
+			m.sandboxconfig = NewSandboxConfigForm(m.theme, false, nil, nil, nil)
+			m.current = viewSandboxConfig
+		}},
 		{"daemonLogs", func(m *Model) { m.current = viewDaemonLogs; m.daemonLogLines = []string{"test log line"} }},
 	}
 	for _, tc := range views {

--- a/internal/ui/root_views.go
+++ b/internal/ui/root_views.go
@@ -43,6 +43,8 @@ func (m Model) View() string {
 		return m.newtask.View() + "\n" + bar
 	case viewNewProject:
 		return m.newproject.View() + "\n" + bar
+	case viewSandboxConfig:
+		return m.sandboxconfig.View() + "\n" + bar
 	}
 
 	tabHeader := m.renderTabHeader()

--- a/internal/ui/sandboxconfig.go
+++ b/internal/ui/sandboxconfig.go
@@ -1,0 +1,171 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// SandboxConfigForm handles editing sandbox configuration in a modal.
+type SandboxConfigForm struct {
+	inputs   []textinput.Model
+	focused  int
+	enabled  bool
+	theme    Theme
+	done     bool
+	canceled bool
+	width    int
+	height   int
+}
+
+const (
+	sbFieldDomains = iota
+	sbFieldDenyRead
+	sbFieldExtraWrite
+	sbFieldCount
+)
+
+// NewSandboxConfigForm creates a sandbox config editor, pre-populated with current values.
+func NewSandboxConfigForm(theme Theme, enabled bool, domains, denyRead, extraWrite []string) SandboxConfigForm {
+	inputs := make([]textinput.Model, sbFieldCount)
+
+	domainsInput := textinput.New()
+	domainsInput.Placeholder = "Comma-separated domains (e.g. github.com,npmjs.org)"
+	domainsInput.CharLimit = 500
+	domainsInput.SetValue(strings.Join(domains, ","))
+	inputs[sbFieldDomains] = domainsInput
+
+	denyInput := textinput.New()
+	denyInput.Placeholder = "Comma-separated paths (e.g. /secrets,~/.private)"
+	denyInput.CharLimit = 500
+	denyInput.SetValue(strings.Join(denyRead, ","))
+	inputs[sbFieldDenyRead] = denyInput
+
+	writeInput := textinput.New()
+	writeInput.Placeholder = "Comma-separated paths (e.g. ~/.npm,/var/cache)"
+	writeInput.CharLimit = 500
+	writeInput.SetValue(strings.Join(extraWrite, ","))
+	inputs[sbFieldExtraWrite] = writeInput
+
+	return SandboxConfigForm{
+		inputs:  inputs,
+		focused: sbFieldDomains,
+		enabled: enabled,
+		theme:   theme,
+	}
+}
+
+func (f *SandboxConfigForm) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyEsc:
+			f.canceled = true
+			return nil
+		case tea.KeyTab, tea.KeyDown:
+			f.focused = (f.focused + 1) % sbFieldCount
+			return f.focusCurrent()
+		case tea.KeyShiftTab, tea.KeyUp:
+			f.focused = (f.focused - 1 + sbFieldCount) % sbFieldCount
+			return f.focusCurrent()
+		case tea.KeyCtrlE:
+			f.enabled = !f.enabled
+			return nil
+		case tea.KeyEnter:
+			if f.focused == sbFieldCount-1 {
+				f.done = true
+				return nil
+			}
+			f.focused++
+			return f.focusCurrent()
+		}
+	}
+
+	var cmd tea.Cmd
+	f.inputs[f.focused], cmd = f.inputs[f.focused].Update(msg)
+	return cmd
+}
+
+func (f *SandboxConfigForm) focusCurrent() tea.Cmd {
+	cmds := make([]tea.Cmd, len(f.inputs))
+	for i := range f.inputs {
+		if i == f.focused {
+			cmds[i] = f.inputs[i].Focus()
+		} else {
+			f.inputs[i].Blur()
+		}
+	}
+	return tea.Batch(cmds...)
+}
+
+// Result returns the edited sandbox config values.
+func (f *SandboxConfigForm) Result() (enabled bool, domains, denyRead, extraWrite string) {
+	return f.enabled,
+		strings.TrimSpace(f.inputs[sbFieldDomains].Value()),
+		strings.TrimSpace(f.inputs[sbFieldDenyRead].Value()),
+		strings.TrimSpace(f.inputs[sbFieldExtraWrite].Value())
+}
+
+func (f *SandboxConfigForm) Done() bool     { return f.done }
+func (f *SandboxConfigForm) Canceled() bool { return f.canceled }
+
+// FocusFirst returns a command that focuses the first input field.
+func (f *SandboxConfigForm) FocusFirst() tea.Cmd {
+	if len(f.inputs) == 0 {
+		return nil
+	}
+	return f.inputs[0].Focus()
+}
+
+func (f *SandboxConfigForm) SetSize(w, h int) {
+	f.width = w
+	f.height = h
+	inputWidth := max(f.modalWidth()-6, 20)
+	for i := range f.inputs {
+		f.inputs[i].Width = inputWidth
+	}
+}
+
+func (f SandboxConfigForm) modalWidth() int {
+	return clampModalWidth(f.width)
+}
+
+func (f SandboxConfigForm) View() string {
+	if len(f.inputs) == 0 {
+		return ""
+	}
+	var b strings.Builder
+
+	// Enabled toggle
+	enabledLabel := f.theme.Error.Render("Disabled")
+	if f.enabled {
+		enabledLabel = f.theme.Complete.Render("Enabled")
+	}
+	b.WriteString(f.theme.Dimmed.Render("Sandbox: ") + enabledLabel)
+	b.WriteString(f.theme.Dimmed.Render("  (ctrl+e to toggle)") + "\n\n")
+
+	labels := []string{"Allowed Domains:", "Deny Read:", "Extra Write:"}
+	for i, label := range labels {
+		style := f.theme.Dimmed
+		if i == f.focused {
+			style = f.theme.Selected
+		}
+		b.WriteString(style.Render(label) + "\n")
+		b.WriteString(f.inputs[i].View() + "\n\n")
+	}
+
+	b.WriteString(f.theme.Help.Render("tab/shift+tab: navigate  ctrl+e: toggle  enter: save  esc: cancel"))
+
+	mw := f.modalWidth()
+
+	modal := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("87")).
+		Padding(1, 2).
+		Width(mw).
+		Render(f.theme.Title.Render("Sandbox Configuration") + "\n\n" + b.String())
+
+	return lipgloss.Place(f.width, f.height, lipgloss.Center, lipgloss.Center, modal)
+}

--- a/internal/ui/sandboxconfig_test.go
+++ b/internal/ui/sandboxconfig_test.go
@@ -1,0 +1,123 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestSandboxConfigForm_NewPrePopulated(t *testing.T) {
+	domains := []string{"github.com", "npmjs.org"}
+	deny := []string{"/secrets"}
+	extra := []string{"~/.npm"}
+
+	f := NewSandboxConfigForm(DefaultTheme(), true, domains, deny, extra)
+
+	if !f.enabled {
+		t.Error("expected enabled=true")
+	}
+	if f.inputs[sbFieldDomains].Value() != "github.com,npmjs.org" {
+		t.Errorf("unexpected domains: %q", f.inputs[sbFieldDomains].Value())
+	}
+	if f.inputs[sbFieldDenyRead].Value() != "/secrets" {
+		t.Errorf("unexpected deny read: %q", f.inputs[sbFieldDenyRead].Value())
+	}
+	if f.inputs[sbFieldExtraWrite].Value() != "~/.npm" {
+		t.Errorf("unexpected extra write: %q", f.inputs[sbFieldExtraWrite].Value())
+	}
+}
+
+func TestSandboxConfigForm_Toggle(t *testing.T) {
+	f := NewSandboxConfigForm(DefaultTheme(), false, nil, nil, nil)
+
+	if f.enabled {
+		t.Error("expected disabled initially")
+	}
+
+	// ctrl+e toggles
+	f.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	if !f.enabled {
+		t.Error("expected enabled after ctrl+e")
+	}
+
+	f.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	if f.enabled {
+		t.Error("expected disabled after second ctrl+e")
+	}
+}
+
+func TestSandboxConfigForm_Cancel(t *testing.T) {
+	f := NewSandboxConfigForm(DefaultTheme(), true, nil, nil, nil)
+	f.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if !f.Canceled() {
+		t.Error("expected canceled after esc")
+	}
+}
+
+func TestSandboxConfigForm_SubmitOnLastField(t *testing.T) {
+	f := NewSandboxConfigForm(DefaultTheme(), true, []string{"github.com"}, nil, nil)
+	f.SetSize(120, 40)
+
+	// Navigate to last field
+	f.focused = sbFieldExtraWrite
+
+	// Enter on last field submits
+	f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !f.Done() {
+		t.Error("expected done after enter on last field")
+	}
+
+	enabled, domains, denyRead, extraWrite := f.Result()
+	if !enabled {
+		t.Error("expected enabled=true in result")
+	}
+	if domains != "github.com" {
+		t.Errorf("unexpected domains: %q", domains)
+	}
+	if denyRead != "" {
+		t.Errorf("unexpected deny read: %q", denyRead)
+	}
+	if extraWrite != "" {
+		t.Errorf("unexpected extra write: %q", extraWrite)
+	}
+}
+
+func TestSandboxConfigForm_TabNavigation(t *testing.T) {
+	f := NewSandboxConfigForm(DefaultTheme(), false, nil, nil, nil)
+	f.SetSize(120, 40)
+
+	if f.focused != sbFieldDomains {
+		t.Errorf("expected initial focus on domains, got %d", f.focused)
+	}
+
+	// Tab moves forward
+	f.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if f.focused != sbFieldDenyRead {
+		t.Errorf("expected focus on deny read after tab, got %d", f.focused)
+	}
+
+	// Shift+tab moves back
+	f.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	if f.focused != sbFieldDomains {
+		t.Errorf("expected focus back on domains, got %d", f.focused)
+	}
+}
+
+func TestSandboxConfigForm_View(t *testing.T) {
+	f := NewSandboxConfigForm(DefaultTheme(), true, []string{"example.com"}, nil, nil)
+	f.SetSize(120, 40)
+
+	v := f.View()
+	if v == "" {
+		t.Error("expected non-empty view")
+	}
+}
+
+func TestSandboxConfigForm_NilInputs(t *testing.T) {
+	// Zero-valued form should not panic
+	var f SandboxConfigForm
+	v := f.View()
+	if v != "" {
+		t.Error("expected empty view for zero-valued form")
+	}
+}

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -358,7 +358,7 @@ func TestModel_DaemonConnectedWarning(t *testing.T) {
 	}
 }
 
-func TestModel_SandboxToggle(t *testing.T) {
+func TestModel_SandboxConfigForm(t *testing.T) {
 	database, err := db.OpenInMemory()
 	if err != nil {
 		t.Fatal(err)
@@ -386,29 +386,107 @@ func TestModel_SandboxToggle(t *testing.T) {
 		t.Error("expected sandbox disabled initially")
 	}
 
-	// Press Enter to toggle on
+	// Press Enter to open sandbox config form
 	enterMsg := tea.KeyMsg{Type: tea.KeyEnter}
 	updated, _ := m.handleSettingsKey(enterMsg)
 	m = updated.(Model)
 
-	cfg = m.db.Config()
-	if !cfg.Sandbox.Enabled {
-		t.Error("expected sandbox enabled after Enter toggle")
+	if m.current != viewSandboxConfig {
+		t.Fatalf("expected viewSandboxConfig, got %d", m.current)
 	}
 
-	// Press Enter again to toggle off.
-	// After the first toggle, refreshSettings rebuilds rows but the cursor index
-	// is preserved, so it should still be on the sandbox row.
-	sel = m.settings.Selected()
-	if sel == nil || sel.kind != settingsRowSandbox {
-		t.Fatalf("expected cursor still on sandbox row after first toggle, got %v", sel)
-	}
-	updated, _ = m.handleSettingsKey(enterMsg)
+	// Toggle enabled via ctrl+e
+	updated, _ = m.handleSandboxConfigKey(tea.KeyMsg{Type: tea.KeyCtrlE})
 	m = updated.(Model)
 
+	if !m.sandboxconfig.enabled {
+		t.Error("expected sandbox enabled after ctrl+e in form")
+	}
+
+	// Navigate to last field and submit
+	m.sandboxconfig.focused = sbFieldExtraWrite
+	updated, _ = m.handleSandboxConfigKey(enterMsg)
+	m = updated.(Model)
+
+	if m.current != viewTaskList {
+		t.Fatalf("expected viewTaskList after submit, got %d", m.current)
+	}
+
 	cfg = m.db.Config()
+	if !cfg.Sandbox.Enabled {
+		t.Error("expected sandbox enabled after form submit")
+	}
+}
+
+func TestModel_SandboxConfigFormCancel(t *testing.T) {
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	agent.ResetSandboxCache()
+	runner := agent.NewRunner(nil)
+	m := NewModel(database, runner, true)
+	m.activeTab = tabSettings
+	m.width = 120
+	m.height = 40
+	m.refreshSettings()
+
+	// Navigate to sandbox row and open form
+	m.settings.CursorDown() // daemon logs
+	m.settings.CursorDown() // sandbox
+	updated, _ := m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	// Toggle enabled then cancel — should NOT persist
+	m.handleSandboxConfigKey(tea.KeyMsg{Type: tea.KeyCtrlE})
+	updated, _ = m.handleSandboxConfigKey(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+
+	if m.current != viewTaskList {
+		t.Fatalf("expected viewTaskList after cancel, got %d", m.current)
+	}
+
+	cfg := m.db.Config()
 	if cfg.Sandbox.Enabled {
-		t.Error("expected sandbox disabled after second Enter toggle")
+		t.Error("expected sandbox still disabled after cancel")
+	}
+}
+
+func TestModel_SandboxConfigFormDomains(t *testing.T) {
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	agent.ResetSandboxCache()
+	runner := agent.NewRunner(nil)
+	m := NewModel(database, runner, true)
+	m.activeTab = tabSettings
+	m.width = 120
+	m.height = 40
+	m.refreshSettings()
+
+	// Navigate to sandbox row and open form
+	m.settings.CursorDown() // daemon logs
+	m.settings.CursorDown() // sandbox
+	updated, _ := m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	// Type domains into the first field
+	m.sandboxconfig.inputs[sbFieldDomains].SetValue("github.com,npmjs.org")
+
+	// Submit from last field
+	m.sandboxconfig.focused = sbFieldExtraWrite
+	updated, _ = m.handleSandboxConfigKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	cfg := m.db.Config()
+	if len(cfg.Sandbox.AllowedDomains) != 2 {
+		t.Fatalf("expected 2 domains, got %d: %v", len(cfg.Sandbox.AllowedDomains), cfg.Sandbox.AllowedDomains)
+	}
+	if cfg.Sandbox.AllowedDomains[0] != "github.com" {
+		t.Errorf("expected github.com, got %q", cfg.Sandbox.AllowedDomains[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Update sandbox config JSON to match `@anthropic-ai/sandbox-runtime` v1.0.0 schema (top-level `network`/`filesystem` fields, required `deniedDomains` and `denyWrite`)
- Add Settings UI form for editing sandbox config (allowed domains, deny read, extra write) — no more manual SQL
- Document sandbox setup and configuration in README

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] Zero-dimensions view test covers new `viewSandboxConfig`
- [x] Form tests: pre-population, toggle, cancel, submit, tab navigation, nil inputs
- [x] Integration tests: form open → edit → save persists to DB, cancel discards changes
- [ ] Manual: open Settings → Sandbox → Enter → verify form, toggle, save domains, confirm srt accepts generated config

🤖 Generated with [Claude Code](https://claude.com/claude-code)