### PR TITLE
Make agent view scrollback unbounded and anchor-locked

### DIFF
--- a/internal/agent/ringbuffer.go
+++ b/internal/agent/ringbuffer.go
@@ -11,7 +11,11 @@ type RingBuffer struct {
 }
 
 // NewRingBuffer creates a ring buffer of the given size.
+// If size is 0, the buffer grows without bound and never overwrites old data.
 func NewRingBuffer(size int) *RingBuffer {
+	if size == 0 {
+		return &RingBuffer{size: 0}
+	}
 	return &RingBuffer{
 		data: make([]byte, size),
 		size: size,
@@ -19,8 +23,14 @@ func NewRingBuffer(size int) *RingBuffer {
 }
 
 // Write appends data to the ring buffer using bulk copy operations.
+// In unbounded mode (size == 0), the buffer grows without limit.
 func (rb *RingBuffer) Write(p []byte) {
 	rb.total += uint64(len(p))
+	if rb.size == 0 {
+		rb.data = append(rb.data, p...)
+		rb.pos = len(rb.data)
+		return
+	}
 	for len(p) > 0 {
 		n := copy(rb.data[rb.pos:], p)
 		p = p[n:]
@@ -39,6 +49,10 @@ func (rb *RingBuffer) TotalWritten() uint64 {
 
 // Bytes returns the buffered data in order (oldest first).
 func (rb *RingBuffer) Bytes() []byte {
+	if rb.size == 0 {
+		// Unbounded: return a copy of all data
+		return append([]byte(nil), rb.data...)
+	}
 	if !rb.full {
 		return append([]byte(nil), rb.data[:rb.pos]...)
 	}
@@ -51,6 +65,9 @@ func (rb *RingBuffer) Bytes() []byte {
 
 // Len returns the number of bytes stored.
 func (rb *RingBuffer) Len() int {
+	if rb.size == 0 {
+		return rb.pos
+	}
 	if rb.full {
 		return rb.size
 	}
@@ -61,4 +78,7 @@ func (rb *RingBuffer) Len() int {
 func (rb *RingBuffer) Reset() {
 	rb.pos = 0
 	rb.full = false
+	if rb.size == 0 {
+		rb.data = rb.data[:0]
+	}
 }

--- a/internal/agent/ringbuffer_test.go
+++ b/internal/agent/ringbuffer_test.go
@@ -67,6 +67,57 @@ func TestRingBuffer_Empty(t *testing.T) {
 	}
 }
 
+func TestRingBuffer_Unbounded(t *testing.T) {
+	rb := NewRingBuffer(0)
+
+	if rb.Len() != 0 {
+		t.Errorf("Len() = %d, want 0", rb.Len())
+	}
+
+	rb.Write([]byte("hello"))
+	rb.Write([]byte(" world"))
+
+	if rb.Len() != 11 {
+		t.Errorf("Len() = %d, want 11", rb.Len())
+	}
+	if !bytes.Equal(rb.Bytes(), []byte("hello world")) {
+		t.Errorf("Bytes() = %q, want %q", rb.Bytes(), "hello world")
+	}
+	if rb.TotalWritten() != 11 {
+		t.Errorf("TotalWritten() = %d, want 11", rb.TotalWritten())
+	}
+}
+
+func TestRingBuffer_Unbounded_NeverWraps(t *testing.T) {
+	rb := NewRingBuffer(0)
+	// Write more data than a fixed 256KB buffer would hold
+	big := make([]byte, 1024*1024) // 1MB
+	for i := range big {
+		big[i] = byte(i % 256)
+	}
+	rb.Write(big)
+
+	if rb.Len() != len(big) {
+		t.Errorf("Len() = %d, want %d", rb.Len(), len(big))
+	}
+	if !bytes.Equal(rb.Bytes(), big) {
+		t.Error("Bytes() does not match original — data was lost")
+	}
+}
+
+func TestRingBuffer_Unbounded_Reset(t *testing.T) {
+	rb := NewRingBuffer(0)
+	rb.Write([]byte("data"))
+	rb.Reset()
+
+	if rb.Len() != 0 {
+		t.Errorf("Len() after reset = %d", rb.Len())
+	}
+	if len(rb.Bytes()) != 0 {
+		t.Errorf("Bytes() after reset = %q", rb.Bytes())
+	}
+}
+
 func TestRingBuffer_TotalWritten(t *testing.T) {
 	rb := NewRingBuffer(5)
 	if rb.TotalWritten() != 0 {

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -11,7 +11,7 @@ import (
 	"github.com/creack/pty"
 )
 
-const defaultBufSize = 256 * 1024 // 256KB ring buffer
+const defaultBufSize = 0 // unbounded: keep all output for full scrollback
 
 // idleThreshold is how long without output before a session is considered idle.
 const idleThreshold = 3 * time.Second

--- a/internal/daemon/client/handle.go
+++ b/internal/daemon/client/handle.go
@@ -9,7 +9,7 @@ import (
 	"github.com/drn/argus/internal/daemon"
 )
 
-const defaultBufSize = 256 * 1024 // 256KB ring buffer, same as agent
+const defaultBufSize = 0 // unbounded: keep all output for full scrollback
 
 // Compile-time assertion.
 var _ agent.SessionHandle = (*RemoteSession)(nil)

--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -598,8 +598,26 @@ func (av *AgentView) renderTerminal(w, h int) string {
 
 	var content string
 	if av.scrollOffset > 0 {
-		// Scrollback mode: full replay (only triggered by scroll events)
+		// Scrollback mode: full replay (only triggered by scroll events).
+		// Capture old line count so we can anchor the view at an absolute
+		// position — when new lines arrive, increment scrollOffset to
+		// compensate so the displayed content stays fixed (tmux-style).
+		oldLineCount := len(av.cachedLines)
 		content = av.formatTerminalOutput(raw, w, h)
+		if oldLineCount > 0 {
+			delta := len(av.cachedLines) - oldLineCount
+			if delta > 0 {
+				av.scrollOffset += delta
+				_, dispH, _ := av.terminalDisplaySize()
+				maxScroll := len(av.cachedLines) - dispH
+				if maxScroll < 0 {
+					maxScroll = 0
+				}
+				if av.scrollOffset > maxScroll {
+					av.scrollOffset = maxScroll
+				}
+			}
+		}
 	} else {
 		// Normal follow-tail mode: incremental feed to persistent vt10x
 		content = av.renderIncremental(sess, raw, writeCount, w, h)


### PR DESCRIPTION
Replace the fixed 256KB ring buffer with a grow-only unbounded buffer so all PTY output is preserved for the lifetime of the session. Fix scrollback so the view anchors to an absolute position (tmux-style) instead of drifting toward the tail when new output arrives.

Co-Authored-By: Claude <noreply@anthropic.com>