### PR TITLE
Add Argus logo banner and centered layout to settings view

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -354,8 +354,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.preview.SetSize(widths[1], previewH)
 		m.detail.SetSize(widths[2], contentHeight)
 
-		// Settings tab uses two-panel split
-		settingsLeft, _ := m.splitWidths()
+		// Settings tab: 20% margin | 20% left | 40% right | 20% margin
+		_, settingsLeft, _ := m.settingsWidths()
 		m.settings.SetSize(settingsLeft, contentHeight)
 
 		// Reviews tab

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -919,32 +919,39 @@ func TestInit_ResetsStartedAtBeforeResume(t *testing.T) {
 	}
 }
 
-func TestModel_SplitWidths(t *testing.T) {
+func TestModel_SettingsWidths(t *testing.T) {
 	m := testModel(t)
 	m.width = 120
 
-	left, right := m.splitWidths()
-	if left+right != 120 {
-		t.Errorf("splitWidths total = %d, want 120", left+right)
+	margin, left, right := m.settingsWidths()
+	if margin != 24 {
+		t.Errorf("margin = %d, want 24 (20%% of 120)", margin)
 	}
-	if left < 30 {
-		t.Errorf("left = %d, want >= 30", left)
+	if left != 24 {
+		t.Errorf("left = %d, want 24 (20%% of 120)", left)
 	}
-	if right < 20 {
-		t.Errorf("right = %d, want >= 20", right)
+	if right != 48 {
+		t.Errorf("right = %d, want 48 (40%% of 120)", right)
+	}
+	if margin+left+right > 120 {
+		t.Errorf("total %d exceeds width 120", margin+left+right)
 	}
 }
 
-func TestModel_SplitWidths_NarrowTerminal(t *testing.T) {
+func TestModel_SettingsWidths_NarrowTerminal(t *testing.T) {
 	m := testModel(t)
-	m.width = 60
+	m.width = 40
 
-	left, right := m.splitWidths()
-	if left+right != 60 {
-		t.Errorf("splitWidths total = %d, want 60", left+right)
+	margin, left, right := m.settingsWidths()
+	// At 40 wide, 20% = 8, left min = 15, right min = 30 → 8+15+30 > 40 → margin = 0
+	if margin != 0 {
+		t.Errorf("margin = %d, want 0 (panels exceed width)", margin)
 	}
-	if left < 30 {
-		t.Errorf("left should be at least 30, got %d", left)
+	if left < 15 {
+		t.Errorf("left = %d, want >= 15", left)
+	}
+	if right < 30 {
+		t.Errorf("right = %d, want >= 30", right)
 	}
 }
 

--- a/internal/ui/root_views.go
+++ b/internal/ui/root_views.go
@@ -88,18 +88,6 @@ func (m Model) splitCenterHeights(total int) (int, int) {
 	return gitH, previewH
 }
 
-// splitWidths returns a two-panel split for the settings tab.
-func (m Model) splitWidths() (int, int) {
-	left := m.width * 2 / 5
-	if left < 30 {
-		left = 30
-	}
-	if left > m.width-20 {
-		left = m.width - 20
-	}
-	right := m.width - left
-	return left, right
-}
 
 
 func (m Model) renderTabHeader() string {
@@ -173,14 +161,37 @@ func (m Model) renderTasksView(tabHeader, bar string) string {
 }
 
 func (m Model) renderSettingsView(tabHeader, bar string) string {
-	leftWidth, rightWidth := m.splitWidths()
-	contentHeight := m.height - 2
+	logo := renderBanner(m.width)
+	logoHeight := lipgloss.Height(logo)
+
+	// Panel area: 20% margin | 20% left | 40% right | 20% margin
+	contentHeight := max(m.height-2-logoHeight, 3) // 2 = tab header + separator
+	marginW, leftWidth, rightWidth := m.settingsWidths()
+
 	leftContent := m.settings.View()
 	leftPanel := borderedPanel(leftWidth, contentHeight, false, leftContent)
 	rightPanel := m.settings.RenderDetail(rightWidth, contentHeight)
-	body := lipgloss.JoinHorizontal(lipgloss.Top, leftPanel, rightPanel)
+	panels := lipgloss.JoinHorizontal(lipgloss.Top, leftPanel, rightPanel)
+
+	if marginW > 0 {
+		panels = lipgloss.NewStyle().PaddingLeft(marginW).Render(panels)
+	}
+
+	body := logo + "\n" + panels
 	content := tabHeader + "\n" + body
 	return m.padToBottom(content, bar)
+}
+
+// settingsWidths returns the margin, left panel, and right panel widths
+// for the settings view layout: 20% margin | 20% left | 40% right | 20% margin.
+func (m Model) settingsWidths() (margin, left, right int) {
+	margin = m.width / 5
+	left = max(m.width/5, 15)
+	right = max(m.width*2/5, 30)
+	if margin+left+right > m.width {
+		margin = 0
+	}
+	return
 }
 
 func (m Model) renderReviewsView(tabHeader, bar string) string {


### PR DESCRIPTION
Renders the full Argus banner at the top of the settings tab with panels in a 20% margin | 20% left | 40% right | 20% margin layout. Reuses renderBanner() from the empty-state view. Adds settingsWidths() helper for consistent width math between SetSize and render.

Co-Authored-By: Claude <noreply@anthropic.com>