### PR TITLE
Add codex --yolo backend support

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,10 @@ func DefaultConfig() Config {
 				Command:    "claude --dangerously-skip-permissions",
 				PromptFlag: "",
 			},
+			"codex": {
+				Command:    "codex --yolo",
+				PromptFlag: "",
+			},
 		},
 		Projects:    make(map[string]Project),
 		Keybindings: DefaultKeybindings(),

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -389,6 +389,36 @@ func TestFixupBackends_MissingDangerouslySkipPermissions(t *testing.T) {
 	}
 }
 
+func TestFixupBackends_MissingYolo(t *testing.T) {
+	d, err := OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	// Simulate a codex backend added manually without --yolo
+	if err := d.SetBackend("codex", config.Backend{
+		Command:    "codex",
+		PromptFlag: "",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.fixupBackends(); err != nil {
+		t.Fatal(err)
+	}
+
+	backends := d.Backends()
+	b, ok := backends["codex"]
+	if !ok {
+		t.Fatal("expected codex backend")
+	}
+	defaultCfg := config.DefaultConfig()
+	if b.Command != defaultCfg.Backends["codex"].Command {
+		t.Errorf("expected command %q, got %q", defaultCfg.Backends["codex"].Command, b.Command)
+	}
+}
+
 func TestFixupBackends_SkipsCorrectConfig(t *testing.T) {
 	d, err := OpenInMemory()
 	if err != nil {
@@ -916,7 +946,7 @@ func TestFixupBackends_NonClaudeBackendUntouched(t *testing.T) {
 	defer d.Close()
 
 	// Add a non-default backend
-	if err := d.SetBackend("codex", config.Backend{Command: "codex", PromptFlag: "-p"}); err != nil {
+	if err := d.SetBackend("gemini", config.Backend{Command: "gemini", PromptFlag: "-p"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -924,10 +954,10 @@ func TestFixupBackends_NonClaudeBackendUntouched(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// codex is not in DefaultConfig, so fixupBackends should not touch it
+	// gemini is not in DefaultConfig, so fixupBackends should not touch it
 	backends := d.Backends()
-	if backends["codex"].PromptFlag != "-p" {
-		t.Errorf("codex prompt_flag should be untouched, got %q", backends["codex"].PromptFlag)
+	if backends["gemini"].PromptFlag != "-p" {
+		t.Errorf("gemini prompt_flag should be untouched, got %q", backends["gemini"].PromptFlag)
 	}
 }
 

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -114,6 +114,11 @@ func (d *DB) fixupBackends() error {
 			needsUpdate = true
 		}
 
+		// Fix: command references "codex" but is missing --yolo.
+		if strings.Contains(command, "codex") && !strings.Contains(command, "--yolo") {
+			needsUpdate = true
+		}
+
 		// Fix: prompt_flag is "-p" (print/non-interactive mode) when the
 		// default is empty (interactive mode).
 		if promptFlag == "-p" && want.PromptFlag == "" {


### PR DESCRIPTION
Adds codex as a built-in default backend using `codex --yolo` (the Codex equivalent of Claude's `--dangerously-skip-permissions`). Includes a self-healing fixup rule so existing databases with a stale codex backend (missing `--yolo`) are corrected on next startup, matching the existing pattern for the claude backend.

Co-Authored-By: Claude <noreply@anthropic.com>