### PR TITLE
Wrap long lines in unified diff view and fix textarea word navigation

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -63,14 +63,17 @@ type AgentView struct {
 	vtRows     int    // vtTerm row count
 
 	// Diff viewer state
-	diffMode      bool              // true when viewing a file's diff
-	diffSplit     bool              // true = side-by-side, false = unified
-	diffParsed    ParsedDiff        // parsed diff structure (for both views)
-	diffRows      []SideBySideLine  // side-by-side rows (computed from diffParsed)
-	diffUnified   []string          // unified view lines (highlighted, computed from diffParsed)
-	diffScrollOff int               // scroll offset within diff
-	worktreeDir   string            // resolved worktree directory for git commands
-	diffFileName  string            // current file being diffed (for highlighting)
+	diffMode         bool              // true when viewing a file's diff
+	diffSplit        bool              // true = side-by-side, false = unified
+	diffParsed       ParsedDiff        // parsed diff structure (for both views)
+	diffRows         []SideBySideLine  // side-by-side rows (computed from diffParsed)
+	diffUnified      []string          // unified view lines (highlighted, computed from diffParsed)
+	diffWrappedLines []string          // diffUnified after Hardwrap — cache
+	diffWrapWidth    int               // width used for diffWrappedLines; 0 = stale
+	diffDispW        int               // last-computed display width for the diff panel
+	diffScrollOff    int               // scroll offset within diff
+	worktreeDir      string            // resolved worktree directory for git commands
+	diffFileName     string            // current file being diffed (for highlighting)
 }
 
 func NewAgentView(theme Theme, runner agent.SessionProvider) AgentView {
@@ -108,6 +111,9 @@ func (av *AgentView) Enter(taskID, taskName string) {
 	av.diffParsed = ParsedDiff{}
 	av.diffRows = nil
 	av.diffUnified = nil
+	av.diffWrappedLines = nil
+	av.diffWrapWidth = 0
+	av.diffDispW = 0
 	av.diffScrollOff = 0
 	av.worktreeDir = ""
 	av.diffFileName = ""
@@ -365,6 +371,11 @@ func (av *AgentView) UpdateFileDiff(msg FileDiffMsg) {
 	av.diffMode = true
 	av.diffScrollOff = 0
 	av.diffFileName = msg.FilePath
+	av.diffWrappedLines = nil
+	av.diffWrapWidth = 0
+	// diffDispW is intentionally preserved: panel width hasn't changed, so
+	// diffLineCount can return correct wrapped counts without waiting for the
+	// next render pass. exitDiffMode clears it since the panel leaves the screen.
 	if msg.Diff == "" {
 		av.diffParsed = ParsedDiff{}
 		av.diffRows = nil
@@ -386,8 +397,28 @@ func (av *AgentView) exitDiffMode() {
 	av.diffParsed = ParsedDiff{}
 	av.diffRows = nil
 	av.diffUnified = nil
+	av.diffWrappedLines = nil
+	av.diffWrapWidth = 0
+	av.diffDispW = 0
 	av.diffScrollOff = 0
 	av.diffFileName = ""
+}
+
+// wrapDiffLines returns unified diff lines hard-wrapped to dispW, caching the
+// result so wrapping is only recomputed when content or width changes.
+func (av *AgentView) wrapDiffLines(dispW int) []string {
+	if av.diffWrappedLines != nil && av.diffWrapWidth == dispW {
+		return av.diffWrappedLines
+	}
+	var wrapped []string
+	for _, line := range av.diffUnified {
+		w := ansi.Hardwrap(line, dispW, true)
+		parts := strings.Split(w, "\n")
+		wrapped = append(wrapped, parts...)
+	}
+	av.diffWrappedLines = wrapped
+	av.diffWrapWidth = dispW
+	return wrapped
 }
 
 func (av *AgentView) handleDiffKey(msg tea.KeyMsg) tea.Cmd {
@@ -434,6 +465,11 @@ func (av *AgentView) diffScrollUp(n int) {
 func (av *AgentView) diffLineCount() int {
 	if av.diffSplit {
 		return len(av.diffRows)
+	}
+	// Always use the wrapped count so scroll bounds are correct. diffDispW is
+	// set by renderDiffPanel on every render; wrapDiffLines caches the result.
+	if av.diffDispW > 0 {
+		return len(av.wrapDiffLines(av.diffDispW))
 	}
 	return len(av.diffUnified)
 }
@@ -583,6 +619,10 @@ func (av *AgentView) renderDiffPanel(w, h int) string {
 		Width(w - 2).
 		Height(innerH)
 
+	dispW := max(w-4, 10)
+	dispH := max(h-4, 3)
+	av.diffDispW = dispW // must be set before diffLineCount so scroll bounds use wrapped widths
+
 	lineCount := av.diffLineCount()
 	if lineCount == 0 {
 		empty := av.theme.Dimmed.
@@ -592,9 +632,6 @@ func (av *AgentView) renderDiffPanel(w, h int) string {
 			AlignVertical(lipgloss.Center)
 		return border.Render(empty.Render("No diff available"))
 	}
-
-	dispW := max(w-4, 10)
-	dispH := max(h-4, 3)
 
 	// Header
 	fileName := av.diffFileName
@@ -617,7 +654,8 @@ func (av *AgentView) renderDiffPanel(w, h int) string {
 	if av.diffSplit {
 		content = RenderSideBySide(av.diffRows, fileName, dispW, visibleH, av.diffScrollOff, av.theme)
 	} else {
-		content = RenderUnified(av.diffUnified, dispW, visibleH, av.diffScrollOff)
+		wrapped := av.wrapDiffLines(dispW)
+		content = RenderUnified(wrapped, visibleH, av.diffScrollOff)
 	}
 
 	return border.Render(header + "\n" + content)

--- a/internal/ui/agentview_test.go
+++ b/internal/ui/agentview_test.go
@@ -1197,6 +1197,111 @@ func TestAgentView_Enter_ResetsDiffMode(t *testing.T) {
 	}
 }
 
+func TestWrapDiffLines_Caching(t *testing.T) {
+	av := newTestAgentView()
+	// A line long enough to wrap at width 20.
+	long := strings.Repeat("x", 50)
+	av.diffUnified = []string{long, "short"}
+
+	// First call: populates cache.
+	wrapped1 := av.wrapDiffLines(20)
+	if len(wrapped1) <= 2 {
+		t.Errorf("expected long line to wrap into multiple entries, got %d lines", len(wrapped1))
+	}
+	if av.diffWrapWidth != 20 {
+		t.Errorf("diffWrapWidth = %d, want 20", av.diffWrapWidth)
+	}
+
+	// Second call same width: returns cache (same slice pointer).
+	wrapped2 := av.wrapDiffLines(20)
+	if &wrapped1[0] != &wrapped2[0] {
+		t.Error("expected cache to be reused on second call with same width")
+	}
+
+	// Call with different width: recomputes.
+	wrapped3 := av.wrapDiffLines(10)
+	if len(wrapped3) <= len(wrapped1) {
+		t.Errorf("narrower width should produce more wrapped lines: got %d, previous %d", len(wrapped3), len(wrapped1))
+	}
+	if av.diffWrapWidth != 10 {
+		t.Errorf("diffWrapWidth = %d, want 10 after resize", av.diffWrapWidth)
+	}
+}
+
+func TestWrapDiffLines_LineCountConsistency(t *testing.T) {
+	// diffLineCount must use wrapped lines in unified mode once dispW is set.
+	av := newTestAgentView()
+	av.diffSplit = false
+	long := strings.Repeat("a", 100)
+	av.diffUnified = []string{long, long, long}
+
+	// Before any render dispW is 0 — falls back to source line count.
+	if got := av.diffLineCount(); got != 3 {
+		t.Errorf("cold diffLineCount = %d, want 3", got)
+	}
+
+	// Simulate renderDiffPanel setting dispW.
+	av.diffDispW = 20
+	count := av.diffLineCount()
+	if count <= 3 {
+		t.Errorf("warm diffLineCount with narrow width should exceed source count, got %d", count)
+	}
+}
+
+func TestWrapDiffLines_ScrollBeforeFirstRender(t *testing.T) {
+	// Verify diffScrollDown doesn't panic and produces a sane offset when called
+	// before any render pass has set diffDispW (cold path).
+	av := newTestAgentView()
+	av.diffSplit = false
+	av.SetSize(100, 40)
+	long := strings.Repeat("a", 200) // wraps to multiple lines at any reasonable width
+	av.diffUnified = []string{long, long, long}
+	// diffDispW is 0 — simulates scroll before first View() call.
+	if av.diffDispW != 0 {
+		t.Fatal("expected diffDispW == 0 before first render")
+	}
+
+	av.diffScrollDown(10)
+	// Should not panic and offset should be >= 0.
+	if av.diffScrollOff < 0 {
+		t.Errorf("diffScrollOff should not go negative, got %d", av.diffScrollOff)
+	}
+}
+
+func TestRenderUnified_Basic(t *testing.T) {
+	lines := []string{"line1", "line2", "line3", "line4", "line5"}
+
+	// All lines visible.
+	out := RenderUnified(lines, 5, 0)
+	for _, l := range lines {
+		if !strings.Contains(out, l) {
+			t.Errorf("expected %q in output", l)
+		}
+	}
+
+	// Scrolled: skip first 2, show 2.
+	out2 := RenderUnified(lines, 2, 2)
+	if !strings.Contains(out2, "line3") || !strings.Contains(out2, "line4") {
+		t.Errorf("scrolled output should show line3 and line4, got: %q", out2)
+	}
+	if strings.Contains(out2, "line1") || strings.Contains(out2, "line2") {
+		t.Errorf("scrolled output should not show line1/line2, got: %q", out2)
+	}
+
+	// Empty input.
+	empty := RenderUnified(nil, 10, 0)
+	if empty != "(no diff)" {
+		t.Errorf("empty lines should return '(no diff)', got %q", empty)
+	}
+
+	// Wide lines pass through as-is (no truncation).
+	wide := []string{strings.Repeat("w", 200)}
+	outWide := RenderUnified(wide, 1, 0)
+	if outWide != wide[0] {
+		t.Errorf("wide line should pass through unchanged")
+	}
+}
+
 func TestFileExplorer_SelectedFile(t *testing.T) {
 	fe := NewFileExplorer(DefaultTheme())
 

--- a/internal/ui/sidebyside.go
+++ b/internal/ui/sidebyside.go
@@ -274,7 +274,8 @@ func RenderUnifiedLines(pd ParsedDiff, filename string) []string {
 }
 
 // RenderUnified renders the unified diff view for the given visible window.
-func RenderUnified(lines []string, dispW, visibleH, scrollOff int) string {
+// Lines must already be hard-wrapped to the display width.
+func RenderUnified(lines []string, visibleH, scrollOff int) string {
 	if len(lines) == 0 {
 		return "(no diff)"
 	}
@@ -290,7 +291,7 @@ func RenderUnified(lines []string, dispW, visibleH, scrollOff int) string {
 
 	var b strings.Builder
 	for i := start; i < end; i++ {
-		b.WriteString(ansi.Truncate(lines[i], dispW, "\x1b[0m"))
+		b.WriteString(lines[i])
 		if i < end-1 {
 			b.WriteString("\n")
 		}

--- a/internal/ui/wordboundary.go
+++ b/internal/ui/wordboundary.go
@@ -97,8 +97,9 @@ func applyWordNavTextinput(msg tea.KeyMsg, m *textinput.Model) bool {
 }
 
 // textareaAbsCursorPos returns the absolute rune index of the cursor within
-// the full textarea value. LineInfo().CharOffset is relative to the current
-// line; this function adds the lengths of all preceding lines.
+// the full textarea value. LineInfo().ColumnOffset is the rune index within
+// the current hard line; this function adds the rune lengths of all preceding
+// lines (including their newline characters) to get the absolute position.
 func textareaAbsCursorPos(m *textarea.Model) int {
 	runes := []rune(m.Value())
 	targetLine := m.Line()
@@ -110,7 +111,7 @@ func textareaAbsCursorPos(m *textarea.Model) int {
 		}
 		pos++
 	}
-	return pos + m.LineInfo().CharOffset
+	return pos + m.LineInfo().ColumnOffset
 }
 
 // textareaSetAbsCursorPos moves the textarea cursor to the given absolute rune
@@ -166,7 +167,7 @@ func applyWordNavTextarea(msg tea.KeyMsg, m *textarea.Model, adjustHeight func()
 		runes := []rune(m.Value())
 		newRunes, newAbsPos := deleteWordLeft(runes, textareaAbsCursorPos(m))
 		newText := string(newRunes)
-		m.SetValue(newText) // resets cursor to (0,0)
+		m.SetValue(newText) // resets cursor to end of new text
 		textareaSetAbsCursorPos(m, newText, newAbsPos)
 		if adjustHeight != nil {
 			adjustHeight()
@@ -175,7 +176,7 @@ func applyWordNavTextarea(msg tea.KeyMsg, m *textarea.Model, adjustHeight func()
 		runes := []rune(m.Value())
 		newRunes, newAbsPos := deleteWordRight(runes, textareaAbsCursorPos(m))
 		newText := string(newRunes)
-		m.SetValue(newText) // resets cursor to (0,0)
+		m.SetValue(newText) // resets cursor to end of new text
 		textareaSetAbsCursorPos(m, newText, newAbsPos)
 		if adjustHeight != nil {
 			adjustHeight()

--- a/internal/ui/wordboundary_test.go
+++ b/internal/ui/wordboundary_test.go
@@ -277,6 +277,95 @@ func TestApplyWordNavTextarea_MultiLine(t *testing.T) {
 	})
 }
 
+func TestApplyWordNavTextarea_SingleLine(t *testing.T) {
+	// Regression: single-line textarea must behave identically to old code.
+	altLeft := tea.KeyMsg{Type: tea.KeyLeft, Alt: true}
+	altRight := tea.KeyMsg{Type: tea.KeyRight, Alt: true}
+	altBackspace := tea.KeyMsg{Type: tea.KeyBackspace, Alt: true}
+	altDelete := tea.KeyMsg{Type: tea.KeyDelete, Alt: true}
+	ctrlW := tea.KeyMsg{Type: tea.KeyCtrlW}
+
+	t.Run("alt+left single line", func(t *testing.T) {
+		ta := newTestTextarea("hello world", 11)
+		applyWordNavTextarea(altLeft, &ta, nil)
+		if got := textareaAbsCursorPos(&ta); got != 6 {
+			t.Errorf("got %d, want 6", got)
+		}
+	})
+
+	t.Run("alt+right single line", func(t *testing.T) {
+		ta := newTestTextarea("hello world", 0)
+		applyWordNavTextarea(altRight, &ta, nil)
+		if got := textareaAbsCursorPos(&ta); got != 5 {
+			t.Errorf("got %d, want 5", got)
+		}
+	})
+
+	t.Run("alt+backspace single line", func(t *testing.T) {
+		ta := newTestTextarea("hello world", 11)
+		applyWordNavTextarea(altBackspace, &ta, nil)
+		if got := ta.Value(); got != "hello " {
+			t.Errorf("value: got %q, want %q", got, "hello ")
+		}
+		if got := textareaAbsCursorPos(&ta); got != 6 {
+			t.Errorf("absPos: got %d, want 6", got)
+		}
+	})
+
+	t.Run("ctrl+w (alias for alt+backspace) single line", func(t *testing.T) {
+		ta := newTestTextarea("hello world", 11)
+		applyWordNavTextarea(ctrlW, &ta, nil)
+		if got := ta.Value(); got != "hello " {
+			t.Errorf("value: got %q, want %q", got, "hello ")
+		}
+	})
+
+	t.Run("alt+delete single line", func(t *testing.T) {
+		ta := newTestTextarea("hello world", 6)
+		applyWordNavTextarea(altDelete, &ta, nil)
+		if got := ta.Value(); got != "hello " {
+			t.Errorf("value: got %q, want %q", got, "hello ")
+		}
+		if got := textareaAbsCursorPos(&ta); got != 6 {
+			t.Errorf("absPos: got %d, want 6", got)
+		}
+	})
+}
+
+func TestApplyWordNavTextarea_ThreeLine(t *testing.T) {
+	// "one\ntwo\nthree" — three hard lines
+	altLeft := tea.KeyMsg{Type: tea.KeyLeft, Alt: true}
+	altRight := tea.KeyMsg{Type: tea.KeyRight, Alt: true}
+
+	t.Run("alt+left from line 2", func(t *testing.T) {
+		// "one\ntwo\nthree": t=8,h=9,r=10,e=11,e=12 (len=13)
+		// cursor at end (abs=13), alt+left → start of "three" (abs=8)
+		ta := newTestTextarea("one\ntwo\nthree", 13)
+		applyWordNavTextarea(altLeft, &ta, nil)
+		if got := textareaAbsCursorPos(&ta); got != 8 {
+			t.Errorf("got %d, want 8", got)
+		}
+	})
+
+	t.Run("alt+right from line 0", func(t *testing.T) {
+		// cursor at start (abs=0), expect end of "one" (abs=3)
+		ta := newTestTextarea("one\ntwo\nthree", 0)
+		applyWordNavTextarea(altRight, &ta, nil)
+		if got := textareaAbsCursorPos(&ta); got != 3 {
+			t.Errorf("got %d, want 3", got)
+		}
+	})
+
+	t.Run("alt+left across two newlines", func(t *testing.T) {
+		// cursor at start of "two" (abs=4), alt+left skips \n → start of "one" (abs=0)
+		ta := newTestTextarea("one\ntwo\nthree", 4)
+		applyWordNavTextarea(altLeft, &ta, nil)
+		if got := textareaAbsCursorPos(&ta); got != 0 {
+			t.Errorf("got %d, want 0", got)
+		}
+	})
+}
+
 func TestDeleteWordRight(t *testing.T) {
 	tests := []struct {
 		input   string


### PR DESCRIPTION
- Add Hardwrap-based line wrapping for unified diff panel with width-keyed cache (diffWrappedLines/diffWrapWidth/diffDispW); RenderUnified now accepts pre-wrapped lines
- Fix diffDispW assignment ordering: set before diffLineCount() so scroll bounds are accurate before first render
- Fix textarea word navigation to use ColumnOffset (rune index) instead of CharOffset (display-width) to avoid out-of-bounds panic on wide chars
- Add tests for wrap cache, line-count consistency, RenderUnified scrolling, and textarea word navigation

Co-Authored-By: Claude <noreply@anthropic.com>