### PR TITLE
Add word boundary navigation matching WORDCHARS config

### DIFF
--- a/internal/ui/newtask.go
+++ b/internal/ui/newtask.go
@@ -154,6 +154,11 @@ func (f *NewTaskForm) Update(msg tea.Msg) tea.Cmd {
 			}
 			return nil
 		}
+		if f.focused == fieldPrompt {
+			if applyWordNavTextarea(msg, &f.promptInput, f.adjustPromptHeight) {
+				return nil
+			}
+		}
 	}
 
 	if f.focused == fieldPrompt {
@@ -166,18 +171,23 @@ func (f *NewTaskForm) Update(msg tea.Msg) tea.Cmd {
 		var cmd tea.Cmd
 		f.promptInput, cmd = f.promptInput.Update(msg)
 		// Shrink height back to fit the actual visual line count
-		lines := f.visualLineCount()
-		if lines < 1 {
-			lines = 1
-		}
-		if lines > maxPromptLines {
-			lines = maxPromptLines
-		}
-		f.promptInput.SetHeight(lines)
+		f.adjustPromptHeight()
 		return cmd
 	}
 
 	return nil
+}
+
+// adjustPromptHeight resizes the prompt textarea to fit its current content.
+func (f *NewTaskForm) adjustPromptHeight() {
+	lines := f.visualLineCount()
+	if lines < 1 {
+		lines = 1
+	}
+	if lines > maxPromptLines {
+		lines = maxPromptLines
+	}
+	f.promptInput.SetHeight(lines)
 }
 
 // visualLineCount returns the total number of visual lines in the textarea,

--- a/internal/ui/projectform.go
+++ b/internal/ui/projectform.go
@@ -153,6 +153,9 @@ func (f *ProjectForm) Update(msg tea.Msg) tea.Cmd {
 			f.focused = f.nextField()
 			return f.focusCurrent()
 		}
+		if applyWordNavTextinput(msg, &f.inputs[f.focused]) {
+			return nil
+		}
 	}
 
 	var cmd tea.Cmd

--- a/internal/ui/sandboxconfig.go
+++ b/internal/ui/sandboxconfig.go
@@ -76,6 +76,12 @@ func (f *SandboxConfigForm) Update(msg tea.Msg) tea.Cmd {
 		}
 	}
 
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		if applyWordNavTextinput(keyMsg, &f.inputs[f.focused]) {
+			return nil
+		}
+	}
+
 	var cmd tea.Cmd
 	f.inputs[f.focused], cmd = f.inputs[f.focused].Update(msg)
 	return cmd

--- a/internal/ui/wordboundary.go
+++ b/internal/ui/wordboundary.go
@@ -1,0 +1,131 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// wordChars matches ~/.dots WORDCHARS='*?_[]~=&;!#$%^(){}<>'.
+// Characters not in this set (and not letters/digits) are word delimiters.
+// This means '/', '-', '.' and whitespace break words, matching zsh behavior.
+const wordCharsSet = `*?_[]~=&;!#$%^(){}<>`
+
+// isWordChar reports whether r is a word character under the configured WORDCHARS.
+func isWordChar(r rune) bool {
+	if r == ' ' || r == '\t' || r == '\n' {
+		return false
+	}
+	if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+		return true
+	}
+	return strings.ContainsRune(wordCharsSet, r)
+}
+
+// wordLeftPos returns the cursor position after a word-left movement.
+func wordLeftPos(runes []rune, pos int) int {
+	// Skip non-word chars (delimiters) going left.
+	for pos > 0 && !isWordChar(runes[pos-1]) {
+		pos--
+	}
+	// Skip word chars going left (the actual word).
+	for pos > 0 && isWordChar(runes[pos-1]) {
+		pos--
+	}
+	return pos
+}
+
+// wordRightPos returns the cursor position after a word-right movement.
+func wordRightPos(runes []rune, pos int) int {
+	// Skip non-word chars (delimiters) going right.
+	for pos < len(runes) && !isWordChar(runes[pos]) {
+		pos++
+	}
+	// Skip word chars going right (the actual word).
+	for pos < len(runes) && isWordChar(runes[pos]) {
+		pos++
+	}
+	return pos
+}
+
+// deleteWordLeft deletes from pos back to the previous word boundary.
+// Returns the new rune slice and the new cursor position.
+func deleteWordLeft(runes []rune, pos int) ([]rune, int) {
+	newPos := wordLeftPos(runes, pos)
+	result := make([]rune, 0, len(runes)-(pos-newPos))
+	result = append(result, runes[:newPos]...)
+	result = append(result, runes[pos:]...)
+	return result, newPos
+}
+
+// deleteWordRight deletes from pos to the next word boundary.
+// Returns the new rune slice and the new cursor position.
+func deleteWordRight(runes []rune, pos int) ([]rune, int) {
+	newPos := wordRightPos(runes, pos)
+	result := make([]rune, 0, len(runes)-(newPos-pos))
+	result = append(result, runes[:pos]...)
+	result = append(result, runes[newPos:]...)
+	return result, pos
+}
+
+// applyWordNavTextinput handles word navigation keys for a textinput.Model.
+// Returns true if the key was handled (caller should skip the normal Update).
+func applyWordNavTextinput(msg tea.KeyMsg, m *textinput.Model) bool {
+	switch msg.String() {
+	case "alt+left", "alt+b":
+		runes := []rune(m.Value())
+		m.SetCursor(wordLeftPos(runes, m.Position()))
+	case "alt+right", "alt+f":
+		runes := []rune(m.Value())
+		m.SetCursor(wordRightPos(runes, m.Position()))
+	case "alt+backspace", "ctrl+w":
+		runes := []rune(m.Value())
+		newRunes, newPos := deleteWordLeft(runes, m.Position())
+		m.SetValue(string(newRunes))
+		m.SetCursor(newPos)
+	case "alt+delete", "alt+d":
+		runes := []rune(m.Value())
+		newRunes, newPos := deleteWordRight(runes, m.Position())
+		m.SetValue(string(newRunes))
+		m.SetCursor(newPos)
+	default:
+		return false
+	}
+	return true
+}
+
+// applyWordNavTextarea handles word navigation keys for a textarea.Model.
+// Returns true if the key was handled (caller should skip the normal Update).
+// Also accepts a height-adjust callback called after delete operations so the
+// caller can resize the textarea to fit the new content.
+func applyWordNavTextarea(msg tea.KeyMsg, m *textarea.Model, adjustHeight func()) bool {
+	switch msg.String() {
+	case "alt+left", "alt+b":
+		runes := []rune(m.Value())
+		m.SetCursor(wordLeftPos(runes, m.LineInfo().CharOffset))
+	case "alt+right", "alt+f":
+		runes := []rune(m.Value())
+		m.SetCursor(wordRightPos(runes, m.LineInfo().CharOffset))
+	case "alt+backspace", "ctrl+w":
+		runes := []rune(m.Value())
+		newRunes, newPos := deleteWordLeft(runes, m.LineInfo().CharOffset)
+		m.SetValue(string(newRunes))
+		m.SetCursor(newPos)
+		if adjustHeight != nil {
+			adjustHeight()
+		}
+	case "alt+delete", "alt+d":
+		runes := []rune(m.Value())
+		newRunes, newPos := deleteWordRight(runes, m.LineInfo().CharOffset)
+		m.SetValue(string(newRunes))
+		m.SetCursor(newPos)
+		if adjustHeight != nil {
+			adjustHeight()
+		}
+	default:
+		return false
+	}
+	return true
+}

--- a/internal/ui/wordboundary_test.go
+++ b/internal/ui/wordboundary_test.go
@@ -1,0 +1,156 @@
+package ui
+
+import (
+	"testing"
+)
+
+func TestIsWordChar(t *testing.T) {
+	tests := []struct {
+		r    rune
+		want bool
+	}{
+		{'a', true},
+		{'Z', true},
+		{'0', true},
+		{'9', true},
+		{'_', true},  // in WORDCHARS
+		{'*', true},  // in WORDCHARS
+		{'/', false}, // excluded from WORDCHARS
+		{'-', false}, // excluded from WORDCHARS
+		{'.', false}, // excluded from WORDCHARS
+		{' ', false},
+		{'\t', false},
+		{'\n', false},
+	}
+	for _, tt := range tests {
+		if got := isWordChar(tt.r); got != tt.want {
+			t.Errorf("isWordChar(%q) = %v, want %v", tt.r, got, tt.want)
+		}
+	}
+}
+
+func TestWordLeftPos(t *testing.T) {
+	tests := []struct {
+		input string
+		pos   int
+		want  int
+	}{
+		// Basic word movement
+		{"hello world", 11, 6}, // end → start of "world"
+		{"hello world", 6, 0},  // start of "world" → start of "hello"
+		{"hello world", 5, 0},  // space → start of "hello"
+		// Slash delimiters
+		{"foo/bar/baz", 11, 8}, // end → start of "baz"
+		{"foo/bar/baz", 8, 4},  // start of "baz" → start of "bar"
+		{"foo/bar/baz", 4, 0},  // start of "bar" → start of "foo"
+		// Dot delimiters
+		{"foo.bar.baz", 11, 8},
+		{"foo.bar.baz", 8, 4},
+		// Dash delimiters
+		{"foo-bar-baz", 11, 8},
+		{"foo-bar-baz", 8, 4},
+		// Mixed
+		{"a/b-c.d", 7, 6}, // end → start of "d"
+		{"a/b-c.d", 6, 4}, // "d" → start of "c"
+		{"a/b-c.d", 4, 2}, // "c" → start of "b"
+		{"a/b-c.d", 2, 0}, // "b" → start of "a"
+		// Edge cases
+		{"hello", 0, 0},  // already at start
+		{"hello", 5, 0},  // end of single word
+		{"///", 3, 0},    // all delimiters
+		{"  foo  ", 7, 2}, // trailing spaces
+	}
+	for _, tt := range tests {
+		runes := []rune(tt.input)
+		got := wordLeftPos(runes, tt.pos)
+		if got != tt.want {
+			t.Errorf("wordLeftPos(%q, %d) = %d, want %d", tt.input, tt.pos, got, tt.want)
+		}
+	}
+}
+
+func TestWordRightPos(t *testing.T) {
+	tests := []struct {
+		input string
+		pos   int
+		want  int
+	}{
+		// Basic word movement
+		{"hello world", 0, 5},  // start → end of "hello"
+		{"hello world", 5, 11}, // space → end of "world"
+		{"hello world", 6, 11}, // start of "world" → end of "world"
+		// Slash delimiters
+		{"foo/bar/baz", 0, 3},  // start → end of "foo"
+		{"foo/bar/baz", 3, 7},  // "/" → end of "bar"
+		{"foo/bar/baz", 7, 11}, // "/" → end of "baz"
+		// Dot delimiters
+		{"foo.bar.baz", 0, 3},
+		{"foo.bar.baz", 3, 7},
+		// Dash delimiters
+		{"foo-bar-baz", 0, 3},
+		{"foo-bar-baz", 3, 7},
+		// Edge cases
+		{"hello", 5, 5},   // already at end
+		{"hello", 0, 5},   // start of single word
+		{"///", 0, 3},     // all delimiters
+		{"  foo  ", 0, 5}, // leading spaces
+	}
+	for _, tt := range tests {
+		runes := []rune(tt.input)
+		got := wordRightPos(runes, tt.pos)
+		if got != tt.want {
+			t.Errorf("wordRightPos(%q, %d) = %d, want %d", tt.input, tt.pos, got, tt.want)
+		}
+	}
+}
+
+func TestDeleteWordLeft(t *testing.T) {
+	tests := []struct {
+		input   string
+		pos     int
+		wantStr string
+		wantPos int
+	}{
+		{"hello world", 11, "hello ", 6},
+		{"hello world", 6, "world", 0},
+		{"foo/bar/baz", 11, "foo/bar/", 8},
+		{"foo/bar/baz", 8, "foo/baz", 4},
+		{"foo/bar/baz", 4, "bar/baz", 0},
+		{"hello", 0, "hello", 0}, // at start, nothing deleted
+	}
+	for _, tt := range tests {
+		runes := []rune(tt.input)
+		gotRunes, gotPos := deleteWordLeft(runes, tt.pos)
+		gotStr := string(gotRunes)
+		if gotStr != tt.wantStr || gotPos != tt.wantPos {
+			t.Errorf("deleteWordLeft(%q, %d) = (%q, %d), want (%q, %d)",
+				tt.input, tt.pos, gotStr, gotPos, tt.wantStr, tt.wantPos)
+		}
+	}
+}
+
+func TestDeleteWordRight(t *testing.T) {
+	tests := []struct {
+		input   string
+		pos     int
+		wantStr string
+		wantPos int
+	}{
+		{"hello world", 0, " world", 0},
+		{"hello world", 5, "hello", 5},
+		{"hello world", 6, "hello ", 6},
+		{"foo/bar/baz", 0, "/bar/baz", 0},
+		{"foo/bar/baz", 3, "foo/baz", 3},
+		{"foo/bar/baz", 7, "foo/bar", 7},
+		{"hello", 5, "hello", 5}, // at end, nothing deleted
+	}
+	for _, tt := range tests {
+		runes := []rune(tt.input)
+		gotRunes, gotPos := deleteWordRight(runes, tt.pos)
+		gotStr := string(gotRunes)
+		if gotStr != tt.wantStr || gotPos != tt.wantPos {
+			t.Errorf("deleteWordRight(%q, %d) = (%q, %d), want (%q, %d)",
+				tt.input, tt.pos, gotStr, gotPos, tt.wantStr, tt.wantPos)
+		}
+	}
+}


### PR DESCRIPTION
Intercepts alt+left/right and alt+backspace/delete in all text input forms (NewTaskForm, NewProjectForm, SandboxConfigForm) using WORDCHARS='*?_[]~=&;!#$%^(){}<>' boundaries — matching the ~/.dots zsh config — so /, -, and . break words like they do everywhere else on the system.

Logic is centralized in wordboundary.go with two drop-in helpers: applyWordNavTextinput and applyWordNavTextarea.

Co-Authored-By: Claude <noreply@anthropic.com>