### PR TITLE
Add project config editing in settings

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -8,6 +8,7 @@ type KeyMap struct {
 	Attach    key.Binding
 	StatusFwd key.Binding
 	StatusRev key.Binding
+	Edit      key.Binding
 	Delete    key.Binding
 	Destroy   key.Binding
 	Quit      key.Binding
@@ -42,6 +43,10 @@ func DefaultKeyMap() KeyMap {
 		StatusRev: key.NewBinding(
 			key.WithKeys("S"),
 			key.WithHelp("S", "revert status"),
+		),
+		Edit: key.NewBinding(
+			key.WithKeys("e"),
+			key.WithHelp("e", "edit"),
 		),
 		Delete: key.NewBinding(
 			key.WithKeys("d"),

--- a/internal/ui/projectform.go
+++ b/internal/ui/projectform.go
@@ -10,15 +10,17 @@ import (
 	"github.com/drn/argus/internal/config"
 )
 
-// NewProjectForm handles the new project creation UI.
-type NewProjectForm struct {
-	inputs   []textinput.Model
-	focused  int
-	theme    Theme
-	done     bool
-	canceled bool
-	width    int
-	height   int
+// NewProjectForm handles the new project creation and editing UI.
+type ProjectForm struct {
+	inputs       []textinput.Model
+	focused      int
+	theme        Theme
+	done         bool
+	canceled     bool
+	width        int
+	height       int
+	editMode     bool   // true when editing an existing project
+	originalName string // project name being edited (read-only in edit mode)
 }
 
 const (
@@ -29,7 +31,7 @@ const (
 	projFieldCount
 )
 
-func NewNewProjectForm(theme Theme) NewProjectForm {
+func NewProjectForm(theme Theme) ProjectForm {
 	inputs := make([]textinput.Model, projFieldCount)
 
 	nameInput := textinput.New()
@@ -53,14 +55,63 @@ func NewNewProjectForm(theme Theme) NewProjectForm {
 	backendInput.CharLimit = 40
 	inputs[projFieldBackend] = backendInput
 
-	return NewProjectForm{
+	return ProjectForm{
 		inputs:  inputs,
 		focused: projFieldName,
 		theme:   theme,
 	}
 }
 
-func (f *NewProjectForm) Update(msg tea.Msg) tea.Cmd {
+// LoadProject switches the form into edit mode, pre-populating all fields
+// with the existing project's values. The name field becomes read-only.
+func (f *ProjectForm) LoadProject(name string, proj config.Project) {
+	f.editMode = true
+	f.originalName = name
+	f.inputs[projFieldName].SetValue(name)
+	f.inputs[projFieldPath].SetValue(proj.Path)
+	f.inputs[projFieldBranch].SetValue(proj.Branch)
+	f.inputs[projFieldBackend].SetValue(proj.Backend)
+	// Start focus on path since name is read-only in edit mode.
+	f.focused = projFieldPath
+}
+
+// nextField returns the next field index in the tab order.
+func (f *ProjectForm) nextField() int {
+	if f.editMode {
+		// Cycle through path → branch → backend → path.
+		switch f.focused {
+		case projFieldPath:
+			return projFieldBranch
+		case projFieldBranch:
+			return projFieldBackend
+		default:
+			return projFieldPath
+		}
+	}
+	return (f.focused + 1) % projFieldCount
+}
+
+// prevField returns the previous field index in the tab order.
+func (f *ProjectForm) prevField() int {
+	if f.editMode {
+		switch f.focused {
+		case projFieldPath:
+			return projFieldBackend
+		case projFieldBranch:
+			return projFieldPath
+		default:
+			return projFieldBranch
+		}
+	}
+	return (f.focused - 1 + projFieldCount) % projFieldCount
+}
+
+// lastField returns the last editable field index (the submit-on-enter field).
+func (f *ProjectForm) lastField() int {
+	return projFieldBackend // same in both modes
+}
+
+func (f *ProjectForm) Update(msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case detectBranchMsg:
 		// Auto-fill branch field if user hasn't manually changed it.
@@ -76,30 +127,30 @@ func (f *NewProjectForm) Update(msg tea.Msg) tea.Cmd {
 			return nil
 		case "tab", "down":
 			prev := f.focused
-			f.focused = (f.focused + 1) % projFieldCount
+			f.focused = f.nextField()
 			cmds := []tea.Cmd{f.focusCurrent()}
-			if prev == projFieldPath {
+			if prev == projFieldPath && !f.editMode {
 				cmds = append(cmds, f.detectDefaultBranch())
 			}
 			return tea.Batch(cmds...)
 		case "shift+tab", "up":
 			prev := f.focused
-			f.focused = (f.focused - 1 + projFieldCount) % projFieldCount
+			f.focused = f.prevField()
 			cmds := []tea.Cmd{f.focusCurrent()}
-			if prev == projFieldPath {
+			if prev == projFieldPath && !f.editMode {
 				cmds = append(cmds, f.detectDefaultBranch())
 			}
 			return tea.Batch(cmds...)
 		case "enter":
-			if f.focused == projFieldCount-1 {
+			if f.focused == f.lastField() {
 				// Submit on enter at last field
-				if strings.TrimSpace(f.inputs[projFieldName].Value()) != "" &&
-					strings.TrimSpace(f.inputs[projFieldPath].Value()) != "" {
+				nameOK := f.editMode || strings.TrimSpace(f.inputs[projFieldName].Value()) != ""
+				if nameOK && strings.TrimSpace(f.inputs[projFieldPath].Value()) != "" {
 					f.done = true
 				}
 				return nil
 			}
-			f.focused++
+			f.focused = f.nextField()
 			return f.focusCurrent()
 		}
 	}
@@ -113,7 +164,7 @@ type detectBranchMsg struct{ branch string }
 
 // detectDefaultBranch returns a tea.Cmd that detects the default remote branch
 // for the path currently entered in the form.
-func (f *NewProjectForm) detectDefaultBranch() tea.Cmd {
+func (f *ProjectForm) detectDefaultBranch() tea.Cmd {
 	path := strings.TrimSpace(f.inputs[projFieldPath].Value())
 	if path == "" {
 		return nil
@@ -159,7 +210,7 @@ func detectRemoteDefaultBranch(repoDir string) string {
 	return ""
 }
 
-func (f *NewProjectForm) focusCurrent() tea.Cmd {
+func (f *ProjectForm) focusCurrent() tea.Cmd {
 	cmds := make([]tea.Cmd, len(f.inputs))
 	for i := range f.inputs {
 		if i == f.focused {
@@ -171,8 +222,11 @@ func (f *NewProjectForm) focusCurrent() tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
-func (f *NewProjectForm) ProjectEntry() (string, config.Project) {
+func (f *ProjectForm) ProjectEntry() (string, config.Project) {
 	name := strings.TrimSpace(f.inputs[projFieldName].Value())
+	if f.editMode {
+		name = f.originalName
+	}
 	path := strings.TrimSpace(f.inputs[projFieldPath].Value())
 	branch := strings.TrimSpace(f.inputs[projFieldBranch].Value())
 	backend := strings.TrimSpace(f.inputs[projFieldBackend].Value())
@@ -184,10 +238,10 @@ func (f *NewProjectForm) ProjectEntry() (string, config.Project) {
 	}
 }
 
-func (f *NewProjectForm) Done() bool     { return f.done }
-func (f *NewProjectForm) Canceled() bool { return f.canceled }
+func (f *ProjectForm) Done() bool     { return f.done }
+func (f *ProjectForm) Canceled() bool { return f.canceled }
 
-func (f *NewProjectForm) SetSize(w, h int) {
+func (f *ProjectForm) SetSize(w, h int) {
 	f.width = w
 	f.height = h
 	inputWidth := f.modalWidth() - 6
@@ -199,11 +253,11 @@ func (f *NewProjectForm) SetSize(w, h int) {
 	}
 }
 
-func (f NewProjectForm) modalWidth() int {
+func (f ProjectForm) modalWidth() int {
 	return clampModalWidth(f.width)
 }
 
-func (f NewProjectForm) View() string {
+func (f ProjectForm) View() string {
 	// Guard against zero-valued form (inputs not initialized via constructor).
 	if len(f.inputs) == 0 {
 		return ""
@@ -212,6 +266,12 @@ func (f NewProjectForm) View() string {
 
 	labels := []string{"Name:", "Path:", "Branch:", "Backend:"}
 	for i, label := range labels {
+		if f.editMode && i == projFieldName {
+			// In edit mode, name is read-only — show as a label, not an input.
+			b.WriteString(f.theme.Dimmed.Render(label) + "\n")
+			b.WriteString(f.theme.Normal.Render(f.originalName) + "\n\n")
+			continue
+		}
 		style := f.theme.Dimmed
 		if i == f.focused {
 			style = f.theme.Selected
@@ -224,12 +284,17 @@ func (f NewProjectForm) View() string {
 
 	mw := f.modalWidth()
 
+	title := "New Project"
+	if f.editMode {
+		title = "Edit Project"
+	}
+
 	modal := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color("87")).
 		Padding(1, 2).
 		Width(mw).
-		Render(f.theme.Title.Render("New Project") + "\n\n" + b.String())
+		Render(f.theme.Title.Render(title) + "\n\n" + b.String())
 
 	return lipgloss.Place(f.width, f.height, lipgloss.Center, lipgloss.Center, modal)
 }

--- a/internal/ui/projectform_test.go
+++ b/internal/ui/projectform_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNewProjectForm_Defaults(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 	if f.Done() {
 		t.Error("new form should not be done")
 	}
@@ -21,7 +21,7 @@ func TestNewProjectForm_Defaults(t *testing.T) {
 }
 
 func TestNewProjectForm_EscCancels(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 	f.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	if !f.Canceled() {
 		t.Error("esc should cancel the form")
@@ -29,7 +29,7 @@ func TestNewProjectForm_EscCancels(t *testing.T) {
 }
 
 func TestNewProjectForm_TabNavigation(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 
 	// Tab: name -> path
 	f.Update(tea.KeyMsg{Type: tea.KeyTab})
@@ -57,7 +57,7 @@ func TestNewProjectForm_TabNavigation(t *testing.T) {
 }
 
 func TestNewProjectForm_ShiftTabNavigation(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 
 	// Shift+tab: name -> wraps to backend
 	f.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
@@ -73,7 +73,7 @@ func TestNewProjectForm_ShiftTabNavigation(t *testing.T) {
 }
 
 func TestNewProjectForm_EnterSubmits(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 
 	// Set required fields
 	f.inputs[projFieldName].SetValue("myproject")
@@ -89,7 +89,7 @@ func TestNewProjectForm_EnterSubmits(t *testing.T) {
 }
 
 func TestNewProjectForm_EnterWithoutNameDoesNotSubmit(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 
 	// Only set path, not name
 	f.inputs[projFieldPath].SetValue("/tmp/myproject")
@@ -102,7 +102,7 @@ func TestNewProjectForm_EnterWithoutNameDoesNotSubmit(t *testing.T) {
 }
 
 func TestNewProjectForm_EnterWithoutPathDoesNotSubmit(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 
 	// Only set name, not path
 	f.inputs[projFieldName].SetValue("myproject")
@@ -115,7 +115,7 @@ func TestNewProjectForm_EnterWithoutPathDoesNotSubmit(t *testing.T) {
 }
 
 func TestNewProjectForm_EnterOnNonLastFieldAdvances(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 	f.focused = projFieldName
 
 	f.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -125,7 +125,7 @@ func TestNewProjectForm_EnterOnNonLastFieldAdvances(t *testing.T) {
 }
 
 func TestNewProjectForm_ProjectEntry(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 	f.inputs[projFieldName].SetValue("testproj")
 	f.inputs[projFieldPath].SetValue("/home/user/testproj")
 	f.inputs[projFieldBranch].SetValue("develop")
@@ -147,14 +147,14 @@ func TestNewProjectForm_ProjectEntry(t *testing.T) {
 }
 
 func TestNewProjectForm_DefaultBranch(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 	if f.inputs[projFieldBranch].Value() != "master" {
 		t.Errorf("default branch = %q, want 'master'", f.inputs[projFieldBranch].Value())
 	}
 }
 
 func TestNewProjectForm_SetSize(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 	f.SetSize(120, 40)
 	if f.width != 120 || f.height != 40 {
 		t.Errorf("SetSize(120,40) gave width=%d height=%d", f.width, f.height)
@@ -168,7 +168,7 @@ func TestNewProjectForm_SetSize(t *testing.T) {
 }
 
 func TestNewProjectForm_ModalWidth(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 
 	// Small width: should be at least 50
 	f.width = 60
@@ -184,7 +184,7 @@ func TestNewProjectForm_ModalWidth(t *testing.T) {
 }
 
 func TestNewProjectForm_DetectBranchMsg(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 
 	// Default is "master" — detectBranchMsg should override it.
 	f.Update(detectBranchMsg{branch: "origin/main"})
@@ -194,7 +194,7 @@ func TestNewProjectForm_DetectBranchMsg(t *testing.T) {
 }
 
 func TestNewProjectForm_DetectBranchMsg_NoOverrideCustom(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 
 	// User manually set a custom branch — should NOT be overridden.
 	f.inputs[projFieldBranch].SetValue("develop")
@@ -213,7 +213,7 @@ func TestDetectRemoteDefaultBranch_BadPath(t *testing.T) {
 }
 
 func TestNewProjectForm_View(t *testing.T) {
-	f := NewNewProjectForm(DefaultTheme())
+	f := NewProjectForm(DefaultTheme())
 	f.SetSize(100, 30)
 
 	view := f.View()

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -28,6 +28,7 @@ const (
 	viewPrompt
 	viewConfirmDelete
 	viewNewProject
+	viewEditProject
 	viewConfirmDeleteProject
 	viewConfirmDestroy
 	viewPruning
@@ -123,7 +124,7 @@ type Model struct {
 	statusbar   StatusBar
 	helpview    HelpView
 	newtask     NewTaskForm
-	newproject    NewProjectForm
+	projectform   ProjectForm
 	sandboxconfig SandboxConfigForm // sandbox settings editor
 	preview     Preview
 	gitstatus   *GitStatus
@@ -316,7 +317,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		m.statusbar.SetWidth(msg.Width)
 		m.newtask.SetSize(msg.Width, msg.Height)
-		m.newproject.SetSize(msg.Width, msg.Height)
+		m.projectform.SetSize(msg.Width, msg.Height)
 		m.sandboxconfig.SetSize(msg.Width, msg.Height)
 		m.agentview.SetSize(msg.Width, msg.Height)
 		return m, nil
@@ -521,8 +522,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case detectBranchMsg:
-		if m.current == viewNewProject {
-			cmd := m.newproject.Update(msg)
+		if m.current == viewNewProject || m.current == viewEditProject {
+			cmd := m.projectform.Update(msg)
 			return m, cmd
 		}
 		return m, nil
@@ -541,6 +542,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleNewTaskKey(msg)
 	case viewNewProject:
 		return m.handleNewProjectKey(msg)
+	case viewEditProject:
+		return m.handleEditProjectKey(msg)
 	case viewHelp:
 		m.current = viewTaskList
 		return m, nil
@@ -1073,10 +1076,21 @@ func (m Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Only allow new project creation when on a project row (or section).
 		sel := m.settings.Selected()
 		if sel == nil || sel.kind == settingsRowProject {
-			m.newproject = NewNewProjectForm(m.theme)
-			m.newproject.SetSize(m.width, m.height)
+			m.projectform = NewProjectForm(m.theme)
+			m.projectform.SetSize(m.width, m.height)
 			m.current = viewNewProject
-			return m, m.newproject.inputs[0].Focus()
+			return m, m.projectform.inputs[0].Focus()
+		}
+		return m, nil
+
+	case key.Matches(msg, m.keys.Edit):
+		// Edit the selected project.
+		if entry := m.settings.SelectedProject(); entry != nil {
+			m.projectform = NewProjectForm(m.theme)
+			m.projectform.SetSize(m.width, m.height)
+			m.projectform.LoadProject(entry.Name, entry.Project)
+			m.current = viewEditProject
+			return m, m.projectform.inputs[projFieldPath].Focus()
 		}
 		return m, nil
 
@@ -1147,18 +1161,41 @@ func (m Model) restartDaemonCmd() tea.Cmd {
 }
 
 func (m Model) handleNewProjectKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	cmd := m.newproject.Update(msg)
+	cmd := m.projectform.Update(msg)
 
-	if m.newproject.Canceled() {
+	if m.projectform.Canceled() {
 		m.current = viewTaskList
+		m.activeTab = tabSettings
 		return m, nil
 	}
 
-	if m.newproject.Done() {
-		name, proj := m.newproject.ProjectEntry()
+	if m.projectform.Done() {
+		name, proj := m.projectform.ProjectEntry()
 		_ = m.db.SetProject(name, proj)
 		m.refreshSettings()
 		m.current = viewTaskList
+		m.activeTab = tabSettings
+		return m, nil
+	}
+
+	return m, cmd
+}
+
+func (m Model) handleEditProjectKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	cmd := m.projectform.Update(msg)
+
+	if m.projectform.Canceled() {
+		m.current = viewTaskList
+		m.activeTab = tabSettings
+		return m, nil
+	}
+
+	if m.projectform.Done() {
+		name, proj := m.projectform.ProjectEntry()
+		_ = m.db.SetProject(name, proj)
+		m.refreshSettings()
+		m.current = viewTaskList
+		m.activeTab = tabSettings
 		return m, nil
 	}
 

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -1099,8 +1099,8 @@ func TestModel_ViewNewTask(t *testing.T) {
 func TestModel_ViewNewProject(t *testing.T) {
 	m := testModel(t)
 	m.current = viewNewProject
-	m.newproject = NewNewProjectForm(m.theme)
-	m.newproject.SetSize(80, 24)
+	m.projectform = NewProjectForm(m.theme)
+	m.projectform.SetSize(80, 24)
 	m.width = 80
 	m.height = 24
 	view := m.View()
@@ -1303,7 +1303,7 @@ func TestModel_NewProjectCancel(t *testing.T) {
 	m := testModel(t)
 	m.activeTab = tabSettings
 	m.current = viewNewProject
-	m.newproject = NewNewProjectForm(m.theme)
+	m.projectform = NewProjectForm(m.theme)
 
 	msg := tea.KeyMsg{Type: tea.KeyEsc}
 	updated, _ := m.Update(msg)
@@ -1698,6 +1698,12 @@ func TestModel_ViewZeroDimensions(t *testing.T) {
 		{"confirmDeleteProject", func(m *Model) { m.current = viewConfirmDeleteProject }},
 		{"newTask", func(m *Model) { m.current = viewNewTask }},
 		{"newProject", func(m *Model) { m.current = viewNewProject }},
+		{"editProject", func(m *Model) {
+			f := NewProjectForm(m.theme)
+			f.LoadProject("proj", config.Project{Path: "/tmp/proj", Branch: "master"})
+			m.projectform = f
+			m.current = viewEditProject
+		}},
 		{"pruning", func(m *Model) { m.current = viewPruning; m.pruneTotal = 3 }},
 		{"daemonRestart", func(m *Model) { m.current = viewDaemonRestart; m.daemonRestarting = true }},
 		{"sandboxConfig", func(m *Model) {

--- a/internal/ui/root_views.go
+++ b/internal/ui/root_views.go
@@ -41,8 +41,8 @@ func (m Model) View() string {
 		return m.padToBottom(m.promptView(), bar)
 	case viewNewTask:
 		return m.newtask.View() + "\n" + bar
-	case viewNewProject:
-		return m.newproject.View() + "\n" + bar
+	case viewNewProject, viewEditProject:
+		return m.projectform.View() + "\n" + bar
 	case viewSandboxConfig:
 		return m.sandboxconfig.View() + "\n" + bar
 	}

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -515,6 +515,8 @@ func (sv SettingsView) renderProjectDetail(sel *settingsRow, innerW int) string 
 	sc := sv.taskCounts[entry.Name]
 	total := sc.Total()
 
+	b.WriteString("\n" + sv.theme.Help.Render("  [e] edit  [d] delete") + "\n")
+
 	b.WriteString("\n" + sv.theme.Section.Render("  TASKS") + "\n")
 
 	if total == 0 {


### PR DESCRIPTION
Press [e] on a project in Settings to open a pre-populated Edit Project form. Name is read-only (primary key); Path, Branch, and Backend are editable. Reuses ProjectForm (renamed from NewProjectForm) with an editMode flag that narrows tab navigation and suppresses branch auto-detection. Adds Edit keybinding to KeyMap.

Co-Authored-By: Claude <noreply@anthropic.com>