### PR TITLE
Make ctrl+q refocus agent pane in file explorer

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -222,6 +222,10 @@ func (av *AgentView) HandleKey(msg tea.KeyMsg) (detach bool, cmd tea.Cmd) {
 			av.exitDiffMode()
 			return false, nil
 		}
+		if av.focus == panelFiles {
+			av.focus = panelAgent
+			return false, nil
+		}
 		return true, nil
 	}
 


### PR DESCRIPTION
When the file explorer panel has focus, ctrl+q now acts like esc — returning focus to the agent terminal pane instead of detaching from the agent view.

Co-Authored-By: Claude <noreply@anthropic.com>