### PR TITLE
Remove 500-char limit on new task prompt textarea

### DIFF
--- a/internal/ui/newtask.go
+++ b/internal/ui/newtask.go
@@ -39,7 +39,7 @@ const maxPromptLines = 10
 func NewNewTaskForm(theme Theme, projects map[string]config.Project, defaultProject string) NewTaskForm {
 	promptInput := textarea.New()
 	promptInput.Placeholder = "Prompt for the agent"
-	promptInput.CharLimit = 500
+	promptInput.CharLimit = 0 // no limit
 	promptInput.ShowLineNumbers = false
 	promptInput.Prompt = ""
 	promptInput.SetHeight(1)


### PR DESCRIPTION
The prompt textarea in the new task form had a hard cap of 500 characters, truncating longer agent prompts. Set CharLimit to 0 (no limit).

Co-Authored-By: Claude <noreply@anthropic.com>