### PR TITLE
Persist session PTY output to disk for post-restart scrollback

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -43,10 +43,15 @@ type Session struct {
 	logFile *os.File // PTY output log for post-session scrollback; nil if unavailable
 }
 
+// SessionsDir returns the directory where session logs are stored.
+func SessionsDir() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".argus", "sessions")
+}
+
 // SessionLogPath returns the path to the PTY output log file for a task.
 func SessionLogPath(taskID string) string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".argus", "sessions", taskID+".log")
+	return filepath.Join(SessionsDir(), taskID+".log")
 }
 
 // StartSession allocates a PTY with the given initial size, starts the command,
@@ -65,10 +70,11 @@ func StartSession(taskID string, cmd *exec.Cmd, rows, cols uint16) (*Session, er
 	}
 
 	// Open log file for PTY output — best effort, nil if unavailable.
+	// 0700/0600 permissions: raw PTY output may contain secrets.
 	var logFile *os.File
 	logPath := SessionLogPath(taskID)
-	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err == nil {
-		logFile, _ = os.Create(logPath)
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err == nil {
+		logFile, _ = os.OpenFile(logPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
 	}
 
 	s := &Session{

--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -27,6 +27,13 @@ const (
 // AgentViewTickMsg triggers a fast refresh of the agent terminal output.
 type AgentViewTickMsg struct{}
 
+// SessionLogLoadedMsg carries the contents of a session log file loaded
+// asynchronously when entering the agent view for a completed task.
+type SessionLogLoadedMsg struct {
+	TaskID string
+	Data   []byte
+}
+
 // AgentView renders a three-panel layout: git status | agent terminal | file explorer.
 type AgentView struct {
 	theme       Theme
@@ -120,14 +127,22 @@ func (av *AgentView) Enter(taskID, taskName string) {
 	av.diffScrollOff = 0
 	av.worktreeDir = ""
 	av.diffFileName = ""
+}
 
-	// Load session log so scrollback works for completed/stopped tasks
-	// even after the daemon has restarted and the in-memory buffer is gone.
-	if av.runner.Get(taskID) == nil && av.sessionsDir != "" {
-		logPath := filepath.Join(av.sessionsDir, taskID+".log")
-		if data, err := os.ReadFile(logPath); err == nil && len(data) > 0 {
-			av.lastOutput = data
+// LoadSessionLogCmd returns a tea.Cmd that asynchronously reads the session log
+// for completed/stopped tasks so scrollback works after a daemon restart.
+// Returns nil when a live session exists (ring buffer is authoritative).
+func (av *AgentView) LoadSessionLogCmd(taskID string) tea.Cmd {
+	if av.runner.Get(taskID) != nil || av.sessionsDir == "" {
+		return nil
+	}
+	logPath := filepath.Join(av.sessionsDir, taskID+".log")
+	return func() tea.Msg {
+		data, err := os.ReadFile(logPath)
+		if err != nil || len(data) == 0 {
+			return nil
 		}
+		return SessionLogLoadedMsg{TaskID: taskID, Data: data}
 	}
 }
 

--- a/internal/ui/agentview_test.go
+++ b/internal/ui/agentview_test.go
@@ -424,7 +424,7 @@ func TestAgentView_Enter_ResetsState(t *testing.T) {
 	}
 }
 
-func TestAgentView_Enter_LoadsSessionLog(t *testing.T) {
+func TestAgentView_LoadSessionLogCmd_LoadsLog(t *testing.T) {
 	sessionsDir := t.TempDir()
 	runner := agent.NewRunner(nil)
 	av := NewAgentView(DefaultTheme(), runner, sessionsDir)
@@ -438,8 +438,44 @@ func TestAgentView_Enter_LoadsSessionLog(t *testing.T) {
 	}
 
 	av.Enter(taskID, "load log task")
-	if string(av.lastOutput) != string(logContent) {
-		t.Errorf("lastOutput = %q, want %q", av.lastOutput, logContent)
+	// Enter() no longer loads the log synchronously — lastOutput stays nil.
+	if av.lastOutput != nil {
+		t.Errorf("Enter should not set lastOutput; got %q", av.lastOutput)
+	}
+
+	// LoadSessionLogCmd returns a cmd that reads the file asynchronously.
+	cmd := av.LoadSessionLogCmd(taskID)
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for existing log file")
+	}
+	msg := cmd()
+	loaded, ok := msg.(SessionLogLoadedMsg)
+	if !ok {
+		t.Fatalf("expected SessionLogLoadedMsg, got %T", msg)
+	}
+	if loaded.TaskID != taskID {
+		t.Errorf("TaskID = %q, want %q", loaded.TaskID, taskID)
+	}
+	if string(loaded.Data) != string(logContent) {
+		t.Errorf("Data = %q, want %q", loaded.Data, logContent)
+	}
+}
+
+func TestAgentView_LoadSessionLogCmd_NoLogFile(t *testing.T) {
+	sessionsDir := t.TempDir()
+	runner := agent.NewRunner(nil)
+	av := NewAgentView(DefaultTheme(), runner, sessionsDir)
+	av.SetSize(120, 40)
+
+	av.Enter("no-log-task", "no log task")
+	// No log file: cmd should return nil msg.
+	cmd := av.LoadSessionLogCmd("no-log-task")
+	if cmd == nil {
+		return // acceptable: no cmd when no log file
+	}
+	msg := cmd()
+	if msg != nil {
+		t.Errorf("expected nil msg for missing log file, got %T: %v", msg, msg)
 	}
 }
 
@@ -451,7 +487,7 @@ func TestAgentView_Enter_NoLogFile(t *testing.T) {
 
 	av.Enter("no-log-task", "no log task")
 	if av.lastOutput != nil {
-		t.Errorf("lastOutput should be nil when no log file exists, got %q", av.lastOutput)
+		t.Errorf("lastOutput should be nil after Enter when no log file exists, got %q", av.lastOutput)
 	}
 }
 

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -170,7 +170,7 @@ func NewModel(database *db.DB, runner agent.SessionProvider, daemonConnected boo
 	pv := NewPreview(theme, runner)
 	gs := NewGitStatus(theme)
 	dt := NewTaskDetail(theme)
-	avv := NewAgentView(theme, runner, filepath.Join(db.DataDir(), "sessions"))
+	avv := NewAgentView(theme, runner, agent.SessionsDir())
 	av := &avv
 
 	m := Model{
@@ -402,6 +402,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case DirFilesMsg:
 		m.agentview.UpdateDirFiles(msg)
+		return m, nil
+
+	case SessionLogLoadedMsg:
+		if m.agentview.taskID == msg.TaskID {
+			m.agentview.SetLastOutput(msg.Data)
+		}
 		return m, nil
 
 	case tea.MouseMsg:
@@ -835,16 +841,20 @@ func (m *Model) enterAgentView(taskID, taskName string) tea.Cmd {
 		m.agentview.SetWorktreeDir(dir)
 	}
 	m.current = viewAgent
+	logCmd := m.agentview.LoadSessionLogCmd(taskID)
 	// Start the 100ms tick chain if not already running. The chain
 	// self-perpetuates via the AgentViewTickMsg handler and stops
 	// itself when m.current leaves viewAgent.
 	if m.agentTickActive {
-		return nil
+		return logCmd
 	}
 	m.agentTickActive = true
-	return tea.Tick(100*time.Millisecond, func(_ time.Time) tea.Msg {
-		return AgentViewTickMsg{}
-	})
+	return tea.Batch(
+		logCmd,
+		tea.Tick(100*time.Millisecond, func(_ time.Time) tea.Msg {
+			return AgentViewTickMsg{}
+		}),
+	)
 }
 
 // determinePostExitStatus decides what status a task should have after its


### PR DESCRIPTION
Tees all PTY output to ~/.argus/sessions/<taskID>.log so agent view scrollback survives daemon restarts. Loads the log asynchronously via tea.Cmd on agent view entry for finished sessions. Permissions are 0700/0600 to protect raw PTY output which may contain secrets.

Co-Authored-By: Claude <noreply@anthropic.com>