### PR TITLE
Make archive section always expanded and non-focusable

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -868,10 +868,6 @@ func (m Model) handleTaskListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case key.Matches(msg, m.keys.Attach):
-		if m.tasklist.CursorOnArchiveHeader() {
-			m.tasklist.ToggleArchive()
-			return m, nil
-		}
 		return m.attachAgent()
 
 	case key.Matches(msg, m.keys.Prompt):

--- a/internal/ui/tasklist.go
+++ b/internal/ui/tasklist.go
@@ -40,10 +40,9 @@ type TaskList struct {
 	running       map[string]bool // task IDs with active agent sessions
 	idle          map[string]bool // task IDs with sessions waiting for input
 	idleUnvisited map[string]bool // task IDs idle since user last viewed the agent view
-	rows            []row           // flattened display rows (headers + tasks)
-	expanded        string          // currently expanded project name
-	archiveExpanded bool            // whether the Archive section is open
-	archiveProject  string          // expanded project within archive section
+	rows           []row   // flattened display rows (headers + tasks)
+	expanded       string  // currently expanded project name
+	archiveProject string  // expanded project within archive section
 	tickEven        bool            // toggles each tick for status icon animation
 }
 
@@ -117,8 +116,46 @@ func (tl *TaskList) moveCursor(dir int) {
 		return
 	}
 
-	// Already on a task row or archive header — done.
-	if tl.rows[c].kind == rowTask || tl.rows[c].kind == rowArchiveHeader {
+	// Already on a task row — done.
+	if tl.rows[c].kind == rowTask {
+		return
+	}
+
+	// On the archive header — skip it like a project header.
+	if tl.rows[c].kind == rowArchiveHeader {
+		if dir > 0 {
+			if c+1 < len(tl.rows) {
+				tl.scroll.CursorDown(len(tl.rows), tl.visibleRows())
+				tl.autoExpand()
+				c = tl.scroll.Cursor()
+				// May have landed on a project header within archive — skip that too.
+				if c >= 0 && c < len(tl.rows) && tl.rows[c].kind == rowProject {
+					if c+1 < len(tl.rows) && tl.rows[c+1].kind == rowTask {
+						tl.scroll.CursorDown(len(tl.rows), tl.visibleRows())
+					}
+				}
+			}
+		} else {
+			tl.scroll.CursorUp()
+			tl.autoExpand()
+			c = tl.scroll.Cursor()
+			if c >= 0 && c < len(tl.rows) && tl.rows[c].kind == rowProject {
+				// Find the last task row in this expanded project.
+				lastTask := -1
+				for i := c + 1; i < len(tl.rows) && tl.rows[i].kind == rowTask; i++ {
+					lastTask = i
+				}
+				if lastTask >= 0 {
+					tl.scroll.SetCursor(lastTask)
+					visible := tl.visibleRows()
+					if lastTask >= tl.scroll.Offset()+visible {
+						tl.scroll.SetOffset(lastTask - visible + 1)
+					}
+				}
+			} else if c < 0 || (c >= 0 && c < len(tl.rows) && tl.rows[c].kind == rowArchiveHeader) {
+				tl.scroll.SetCursor(prev)
+			}
+		}
 		return
 	}
 
@@ -134,10 +171,6 @@ func (tl *TaskList) moveCursor(dir int) {
 			tl.scroll.CursorUp()
 			tl.autoExpand()
 			c = tl.scroll.Cursor()
-			if c >= 0 && c < len(tl.rows) && tl.rows[c].kind == rowArchiveHeader {
-				// Landed on archive header — that's fine, stop here.
-				return
-			}
 			if c >= 0 && c < len(tl.rows) && tl.rows[c].kind == rowProject {
 				// Find the last task row in this expanded project.
 				lastTask := -1
@@ -312,30 +345,28 @@ func (tl *TaskList) buildRows() {
 	// Add archive section if there are archived tasks.
 	if len(archivedTasks) > 0 {
 		tl.rows = append(tl.rows, row{kind: rowArchiveHeader})
-		if tl.archiveExpanded {
-			archiveGroups := tl.groupByProject(archivedTasks)
-			// Reset archiveProject if it no longer exists.
-			if tl.archiveProject != "" {
-				found := false
-				for _, g := range archiveGroups {
-					if g.name == tl.archiveProject {
-						found = true
-						break
-					}
-				}
-				if !found {
-					tl.archiveProject = ""
-				}
-			}
-			if tl.archiveProject == "" && len(archiveGroups) > 0 {
-				tl.archiveProject = archiveGroups[0].name
-			}
+		archiveGroups := tl.groupByProject(archivedTasks)
+		// Reset archiveProject if it no longer exists.
+		if tl.archiveProject != "" {
+			found := false
 			for _, g := range archiveGroups {
-				tl.rows = append(tl.rows, row{kind: rowProject, project: g.name})
 				if g.name == tl.archiveProject {
-					for _, t := range g.tasks {
-						tl.rows = append(tl.rows, row{kind: rowTask, project: g.name, task: t})
-					}
+					found = true
+					break
+				}
+			}
+			if !found {
+				tl.archiveProject = ""
+			}
+		}
+		if tl.archiveProject == "" && len(archiveGroups) > 0 {
+			tl.archiveProject = archiveGroups[0].name
+		}
+		for _, g := range archiveGroups {
+			tl.rows = append(tl.rows, row{kind: rowProject, project: g.name})
+			if g.name == tl.archiveProject {
+				for _, t := range g.tasks {
+					tl.rows = append(tl.rows, row{kind: rowTask, project: g.name, task: t})
 				}
 			}
 		}
@@ -491,7 +522,7 @@ func (tl TaskList) View() string {
 			tl.renderProjectHeader(&b, r.project, selected, tl.isInArchiveSection(i))
 		case rowArchiveHeader:
 			b.WriteString("\n")
-			tl.renderArchiveHeader(&b, selected)
+			tl.renderArchiveHeader(&b)
 		case rowTask:
 			tl.renderTaskRow(&b, r.task, selected, tl.isInArchiveSection(i))
 		}
@@ -634,12 +665,7 @@ func (tl TaskList) renderProjectHeader(b *strings.Builder, project string, selec
 	}
 }
 
-func (tl TaskList) renderArchiveHeader(b *strings.Builder, selected bool) {
-	chevron := "▸"
-	if tl.archiveExpanded {
-		chevron = "▾"
-	}
-
+func (tl TaskList) renderArchiveHeader(b *strings.Builder) {
 	// Count archived tasks.
 	count := 0
 	for _, t := range tl.filtered {
@@ -648,31 +674,10 @@ func (tl TaskList) renderArchiveHeader(b *strings.Builder, selected bool) {
 		}
 	}
 
-	nameStyle := tl.theme.Dimmed
-	chevronStyle := tl.theme.Dimmed
-	cursorStr := "  "
-	if selected {
-		nameStyle = tl.theme.Selected
-		chevronStyle = tl.theme.Selected
-		cursorStr = tl.theme.Selected.Render(" >")
-	}
-
 	countStr := tl.theme.Dimmed.Render(fmt.Sprintf(" (%d)", count))
-	fmt.Fprintf(b, "%s %s %s%s\n", cursorStr, chevronStyle.Render(chevron), nameStyle.Render("Archive"), countStr)
+	fmt.Fprintf(b, "%s%s\n", tl.theme.Dimmed.Render("Archive"), countStr)
 }
 
-// ToggleArchive toggles the archive section open/closed.
-func (tl *TaskList) ToggleArchive() {
-	tl.archiveExpanded = !tl.archiveExpanded
-	tl.buildRows()
-	tl.scroll.ClampCursor(len(tl.rows))
-}
-
-// CursorOnArchiveHeader returns true if the cursor is on the archive section header.
-func (tl *TaskList) CursorOnArchiveHeader() bool {
-	c := tl.scroll.Cursor()
-	return c >= 0 && c < len(tl.rows) && tl.rows[c].kind == rowArchiveHeader
-}
 
 func (tl TaskList) renderTaskRow(b *strings.Builder, t *model.Task, selected, inArchive bool) {
 	icon := tl.taskStatusIcon(t)

--- a/internal/ui/tasklist_test.go
+++ b/internal/ui/tasklist_test.go
@@ -676,7 +676,7 @@ func TestTaskList_ArchivedSection(t *testing.T) {
 		t.Error("expected archive header row when archived tasks exist")
 	}
 
-	// Active task should be in rows, archived should not (archive collapsed by default).
+	// Archive is always expanded — both active and archived tasks should be in rows.
 	activeFound, archivedFound := false, false
 	for _, r := range tl.rows {
 		if r.kind == rowTask {
@@ -691,44 +691,8 @@ func TestTaskList_ArchivedSection(t *testing.T) {
 	if !activeFound {
 		t.Error("expected active task in rows")
 	}
-	if archivedFound {
-		t.Error("archived task should not be visible when archive is collapsed")
-	}
-}
-
-func TestTaskList_ArchiveToggle(t *testing.T) {
-	tl := NewTaskList(DefaultTheme())
-	tl.SetSize(80, 40)
-	tasks := []*model.Task{
-		{ID: "t1", Name: "Active", Project: "proj"},
-		{ID: "t2", Name: "Archived", Project: "proj", Archived: true},
-	}
-	tl.SetTasks(tasks)
-
-	// Toggle archive open.
-	tl.ToggleArchive()
-
-	// Archived task should now be visible.
-	archivedFound := false
-	for _, r := range tl.rows {
-		if r.kind == rowTask && r.task.ID == "t2" {
-			archivedFound = true
-		}
-	}
 	if !archivedFound {
-		t.Error("expected archived task visible after expanding archive")
-	}
-
-	// Toggle archive closed.
-	tl.ToggleArchive()
-	archivedFound = false
-	for _, r := range tl.rows {
-		if r.kind == rowTask && r.task.ID == "t2" {
-			archivedFound = true
-		}
-	}
-	if archivedFound {
-		t.Error("archived task should not be visible after collapsing archive")
+		t.Error("expected archived task in rows (archive is always expanded)")
 	}
 }
 
@@ -762,7 +726,7 @@ func TestTaskList_ArchiveViewRendersHeader(t *testing.T) {
 	}
 }
 
-func TestTaskList_CursorOnArchiveHeader(t *testing.T) {
+func TestTaskList_CursorSkipsArchiveHeader(t *testing.T) {
 	tl := NewTaskList(DefaultTheme())
 	tl.SetSize(80, 40)
 	tasks := []*model.Task{
@@ -771,13 +735,14 @@ func TestTaskList_CursorOnArchiveHeader(t *testing.T) {
 	}
 	tl.SetTasks(tasks)
 
-	// Navigate down to archive header.
-	for range 10 {
+	// Navigate down past all rows — cursor should never land on archive header.
+	for range 20 {
 		tl.CursorDown()
 	}
 
-	if !tl.CursorOnArchiveHeader() {
-		t.Error("expected cursor to land on archive header")
+	c := tl.scroll.Cursor()
+	if c >= 0 && c < len(tl.rows) && tl.rows[c].kind == rowArchiveHeader {
+		t.Error("cursor should never land on the archive header")
 	}
 }
 
@@ -790,7 +755,6 @@ func TestTaskList_ArchiveMultipleProjects(t *testing.T) {
 		{ID: "t3", Name: "Archived B", Project: "beta", Archived: true},
 	}
 	tl.SetTasks(tasks)
-	tl.ToggleArchive()
 
 	// Both archived projects should appear as headers in the archive section.
 	archiveProjectHeaders := 0


### PR DESCRIPTION
Remove archive toggle — archive section is always open. Cursor skips the archive header row (non-interactive). Archive header shifted left with no chevron or cursor indicator.

Co-Authored-By: Claude <noreply@anthropic.com>