### PR TITLE
Fix stream failure auto-completing running tasks

### DIFF
--- a/internal/daemon/client/client_test.go
+++ b/internal/daemon/client/client_test.go
@@ -123,3 +123,77 @@ func TestClient_StopAll(t *testing.T) {
 	// StopAll should not panic with no sessions.
 	c.StopAll()
 }
+
+func TestClient_SessionExitCallback(t *testing.T) {
+	_, sockPath := testSetup(t)
+
+	c, err := Connect(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	exitCh := make(chan string, 1)
+	c.OnSessionExit(func(taskID string, info daemon.ExitInfo) {
+		exitCh <- taskID
+	})
+
+	task := &model.Task{ID: "t-exit", Name: "exit-test", Backend: "test"}
+	_, err = c.Start(task, config.Config{}, 24, 80, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// "echo hello" exits quickly — callback should fire.
+	select {
+	case id := <-exitCh:
+		if id != "t-exit" {
+			t.Errorf("expected task ID 't-exit', got %q", id)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for session exit callback")
+	}
+}
+
+func TestAlive_Dead(t *testing.T) {
+	_, sockPath := testSetup(t)
+
+	c, err := Connect(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	// Create a session for a quick-exit command.
+	task := &model.Task{ID: "t-dead", Name: "dead-test", Backend: "test"}
+	_, err = c.Start(task, config.Config{}, 24, 80, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for process to exit.
+	time.Sleep(1 * time.Second)
+
+	// Create a RemoteSession to test isSessionAlive against a dead process.
+	rs := &RemoteSession{taskID: "t-dead", client: c}
+	if rs.isSessionAlive() {
+		t.Error("expected isSessionAlive to return false for exited process")
+	}
+}
+
+func TestAlive_NoSession(t *testing.T) {
+	_, sockPath := testSetup(t)
+
+	c, err := Connect(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	// isSessionAlive for a session that never existed should return false.
+	// SessionStatus returns empty info (Alive=false, PID=0) for unknown task IDs.
+	rs := &RemoteSession{taskID: "nonexistent", client: c}
+	if rs.isSessionAlive() {
+		t.Error("expected isSessionAlive to return false for nonexistent session")
+	}
+}

--- a/internal/daemon/client/stream.go
+++ b/internal/daemon/client/stream.go
@@ -3,28 +3,70 @@ package client
 import (
 	"encoding/json"
 	"net"
+	"time"
 
 	"github.com/drn/argus/internal/daemon"
 	"github.com/drn/argus/internal/uxlog"
 )
 
+// maxStreamRetries is the maximum number of times to retry the stream
+// connection when it drops but the process is still alive on the daemon.
+const maxStreamRetries = 3
+
 // connectStream opens a stream connection to the daemon for this session's output.
-// Reads raw bytes and writes them to the local ring buffer. Closes rs.done on EOF.
+// Reads raw bytes and writes them to the local ring buffer. If the stream drops
+// but the daemon reports the session is still alive, retries up to maxStreamRetries
+// times before giving up. Calls removeSession only when the process has actually
+// exited or retries are exhausted.
 func (rs *RemoteSession) connectStream(sockPath string) {
+	for attempt := 0; attempt <= maxStreamRetries; attempt++ {
+		if attempt > 0 {
+			uxlog.Log("stream: retry %d/%d task=%s", attempt, maxStreamRetries, rs.taskID)
+			time.Sleep(500 * time.Millisecond)
+		}
+
+		exited := rs.streamOnce(sockPath)
+		if exited {
+			// Process actually exited — fire the exit callback.
+			rs.close()
+			rs.client.removeSession(rs.taskID)
+			return
+		}
+
+		// Stream dropped but process is still alive — check if we
+		// should retry or if we've been closed externally.
+		select {
+		case <-rs.done:
+			// Session was closed (e.g., client shutdown) — don't retry.
+			uxlog.Log("stream: session closed externally task=%s, not retrying", rs.taskID)
+			rs.client.removeSession(rs.taskID)
+			return
+		default:
+		}
+	}
+
+	// Exhausted retries — treat as exit to avoid silently losing the session.
+	uxlog.Log("stream: exhausted %d retries task=%s, treating as exit", maxStreamRetries, rs.taskID)
+	rs.close()
+	rs.client.removeSession(rs.taskID)
+}
+
+// streamOnce opens a single stream connection and reads until EOF or error.
+// Returns true if the process has exited (should fire exit callback),
+// false if the stream dropped but the process is still alive (should retry).
+func (rs *RemoteSession) streamOnce(sockPath string) (processExited bool) {
 	uxlog.Log("stream: connecting task=%s", rs.taskID)
 	conn, err := net.Dial("unix", sockPath)
 	if err != nil {
 		uxlog.Log("stream: DIAL FAILED task=%s err=%v", rs.taskID, err)
-		rs.client.removeSession(rs.taskID)
-		return
+		return !rs.isSessionAlive()
 	}
 	defer conn.Close()
 
 	// Send stream prefix byte.
 	if _, err := conn.Write([]byte("S")); err != nil {
 		uxlog.Log("stream: WRITE PREFIX FAILED task=%s err=%v", rs.taskID, err)
-		rs.client.removeSession(rs.taskID)
-		return
+		return !rs.isSessionAlive()
 	}
 
 	// Send stream header to subscribe to this session's output.
@@ -33,8 +75,7 @@ func (rs *RemoteSession) connectStream(sockPath string) {
 		TaskID: rs.taskID,
 	}); err != nil {
 		uxlog.Log("stream: ENCODE HEADER FAILED task=%s err=%v", rs.taskID, err)
-		rs.client.removeSession(rs.taskID)
-		return
+		return !rs.isSessionAlive()
 	}
 
 	uxlog.Log("stream: connected task=%s", rs.taskID)
@@ -50,11 +91,22 @@ func (rs *RemoteSession) connectStream(sockPath string) {
 		}
 		if err != nil {
 			uxlog.Log("stream: ended task=%s err=%v", rs.taskID, err)
-			break // EOF or connection error — treat as session exit
+			break
 		}
 	}
 
-	// Stream ended — session exited or daemon shut down.
-	rs.close()
-	rs.client.removeSession(rs.taskID)
+	// Stream ended — check if the process actually exited.
+	return !rs.isSessionAlive()
+}
+
+// isSessionAlive checks with the daemon whether the session's process is
+// still running. Returns false if the RPC fails (daemon may be down).
+func (rs *RemoteSession) isSessionAlive() bool {
+	var info daemon.SessionInfo
+	if err := rs.client.call("Daemon.SessionStatus", &daemon.TaskIDReq{TaskID: rs.taskID}, &info); err != nil {
+		uxlog.Log("stream: SessionStatus RPC failed task=%s err=%v (assuming dead)", rs.taskID, err)
+		return false
+	}
+	uxlog.Log("stream: SessionStatus task=%s alive=%v pid=%d", rs.taskID, info.Alive, info.PID)
+	return info.Alive
 }


### PR DESCRIPTION
## Summary
- Stream connection failures (socket errors, transient issues) were incorrectly triggering the session exit callback, causing running tasks to be marked Complete
- `connectStream` now checks `Daemon.SessionStatus` to verify the process actually exited before firing exit callback
- If process is still alive, retries stream connection up to 3 times with 500ms backoff
- Root cause: `GetExitInfo` returns empty data for still-running processes, which the TUI interpreted as a clean successful exit

## Test plan
- [x] `go test ./...` all passing
- [x] New tests: `TestClient_SessionExitCallback`, `TestAlive_Dead`, `TestAlive_NoSession`
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)