### PR TITLE
Enforce worktree requirement with defense-in-depth

### DIFF
--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -149,7 +149,9 @@
 - Fix: moved worktree creation from `startOrAttach` to `handleNewTaskKey`, BEFORE `db.Add()`. If creation fails, the task form stays open with the error message (new `SetError()` method on `NewTaskForm`). Task is never persisted without a valid worktree.
 - `CreateWorktree` now returns `(wtPath, finalName, err)` and handles name conflicts by appending `-1`, `-2`, ... `-99` suffixes.
 - `ResolveTaskDirMsg` handler now guards with `isWorktreeSubdir()` before persisting `msg.Dir` as `t.Worktree`.
-- `BuildCmd` no longer falls back to `ResolveDir()` when `Worktree` is empty — every task must have a worktree.
+- `BuildCmd` no longer falls back to `ResolveDir()` when `Worktree` is empty — every task must have a worktree. As of 2026-03-16, `BuildCmd` returns a hard error (`"task %q has no worktree set"`) when `Worktree` is empty.
+- Defense-in-depth enforcement (2026-03-16): worktree requirement is now checked at four layers: (a) task creation (`CreateWorktree` before `db.Add`), (b) `Init()` resume path (revert to Pending if no worktree found), (c) `startOrAttach()` early guard with user-visible error, (d) `BuildCmd` hard error return. Each layer catches independently.
+- `Init()` revert for worktree-less tasks: clears `SessionID`, `StartedAt`, and sets `StatusPending`. This differs from `DaemonRestartedMsg` (which preserves `SessionID`) because a missing worktree means the session cannot run at all.
 - **Pattern:** Infrastructure prerequisites (worktree, branch) must be validated BEFORE persisting a record. Silent error swallowing on infrastructure setup creates subtle state corruption that compounds with async handlers.
 
 ### Remote Branch Resolution for Worktrees (2026-03-16)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -89,13 +89,19 @@ func BuildCmd(task *model.Task, cfg config.Config, resume bool) (*exec.Cmd, func
 		// If sandbox config generation fails, fall through to unsandboxed
 	}
 
-	cmd := exec.Command("sh", "-c", cmdStr)
-
-	// Use worktree as working directory. Every task must have a worktree
-	// set during creation — there is no fallback to the project directory.
-	if task.Worktree != "" {
-		cmd.Dir = task.Worktree
+	// Every task must have a worktree — never run in the project directory.
+	if task.Worktree == "" {
+		// sandboxCleanup is currently always nil here (sandbox block above
+		// guards on task.Worktree != ""), but we clean up defensively in case
+		// that guard is relaxed in the future.
+		if sandboxCleanup != nil {
+			sandboxCleanup()
+		}
+		return nil, nil, fmt.Errorf("task %q has no worktree set — refusing to start without worktree isolation", task.Name)
 	}
+
+	cmd := exec.Command("sh", "-c", cmdStr)
+	cmd.Dir = task.Worktree
 
 	return cmd, sandboxCleanup, nil
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/drn/argus/internal/config"
@@ -110,9 +111,22 @@ func TestResolveDir(t *testing.T) {
 	}
 }
 
-func TestBuildCmd(t *testing.T) {
+func TestBuildCmd_NoWorktree(t *testing.T) {
 	cfg := testConfig()
 	task := &model.Task{Name: "fix-bug", Prompt: "fix the bug"}
+
+	_, _, err := BuildCmd(task, cfg, false)
+	if err == nil {
+		t.Fatal("expected error when Worktree is empty")
+	}
+	if !strings.Contains(err.Error(), "no worktree set") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildCmd(t *testing.T) {
+	cfg := testConfig()
+	task := &model.Task{Name: "fix-bug", Prompt: "fix the bug", Worktree: t.TempDir()}
 
 	cmd, _, err := BuildCmd(task, cfg, false)
 	if err != nil {
@@ -150,7 +164,7 @@ func TestBuildCmd_WithProject(t *testing.T) {
 
 func TestBuildCmd_EmptyPromptFlag(t *testing.T) {
 	cfg := testConfig()
-	task := &model.Task{Backend: "bare", Prompt: "do stuff"}
+	task := &model.Task{Backend: "bare", Prompt: "do stuff", Worktree: t.TempDir()}
 
 	cmd, _, err := BuildCmd(task, cfg, false)
 	if err != nil {
@@ -165,7 +179,7 @@ func TestBuildCmd_EmptyPromptFlag(t *testing.T) {
 
 func TestBuildCmd_NewSessionWithID(t *testing.T) {
 	cfg := testConfig()
-	task := &model.Task{Name: "fix-bug", Prompt: "fix the bug", SessionID: "aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee"}
+	task := &model.Task{Name: "fix-bug", Prompt: "fix the bug", SessionID: "aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee", Worktree: t.TempDir()}
 
 	cmd, _, err := BuildCmd(task, cfg, false)
 	if err != nil {
@@ -180,7 +194,7 @@ func TestBuildCmd_NewSessionWithID(t *testing.T) {
 
 func TestBuildCmd_Resume(t *testing.T) {
 	cfg := testConfig()
-	task := &model.Task{Prompt: "fix the bug", SessionID: "aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee"}
+	task := &model.Task{Prompt: "fix the bug", SessionID: "aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee", Worktree: t.TempDir()}
 
 	cmd, _, err := BuildCmd(task, cfg, true)
 	if err != nil {

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -25,7 +25,7 @@ func TestRunner_StartAndGet(t *testing.T) {
 		finished <- taskID
 	})
 
-	task := &model.Task{ID: "t1", Name: "test"}
+	task := &model.Task{ID: "t1", Name: "test", Worktree: t.TempDir()}
 	cfg := runnerTestConfig()
 
 	sess, err := r.Start(task, cfg, 24, 80, false)
@@ -67,7 +67,7 @@ func TestRunner_DuplicateStart(t *testing.T) {
 		Projects: make(map[string]config.Project),
 	}
 
-	task := &model.Task{ID: "t2", Name: "test"}
+	task := &model.Task{ID: "t2", Name: "test", Worktree: t.TempDir()}
 	sess, err := r.Start(task, cfg, 24, 80, false)
 	if err != nil {
 		t.Fatal(err)
@@ -90,7 +90,7 @@ func TestRunner_StopAndRunning(t *testing.T) {
 		Projects: make(map[string]config.Project),
 	}
 
-	task := &model.Task{ID: "t3", Name: "test"}
+	task := &model.Task{ID: "t3", Name: "test", Worktree: t.TempDir()}
 	_, err := r.Start(task, cfg, 24, 80, false)
 	if err != nil {
 		t.Fatal(err)
@@ -130,7 +130,7 @@ func TestRunner_StopSetsStopped(t *testing.T) {
 		Projects: make(map[string]config.Project),
 	}
 
-	task := &model.Task{ID: "t-stop", Name: "test"}
+	task := &model.Task{ID: "t-stop", Name: "test", Worktree: t.TempDir()}
 	_, err := r.Start(task, cfg, 24, 80, false)
 	if err != nil {
 		t.Fatal(err)
@@ -161,7 +161,7 @@ func TestRunner_NaturalExitNotStopped(t *testing.T) {
 	})
 	cfg := runnerTestConfig() // "echo hello" exits naturally
 
-	task := &model.Task{ID: "t-natural", Name: "test"}
+	task := &model.Task{ID: "t-natural", Name: "test", Worktree: t.TempDir()}
 	_, err := r.Start(task, cfg, 24, 80, false)
 	if err != nil {
 		t.Fatal(err)
@@ -188,7 +188,7 @@ func TestRunner_OnFinishFiresBeforeRemoval(t *testing.T) {
 	})
 	cfg := runnerTestConfig() // "echo hello" exits quickly
 
-	task := &model.Task{ID: "t-order", Name: "test"}
+	task := &model.Task{ID: "t-order", Name: "test", Worktree: t.TempDir()}
 	_, err := r.Start(task, cfg, 24, 80, false)
 	if err != nil {
 		t.Fatal(err)
@@ -234,7 +234,7 @@ func TestRunner_Idle(t *testing.T) {
 		Projects: make(map[string]config.Project),
 	}
 
-	task := &model.Task{ID: "idle-t1", Name: "test"}
+	task := &model.Task{ID: "idle-t1", Name: "test", Worktree: t.TempDir()}
 	_, err := r.Start(task, cfg, 24, 80, false)
 	if err != nil {
 		t.Fatal(err)
@@ -275,7 +275,7 @@ func TestRunner_WorkDir(t *testing.T) {
 		Projects: make(map[string]config.Project),
 	}
 
-	task := &model.Task{ID: "wd-t1", Name: "test"}
+	task := &model.Task{ID: "wd-t1", Name: "test", Worktree: t.TempDir()}
 	_, err := r.Start(task, cfg, 24, 80, false)
 	if err != nil {
 		t.Fatal(err)
@@ -304,7 +304,7 @@ func TestRunner_HasSession_MoreCases(t *testing.T) {
 		Projects: make(map[string]config.Project),
 	}
 
-	task := &model.Task{ID: "hs-1", Name: "test"}
+	task := &model.Task{ID: "hs-1", Name: "test", Worktree: t.TempDir()}
 	_, err := r.Start(task, cfg, 24, 80, false)
 	if err != nil {
 		t.Fatal(err)
@@ -329,8 +329,8 @@ func TestRunner_StopAll(t *testing.T) {
 		Projects: make(map[string]config.Project),
 	}
 
-	task1 := &model.Task{ID: "sa-1", Name: "test1"}
-	task2 := &model.Task{ID: "sa-2", Name: "test2"}
+	task1 := &model.Task{ID: "sa-1", Name: "test1", Worktree: t.TempDir()}
+	task2 := &model.Task{ID: "sa-2", Name: "test2", Worktree: t.TempDir()}
 
 	_, err := r.Start(task1, cfg, 24, 80, false)
 	if err != nil {

--- a/internal/daemon/client/client_test.go
+++ b/internal/daemon/client/client_test.go
@@ -66,7 +66,7 @@ func TestClient_StartAndGetOutput(t *testing.T) {
 	}
 	defer c.Close()
 
-	task := &model.Task{ID: "t1", Name: "test-task", Backend: "test"}
+	task := &model.Task{ID: "t1", Name: "test-task", Backend: "test", Worktree: t.TempDir()}
 	sess, err := c.Start(task, config.Config{}, 24, 80, false)
 	if err != nil {
 		t.Fatal(err)
@@ -138,7 +138,7 @@ func TestClient_SessionExitCallback(t *testing.T) {
 		exitCh <- taskID
 	})
 
-	task := &model.Task{ID: "t-exit", Name: "exit-test", Backend: "test"}
+	task := &model.Task{ID: "t-exit", Name: "exit-test", Backend: "test", Worktree: t.TempDir()}
 	_, err = c.Start(task, config.Config{}, 24, 80, false)
 	if err != nil {
 		t.Fatal(err)
@@ -165,7 +165,7 @@ func TestAlive_Dead(t *testing.T) {
 	defer c.Close()
 
 	// Create a session for a quick-exit command.
-	task := &model.Task{ID: "t-dead", Name: "dead-test", Backend: "test"}
+	task := &model.Task{ID: "t-dead", Name: "dead-test", Backend: "test", Worktree: t.TempDir()}
 	_, err = c.Start(task, config.Config{}, 24, 80, false)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -111,12 +111,14 @@ func TestDaemon_StartAndStop(t *testing.T) {
 	client := dialRPC(t, sockPath)
 
 	// Start a session.
+	wtDir := t.TempDir()
 	var startResp StartResp
 	err := client.Call("Daemon.StartSession", &StartReq{
-		TaskID:  "t1",
-		Backend: "test",
-		Rows:    24,
-		Cols:    80,
+		TaskID:   "t1",
+		Backend:  "test",
+		Worktree: wtDir,
+		Rows:     24,
+		Cols:     80,
 	}, &startResp)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -274,6 +274,16 @@ func (m Model) Init() tea.Cmd {
 					}
 				}
 
+				// If we still have no worktree, don't resume — revert to pending.
+				if task.Worktree == "" {
+					uxlog.Log("Init: no worktree for task %s (%s), reverting to pending", task.ID, task.Name)
+					task.SetStatus(model.StatusPending)
+					task.SessionID = ""
+					task.StartedAt = time.Time{}
+					_ = m.db.Update(task)
+					continue
+				}
+
 				// Reset StartedAt before starting so the quick-exit check in
 				// handleAgentFinished uses the resume time, not the original start.
 				task.StartedAt = time.Now()
@@ -763,6 +773,13 @@ func (m Model) startOrAttach(t *model.Task) (tea.Model, tea.Cmd) {
 	if m.runner.Get(t.ID) != nil {
 		uxlog.Log("startOrAttach: session already exists for %s, attaching", t.ID)
 		return m, m.enterAgentView(t.ID, t.Name)
+	}
+
+	// Never start an agent without worktree isolation.
+	if t.Worktree == "" {
+		uxlog.Log("startOrAttach: BLOCKED task=%s has no worktree", t.ID)
+		m.statusbar.SetError("task has no worktree — delete and recreate it")
+		return m, nil
 	}
 
 	// If sandbox is enabled but srt is not installed, show install modal

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -647,13 +649,42 @@ func TestAgentFinished_StoppedMarksInReview(t *testing.T) {
 	}
 }
 
+func TestStartOrAttach_BlocksWithoutWorktree(t *testing.T) {
+	task := &model.Task{
+		ID:     "task-1",
+		Name:   "no-worktree task",
+		Status: model.StatusPending,
+		// No Worktree set — should be blocked by the early guard.
+	}
+	m := testModel(t, task)
+	m.width = 120
+	m.height = 40
+
+	result, _ := m.startOrAttach(task)
+	um := result.(Model)
+
+	got, err := um.db.Get("task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Task should remain Pending — never set to InProgress.
+	if got.Status != model.StatusPending {
+		t.Errorf("expected status Pending (blocked by worktree guard), got %v", got.Status)
+	}
+	// SessionID should not have been generated.
+	if got.SessionID != "" {
+		t.Errorf("expected no SessionID, got %q", got.SessionID)
+	}
+}
+
 func TestStartOrAttach_FailureRevertsStatus(t *testing.T) {
 	task := &model.Task{
-		ID:      "task-1",
-		Name:    "failing task",
-		Status:  model.StatusPending,
-		Project: "proj",
-		Backend: "nonexistent-backend", // backend not in config → Start fails
+		ID:       "task-1",
+		Name:     "failing task",
+		Status:   model.StatusPending,
+		Project:  "proj",
+		Backend:  "nonexistent-backend", // backend not in config → Start fails
+		Worktree: t.TempDir(),
 	}
 	m := testModel(t, task)
 	m.width = 120
@@ -853,13 +884,20 @@ func TestDeleteProject_ModalView(t *testing.T) {
 
 func TestInit_ResetsStartedAtBeforeResume(t *testing.T) {
 	oldStart := time.Now().Add(-10 * time.Minute)
+	// Worktree must pass isWorktreeSubdir() check (contains /.argus/worktrees/).
+	wtDir := filepath.Join(t.TempDir(), ".argus", "worktrees", "proj", "old-task")
+	if err := os.MkdirAll(wtDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	task := &model.Task{
 		ID:        "t1",
 		Name:      "old task",
+		Project:   "proj",
 		Status:    model.StatusInProgress,
 		SessionID: "sess-1",
 		StartedAt: oldStart,
 		AgentPID:  0,
+		Worktree:  wtDir,
 	}
 	m := testModel(t, task)
 
@@ -1390,6 +1428,38 @@ func TestInit_ResumesOnlyInProgressWithSessionID(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("expected 1 task eligible for resume, got %d", count)
+	}
+}
+
+func TestInit_RevertsTaskWithoutWorktree(t *testing.T) {
+	// A task that is InProgress with a SessionID but no worktree
+	// should be reverted to Pending by Init() (not queued for resume).
+	task := &model.Task{
+		ID:        "t-no-wt",
+		Name:      "orphaned task",
+		Status:    model.StatusInProgress,
+		SessionID: "sess-orphan",
+		StartedAt: time.Now().Add(-10 * time.Minute),
+	}
+	m := testModel(t, task)
+
+	// Init runs the resume logic. Since the task has no Worktree
+	// and discoverWorktree will find nothing (no project set), it
+	// should be reverted to Pending with SessionID and StartedAt cleared.
+	m.Init()
+
+	got, err := m.db.Get("t-no-wt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != model.StatusPending {
+		t.Errorf("expected status reverted to Pending, got %v", got.Status)
+	}
+	if got.SessionID != "" {
+		t.Errorf("expected SessionID cleared, got %q", got.SessionID)
+	}
+	if got.StartedAt != (time.Time{}) {
+		t.Errorf("expected StartedAt cleared, got %v", got.StartedAt)
 	}
 }
 


### PR DESCRIPTION
BuildCmd returns hard error when task.Worktree is empty. Guards in Init() and startOrAttach() prevent tasks without worktree isolation from starting. Tests added for all new code paths.

Co-Authored-By: Claude <noreply@anthropic.com>