### PR TITLE
Add Reviews tab for GitHub PR review in TUI

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1,0 +1,269 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// ReviewAction is the type of review to submit.
+type ReviewAction string
+
+const (
+	ReviewApprove        ReviewAction = "APPROVE"
+	ReviewRequestChanges ReviewAction = "REQUEST_CHANGES"
+	ReviewComment        ReviewAction = "COMMENT"
+)
+
+// PR represents a GitHub pull request.
+type PR struct {
+	Number          int
+	Title           string
+	Author          string
+	RepoOwner       string
+	Repo            string
+	ReviewDecision  string // APPROVED / CHANGES_REQUESTED / REVIEW_REQUIRED / ""
+	IsReviewRequest bool   // came from review-requested:@me query
+	IsDraft         bool
+	HeadSHA         string
+	UpdatedAt       time.Time
+}
+
+// PRComment represents a review comment on a pull request.
+type PRComment struct {
+	ID        int
+	Author    string
+	Body      string
+	Path      string // file path for line comments; "" for general comments
+	Line      int    // diff line number; 0 for general comments
+	CreatedAt time.Time
+}
+
+// ErrRateLimit is returned when the GitHub API rate limit is exceeded.
+// Primary rate limit: 5,000 req/hr for REST, 30 req/min for Search API.
+var ErrRateLimit = fmt.Errorf("github rate limit exceeded — try again later")
+
+// runGh runs a gh CLI command and returns stdout.
+// Timeout: 10 seconds. Returns ErrRateLimit for 403/429 responses.
+func runGh(args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		stderrStr := stderr.String()
+		// gh CLI surfaces rate limit errors as "HTTP 403" or "HTTP 429" in stderr.
+		// Both the primary REST limit (5k/hr) and Search limit (30/min) produce these.
+		if strings.Contains(stderrStr, "HTTP 429") ||
+			strings.Contains(stderrStr, "HTTP 403") && strings.Contains(stderrStr, "rate limit") ||
+			strings.Contains(stderrStr, "API rate limit exceeded") ||
+			strings.Contains(stderrStr, "secondary rate limit") {
+			return "", ErrRateLimit
+		}
+		return "", fmt.Errorf("gh %s: %w: %s", strings.Join(args, " "), err, stderrStr)
+	}
+	return stdout.String(), nil
+}
+
+// FetchPRList returns all open PRs + review requests for the authenticated user.
+// Uses gh search prs to work across all repos regardless of current directory.
+func FetchPRList() ([]PR, error) {
+	type ghSearchPR struct {
+		Number    int    `json:"number"`
+		Title     string `json:"title"`
+		Author    struct{ Login string } `json:"author"`
+		IsDraft   bool   `json:"isDraft"`
+		Repository struct {
+			NameWithOwner string `json:"nameWithOwner"`
+		} `json:"repository"`
+		UpdatedAt      time.Time `json:"updatedAt"`
+		ReviewDecision string    `json:"reviewDecision"`
+	}
+
+	// Fetch PRs authored by current user
+	myOut, myErr := runGh("search", "prs",
+		"--author=@me", "--state=open",
+		"--json", "number,title,author,isDraft,repository,updatedAt,reviewDecision",
+		"--limit", "50")
+
+	// Fetch PRs requesting review from current user
+	reviewOut, reviewErr := runGh("search", "prs",
+		"--review-requested=@me", "--state=open",
+		"--json", "number,title,author,isDraft,repository,updatedAt,reviewDecision",
+		"--limit", "50")
+
+	if myErr != nil && reviewErr != nil {
+		return nil, fmt.Errorf("gh search failed: %w", myErr)
+	}
+
+	var prs []PR
+	seen := make(map[string]bool)
+	var parseErr error
+
+	parseSearchPRs := func(out string, isReviewReq bool) {
+		if out == "" {
+			return
+		}
+		var raw []ghSearchPR
+		if err := json.Unmarshal([]byte(out), &raw); err != nil {
+			parseErr = fmt.Errorf("parse search results: %w", err)
+			return
+		}
+		for _, p := range raw {
+			parts := strings.SplitN(p.Repository.NameWithOwner, "/", 2)
+			var owner, repo string
+			if len(parts) == 2 {
+				owner, repo = parts[0], parts[1]
+			} else {
+				owner = p.Repository.NameWithOwner
+				repo = p.Repository.NameWithOwner
+			}
+			key := fmt.Sprintf("%s/%s#%d", owner, repo, p.Number)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			prs = append(prs, PR{
+				Number:          p.Number,
+				Title:           p.Title,
+				Author:          p.Author.Login,
+				RepoOwner:       owner,
+				Repo:            repo,
+				IsDraft:         p.IsDraft,
+				IsReviewRequest: isReviewReq,
+				ReviewDecision:  p.ReviewDecision,
+				UpdatedAt:       p.UpdatedAt,
+			})
+		}
+	}
+
+	if myErr == nil {
+		parseSearchPRs(myOut, false)
+	}
+	if reviewErr == nil {
+		parseSearchPRs(reviewOut, true)
+	}
+
+	// Surface parse errors only when we got no PRs at all (partial results are
+	// better than an error when one query succeeded and the other had bad JSON).
+	if parseErr != nil && len(prs) == 0 {
+		return nil, parseErr
+	}
+
+	return prs, nil
+}
+
+// FetchPRFiles returns the list of changed files for a given PR.
+func FetchPRFiles(owner, repo string, number int) ([]string, error) {
+	out, err := runGh("api",
+		fmt.Sprintf("repos/%s/%s/pulls/%d/files", owner, repo, number),
+		"--jq", ".[].filename")
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line != "" {
+			files = append(files, line)
+		}
+	}
+	return files, nil
+}
+
+// FetchPRFullDiff returns the complete unified diff for a PR.
+// Callers should cache this and use ExtractFileDiff to slice per-file,
+// avoiding repeated API calls when the user browses different files.
+func FetchPRFullDiff(owner, repo string, number int) (string, error) {
+	return runGh("pr", "diff", fmt.Sprintf("%d", number),
+		"-R", fmt.Sprintf("%s/%s", owner, repo))
+}
+
+// ExtractFileDiff extracts the diff for a single file from a full unified diff.
+// This is exported so ReviewsView can re-slice the cached full diff on file
+// cursor changes without issuing additional API calls.
+func ExtractFileDiff(fullDiff, filePath string) string {
+	lines := strings.Split(fullDiff, "\n")
+	var result []string
+	inFile := false
+
+	// Match the exact "diff --git a/<path> b/<path>" header to avoid false
+	// matches on files whose names share a common prefix (e.g., "api" matching
+	// "api_test.go"). We check both the suffix (" b/"+path) and full format.
+	wantSuffix := " b/" + filePath
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "diff --git ") {
+			inFile = strings.HasSuffix(line, wantSuffix)
+		}
+		if inFile {
+			result = append(result, line)
+		}
+	}
+
+	return strings.Join(result, "\n")
+}
+
+// FetchPRComments returns review comments for a PR.
+func FetchPRComments(owner, repo string, number int) ([]PRComment, error) {
+	out, err := runGh("api",
+		fmt.Sprintf("repos/%s/%s/pulls/%d/comments", owner, repo, number))
+	if err != nil {
+		return nil, err
+	}
+
+	type ghComment struct {
+		ID        int    `json:"id"`
+		User      struct{ Login string } `json:"user"`
+		Body      string `json:"body"`
+		Path      string `json:"path"`
+		Line      int    `json:"line"`
+		CreatedAt time.Time `json:"created_at"`
+	}
+
+	var raw []ghComment
+	if err := json.Unmarshal([]byte(out), &raw); err != nil {
+		return nil, fmt.Errorf("parse comments: %w", err)
+	}
+
+	comments := make([]PRComment, len(raw))
+	for i, c := range raw {
+		comments[i] = PRComment{
+			ID:        c.ID,
+			Author:    c.User.Login,
+			Body:      c.Body,
+			Path:      c.Path,
+			Line:      c.Line,
+			CreatedAt: c.CreatedAt,
+		}
+	}
+	return comments, nil
+}
+
+// PostReviewComment posts a single line comment on a PR diff.
+func PostReviewComment(owner, repo string, number int, commitSHA, path string, line int, body string) error {
+	_, err := runGh("api",
+		fmt.Sprintf("repos/%s/%s/pulls/%d/comments", owner, repo, number),
+		"-f", "body="+body,
+		"-f", "path="+path,
+		"-f", "commit_id="+commitSHA,
+		"-F", fmt.Sprintf("line=%d", line),
+	)
+	return err
+}
+
+// SubmitReview submits a PR review (APPROVE, REQUEST_CHANGES, COMMENT).
+func SubmitReview(owner, repo string, number int, action ReviewAction, body string) error {
+	_, err := runGh("api",
+		fmt.Sprintf("repos/%s/%s/pulls/%d/reviews", owner, repo, number),
+		"-f", "body="+body,
+		"-f", "event="+string(action),
+	)
+	return err
+}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -1,0 +1,61 @@
+package github
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractFileDiff(t *testing.T) {
+	fullDiff := `diff --git a/foo/bar.go b/foo/bar.go
+index abc..def 100644
+--- a/foo/bar.go
++++ b/foo/bar.go
+@@ -1,3 +1,4 @@
+ package foo
++// added
+ func Foo() {}
+diff --git a/other.go b/other.go
+index 111..222 100644
+--- a/other.go
++++ b/other.go
+@@ -1 +1 @@
+-old
++new`
+
+	got := ExtractFileDiff(fullDiff, "foo/bar.go")
+	if !strings.Contains(got, "+++ b/foo/bar.go") {
+		t.Errorf("expected diff header for foo/bar.go, got: %q", got)
+	}
+	if strings.Contains(got, "other.go") {
+		t.Errorf("expected no other.go content, got: %q", got)
+	}
+}
+
+func TestExtractFileDiff_NotFound(t *testing.T) {
+	fullDiff := `diff --git a/foo.go b/foo.go
+--- a/foo.go
++++ b/foo.go
+@@ -1 +1 @@
+-old
++new`
+
+	got := ExtractFileDiff(fullDiff, "nonexistent.go")
+	if got != "" {
+		t.Errorf("expected empty string for missing file, got: %q", got)
+	}
+}
+
+func TestExtractFileDiff_Empty(t *testing.T) {
+	got := ExtractFileDiff("", "foo.go")
+	if got != "" {
+		t.Errorf("expected empty string for empty diff, got: %q", got)
+	}
+}
+
+func TestRunGhError(t *testing.T) {
+	// runGh with a nonexistent subcommand should return an error
+	_, err := runGh("__nonexistent_subcommand__")
+	if err == nil {
+		t.Error("expected error from nonexistent gh subcommand, got nil")
+	}
+}

--- a/internal/ui/reviews.go
+++ b/internal/ui/reviews.go
@@ -1,0 +1,839 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/drn/argus/internal/github"
+)
+
+// prListCooldown is the minimum time between PR list refreshes.
+// GitHub Search API is limited to 30 requests/minute; FetchPRList makes 2
+// search calls, so 30 seconds between refreshes is a safe lower bound.
+const prListCooldown = 30 * time.Second
+
+// commentsTTL is how long comments are considered fresh before auto-refresh.
+// Comments change frequently (others reviewing in parallel), so 2 minutes is
+// a reasonable balance between freshness and REST API usage (5k req/hr).
+const commentsTTL = 2 * time.Minute
+
+type reviewFocus int
+
+const (
+	focusList    reviewFocus = iota
+	focusDiff
+	focusComment
+)
+
+// ReviewsView is the three-panel GitHub PR review interface.
+// It follows the plain-struct pattern (not tea.Model) — root.go drives it.
+type ReviewsView struct {
+	theme         Theme
+	width, height int
+
+	// PR list panel
+	prs          []github.PR
+	prCursor     int
+	prScrollOff  int
+	loading      bool
+	loadErr      string
+	lastFetchTime time.Time // when the PR list was last successfully fetched
+
+	// File list for selected PR
+	selectedPR *github.PR
+	files      []string
+	fileCursor int
+
+	// Diff panel
+	// fullDiff is the complete PR diff fetched once per PR; individual file
+	// diffs are extracted from it without additional API calls.
+	fullDiff      string     // cached full diff for selectedPR
+	diffFetchedAt time.Time  // when fullDiff was fetched; used for staleness check
+	rawDiff       string     // extracted diff for the currently viewed file
+	parsedDiff    *ParsedDiff
+	unifiedLines  []string // cached RenderUnifiedLines output
+	diffScrollOff int
+	splitMode     bool
+
+	// Comments panel
+	// comments is fetched once per PR (not per file) and cached here.
+	// commentsFetchedAt drives the 2-minute auto-refresh TTL.
+	comments           []github.PRComment
+	commentsFetchedAt  time.Time
+	commentCursor      int
+
+	// Comment compose
+	focus     reviewFocus
+	draftBody string
+	draftLine int
+	draftPath string
+
+	// Review submission state
+	submitErr string
+
+	// reviewDraftMode distinguishes between a line comment (false) and a full
+	// review REQUEST_CHANGES (true) when focus == focusComment.
+	reviewDraftMode bool
+
+	// Fetching guards — prevent the TickMsg auto-refresh from queuing multiple
+	// concurrent gh CLI processes when a fetch is already in flight.
+	commentsFetching bool
+	diffFetching     bool
+}
+
+// NewReviewsView creates a new ReviewsView.
+func NewReviewsView(theme Theme) *ReviewsView {
+	return &ReviewsView{theme: theme}
+}
+
+// truncString returns s truncated to maxRunes runes, appending "..." if truncated.
+// keepRunes is the number of runes to keep before "...". Uses rune arithmetic
+// to avoid panics on non-ASCII characters.
+func truncString(s string, maxRunes, keepRunes int) string {
+	r := []rune(s)
+	if len(r) <= maxRunes {
+		return s
+	}
+	return string(r[:keepRunes]) + "..."
+}
+
+// StartLoading marks the PR list as loading and returns the fetch command.
+// Use this instead of setting loading=true directly from outside the view.
+func (rv *ReviewsView) StartLoading() tea.Cmd {
+	rv.loading = true
+	rv.loadErr = ""
+	return fetchPRListCmd()
+}
+
+// SetSize propagates dimensions to internal components.
+func (rv *ReviewsView) SetSize(w, h int) {
+	rv.width = w
+	rv.height = h
+}
+
+// canFetchPRList reports whether the cooldown has expired since the last fetch.
+// This guards against spamming the GitHub Search API (30 req/min limit).
+func (rv *ReviewsView) canFetchPRList() bool {
+	return rv.lastFetchTime.IsZero() || time.Since(rv.lastFetchTime) >= prListCooldown
+}
+
+// SetPRs replaces the PR list and resets all selection state.
+func (rv *ReviewsView) SetPRs(prs []github.PR) {
+	rv.lastFetchTime = time.Now()
+	rv.prs = prs
+	rv.loading = false
+	rv.loadErr = ""
+	rv.prCursor = 0
+	rv.prScrollOff = 0
+	rv.selectedPR = nil
+	rv.files = nil
+	rv.fileCursor = 0
+	rv.rawDiff = ""
+	rv.parsedDiff = nil
+	rv.unifiedLines = nil
+	rv.diffScrollOff = 0
+	rv.comments = nil
+	rv.focus = focusList
+}
+
+// SetFiles sets the changed files for the currently selected PR.
+// Clears the full diff and comment caches so fresh fetches are triggered.
+func (rv *ReviewsView) SetFiles(files []string) {
+	rv.files = files
+	rv.fileCursor = 0
+	rv.fullDiff = ""
+	rv.diffFetchedAt = time.Time{}
+	rv.rawDiff = ""
+	rv.parsedDiff = nil
+	rv.unifiedLines = nil
+	rv.diffScrollOff = 0
+	rv.comments = nil
+	rv.commentsFetchedAt = time.Time{}
+}
+
+// SetFullDiff stores the complete PR diff and immediately extracts the view
+// for the currently selected file — no further API calls needed for other files.
+func (rv *ReviewsView) SetFullDiff(fullDiff string) {
+	rv.fullDiff = fullDiff
+	rv.diffFetchedAt = time.Now()
+	rv.diffFetching = false
+	rv.applyFileDiff()
+}
+
+// isDiffStale reports whether the cached diff is outdated relative to the PR's
+// own UpdatedAt timestamp. When true, re-fetching is warranted.
+// This check is free — UpdatedAt comes from the already-cached PR list.
+// Returns false when a fetch is already in flight to prevent duplicate requests.
+func (rv *ReviewsView) isDiffStale() bool {
+	if rv.selectedPR == nil || rv.diffFetchedAt.IsZero() || rv.diffFetching {
+		return false
+	}
+	return rv.selectedPR.UpdatedAt.After(rv.diffFetchedAt)
+}
+
+// areCommentsStale reports whether comments should be auto-refreshed.
+// Returns true when the TTL has expired or the PR was updated after the last fetch.
+// Returns false when a fetch is already in flight to prevent duplicate requests.
+func (rv *ReviewsView) areCommentsStale() bool {
+	if rv.selectedPR == nil || rv.commentsFetchedAt.IsZero() || rv.commentsFetching {
+		return false
+	}
+	if time.Since(rv.commentsFetchedAt) >= commentsTTL {
+		return true
+	}
+	return rv.selectedPR.UpdatedAt.After(rv.commentsFetchedAt)
+}
+
+// applyFileDiff extracts the diff for the currently selected file from the
+// cached full diff. Called after SetFullDiff and on every file cursor change.
+func (rv *ReviewsView) applyFileDiff() {
+	rv.diffScrollOff = 0
+	rv.unifiedLines = nil
+	file := rv.SelectedFile()
+	if file == "" || rv.fullDiff == "" {
+		rv.rawDiff = ""
+		rv.parsedDiff = nil
+		return
+	}
+	rv.rawDiff = github.ExtractFileDiff(rv.fullDiff, file)
+	pd := ParseUnifiedDiff(rv.rawDiff)
+	rv.parsedDiff = &pd
+}
+
+// SetDiff sets the raw diff for the selected file and parses it.
+// Used as a fallback when a full diff is not available.
+func (rv *ReviewsView) SetDiff(diff string) {
+	rv.rawDiff = diff
+	rv.diffScrollOff = 0
+	pd := ParseUnifiedDiff(diff)
+	rv.parsedDiff = &pd
+	rv.unifiedLines = nil
+}
+
+// SetComments replaces the comments for the selected PR and records fetch time.
+func (rv *ReviewsView) SetComments(comments []github.PRComment) {
+	rv.comments = comments
+	rv.commentsFetchedAt = time.Now()
+	rv.commentCursor = 0
+	rv.commentsFetching = false
+}
+
+// SetLoadError records a load error.
+func (rv *ReviewsView) SetLoadError(err string) {
+	rv.loadErr = err
+	rv.loading = false
+}
+
+// SelectedPR returns the currently selected PR, or nil.
+func (rv *ReviewsView) SelectedPR() *github.PR {
+	return rv.selectedPR
+}
+
+// SelectedFile returns the currently selected file path.
+func (rv *ReviewsView) SelectedFile() string {
+	if len(rv.files) == 0 || rv.fileCursor >= len(rv.files) {
+		return ""
+	}
+	return rv.files[rv.fileCursor]
+}
+
+// DraftComment returns the current in-progress comment (path, line, body).
+func (rv *ReviewsView) DraftComment() (path string, line int, body string) {
+	return rv.draftPath, rv.draftLine, rv.draftBody
+}
+
+// HandleKey processes keyboard input and returns a tea.Cmd (may be nil).
+func (rv *ReviewsView) HandleKey(msg tea.KeyMsg) tea.Cmd {
+	if rv.focus == focusComment {
+		return rv.handleCommentKey(msg)
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		rv.moveCursorUp()
+	case "down", "j":
+		rv.moveCursorDown()
+	case "R":
+		if !rv.canFetchPRList() {
+			// Still in cooldown — show how long until next refresh is allowed
+			remaining := prListCooldown - time.Since(rv.lastFetchTime)
+			rv.loadErr = fmt.Sprintf("rate limit cooldown: wait %ds before refreshing", int(remaining.Seconds())+1)
+			return nil
+		}
+		rv.loading = true
+		rv.loadErr = ""
+		return fetchPRListCmd()
+	case "s":
+		rv.splitMode = !rv.splitMode
+		rv.unifiedLines = nil
+	case "tab":
+		if rv.selectedPR != nil {
+			if rv.focus == focusList {
+				rv.focus = focusDiff
+			} else {
+				rv.focus = focusList
+			}
+		}
+	case "enter":
+		return rv.handleEnter()
+	case "esc":
+		if rv.focus == focusDiff {
+			rv.focus = focusList
+			rv.rawDiff = ""
+			rv.parsedDiff = nil
+			rv.unifiedLines = nil
+		} else if rv.selectedPR != nil {
+			rv.selectedPR = nil
+			rv.files = nil
+			rv.focus = focusList
+		}
+	case "c":
+		if rv.focus == focusDiff && rv.parsedDiff != nil {
+			line := rv.currentDiffLine()
+			if line == 0 {
+				break // no valid diff line at current scroll position
+			}
+			rv.focus = focusComment
+			rv.reviewDraftMode = false
+			rv.draftBody = ""
+			rv.draftPath = rv.SelectedFile()
+			rv.draftLine = line
+		}
+	case "a":
+		if rv.selectedPR != nil {
+			pr := rv.selectedPR
+			return func() tea.Msg {
+				err := github.SubmitReview(pr.RepoOwner, pr.Repo, pr.Number, github.ReviewApprove, "")
+				return SubmitReviewMsg{Err: err}
+			}
+		}
+	case "r":
+		// REQUEST_CHANGES requires a non-empty body per GitHub API.
+		// Open the compose box in review-draft mode so the user can type one.
+		if rv.selectedPR != nil {
+			rv.focus = focusComment
+			rv.reviewDraftMode = true
+			rv.draftBody = ""
+			rv.draftPath = ""
+			rv.draftLine = 0
+		}
+	}
+	return nil
+}
+
+func (rv *ReviewsView) handleCommentKey(msg tea.KeyMsg) tea.Cmd {
+	switch msg.String() {
+	case "esc":
+		rv.focus = focusDiff
+		rv.draftBody = ""
+		rv.reviewDraftMode = false
+	case "ctrl+s":
+		if rv.draftBody != "" && rv.selectedPR != nil {
+			pr := rv.selectedPR
+			path := rv.draftPath
+			line := rv.draftLine
+			body := rv.draftBody
+			isDraftReview := rv.reviewDraftMode
+			rv.focus = focusDiff
+			rv.draftBody = ""
+			rv.reviewDraftMode = false
+			if isDraftReview {
+				return func() tea.Msg {
+					err := github.SubmitReview(pr.RepoOwner, pr.Repo, pr.Number, github.ReviewRequestChanges, body)
+					return SubmitReviewMsg{Err: err}
+				}
+			}
+			return postCommentCmd(pr, path, line, body)
+		}
+	case "enter":
+		// Allow multi-line comments by inserting a newline.
+		rv.draftBody += "\n"
+	case "backspace":
+		if len(rv.draftBody) > 0 {
+			// Remove last rune (handles multi-byte UTF-8 correctly).
+			runes := []rune(rv.draftBody)
+			rv.draftBody = string(runes[:len(runes)-1])
+		}
+	default:
+		// Accept printable characters
+		if len(msg.Runes) > 0 {
+			rv.draftBody += string(msg.Runes)
+		}
+	}
+	return nil
+}
+
+func (rv *ReviewsView) handleEnter() tea.Cmd {
+	if rv.focus == focusList {
+		if rv.selectedPR == nil {
+			// Select a PR from the list
+			if len(rv.prs) == 0 || rv.prCursor >= len(rv.prs) {
+				return nil
+			}
+			pr := rv.prs[rv.prCursor]
+			rv.selectedPR = &pr
+			rv.files = nil
+			rv.fileCursor = 0
+			rv.rawDiff = ""
+			rv.parsedDiff = nil
+			rv.unifiedLines = nil
+			return fetchPRFilesCmd(pr.RepoOwner, pr.Repo, pr.Number)
+		}
+		// Select a file from the file list
+		if len(rv.files) > 0 && rv.fileCursor < len(rv.files) {
+			pr := rv.selectedPR
+			rv.focus = focusDiff
+			// If we already have the full diff cached, extract immediately —
+			// no API call needed. Otherwise fetch the full diff once.
+			if rv.fullDiff != "" {
+				rv.applyFileDiff()
+				// Comments are already cached from the first file selection.
+				return nil
+			}
+			rv.rawDiff = ""
+			rv.parsedDiff = nil
+			rv.unifiedLines = nil
+			rv.diffScrollOff = 0
+			rv.diffFetching = true
+			rv.commentsFetching = true
+			// Fetch full diff + comments in parallel (once per PR).
+			return tea.Batch(
+				fetchPRFullDiffCmd(pr.RepoOwner, pr.Repo, pr.Number),
+				fetchPRCommentsCmd(pr.RepoOwner, pr.Repo, pr.Number),
+			)
+		}
+	}
+	return nil
+}
+
+func (rv *ReviewsView) moveCursorUp() {
+	if rv.focus == focusDiff {
+		if rv.diffScrollOff > 0 {
+			rv.diffScrollOff--
+		}
+		return
+	}
+	// focusList
+	if rv.selectedPR != nil {
+		if rv.fileCursor > 0 {
+			rv.fileCursor--
+			// Re-slice from cached full diff immediately — no API call.
+			if rv.fullDiff != "" {
+				rv.applyFileDiff()
+			}
+		}
+	} else {
+		if rv.prCursor > 0 {
+			rv.prCursor--
+		}
+	}
+}
+
+func (rv *ReviewsView) moveCursorDown() {
+	if rv.focus == focusDiff {
+		if rv.diffScrollOff < rv.maxDiffScroll() {
+			rv.diffScrollOff++
+		}
+		return
+	}
+	// focusList
+	if rv.selectedPR != nil {
+		if rv.fileCursor < len(rv.files)-1 {
+			rv.fileCursor++
+			// Re-slice from cached full diff immediately — no API call.
+			if rv.fullDiff != "" {
+				rv.applyFileDiff()
+			}
+		}
+	} else {
+		if rv.prCursor < len(rv.prs)-1 {
+			rv.prCursor++
+		}
+	}
+}
+
+func (rv *ReviewsView) maxDiffScroll() int {
+	lines := rv.cachedDiffLines()
+	h := rv.diffHeight()
+	if len(lines) <= h {
+		return 0
+	}
+	return len(lines) - h
+}
+
+func (rv *ReviewsView) diffHeight() int {
+	h := rv.height - 4
+	if h < 5 {
+		h = 5
+	}
+	return h
+}
+
+func (rv *ReviewsView) cachedDiffLines() []string {
+	if rv.parsedDiff == nil {
+		return nil
+	}
+	if rv.unifiedLines == nil {
+		rv.unifiedLines = RenderUnifiedLines(*rv.parsedDiff, rv.SelectedFile())
+	}
+	return rv.unifiedLines
+}
+
+// currentDiffLine returns the diff line number at the current scroll position.
+// Returns 0 when the scroll position is out of range (e.g. after a diff reload
+// with fewer lines). Callers must treat 0 as "no line selected" and guard
+// before passing it to the GitHub API (line=0 is rejected by GitHub).
+func (rv *ReviewsView) currentDiffLine() int {
+	if rv.parsedDiff == nil || len(rv.parsedDiff.Hunks) == 0 {
+		return 0
+	}
+	lineCount := 0
+	for _, hunk := range rv.parsedDiff.Hunks {
+		for _, dl := range hunk.Lines {
+			if lineCount == rv.diffScrollOff {
+				if dl.NewNum > 0 {
+					return dl.NewNum
+				}
+				if dl.OldNum > 0 {
+					return dl.OldNum
+				}
+				return 0
+			}
+			lineCount++
+		}
+	}
+	return 0
+}
+
+// HandleMouse handles mouse wheel events for scrolling.
+func (rv *ReviewsView) HandleMouse(msg tea.MouseMsg) {
+	switch msg.Button {
+	case tea.MouseButtonWheelUp:
+		rv.scrollUp()
+	case tea.MouseButtonWheelDown:
+		rv.scrollDown()
+	}
+}
+
+func (rv *ReviewsView) scrollUp() {
+	switch rv.focus {
+	case focusDiff:
+		if rv.diffScrollOff > 0 {
+			rv.diffScrollOff--
+		}
+	case focusList:
+		if rv.selectedPR != nil {
+			if rv.fileCursor > 0 {
+				rv.fileCursor--
+				if rv.fullDiff != "" {
+					rv.applyFileDiff()
+				}
+			}
+		} else {
+			if rv.prCursor > 0 {
+				rv.prCursor--
+			}
+		}
+	case focusComment:
+		if rv.commentCursor > 0 {
+			rv.commentCursor--
+		}
+	}
+}
+
+func (rv *ReviewsView) scrollDown() {
+	switch rv.focus {
+	case focusDiff:
+		if rv.diffScrollOff < rv.maxDiffScroll() {
+			rv.diffScrollOff++
+		}
+	case focusList:
+		if rv.selectedPR != nil {
+			if rv.fileCursor < len(rv.files)-1 {
+				rv.fileCursor++
+				if rv.fullDiff != "" {
+					rv.applyFileDiff()
+				}
+			}
+		} else {
+			if rv.prCursor < len(rv.prs)-1 {
+				rv.prCursor++
+			}
+		}
+	case focusComment:
+		if rv.commentCursor < len(rv.comments)-1 {
+			rv.commentCursor++
+		}
+	}
+}
+
+// View renders the left (PR list) panel content.
+func (rv *ReviewsView) View() string {
+	if rv.width == 0 || rv.height == 0 {
+		return ""
+	}
+	if rv.loading {
+		return rv.theme.Dimmed.Render("Loading PRs...")
+	}
+	if rv.loadErr != "" {
+		return rv.theme.Error.Render("Error: " + rv.loadErr)
+	}
+
+	// Show file list if a PR is selected
+	if rv.selectedPR != nil {
+		return rv.renderFileList()
+	}
+
+	return rv.renderPRList()
+}
+
+func (rv *ReviewsView) renderPRList() string {
+	if len(rv.prs) == 0 {
+		return rv.theme.Dimmed.Render("No open PRs\n\nPress R to refresh")
+	}
+
+	// Separate into review requests and my PRs
+	var reviewReqs, myPRs []github.PR
+	var reviewReqIdxs, myPRIdxs []int
+	for i, pr := range rv.prs {
+		if pr.IsReviewRequest {
+			reviewReqIdxs = append(reviewReqIdxs, i)
+			reviewReqs = append(reviewReqs, pr)
+		} else {
+			myPRIdxs = append(myPRIdxs, i)
+			myPRs = append(myPRs, pr)
+		}
+	}
+
+	var b strings.Builder
+
+	if len(reviewReqs) > 0 {
+		b.WriteString(rv.theme.Section.Render("Review Requests"))
+		b.WriteString("\n")
+		for j, pr := range reviewReqs {
+			globalIdx := reviewReqIdxs[j]
+			rv.writePRRow(&b, pr, globalIdx == rv.prCursor)
+		}
+	}
+
+	if len(myPRs) > 0 {
+		if len(reviewReqs) > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(rv.theme.Section.Render("My Open PRs"))
+		b.WriteString("\n")
+		for j, pr := range myPRs {
+			globalIdx := myPRIdxs[j]
+			rv.writePRRow(&b, pr, globalIdx == rv.prCursor)
+		}
+	}
+
+	b.WriteString("\n")
+	// Show last fetch time + cooldown warning
+	if !rv.lastFetchTime.IsZero() {
+		age := time.Since(rv.lastFetchTime).Round(time.Second)
+		b.WriteString(rv.theme.Dimmed.Render(fmt.Sprintf("updated %s ago", age)))
+		b.WriteString("\n")
+	}
+	b.WriteString(rv.theme.Help.Render("[↑↓] navigate  [RET] select  [R] refresh"))
+
+	return b.String()
+}
+
+func (rv *ReviewsView) renderFileList() string {
+	var b strings.Builder
+	pr := rv.selectedPR
+
+	title := truncString(pr.Title, 35, 32)
+	b.WriteString(rv.theme.Title.Render(title))
+	b.WriteString("\n")
+	b.WriteString(rv.theme.Dimmed.Render(fmt.Sprintf("#%d · %s/%s", pr.Number, pr.RepoOwner, pr.Repo)))
+	b.WriteString("\n\n")
+
+	if len(rv.files) == 0 {
+		b.WriteString(rv.theme.Dimmed.Render("Loading files..."))
+		return b.String()
+	}
+
+	b.WriteString(rv.theme.Section.Render("Changed Files"))
+	b.WriteString("\n")
+	for i, f := range rv.files {
+		name := f
+		// Truncate long paths using rune-safe arithmetic to avoid panics on
+		// non-ASCII characters (e.g., repos with Unicode in file paths).
+		runes := []rune(name)
+		if len(runes) > 30 {
+			name = "…" + string(runes[len(runes)-29:])
+		}
+		if i == rv.fileCursor {
+			b.WriteString(rv.theme.Selected.Render("▶ " + name))
+		} else {
+			b.WriteString(rv.theme.Normal.Render("  " + name))
+		}
+		if i < len(rv.files)-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("\n\n")
+	b.WriteString(rv.theme.Help.Render("[RET] view diff  [esc] back"))
+
+	return b.String()
+}
+
+func (rv *ReviewsView) writePRRow(b *strings.Builder, pr github.PR, selected bool) {
+	title := truncString(pr.Title, 35, 32)
+
+	var badge string
+	switch pr.ReviewDecision {
+	case "APPROVED":
+		badge = " ✓"
+	case "CHANGES_REQUESTED":
+		badge = " ✗"
+	case "REVIEW_REQUIRED":
+		badge = " ?"
+	}
+	if pr.IsDraft {
+		badge += " [draft]"
+	}
+
+	meta := fmt.Sprintf("#%d %s/%s", pr.Number, pr.RepoOwner, pr.Repo)
+
+	if selected {
+		b.WriteString(rv.theme.Selected.Render("▶ " + title + badge))
+		b.WriteString("\n")
+		b.WriteString(rv.theme.Dimmed.Render("  " + meta))
+		b.WriteString("\n")
+	} else {
+		b.WriteString(rv.theme.Normal.Render("  " + title + badge))
+		b.WriteString("\n")
+		b.WriteString(rv.theme.Dimmed.Render("  " + meta))
+		b.WriteString("\n")
+	}
+}
+
+// RenderDiff renders the center (diff) panel content.
+func (rv *ReviewsView) RenderDiff(w, h int) string {
+	if rv.width == 0 || rv.height == 0 {
+		return ""
+	}
+	if rv.parsedDiff == nil {
+		if rv.selectedPR != nil && rv.focus == focusDiff {
+			return rv.theme.Dimmed.Render("Loading diff...")
+		}
+		if rv.selectedPR != nil {
+			return rv.theme.Dimmed.Render("Select a file to view diff\n\n[Tab] switch focus  [↑↓] navigate files")
+		}
+		return rv.theme.Dimmed.Render("Select a PR to view its diff")
+	}
+
+	lines := rv.cachedDiffLines()
+	if len(lines) == 0 {
+		return rv.theme.Dimmed.Render("(no changes in this file)")
+	}
+
+	file := rv.SelectedFile()
+	visibleH := h - 4
+	if visibleH < 1 {
+		visibleH = 1
+	}
+
+	content := RenderUnified(lines, visibleH, rv.diffScrollOff)
+
+	total := len(lines)
+	scrollPct := 0
+	if total > visibleH {
+		scrollPct = rv.diffScrollOff * 100 / (total - visibleH)
+	}
+	footer := rv.theme.Dimmed.Render(fmt.Sprintf("  %s  [%d%%]  [↑↓] scroll  [c] comment  [Tab] focus list", file, scrollPct))
+
+	return content + "\n" + footer
+}
+
+// RenderComments renders the right (comments + compose) panel content.
+func (rv *ReviewsView) RenderComments(w, h int) string {
+	if rv.width == 0 || rv.height == 0 {
+		return ""
+	}
+
+	if rv.focus == focusComment {
+		return rv.renderCommentCompose()
+	}
+
+	var b strings.Builder
+
+	if len(rv.comments) == 0 {
+		b.WriteString(rv.theme.Dimmed.Render("No comments"))
+		if rv.selectedPR != nil {
+			b.WriteString("\n\n")
+			b.WriteString(rv.theme.Help.Render("[c] add comment"))
+			b.WriteString("\n")
+			b.WriteString(rv.theme.Help.Render("[a] approve"))
+			b.WriteString("\n")
+			b.WriteString(rv.theme.Help.Render("[r] request changes"))
+		}
+		return b.String()
+	}
+
+	b.WriteString(rv.theme.Title.Render(fmt.Sprintf("Comments (%d)", len(rv.comments))))
+	b.WriteString("\n\n")
+
+	maxVisible := h - 5
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
+	start := 0
+	if rv.commentCursor >= maxVisible {
+		start = rv.commentCursor - maxVisible + 1
+	}
+	end := start + maxVisible
+	if end > len(rv.comments) {
+		end = len(rv.comments)
+	}
+
+	for i := start; i < end; i++ {
+		c := rv.comments[i]
+		header := rv.theme.Dimmed.Render(c.Author)
+		if c.Path != "" {
+			header += rv.theme.Dimmed.Render(fmt.Sprintf(" [%s:%d]", c.Path, c.Line))
+		}
+		body := truncString(c.Body, 60, 57)
+		if i == rv.commentCursor {
+			b.WriteString(rv.theme.Selected.Render("▶ ") + header + "\n")
+			b.WriteString(rv.theme.Normal.Render("  "+body) + "\n\n")
+		} else {
+			b.WriteString("  " + header + "\n")
+			b.WriteString(rv.theme.Dimmed.Render("  "+body) + "\n\n")
+		}
+	}
+
+	return b.String()
+}
+
+func (rv *ReviewsView) renderCommentCompose() string {
+	var b strings.Builder
+	if rv.reviewDraftMode {
+		b.WriteString(rv.theme.Title.Render("Request Changes"))
+		b.WriteString("\n\n")
+		b.WriteString(rv.theme.Dimmed.Render("Body (required by GitHub)"))
+		b.WriteString("\n")
+	} else {
+		b.WriteString(rv.theme.Title.Render("New Comment"))
+		b.WriteString("\n\n")
+		if rv.draftPath != "" {
+			b.WriteString(rv.theme.Dimmed.Render("File: " + rv.draftPath))
+			b.WriteString("\n")
+		}
+		if rv.draftLine > 0 {
+			b.WriteString(rv.theme.Dimmed.Render(fmt.Sprintf("Line: %d", rv.draftLine)))
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("\n")
+	b.WriteString(rv.theme.Normal.Render(rv.draftBody))
+	b.WriteString("█\n\n")
+	b.WriteString(rv.theme.Help.Render("[enter] newline  [ctrl+s] submit  [esc] cancel"))
+	return b.String()
+}

--- a/internal/ui/reviews_test.go
+++ b/internal/ui/reviews_test.go
@@ -1,0 +1,222 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/drn/argus/internal/github"
+)
+
+func TestReviewsView_Empty(t *testing.T) {
+	rv := NewReviewsView(DefaultTheme())
+	rv.SetSize(120, 40)
+	got := rv.View()
+	if got == "" {
+		t.Error("View() returned empty string with no PRs")
+	}
+	if !strings.Contains(got, "No open PRs") && !strings.Contains(got, "R") {
+		t.Errorf("expected 'No open PRs' message, got: %q", got)
+	}
+}
+
+func TestReviewsView_SetPRs(t *testing.T) {
+	rv := NewReviewsView(DefaultTheme())
+	rv.SetSize(120, 40)
+
+	prs := []github.PR{
+		{Number: 42, Title: "Fix critical bug", Author: "alice", RepoOwner: "org", Repo: "repo"},
+		{Number: 43, Title: "Review request PR", Author: "bob", RepoOwner: "org", Repo: "repo", IsReviewRequest: true},
+	}
+	rv.SetPRs(prs)
+
+	got := rv.View()
+	if !strings.Contains(got, "Fix critical bug") {
+		t.Errorf("expected PR title in View(), got: %q", got)
+	}
+	if !strings.Contains(got, "Review request PR") {
+		t.Errorf("expected review request PR title in View(), got: %q", got)
+	}
+	if !strings.Contains(got, "Review Requests") {
+		t.Errorf("expected 'Review Requests' section header, got: %q", got)
+	}
+	if !strings.Contains(got, "My Open PRs") {
+		t.Errorf("expected 'My Open PRs' section header, got: %q", got)
+	}
+}
+
+func TestReviewsView_Navigation(t *testing.T) {
+	rv := NewReviewsView(DefaultTheme())
+	rv.SetSize(120, 40)
+
+	prs := []github.PR{
+		{Number: 1, Title: "PR One", Author: "alice", RepoOwner: "org", Repo: "repo"},
+		{Number: 2, Title: "PR Two", Author: "alice", RepoOwner: "org", Repo: "repo"},
+		{Number: 3, Title: "PR Three", Author: "alice", RepoOwner: "org", Repo: "repo"},
+	}
+	rv.SetPRs(prs)
+
+	// Initial position
+	if rv.prCursor != 0 {
+		t.Errorf("expected prCursor=0, got %d", rv.prCursor)
+	}
+
+	// Move down
+	rv.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if rv.prCursor != 1 {
+		t.Errorf("expected prCursor=1 after j, got %d", rv.prCursor)
+	}
+
+	// Move down again
+	rv.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if rv.prCursor != 2 {
+		t.Errorf("expected prCursor=2 after j, got %d", rv.prCursor)
+	}
+
+	// Can't go past end
+	rv.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if rv.prCursor != 2 {
+		t.Errorf("expected prCursor=2 (clamped), got %d", rv.prCursor)
+	}
+
+	// Move up
+	rv.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	if rv.prCursor != 1 {
+		t.Errorf("expected prCursor=1 after k, got %d", rv.prCursor)
+	}
+}
+
+func TestReviewsView_ZeroDimensions(t *testing.T) {
+	// Verify no panic with zero dimensions
+	rv := NewReviewsView(DefaultTheme())
+	// Don't call SetSize — width/height remain 0
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("View() panicked with zero dimensions: %v", r)
+		}
+	}()
+
+	_ = rv.View()
+	_ = rv.RenderDiff(0, 0)
+	_ = rv.RenderComments(0, 0)
+}
+
+func TestReviewsView_HandleKey_Refresh(t *testing.T) {
+	rv := NewReviewsView(DefaultTheme())
+	rv.SetSize(120, 40)
+
+	// First refresh always succeeds (no cooldown yet)
+	cmd := rv.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("R")})
+	if cmd == nil {
+		t.Error("expected non-nil cmd from R key on first press")
+	}
+}
+
+func TestReviewsView_HandleKey_RefreshCooldown(t *testing.T) {
+	rv := NewReviewsView(DefaultTheme())
+	rv.SetSize(120, 40)
+
+	// Simulate that we just fetched
+	rv.lastFetchTime = time.Now()
+
+	// Refresh should be blocked by cooldown
+	cmd := rv.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("R")})
+	if cmd != nil {
+		t.Error("expected nil cmd from R key during cooldown")
+	}
+	if !strings.Contains(rv.loadErr, "cooldown") {
+		t.Errorf("expected cooldown error message, got: %q", rv.loadErr)
+	}
+}
+
+func TestReviewsView_SelectPR(t *testing.T) {
+	rv := NewReviewsView(DefaultTheme())
+	rv.SetSize(120, 40)
+
+	prs := []github.PR{
+		{Number: 42, Title: "Fix bug", Author: "alice", RepoOwner: "org", Repo: "repo"},
+	}
+	rv.SetPRs(prs)
+
+	// Press Enter to select the PR
+	cmd := rv.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Error("expected non-nil cmd after selecting PR")
+	}
+	if rv.selectedPR == nil {
+		t.Error("expected selectedPR to be set after Enter")
+	}
+	if rv.selectedPR.Number != 42 {
+		t.Errorf("expected PR #42 selected, got #%d", rv.selectedPR.Number)
+	}
+}
+
+func TestReviewsView_EscBack(t *testing.T) {
+	rv := NewReviewsView(DefaultTheme())
+	rv.SetSize(120, 40)
+
+	prs := []github.PR{
+		{Number: 1, Title: "PR", Author: "a", RepoOwner: "o", Repo: "r"},
+	}
+	rv.SetPRs(prs)
+	rv.HandleKey(tea.KeyMsg{Type: tea.KeyEnter}) // select PR
+
+	if rv.selectedPR == nil {
+		t.Fatal("setup: expected PR to be selected")
+	}
+
+	// Esc clears selection
+	rv.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if rv.selectedPR != nil {
+		t.Error("expected selectedPR to be cleared after Esc")
+	}
+}
+
+func TestReviewsView_DiffRender(t *testing.T) {
+	rv := NewReviewsView(DefaultTheme())
+	rv.SetSize(120, 40)
+
+	pr := github.PR{Number: 1, Title: "PR", Author: "a", RepoOwner: "o", Repo: "r", HeadSHA: "abc"}
+	rv.SetPRs([]github.PR{pr})
+	rv.HandleKey(tea.KeyMsg{Type: tea.KeyEnter}) // select PR
+	rv.SetFiles([]string{"main.go"})
+
+	rawDiff := `diff --git a/main.go b/main.go
+--- a/main.go
++++ b/main.go
+@@ -1,3 +1,4 @@
+ package main
++// added line
+ func main() {}
+`
+	rv.SetDiff(rawDiff)
+	rv.focus = focusDiff
+
+	got := rv.RenderDiff(60, 20)
+	if got == "" {
+		t.Error("RenderDiff() returned empty string with valid diff")
+	}
+}
+
+func TestReviewsView_CanFetchPRList(t *testing.T) {
+	rv := NewReviewsView(DefaultTheme())
+
+	// Should be allowed initially (no previous fetch)
+	if !rv.canFetchPRList() {
+		t.Error("expected canFetchPRList()=true on first call")
+	}
+
+	// After SetPRs, lastFetchTime is set — should be blocked
+	rv.SetPRs(nil)
+	if rv.canFetchPRList() {
+		t.Error("expected canFetchPRList()=false immediately after fetch")
+	}
+
+	// After cooldown expires, should be allowed again
+	rv.lastFetchTime = time.Now().Add(-prListCooldown - time.Second)
+	if !rv.canFetchPRList() {
+		t.Error("expected canFetchPRList()=true after cooldown expires")
+	}
+}

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/drn/argus/internal/daemon"
 	dclient "github.com/drn/argus/internal/daemon/client"
 	"github.com/drn/argus/internal/db"
+	"github.com/drn/argus/internal/github"
 	"github.com/drn/argus/internal/model"
 	"github.com/drn/argus/internal/uxlog"
 )
@@ -43,6 +44,7 @@ type tab int
 
 const (
 	tabTasks tab = iota
+	tabReviews
 	tabSettings
 )
 
@@ -104,6 +106,40 @@ type UXLogsMsg struct {
 	Err   error
 }
 
+// FetchPRListMsg carries the result of a GitHub PR list fetch.
+type FetchPRListMsg struct {
+	PRs []github.PR
+	Err error
+}
+
+// FetchPRFilesMsg carries changed files for a PR.
+type FetchPRFilesMsg struct {
+	Files []string
+	Err   error
+}
+
+// FetchPRDiffMsg carries the raw diff for a single PR file.
+type FetchPRDiffMsg struct {
+	Diff string
+	Err  error
+}
+
+// FetchPRCommentsMsg carries comments for a PR.
+type FetchPRCommentsMsg struct {
+	Comments []github.PRComment
+	Err      error
+}
+
+// PostCommentMsg carries the result of posting a review comment.
+type PostCommentMsg struct {
+	Err error
+}
+
+// SubmitReviewMsg carries the result of submitting a full review.
+type SubmitReviewMsg struct {
+	Err error
+}
+
 // Model is the top-level Bubble Tea model.
 type Model struct {
 	db          *db.DB
@@ -112,6 +148,7 @@ type Model struct {
 	theme       Theme
 	tasklist    TaskList
 	settings    SettingsView
+	reviews     *ReviewsView
 	statusbar   StatusBar
 	helpview    HelpView
 	newtask     NewTaskForm
@@ -164,6 +201,7 @@ func NewModel(database *db.DB, runner agent.SessionProvider, daemonConnected boo
 
 	tl := NewTaskList(theme)
 	sv := NewSettingsView(theme)
+	rv := NewReviewsView(theme)
 	sb := NewStatusBar(theme)
 	hv := NewHelpView(keys, theme)
 
@@ -185,6 +223,7 @@ func NewModel(database *db.DB, runner agent.SessionProvider, daemonConnected boo
 		restartedClient: new(*dclient.Client),
 		tasklist:    tl,
 		settings:    sv,
+		reviews:     rv,
 		statusbar:   sb,
 		helpview:    hv,
 		preview:     pv,
@@ -308,6 +347,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		settingsLeft, _ := m.splitWidths()
 		m.settings.SetSize(settingsLeft, contentHeight)
 
+		// Reviews tab
+		m.reviews.SetSize(msg.Width, contentHeight)
+
 		m.statusbar.SetWidth(msg.Width)
 		m.newtask.SetSize(msg.Width, msg.Height)
 		m.projectform.SetSize(msg.Width, msg.Height)
@@ -333,6 +375,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !m.daemonRestarting {
 			if cmd := m.scheduleGitRefresh(); cmd != nil {
 				cmds = append(cmds, cmd)
+			}
+		}
+		// Reviews tab: auto-refresh stale data while the user is actively viewing.
+		// - Comments: TTL 2 min, OR if PR.UpdatedAt is newer than last fetch.
+		// - Diff: if PR.UpdatedAt is newer than when we fetched it (free check).
+		if m.activeTab == tabReviews {
+			if pr := m.reviews.SelectedPR(); pr != nil {
+				if m.reviews.areCommentsStale() {
+					cmds = append(cmds, fetchPRCommentsCmd(pr.RepoOwner, pr.Repo, pr.Number))
+				}
+				if m.reviews.isDiffStale() {
+					// Re-fetch full diff; applyFileDiff will re-slice current file.
+					cmds = append(cmds, fetchPRFullDiffCmd(pr.RepoOwner, pr.Repo, pr.Number))
+				}
 			}
 		}
 		// Daemon health check — auto-restart if N consecutive ping failures.
@@ -419,6 +475,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.current == viewUXLogs {
 			m.handleUXLogsMouse(msg)
+		}
+		if m.activeTab == tabReviews {
+			m.reviews.HandleMouse(msg)
 		}
 		return m, nil
 
@@ -515,6 +574,56 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.refreshTasks()
 		return m, nil
 
+	case FetchPRListMsg:
+		if msg.Err != nil {
+			m.reviews.SetLoadError(githubErrMsg(msg.Err))
+		} else {
+			m.reviews.SetPRs(msg.PRs)
+		}
+		return m, nil
+
+	case FetchPRFilesMsg:
+		if msg.Err != nil {
+			m.statusbar.SetError(githubErrMsg(msg.Err))
+		} else {
+			m.reviews.SetFiles(msg.Files)
+		}
+		return m, nil
+
+	case FetchPRDiffMsg:
+		if msg.Err != nil {
+			m.statusbar.SetError(githubErrMsg(msg.Err))
+		} else {
+			// SetFullDiff caches the complete PR diff and extracts the current
+			// file's slice immediately — subsequent file changes are free.
+			m.reviews.SetFullDiff(msg.Diff)
+		}
+		return m, nil
+
+	case FetchPRCommentsMsg:
+		if msg.Err != nil {
+			m.statusbar.SetError(githubErrMsg(msg.Err))
+		} else {
+			m.reviews.SetComments(msg.Comments)
+		}
+		return m, nil
+
+	case PostCommentMsg:
+		if msg.Err != nil {
+			m.statusbar.SetError(githubErrMsg(msg.Err))
+		}
+		// Refresh comments after posting
+		if pr := m.reviews.SelectedPR(); pr != nil {
+			return m, fetchPRCommentsCmd(pr.RepoOwner, pr.Repo, pr.Number)
+		}
+		return m, nil
+
+	case SubmitReviewMsg:
+		if msg.Err != nil {
+			m.statusbar.SetError(githubErrMsg(msg.Err))
+		}
+		return m, nil
+
 	case detectBranchMsg:
 		if m.current == viewNewProject || m.current == viewEditProject {
 			cmd := m.projectform.Update(msg)
@@ -562,12 +671,18 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case viewAgent:
 		return m.handleAgentViewKey(msg)
 	default:
-		// Tab switching with 1/2 keys or left/right arrows
+		// Tab switching with 1/2/3 keys or left/right arrows
 		switch msg.String() {
 		case "1":
 			m.activeTab = tabTasks
 			return m, nil
 		case "2":
+			m.activeTab = tabReviews
+			if m.reviews.canFetchPRList() {
+				return m, m.reviews.StartLoading()
+			}
+			return m, nil
+		case "3":
 			m.activeTab = tabSettings
 			return m, nil
 		}
@@ -580,11 +695,17 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.TabRight):
 			if m.activeTab < tabSettings {
 				m.activeTab++
+				if m.activeTab == tabReviews && m.reviews.canFetchPRList() {
+					return m, m.reviews.StartLoading()
+				}
 			}
 			return m, nil
 		}
 		if m.activeTab == tabSettings {
 			return m.handleSettingsKey(msg)
+		}
+		if m.activeTab == tabReviews {
+			return m.handleReviewsKey(msg)
 		}
 		return m.handleTaskListKey(msg)
 	}
@@ -607,6 +728,17 @@ func (m Model) handleAgentViewKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.refreshTasks()
 		return m, nil
 	}
+	return m, cmd
+}
+
+func (m Model) handleReviewsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Global quit
+	switch msg.String() {
+	case "q":
+		m.quitting = true
+		return m, tea.Quit
+	}
+	cmd := m.reviews.HandleKey(msg)
 	return m, cmd
 }
 
@@ -1569,6 +1701,57 @@ func (m Model) handleUXLogsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+// githubErrMsg returns a user-friendly error message for GitHub API errors,
+// with a distinct message for rate limit errors (403/429).
+func githubErrMsg(err error) string {
+	if errors.Is(err, github.ErrRateLimit) {
+		return "GitHub rate limit exceeded — wait a minute and try again (5k req/hr REST, 30 req/min Search)"
+	}
+	return err.Error()
+}
+
+// fetchPRListCmd kicks off an async fetch of all open PRs and review requests.
+func fetchPRListCmd() tea.Cmd {
+	return func() tea.Msg {
+		prs, err := github.FetchPRList()
+		return FetchPRListMsg{PRs: prs, Err: err}
+	}
+}
+
+// fetchPRFilesCmd kicks off an async fetch of changed files for a PR.
+func fetchPRFilesCmd(owner, repo string, number int) tea.Cmd {
+	return func() tea.Msg {
+		files, err := github.FetchPRFiles(owner, repo, number)
+		return FetchPRFilesMsg{Files: files, Err: err}
+	}
+}
+
+// fetchPRFullDiffCmd fetches the complete diff for a PR once and caches it.
+// Subsequent file selections re-slice the cached diff without API calls.
+func fetchPRFullDiffCmd(owner, repo string, number int) tea.Cmd {
+	return func() tea.Msg {
+		diff, err := github.FetchPRFullDiff(owner, repo, number)
+		return FetchPRDiffMsg{Diff: diff, Err: err}
+	}
+}
+
+
+// fetchPRCommentsCmd kicks off an async fetch of review comments for a PR.
+func fetchPRCommentsCmd(owner, repo string, number int) tea.Cmd {
+	return func() tea.Msg {
+		comments, err := github.FetchPRComments(owner, repo, number)
+		return FetchPRCommentsMsg{Comments: comments, Err: err}
+	}
+}
+
+// postCommentCmd kicks off an async post of a review comment.
+func postCommentCmd(pr *github.PR, path string, line int, body string) tea.Cmd {
+	return func() tea.Msg {
+		err := github.PostReviewComment(pr.RepoOwner, pr.Repo, pr.Number, pr.HeadSHA, path, line, body)
+		return PostCommentMsg{Err: err}
+	}
 }
 
 func (m *Model) handleUXLogsMouse(msg tea.MouseMsg) {

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -706,27 +706,41 @@ func TestTabSwitching_LeftRightArrows(t *testing.T) {
 		t.Fatalf("expected initial tab to be tabTasks")
 	}
 
-	// Right arrow → projects
+	// Right arrow → reviews
 	msg := tea.KeyMsg{Type: tea.KeyRight}
 	updated, _ := m.Update(msg)
 	m = updated.(Model)
-	if m.activeTab != tabSettings {
-		t.Errorf("expected tabSettings after right arrow, got %d", m.activeTab)
+	if m.activeTab != tabReviews {
+		t.Errorf("expected tabReviews after right arrow, got %d", m.activeTab)
 	}
 
-	// Right arrow again → should stay on projects (no wrap)
+	// Right arrow again → settings
 	updated, _ = m.Update(msg)
 	m = updated.(Model)
 	if m.activeTab != tabSettings {
 		t.Errorf("expected tabSettings after second right arrow, got %d", m.activeTab)
 	}
 
-	// Left arrow → tasks
+	// Right arrow again → should stay on settings (no wrap)
+	updated, _ = m.Update(msg)
+	m = updated.(Model)
+	if m.activeTab != tabSettings {
+		t.Errorf("expected tabSettings after third right arrow (no wrap), got %d", m.activeTab)
+	}
+
+	// Left arrow → reviews
 	msg = tea.KeyMsg{Type: tea.KeyLeft}
 	updated, _ = m.Update(msg)
 	m = updated.(Model)
+	if m.activeTab != tabReviews {
+		t.Errorf("expected tabReviews after left arrow, got %d", m.activeTab)
+	}
+
+	// Left arrow again → tasks
+	updated, _ = m.Update(msg)
+	m = updated.(Model)
 	if m.activeTab != tabTasks {
-		t.Errorf("expected tabTasks after left arrow, got %d", m.activeTab)
+		t.Errorf("expected tabTasks after second left arrow, got %d", m.activeTab)
 	}
 
 	// Left arrow again → should stay on tasks (no wrap)
@@ -1306,12 +1320,20 @@ func TestModel_NewProjectCancel(t *testing.T) {
 func TestModel_TabSwitching_NumberKeys(t *testing.T) {
 	m := testModel(t)
 
-	// Press '2' for projects
+	// Press '2' for reviews
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
 	updated, _ := m.Update(msg)
 	um := updated.(Model)
+	if um.activeTab != tabReviews {
+		t.Errorf("expected tabReviews after '2', got %d", um.activeTab)
+	}
+
+	// Press '3' for settings
+	msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	updated, _ = um.Update(msg)
+	um = updated.(Model)
 	if um.activeTab != tabSettings {
-		t.Errorf("expected tabSettings after '2', got %d", um.activeTab)
+		t.Errorf("expected tabSettings after '3', got %d", um.activeTab)
 	}
 
 	// Press '1' for tasks
@@ -1701,6 +1723,8 @@ func TestModel_ViewZeroDimensions(t *testing.T) {
 		}},
 		{"daemonLogs", func(m *Model) { m.current = viewDaemonLogs; m.daemonLogLines = []string{"test log line"} }},
 		{"uxLogs", func(m *Model) { m.current = viewUXLogs; m.uxLogLines = []string{"test ux log line"} }},
+		{"reviews", func(m *Model) { m.activeTab = tabReviews }},
+		{"reviewsLoading", func(m *Model) { m.activeTab = tabReviews; m.reviews.loading = true }},
 	}
 	for _, tc := range views {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/ui/root_views.go
+++ b/internal/ui/root_views.go
@@ -14,6 +14,7 @@ func (m Model) View() string {
 	}
 
 	m.statusbar.SetSettingsTab(m.activeTab == tabSettings)
+	m.statusbar.SetReviewsTab(m.activeTab == tabReviews)
 	bar := m.statusbar.View()
 
 	if m.current == viewAgent {
@@ -51,6 +52,8 @@ func (m Model) View() string {
 	switch m.activeTab {
 	case tabSettings:
 		return m.renderSettingsView(tabHeader, bar)
+	case tabReviews:
+		return m.renderReviewsView(tabHeader, bar)
 	default:
 		return m.renderTasksView(tabHeader, bar)
 	}
@@ -119,6 +122,7 @@ func (m Model) renderTabHeader() string {
 		t     tab
 	}{
 		{"Tasks", tabTasks},
+		{"Reviews", tabReviews},
 		{"Settings", tabSettings},
 	}
 
@@ -175,6 +179,32 @@ func (m Model) renderSettingsView(tabHeader, bar string) string {
 	leftPanel := borderedPanel(leftWidth, contentHeight, false, leftContent)
 	rightPanel := m.settings.RenderDetail(rightWidth, contentHeight)
 	body := lipgloss.JoinHorizontal(lipgloss.Top, leftPanel, rightPanel)
+	content := tabHeader + "\n" + body
+	return m.padToBottom(content, bar)
+}
+
+func (m Model) renderReviewsView(tabHeader, bar string) string {
+	// 30 / 50 / 20 split
+	layout := NewPanelLayout([]PanelConfig{
+		{Pct: 30, Min: 25},
+		{Pct: 50, Min: 40},
+		{Pct: 20, Min: 20},
+	})
+	contentHeight := m.height - 2
+	layout.SetSize(m.width, contentHeight)
+	widths := layout.SplitWidths()
+	h := layout.Height()
+
+	leftContent := m.reviews.View()
+	leftPanel := borderedPanel(widths[0], h, m.reviews.focus == focusList, leftContent)
+
+	diffContent := m.reviews.RenderDiff(widths[1], h)
+	diffPanel := borderedPanel(widths[1], h, m.reviews.focus == focusDiff, diffContent)
+
+	commentsContent := m.reviews.RenderComments(widths[2], h)
+	commentsPanel := borderedPanel(widths[2], h, m.reviews.focus == focusComment, commentsContent)
+
+	body := layout.Render([]string{leftPanel, diffPanel, commentsPanel})
 	content := tabHeader + "\n" + body
 	return m.padToBottom(content, bar)
 }

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -10,12 +10,13 @@ import (
 
 // StatusBar renders the bottom status bar.
 type StatusBar struct {
-	theme      Theme
-	width      int
-	tasks      []*model.Task
-	running    map[string]bool
+	theme       Theme
+	width       int
+	tasks       []*model.Task
+	running     map[string]bool
 	errMsg      string
 	settingsTab bool
+	reviewsTab  bool
 }
 
 func NewStatusBar(theme Theme) StatusBar {
@@ -36,6 +37,10 @@ func (sb *StatusBar) SetRunning(ids []string) {
 
 func (sb *StatusBar) SetSettingsTab(active bool) {
 	sb.settingsTab = active
+}
+
+func (sb *StatusBar) SetReviewsTab(active bool) {
+	sb.reviewsTab = active
 }
 
 func (sb *StatusBar) SetError(msg string) {
@@ -71,7 +76,19 @@ func (sb StatusBar) View() string {
 
 	// Keybinding hints with highlighted keys
 	var keys []struct{ key, label string }
-	if sb.settingsTab {
+	if sb.reviewsTab {
+		keys = []struct{ key, label string }{
+			{"↑↓", "navigate"},
+			{"RET", "select"},
+			{"c", "comment"},
+			{"a", "approve"},
+			{"r", "req changes"},
+			{"R", "refresh"},
+			{"1", "tasks"},
+			{"3", "settings"},
+			{"q", "quit"},
+		}
+	} else if sb.settingsTab {
 		keys = []struct{ key, label string }{
 			{"n", "new project"},
 			{"d", "del"},
@@ -85,7 +102,8 @@ func (sb StatusBar) View() string {
 			{"RET", "attach"},
 			{"s", "status"},
 			{"d", "del"},
-			{"2", "settings"},
+			{"2", "reviews"},
+			{"3", "settings"},
 			{"?", "help"},
 			{"q", "quit"},
 		}


### PR DESCRIPTION
Adds a three-panel GitHub PR review tab (PR list | diff | comments) between Tasks and Settings. Supports browsing open PRs and review requests, viewing diffs inline using the existing diff pipeline, posting line comments, approving, and requesting changes. Full diff cached per PR to minimize API calls; 30s Search API cooldown and per-tick fetch guards prevent rate limiting.

Co-Authored-By: Claude <noreply@anthropic.com>