### PR TITLE
Display idle+unvisited tasks as in review

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -141,6 +141,7 @@ type Model struct {
 	daemonRestarting   bool              // true while daemon restart is in progress
 	daemonFailures     int               // consecutive daemon ping failures
 	resolvedDirs       map[string]string // taskID → resolved worktree dir (cache)
+	idleUnvisited      map[string]bool   // task IDs idle since user last opened their agent view
 
 	// Prune progress state (shown in viewPruning modal)
 	pruneTotal   int // total worktrees being cleaned up
@@ -188,6 +189,7 @@ func NewModel(database *db.DB, runner agent.SessionProvider, daemonConnected boo
 		theme:           theme,
 		daemonConnected: daemonConnected,
 		resolvedDirs:    make(map[string]string),
+		idleUnvisited:   make(map[string]bool),
 		program:         new(*tea.Program),
 		restartedClient: new(*dclient.Client),
 		tasklist:    tl,
@@ -833,6 +835,15 @@ func (m Model) startOrAttach(t *model.Task) (tea.Model, tea.Cmd) {
 // (if not already running). All agent view entry must go through here
 // to prevent tick accumulation from multiple start points.
 func (m *Model) enterAgentView(taskID, taskName string) tea.Cmd {
+	// User is viewing the agent — clear the "idle unvisited" flag so the task
+	// no longer displays as "in review" in the task list. Also sync the copy on
+	// TaskList immediately (rather than waiting for the next tick).
+	delete(m.idleUnvisited, taskID)
+	idleUnvisited := make([]string, 0, len(m.idleUnvisited))
+	for id := range m.idleUnvisited {
+		idleUnvisited = append(idleUnvisited, id)
+	}
+	m.tasklist.SetIdleUnvisited(idleUnvisited)
 	m.agentview.Enter(taskID, taskName)
 	m.agentview.SetSize(m.width, m.height)
 	if dir, ok := m.resolvedDirs[taskID]; ok && dir != "" {
@@ -1347,9 +1358,31 @@ func (m *Model) refreshTasks() {
 	tasks := m.db.Tasks()
 	running := m.runner.Running()
 	idle := m.runner.Idle()
+
+	// Update idleUnvisited: add newly-idle tasks, remove tasks no longer idle.
+	newIdle := toStringSet(idle)
+	for id := range newIdle {
+		if !m.tasklist.idle[id] {
+			// Newly idle — mark as unvisited until user opens the agent view.
+			m.idleUnvisited[id] = true
+		}
+	}
+	for id := range m.idleUnvisited {
+		if !newIdle[id] {
+			// No longer idle (agent produced output again) — clear unvisited.
+			delete(m.idleUnvisited, id)
+		}
+	}
+
+	idleUnvisited := make([]string, 0, len(m.idleUnvisited))
+	for id := range m.idleUnvisited {
+		idleUnvisited = append(idleUnvisited, id)
+	}
+
 	m.tasklist.SetTasks(tasks)
 	m.tasklist.SetRunning(running)
 	m.tasklist.SetIdle(idle)
+	m.tasklist.SetIdleUnvisited(idleUnvisited)
 	m.statusbar.SetTasks(tasks)
 	m.statusbar.SetRunning(running)
 }

--- a/internal/ui/tasklist.go
+++ b/internal/ui/tasklist.go
@@ -29,22 +29,28 @@ const uncategorized = "Uncategorized"
 
 // TaskList renders the task list view with collapsible project folders.
 type TaskList struct {
-	tasks    []*model.Task
-	scroll   ScrollState
-	theme    Theme
-	width    int
-	height   int
-	filter   string
-	filtered []*model.Task
-	running  map[string]bool // task IDs with active agent sessions
-	idle     map[string]bool // task IDs with sessions waiting for input
-	rows     []row           // flattened display rows (headers + tasks)
-	expanded string          // currently expanded project name
-	tickEven bool            // toggles each tick for status icon animation
+	tasks         []*model.Task
+	scroll        ScrollState
+	theme         Theme
+	width         int
+	height        int
+	filter        string
+	filtered      []*model.Task
+	running       map[string]bool // task IDs with active agent sessions
+	idle          map[string]bool // task IDs with sessions waiting for input
+	idleUnvisited map[string]bool // task IDs idle since user last viewed the agent view
+	rows          []row           // flattened display rows (headers + tasks)
+	expanded      string          // currently expanded project name
+	tickEven      bool            // toggles each tick for status icon animation
 }
 
 func NewTaskList(theme Theme) TaskList {
-	return TaskList{theme: theme, running: make(map[string]bool), idle: make(map[string]bool)}
+	return TaskList{
+		theme:         theme,
+		running:       make(map[string]bool),
+		idle:          make(map[string]bool),
+		idleUnvisited: make(map[string]bool),
+	}
 }
 
 func (tl *TaskList) Tick() {
@@ -57,6 +63,10 @@ func (tl *TaskList) SetRunning(ids []string) {
 
 func (tl *TaskList) SetIdle(ids []string) {
 	tl.idle = toStringSet(ids)
+}
+
+func (tl *TaskList) SetIdleUnvisited(ids []string) {
+	tl.idleUnvisited = toStringSet(ids)
 }
 
 func (tl *TaskList) SetTasks(tasks []*model.Task) {
@@ -418,29 +428,42 @@ func (tl TaskList) projectTasks(project string) []*model.Task {
 // animation logic for in-progress tasks (running/idle/tick).
 func (tl TaskList) taskStatusIcon(t *model.Task) string {
 	displayText := t.Status.Display()
+	displayStatus := t.Status // only overridden when idleUnvisited promotes to in_review
 	if t.Status == model.StatusInProgress {
-		if !tl.running[t.ID] || tl.idle[t.ID] {
+		if tl.idleUnvisited[t.ID] {
+			// Idle and not yet viewed since going idle → show as in review
+			displayStatus = model.StatusInReview
+			displayText = model.StatusInReview.Display()
+		} else if !tl.running[t.ID] || tl.idle[t.ID] {
 			displayText = "\uF186" // moon: idle
 		} else if tl.tickEven {
 			displayText = t.Status.DisplayAlt()
 		}
 	}
-	return tl.statusStyle(t.Status).Render(displayText)
+	return tl.statusStyle(displayStatus).Render(displayText)
 }
 
 // projectStatusIcon returns a single styled icon summarizing the aggregate
-// status of all tasks in a project. Priority: in_progress > in_review > all
-// complete > mixed (partial) > all pending.
+// status of all tasks in a project. Priority: in_review > in_progress >
+// all complete > mixed (partial) > all pending.
+// "in review" includes tasks with StatusInReview and idle+unvisited InProgress tasks.
 func (tl TaskList) projectStatusIcon(tasks []*model.Task) string {
-	var hasInProgress, hasInReview, hasPending, hasComplete bool
-	var allInProgressIdle bool = true
+	var hasActiveInProgress, hasInReview, hasPending, hasComplete bool
+	// hasActivelyRunning is only set for non-idleUnvisited in-progress tasks;
+	// used to pick between spinner and moon in the hasActiveInProgress case below.
+	var hasActivelyRunning bool
 
 	for _, t := range tasks {
 		switch t.Status {
 		case model.StatusInProgress:
-			hasInProgress = true
-			if tl.running[t.ID] && !tl.idle[t.ID] {
-				allInProgressIdle = false
+			if tl.idleUnvisited[t.ID] {
+				// Idle and unvisited → counts as in review for project summary
+				hasInReview = true
+			} else {
+				hasActiveInProgress = true
+				if tl.running[t.ID] && !tl.idle[t.ID] {
+					hasActivelyRunning = true
+				}
 			}
 		case model.StatusInReview:
 			hasInReview = true
@@ -452,16 +475,16 @@ func (tl TaskList) projectStatusIcon(tasks []*model.Task) string {
 	}
 
 	switch {
-	case hasInProgress:
+	case hasInReview:
+		return tl.statusStyle(model.StatusInReview).Render(model.StatusInReview.Display())
+	case hasActiveInProgress:
 		displayText := model.StatusInProgress.Display()
-		if allInProgressIdle {
-			displayText = "\uF186" // moon: all in-progress tasks idle
+		if !hasActivelyRunning {
+			displayText = "\uF186" // moon: all in-progress tasks are idle or not running
 		} else if tl.tickEven {
 			displayText = model.StatusInProgress.DisplayAlt()
 		}
 		return tl.statusStyle(model.StatusInProgress).Render(displayText)
-	case hasInReview:
-		return tl.statusStyle(model.StatusInReview).Render(model.StatusInReview.Display())
 	case hasComplete && !hasPending:
 		return tl.statusStyle(model.StatusComplete).Render(model.StatusComplete.Display())
 	case hasComplete && hasPending:

--- a/internal/ui/tasklist_test.go
+++ b/internal/ui/tasklist_test.go
@@ -530,7 +530,7 @@ func TestTaskList_projectStatusIcon(t *testing.T) {
 		{"all complete", []model.Status{model.StatusComplete, model.StatusComplete}, model.StatusComplete.Display()},
 		{"has in_progress", []model.Status{model.StatusPending, model.StatusInProgress}, "\uF186"}, // moon (not running)
 		{"has in_review", []model.Status{model.StatusPending, model.StatusInReview}, model.StatusInReview.Display()},
-		{"in_progress beats in_review", []model.Status{model.StatusInReview, model.StatusInProgress}, "\uF186"},
+		{"in_review beats in_progress", []model.Status{model.StatusInReview, model.StatusInProgress}, model.StatusInReview.Display()},
 		{"mixed pending+complete", []model.Status{model.StatusPending, model.StatusComplete}, model.StatusComplete.Display()},
 	}
 	for _, tt := range tests {
@@ -544,6 +544,59 @@ func TestTaskList_projectStatusIcon(t *testing.T) {
 				t.Errorf("expected icon to contain %q, got %q", tt.wantIcon, icon)
 			}
 		})
+	}
+}
+
+func TestTaskList_taskStatusIcon_IdleUnvisited(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+
+	task := &model.Task{ID: "t1", Status: model.StatusInProgress}
+
+	// Idle and unvisited → in review icon
+	tl.SetRunning([]string{"t1"})
+	tl.SetIdle([]string{"t1"})
+	tl.SetIdleUnvisited([]string{"t1"})
+	icon := tl.taskStatusIcon(task)
+	if !strings.Contains(icon, model.StatusInReview.Display()) {
+		t.Errorf("expected in-review icon for idle+unvisited task, got %q", icon)
+	}
+
+	// After clearing idleUnvisited → back to moon
+	tl.SetIdleUnvisited([]string{})
+	icon = tl.taskStatusIcon(task)
+	if !strings.Contains(icon, "\uF186") {
+		t.Error("expected moon icon once idle+unvisited cleared")
+	}
+}
+
+func TestTaskList_projectStatusIcon_IdleUnvisited(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+
+	tasks := []*model.Task{
+		{ID: "t1", Status: model.StatusInProgress},
+		{ID: "t2", Status: model.StatusPending},
+	}
+
+	// Idle+unvisited → project shows in review
+	tl.SetRunning([]string{"t1"})
+	tl.SetIdle([]string{"t1"})
+	tl.SetIdleUnvisited([]string{"t1"})
+	icon := tl.projectStatusIcon(tasks)
+	if !strings.Contains(icon, model.StatusInReview.Display()) {
+		t.Errorf("expected in-review project icon for idle+unvisited task, got %q", icon)
+	}
+
+	// Mixed: one idle+unvisited, one actively running → in review wins
+	tasks2 := []*model.Task{
+		{ID: "t1", Status: model.StatusInProgress}, // idle+unvisited
+		{ID: "t2", Status: model.StatusInProgress}, // actively running
+	}
+	tl.SetRunning([]string{"t1", "t2"})
+	tl.SetIdle([]string{"t1"})
+	tl.SetIdleUnvisited([]string{"t1"})
+	icon = tl.projectStatusIcon(tasks2)
+	if !strings.Contains(icon, model.StatusInReview.Display()) {
+		t.Errorf("expected in-review to win over in-progress, got %q", icon)
 	}
 }
 


### PR DESCRIPTION
Tasks with an idle agent session that haven't been opened since going idle now display as 'In Review' in the task list, with the in_review icon and color. Idle+unvisited InProgress tasks are treated the same as StatusInReview for both task-level and project-level status icons — in review beats in progress.

Co-Authored-By: Claude <noreply@anthropic.com>