### PR TITLE
Persist session PTY output to disk for post-restart scrollback

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"syscall"
 	"time"
@@ -38,6 +39,14 @@ type Session struct {
 	ptyCols    uint16    // current PTY width
 	ptyRows    uint16    // current PTY height
 	lastOutput time.Time // last time output was received from PTY
+
+	logFile *os.File // PTY output log for post-session scrollback; nil if unavailable
+}
+
+// SessionLogPath returns the path to the PTY output log file for a task.
+func SessionLogPath(taskID string) string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".argus", "sessions", taskID+".log")
 }
 
 // StartSession allocates a PTY with the given initial size, starts the command,
@@ -55,6 +64,13 @@ func StartSession(taskID string, cmd *exec.Cmd, rows, cols uint16) (*Session, er
 		return nil, err
 	}
 
+	// Open log file for PTY output — best effort, nil if unavailable.
+	var logFile *os.File
+	logPath := SessionLogPath(taskID)
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err == nil {
+		logFile, _ = os.Create(logPath)
+	}
+
 	s := &Session{
 		TaskID:   taskID,
 		Cmd:      cmd,
@@ -64,6 +80,7 @@ func StartSession(taskID string, cmd *exec.Cmd, rows, cols uint16) (*Session, er
 		detachCh: make(chan struct{}),
 		ptyCols:  cols,
 		ptyRows:  rows,
+		logFile:  logFile,
 	}
 
 	// Single reader: PTY → ring buffer (+ attached writer when set)
@@ -76,8 +93,11 @@ func StartSession(taskID string, cmd *exec.Cmd, rows, cols uint16) (*Session, er
 }
 
 // readLoop is the sole reader of the PTY. It always writes to the ring buffer,
-// and tees output to all attached writers.
+// tees output to all attached writers, and appends to the session log file.
 func (s *Session) readLoop() {
+	if s.logFile != nil {
+		defer s.logFile.Close()
+	}
 	tmp := make([]byte, 4096)
 	for {
 		n, err := s.ptmx.Read(tmp)
@@ -91,6 +111,10 @@ func (s *Session) readLoop() {
 			ws := make([]io.Writer, len(s.writers))
 			copy(ws, s.writers)
 			s.mu.Unlock()
+			// Write to log file — sole writer, no lock needed.
+			if s.logFile != nil {
+				s.logFile.Write(chunk) //nolint:errcheck // best-effort
+			}
 			// Write to all attached writers, collect any that error.
 			var failed []io.Writer
 			for _, w := range ws {

--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -28,14 +29,15 @@ type AgentViewTickMsg struct{}
 
 // AgentView renders a three-panel layout: git status | agent terminal | file explorer.
 type AgentView struct {
-	theme    Theme
-	runner   agent.SessionProvider
-	taskID   string
-	taskName string
-	focus    AgentPanel
-	layout   PanelLayout
-	width    int
-	height   int
+	theme       Theme
+	runner      agent.SessionProvider
+	sessionsDir string // directory where session logs are stored
+	taskID      string
+	taskName    string
+	focus       AgentPanel
+	layout      PanelLayout
+	width       int
+	height      int
 
 	gitstatus GitStatus
 	files     FileExplorer
@@ -76,12 +78,13 @@ type AgentView struct {
 	diffFileName     string            // current file being diffed (for highlighting)
 }
 
-func NewAgentView(theme Theme, runner agent.SessionProvider) AgentView {
+func NewAgentView(theme Theme, runner agent.SessionProvider, sessionsDir string) AgentView {
 	return AgentView{
-		theme:     theme,
-		runner:    runner,
-		focus:     panelAgent,
-		diffSplit: true,
+		theme:       theme,
+		runner:      runner,
+		sessionsDir: sessionsDir,
+		focus:       panelAgent,
+		diffSplit:   true,
 		layout: NewPanelLayout([]PanelConfig{
 			{Pct: 20, Min: 20},
 			{Pct: 60, Min: 60},
@@ -117,6 +120,15 @@ func (av *AgentView) Enter(taskID, taskName string) {
 	av.diffScrollOff = 0
 	av.worktreeDir = ""
 	av.diffFileName = ""
+
+	// Load session log so scrollback works for completed/stopped tasks
+	// even after the daemon has restarted and the in-memory buffer is gone.
+	if av.runner.Get(taskID) == nil && av.sessionsDir != "" {
+		logPath := filepath.Join(av.sessionsDir, taskID+".log")
+		if data, err := os.ReadFile(logPath); err == nil && len(data) > 0 {
+			av.lastOutput = data
+		}
+	}
 }
 
 // SetLastOutput stores the final ring buffer from a finished session

--- a/internal/ui/agentview_test.go
+++ b/internal/ui/agentview_test.go
@@ -2,7 +2,9 @@ package ui
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -13,7 +15,7 @@ import (
 
 func newTestAgentView() *AgentView {
 	runner := agent.NewRunner(nil)
-	av := NewAgentView(DefaultTheme(), runner)
+	av := NewAgentView(DefaultTheme(), runner, "")
 	av.SetSize(120, 40)
 	av.Enter("task-1", "test task")
 	return &av
@@ -380,7 +382,7 @@ func TestAgentView_HandleKey_FilePanelKeys(t *testing.T) {
 
 func TestAgentView_NeedsGitRefresh_NoTask(t *testing.T) {
 	runner := agent.NewRunner(nil)
-	av := NewAgentView(DefaultTheme(), runner)
+	av := NewAgentView(DefaultTheme(), runner, "")
 	if av.NeedsGitRefresh() {
 		t.Error("NeedsGitRefresh should be false with no task")
 	}
@@ -419,6 +421,37 @@ func TestAgentView_Enter_ResetsState(t *testing.T) {
 	}
 	if av.lastOutput != nil {
 		t.Error("lastOutput should be nil after Enter")
+	}
+}
+
+func TestAgentView_Enter_LoadsSessionLog(t *testing.T) {
+	sessionsDir := t.TempDir()
+	runner := agent.NewRunner(nil)
+	av := NewAgentView(DefaultTheme(), runner, sessionsDir)
+	av.SetSize(120, 40)
+
+	// Write a fake session log
+	taskID := "load-log-task"
+	logContent := []byte("previous session output\n")
+	if err := os.WriteFile(filepath.Join(sessionsDir, taskID+".log"), logContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	av.Enter(taskID, "load log task")
+	if string(av.lastOutput) != string(logContent) {
+		t.Errorf("lastOutput = %q, want %q", av.lastOutput, logContent)
+	}
+}
+
+func TestAgentView_Enter_NoLogFile(t *testing.T) {
+	sessionsDir := t.TempDir()
+	runner := agent.NewRunner(nil)
+	av := NewAgentView(DefaultTheme(), runner, sessionsDir)
+	av.SetSize(120, 40)
+
+	av.Enter("no-log-task", "no log task")
+	if av.lastOutput != nil {
+		t.Errorf("lastOutput should be nil when no log file exists, got %q", av.lastOutput)
 	}
 }
 

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -179,7 +179,7 @@ func NewModel(database *db.DB, runner agent.SessionProvider, daemonConnected boo
 	pv := NewPreview(theme, runner)
 	gs := NewGitStatus(theme)
 	dt := NewTaskDetail(theme)
-	avv := NewAgentView(theme, runner)
+	avv := NewAgentView(theme, runner, filepath.Join(db.DataDir(), "sessions"))
 	av := &avv
 
 	m := Model{
@@ -1019,6 +1019,7 @@ func (m Model) handleConfirmDeleteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				deleteRemoteBranch(repoDir, t.Branch)
 			}
 		}
+		os.Remove(agent.SessionLogPath(t.ID)) //nolint:errcheck
 	})
 }
 
@@ -1034,6 +1035,7 @@ func (m Model) handleConfirmDestroyKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				deleteRemoteBranch(repoDir, t.Branch)
 			}
 		}
+		os.Remove(agent.SessionLogPath(t.ID)) //nolint:errcheck
 	})
 }
 


### PR DESCRIPTION
Each agent session now tees its raw PTY output to ~/.argus/sessions/<taskID>.log (created fresh on session start, closed when the process exits). When the agent view enters a stopped/completed task, it loads the log file into lastOutput so full scrollback is available even after a daemon restart. Log files are deleted when the task is deleted or destroyed.

Co-Authored-By: Claude <noreply@anthropic.com>