### PR TITLE
Auto-expand directories in file explorer on cursor movement

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -279,13 +279,14 @@ func (av *AgentView) HandleKey(msg tea.KeyMsg) (detach bool, cmd tea.Cmd) {
 		case "esc":
 			av.focus = panelAgent
 		case "up", "k":
-			av.files.CursorUp()
-		case "down", "j":
-			av.files.CursorDown()
-		case "enter":
-			if row := av.files.SelectedRow(); row != nil && row.IsDir {
-				return false, av.toggleDir(row.Path)
+			if dir := av.files.CursorUp(); dir != "" {
+				return false, av.fetchDirChildren(dir)
 			}
+		case "down", "j":
+			if dir := av.files.CursorDown(); dir != "" {
+				return false, av.fetchDirChildren(dir)
+			}
+		case "enter":
 			return false, av.openFileDiff()
 		case "o":
 			return false, av.openInFinder()
@@ -320,13 +321,8 @@ func (av *AgentView) HandleMouse(msg tea.MouseMsg) {
 	}
 }
 
-// toggleDir toggles a directory's expansion state. If newly expanded and
-// children haven't been fetched yet, returns a command to fetch them.
-func (av *AgentView) toggleDir(dirPath string) tea.Cmd {
-	needsFetch := av.files.ToggleDir(dirPath)
-	if !needsFetch {
-		return nil
-	}
+// fetchDirChildren returns a command to fetch children for an expanded directory.
+func (av *AgentView) fetchDirChildren(dirPath string) tea.Cmd {
 	taskID := av.taskID
 	dir := av.worktreeDir
 	return func() tea.Msg {

--- a/internal/ui/fileexplorer.go
+++ b/internal/ui/fileexplorer.go
@@ -111,12 +111,75 @@ func (fe *FileExplorer) buildDisplayRows() {
 	}
 }
 
-func (fe *FileExplorer) CursorUp() {
+func (fe *FileExplorer) CursorUp() string {
 	fe.scroll.CursorUp()
+	return fe.autoExpand()
 }
 
-func (fe *FileExplorer) CursorDown() {
+func (fe *FileExplorer) CursorDown() string {
 	fe.scroll.CursorDown(len(fe.rows), fe.visibleRows())
+	return fe.autoExpand()
+}
+
+// autoExpand expands the directory the cursor is on (or the parent directory
+// if cursor is on a child row) and collapses all others — mirroring the task
+// list's one-expanded-at-a-time behavior. Returns the dir path that needs
+// children fetched (empty string if none).
+func (fe *FileExplorer) autoExpand() string {
+	row := fe.SelectedRow()
+	if row == nil {
+		return ""
+	}
+
+	// Save the path at cursor so we can restore position after rebuild.
+	cursorPath := row.Path
+
+	// Determine which directory should be expanded.
+	var targetDir string
+	if row.IsDir {
+		targetDir = row.Path
+	} else if row.indent > 0 {
+		// Child row — find its parent directory by walking backward.
+		targetDir = fe.parentDir(fe.scroll.Cursor())
+	}
+	// If cursor is on a top-level file, no directory should be expanded.
+
+	// Collapse all directories except the target.
+	for dir := range fe.expanded {
+		if dir != targetDir {
+			fe.expanded[dir] = false
+		}
+	}
+
+	var needsFetch string
+	if targetDir != "" && !fe.expanded[targetDir] {
+		fe.expanded[targetDir] = true
+		if _, ok := fe.dirChildren[targetDir]; !ok {
+			needsFetch = targetDir
+		}
+	}
+
+	fe.buildDisplayRows()
+
+	// Restore cursor to the same logical row after rebuild.
+	for i, r := range fe.rows {
+		if r.Path == cursorPath {
+			fe.scroll.SetCursor(i)
+			break
+		}
+	}
+	fe.scroll.ClampCursor(len(fe.rows))
+	return needsFetch
+}
+
+// parentDir walks backward from idx to find the parent directory row.
+func (fe *FileExplorer) parentDir(idx int) string {
+	for i := idx - 1; i >= 0; i-- {
+		if fe.rows[i].IsDir && fe.rows[i].indent == 0 {
+			return fe.rows[i].Path
+		}
+	}
+	return ""
 }
 
 // SelectedRow returns the currently selected display row, or nil if none.

--- a/internal/ui/fileexplorer_test.go
+++ b/internal/ui/fileexplorer_test.go
@@ -457,6 +457,99 @@ func TestFileExplorer_SetFiles_PrunesStaleExpansion(t *testing.T) {
 	}
 }
 
+func TestFileExplorer_AutoExpand(t *testing.T) {
+	fe := NewFileExplorer(DefaultTheme())
+	fe.SetSize(40, 20)
+	fe.SetFiles([]ChangedFile{
+		{Status: "M", Path: "top.go"},
+		{Status: "??", Path: "dir1/", IsDir: true},
+		{Status: "??", Path: "dir2/", IsDir: true},
+	})
+	fe.SetDirChildren("dir1/", []ChangedFile{
+		{Status: "A", Path: "dir1/a.go"},
+	})
+	fe.SetDirChildren("dir2/", []ChangedFile{
+		{Status: "A", Path: "dir2/b.go"},
+	})
+
+	// Cursor starts on top.go (non-dir), no dir should be expanded
+	row := fe.SelectedRow()
+	if row == nil || row.Path != "top.go" {
+		t.Fatalf("expected cursor on top.go, got %+v", row)
+	}
+
+	// Move down to dir1/ — should auto-expand
+	fe.CursorDown()
+	row = fe.SelectedRow()
+	if row == nil || row.Path != "dir1/" {
+		t.Fatalf("expected cursor on dir1/, got %+v", row)
+	}
+	if !fe.expanded["dir1/"] {
+		t.Error("dir1/ should be auto-expanded when cursor enters")
+	}
+	// rows: top.go, dir1/, dir1/a.go, dir2/
+	if fe.DisplayRowCount() != 4 {
+		t.Errorf("expected 4 rows with dir1 expanded, got %d", fe.DisplayRowCount())
+	}
+
+	// Move down to dir1/a.go — dir1 should stay expanded
+	fe.CursorDown()
+	row = fe.SelectedRow()
+	if row == nil || row.Path != "dir1/a.go" {
+		t.Fatalf("expected cursor on dir1/a.go, got %+v", row)
+	}
+	if !fe.expanded["dir1/"] {
+		t.Error("dir1/ should stay expanded when cursor is on child")
+	}
+
+	// Move down to dir2/ — dir1 should collapse, dir2 should expand
+	fe.CursorDown()
+	row = fe.SelectedRow()
+	if row == nil || row.Path != "dir2/" {
+		t.Fatalf("expected cursor on dir2/, got %+v", row)
+	}
+	if fe.expanded["dir1/"] {
+		t.Error("dir1/ should collapse when cursor moves to dir2/")
+	}
+	if !fe.expanded["dir2/"] {
+		t.Error("dir2/ should auto-expand when cursor enters")
+	}
+
+	// Move back up to top.go — all dirs should collapse
+	fe.CursorUp()
+	fe.CursorUp()
+	row = fe.SelectedRow()
+	if row == nil || row.Path != "top.go" {
+		t.Fatalf("expected cursor on top.go, got %+v", row)
+	}
+	if fe.expanded["dir1/"] || fe.expanded["dir2/"] {
+		t.Error("all dirs should collapse when cursor is on a top-level file")
+	}
+}
+
+func TestFileExplorer_AutoExpand_NeedsFetch(t *testing.T) {
+	fe := NewFileExplorer(DefaultTheme())
+	fe.SetSize(40, 20)
+	fe.SetFiles([]ChangedFile{
+		{Status: "??", Path: "dir/", IsDir: true},
+	})
+
+	// Move cursor to dir/ — should auto-expand and request fetch
+	needsFetch := fe.CursorDown()
+	// Cursor doesn't move past end so it stays on dir/ (first row after down from 0 is still 0 if only 1 row)
+	// Actually with 1 row, cursor starts at 0 (dir/) — autoExpand runs on initial CursorDown
+	// Let's check the initial position
+	row := fe.SelectedRow()
+	if row == nil || row.Path != "dir/" {
+		t.Fatalf("expected cursor on dir/, got %+v", row)
+	}
+	// The initial SetFiles doesn't trigger autoExpand, but CursorDown does.
+	// With only 1 row, CursorDown doesn't move but autoExpand still runs.
+	if needsFetch != "dir/" {
+		t.Errorf("expected needsFetch=dir/, got %q", needsFetch)
+	}
+}
+
 func TestFileExplorer_StatusStyle(t *testing.T) {
 	theme := DefaultTheme()
 	fe := NewFileExplorer(theme)


### PR DESCRIPTION
Directories in the files changed panel now auto-expand when the cursor enters them and auto-collapse when the cursor leaves, matching the task list's one-expanded-at-a-time behavior. Enter always opens diff view.

Co-Authored-By: Claude <noreply@anthropic.com>