### PR TITLE
Rename 'All systems nominal' to 'System status' in settings

### DIFF
--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -1874,7 +1874,7 @@ func TestSettingsKey_RestartDaemon_WithDaemon(t *testing.T) {
 func TestSettingsWarningDetail_ShowsRestartHint(t *testing.T) {
 	sv := NewSettingsView(DefaultTheme())
 	sv.SetSize(40, 30)
-	sv.SetWarnings(nil) // no warnings = "All systems nominal"
+	sv.SetWarnings(nil) // no warnings = "System status"
 	sv.SetProjects(nil)
 	sv.SetBackends(nil)
 

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -133,7 +133,7 @@ func (sv *SettingsView) rebuildRows() {
 	sv.rows = append(sv.rows, settingsRow{kind: settingsRowSection, label: "STATUS"})
 	if len(sv.warnings) == 0 {
 		// No warnings — still show an "all good" row
-		sv.rows = append(sv.rows, settingsRow{kind: settingsRowWarning, label: "All systems nominal", key: "_ok"})
+		sv.rows = append(sv.rows, settingsRow{kind: settingsRowWarning, label: "System status", key: "_ok"})
 	} else {
 		for i, w := range sv.warnings {
 			sv.rows = append(sv.rows, settingsRow{kind: settingsRowWarning, label: w, key: fmt.Sprintf("_warn_%d", i)})
@@ -469,7 +469,7 @@ func (sv SettingsView) renderWarningDetail(sel *settingsRow, _ int) string {
 
 	if sel.key == "_ok" {
 		b.WriteString(sv.theme.Title.Render(" System Status") + "\n\n")
-		b.WriteString(sv.theme.Complete.Render("  All systems nominal") + "\n\n")
+		b.WriteString(sv.theme.Complete.Render("  System status") + "\n\n")
 		b.WriteString("  " + sv.theme.Dimmed.Render("Daemon is running. Sessions will persist") + "\n")
 		b.WriteString("  " + sv.theme.Dimmed.Render("across TUI restarts.") + "\n\n")
 		b.WriteString("  " + sv.theme.Dimmed.Render("Press [r] to restart the daemon.") + "\n")

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -62,8 +62,8 @@ func TestSettingsView_NoWarnings(t *testing.T) {
 	sv.SetBackends(nil)
 
 	view := sv.View()
-	if !strings.Contains(view, "All systems nominal") {
-		t.Error("expected 'All systems nominal' when no warnings")
+	if !strings.Contains(view, "System status") {
+		t.Error("expected 'System status' when no warnings")
 	}
 }
 
@@ -367,8 +367,8 @@ func TestModel_DaemonConnectedWarning(t *testing.T) {
 	if strings.Contains(view2, "In-process mode") {
 		t.Error("should not show in-process warning when daemon connected")
 	}
-	if !strings.Contains(view2, "All systems nominal") {
-		t.Error("expected 'All systems nominal' when daemon connected")
+	if !strings.Contains(view2, "System status") {
+		t.Error("expected 'System status' when daemon connected")
 	}
 }
 


### PR DESCRIPTION
Updates the settings view row label and detail panel body text from 'All systems nominal' to 'System status', with matching test updates.

Co-Authored-By: Claude <noreply@anthropic.com>