### PR TITLE
Fix word navigation in multi-line textarea

### DIFF
--- a/internal/ui/wordboundary.go
+++ b/internal/ui/wordboundary.go
@@ -96,6 +96,58 @@ func applyWordNavTextinput(msg tea.KeyMsg, m *textinput.Model) bool {
 	return true
 }
 
+// textareaAbsCursorPos returns the absolute rune index of the cursor within
+// the full textarea value. LineInfo().CharOffset is relative to the current
+// line; this function adds the lengths of all preceding lines.
+func textareaAbsCursorPos(m *textarea.Model) int {
+	runes := []rune(m.Value())
+	targetLine := m.Line()
+	pos := 0
+	currentLine := 0
+	for pos < len(runes) && currentLine < targetLine {
+		if runes[pos] == '\n' {
+			currentLine++
+		}
+		pos++
+	}
+	return pos + m.LineInfo().CharOffset
+}
+
+// textareaSetAbsCursorPos moves the textarea cursor to the given absolute rune
+// position within text. It navigates line-by-line from the current cursor line
+// using CursorUp/CursorDown, then sets the column with SetCursor.
+// After SetValue the cursor resets to (0,0), so pass the new text and call
+// this from line 0 in that case.
+func textareaSetAbsCursorPos(m *textarea.Model, text string, absPos int) {
+	runes := []rune(text)
+	if absPos < 0 {
+		absPos = 0
+	}
+	if absPos > len(runes) {
+		absPos = len(runes)
+	}
+	targetLine := 0
+	col := 0
+	for i := 0; i < absPos; i++ {
+		if runes[i] == '\n' {
+			targetLine++
+			col = 0
+		} else {
+			col++
+		}
+	}
+	currentLine := m.Line()
+	for currentLine < targetLine {
+		m.CursorDown()
+		currentLine++
+	}
+	for currentLine > targetLine {
+		m.CursorUp()
+		currentLine--
+	}
+	m.SetCursor(col)
+}
+
 // applyWordNavTextarea handles word navigation keys for a textarea.Model.
 // Returns true if the key was handled (caller should skip the normal Update).
 // Also accepts a height-adjust callback called after delete operations so the
@@ -104,23 +156,27 @@ func applyWordNavTextarea(msg tea.KeyMsg, m *textarea.Model, adjustHeight func()
 	switch msg.String() {
 	case "alt+left", "alt+b":
 		runes := []rune(m.Value())
-		m.SetCursor(wordLeftPos(runes, m.LineInfo().CharOffset))
+		newAbsPos := wordLeftPos(runes, textareaAbsCursorPos(m))
+		textareaSetAbsCursorPos(m, m.Value(), newAbsPos)
 	case "alt+right", "alt+f":
 		runes := []rune(m.Value())
-		m.SetCursor(wordRightPos(runes, m.LineInfo().CharOffset))
+		newAbsPos := wordRightPos(runes, textareaAbsCursorPos(m))
+		textareaSetAbsCursorPos(m, m.Value(), newAbsPos)
 	case "alt+backspace", "ctrl+w":
 		runes := []rune(m.Value())
-		newRunes, newPos := deleteWordLeft(runes, m.LineInfo().CharOffset)
-		m.SetValue(string(newRunes))
-		m.SetCursor(newPos)
+		newRunes, newAbsPos := deleteWordLeft(runes, textareaAbsCursorPos(m))
+		newText := string(newRunes)
+		m.SetValue(newText) // resets cursor to (0,0)
+		textareaSetAbsCursorPos(m, newText, newAbsPos)
 		if adjustHeight != nil {
 			adjustHeight()
 		}
 	case "alt+delete", "alt+d":
 		runes := []rune(m.Value())
-		newRunes, newPos := deleteWordRight(runes, m.LineInfo().CharOffset)
-		m.SetValue(string(newRunes))
-		m.SetCursor(newPos)
+		newRunes, newAbsPos := deleteWordRight(runes, textareaAbsCursorPos(m))
+		newText := string(newRunes)
+		m.SetValue(newText) // resets cursor to (0,0)
+		textareaSetAbsCursorPos(m, newText, newAbsPos)
 		if adjustHeight != nil {
 			adjustHeight()
 		}

--- a/internal/ui/wordboundary_test.go
+++ b/internal/ui/wordboundary_test.go
@@ -2,6 +2,9 @@ package ui
 
 import (
 	"testing"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestIsWordChar(t *testing.T) {
@@ -127,6 +130,151 @@ func TestDeleteWordLeft(t *testing.T) {
 				tt.input, tt.pos, gotStr, gotPos, tt.wantStr, tt.wantPos)
 		}
 	}
+}
+
+// newTestTextarea returns a textarea initialized with the given value,
+// cursor positioned at the given absolute rune offset.
+func newTestTextarea(value string, absPos int) textarea.Model {
+	ta := textarea.New()
+	ta.SetWidth(200) // wide enough to avoid soft wraps in tests
+	ta.SetValue(value)
+	// SetValue resets cursor to (0,0); navigate to absPos.
+	textareaSetAbsCursorPos(&ta, value, absPos)
+	return ta
+}
+
+func TestTextareaAbsCursorPos(t *testing.T) {
+	tests := []struct {
+		value  string
+		absPos int // cursor position to set before the call
+		want   int
+	}{
+		// Single line
+		{"hello world", 0, 0},
+		{"hello world", 6, 6},
+		{"hello world", 11, 11},
+		// Multi-line: "hello\nfoo bar" — newline at index 5
+		{"hello\nfoo bar", 0, 0},
+		{"hello\nfoo bar", 5, 5},  // end of first line (at \n)
+		{"hello\nfoo bar", 6, 6},  // start of second line ('f')
+		{"hello\nfoo bar", 13, 13}, // end of second line
+	}
+	for _, tt := range tests {
+		ta := newTestTextarea(tt.value, tt.absPos)
+		got := textareaAbsCursorPos(&ta)
+		if got != tt.want {
+			t.Errorf("textareaAbsCursorPos value=%q absPos=%d: got %d, want %d (line=%d charOffset=%d)",
+				tt.value, tt.absPos, got, tt.want, ta.Line(), ta.LineInfo().CharOffset)
+		}
+	}
+}
+
+func TestTextareaSetAbsCursorPos(t *testing.T) {
+	tests := []struct {
+		value    string
+		absPos   int
+		wantLine int
+		wantCol  int
+	}{
+		// Single line
+		{"hello world", 0, 0, 0},
+		{"hello world", 6, 0, 6},
+		{"hello world", 11, 0, 11},
+		// Multi-line: "hello\nfoo bar"
+		{"hello\nfoo bar", 0, 0, 0},
+		{"hello\nfoo bar", 5, 0, 5},  // just before \n — still line 0
+		{"hello\nfoo bar", 6, 1, 0},  // just after \n — line 1, col 0
+		{"hello\nfoo bar", 10, 1, 4}, // "foo " = 4 chars into line 1
+		{"hello\nfoo bar", 13, 1, 7}, // end of "foo bar"
+	}
+	for _, tt := range tests {
+		ta := textarea.New()
+		ta.SetWidth(200)
+		ta.SetValue(tt.value)
+		textareaSetAbsCursorPos(&ta, tt.value, tt.absPos)
+		gotLine := ta.Line()
+		gotCol := ta.LineInfo().CharOffset
+		if gotLine != tt.wantLine || gotCol != tt.wantCol {
+			t.Errorf("textareaSetAbsCursorPos value=%q absPos=%d: got (line=%d col=%d), want (line=%d col=%d)",
+				tt.value, tt.absPos, gotLine, gotCol, tt.wantLine, tt.wantCol)
+		}
+	}
+}
+
+func TestApplyWordNavTextarea_MultiLine(t *testing.T) {
+	altLeft := tea.KeyMsg{Type: tea.KeyLeft, Alt: true}
+	altRight := tea.KeyMsg{Type: tea.KeyRight, Alt: true}
+	altBackspace := tea.KeyMsg{Type: tea.KeyBackspace, Alt: true}
+	altDelete := tea.KeyMsg{Type: tea.KeyDelete, Alt: true}
+
+	t.Run("alt+left from middle of second line", func(t *testing.T) {
+		// "hello\nfoo bar" — cursor at end (abs=13), alt+left → start of "bar" (abs=10)
+		ta := newTestTextarea("hello\nfoo bar", 13)
+		applyWordNavTextarea(altLeft, &ta, nil)
+		got := textareaAbsCursorPos(&ta)
+		if got != 10 {
+			t.Errorf("alt+left: got absPos %d, want 10", got)
+		}
+	})
+
+	t.Run("alt+left across line boundary", func(t *testing.T) {
+		// "hello\nfoo bar" — cursor at start of second line (abs=6)
+		// alt+left should skip \n and land at start of "hello" (abs=0)
+		ta := newTestTextarea("hello\nfoo bar", 6)
+		applyWordNavTextarea(altLeft, &ta, nil)
+		got := textareaAbsCursorPos(&ta)
+		if got != 0 {
+			t.Errorf("alt+left across newline: got absPos %d, want 0", got)
+		}
+	})
+
+	t.Run("alt+right from middle of first line", func(t *testing.T) {
+		// "hello\nfoo bar" — cursor at abs=0, alt+right → end of "hello" (abs=5)
+		ta := newTestTextarea("hello\nfoo bar", 0)
+		applyWordNavTextarea(altRight, &ta, nil)
+		got := textareaAbsCursorPos(&ta)
+		if got != 5 {
+			t.Errorf("alt+right: got absPos %d, want 5", got)
+		}
+	})
+
+	t.Run("alt+right across line boundary", func(t *testing.T) {
+		// "hello\nfoo bar" — cursor at abs=5 (at \n), alt+right skips \n and space → end of "foo" (abs=9)
+		ta := newTestTextarea("hello\nfoo bar", 5)
+		applyWordNavTextarea(altRight, &ta, nil)
+		got := textareaAbsCursorPos(&ta)
+		if got != 9 {
+			t.Errorf("alt+right across newline: got absPos %d, want 9", got)
+		}
+	})
+
+	t.Run("alt+backspace on second line", func(t *testing.T) {
+		// "hello\nfoo bar" — cursor at end (abs=13), alt+backspace deletes "bar"
+		ta := newTestTextarea("hello\nfoo bar", 13)
+		applyWordNavTextarea(altBackspace, &ta, nil)
+		gotVal := ta.Value()
+		gotPos := textareaAbsCursorPos(&ta)
+		if gotVal != "hello\nfoo " {
+			t.Errorf("alt+backspace value: got %q, want %q", gotVal, "hello\nfoo ")
+		}
+		if gotPos != 10 {
+			t.Errorf("alt+backspace absPos: got %d, want 10", gotPos)
+		}
+	})
+
+	t.Run("alt+delete on second line", func(t *testing.T) {
+		// "hello\nfoo bar" — cursor at abs=6 (start of "foo"), alt+delete deletes "foo"
+		ta := newTestTextarea("hello\nfoo bar", 6)
+		applyWordNavTextarea(altDelete, &ta, nil)
+		gotVal := ta.Value()
+		gotPos := textareaAbsCursorPos(&ta)
+		if gotVal != "hello\n bar" {
+			t.Errorf("alt+delete value: got %q, want %q", gotVal, "hello\n bar")
+		}
+		if gotPos != 6 {
+			t.Errorf("alt+delete absPos: got %d, want 6", gotPos)
+		}
+	})
 }
 
 func TestDeleteWordRight(t *testing.T) {


### PR DESCRIPTION
option+arrows and option+delete used LineInfo().CharOffset (line-relative) as an absolute position against the full textarea value — correct for single-line, broken for multi-line pasted content. Adds textareaAbsCursorPos and textareaSetAbsCursorPos helpers and updates applyWordNavTextarea to use them so word movement works correctly across line boundaries.

Co-Authored-By: Claude <noreply@anthropic.com>