### PR TITLE
Fix archive nav jumping to main section for same-named projects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,8 @@ go test ./internal/db/      # run tests for a single package
 
 - **`fixupBackends()` migrates `--yolo` to `--full-auto` and sets `resume_command` for codex.** Detection: command contains "codex" but not `--full-auto`, or codex command missing `resume_command`. The `resume_command` DB column is added via `ALTER TABLE backends ADD COLUMN resume_command TEXT NOT NULL DEFAULT ''` (idempotent).
 
+- **`restoreCursor` must filter by archive section to avoid cross-section project name collisions.** When a project has both active and archived tasks, its name appears as a `rowProject` header in BOTH the main section and the archive section. The old `restoreCursor` iterated rows and took the first match on `(kind, project)` — always finding the main-section header, jumping the cursor out of the archive. Fix: `restoreCursor` now takes an `inArchive bool` and skips candidate rows where `tl.isInArchiveSection(i) != inArchive`. Both call sites in `autoExpand()` pass the correct value (true for archive, false for main).
+
 ## Planned but Not Yet Implemented
 
 - Task import from markdown/JSON (`internal/import/`) — Phase 4

--- a/internal/ui/tasklist.go
+++ b/internal/ui/tasklist.go
@@ -486,7 +486,7 @@ func (tl *TaskList) autoExpand() {
 			currentRow := tl.rows[c]
 			tl.archiveProject = r.project
 			tl.buildRows()
-			tl.restoreCursor(currentRow)
+			tl.restoreCursor(currentRow, true)
 		}
 	} else {
 		// Expand the project in the active section.
@@ -494,7 +494,7 @@ func (tl *TaskList) autoExpand() {
 			currentRow := tl.rows[c]
 			tl.expanded = r.project
 			tl.buildRows()
-			tl.restoreCursor(currentRow)
+			tl.restoreCursor(currentRow, false)
 		}
 	}
 }
@@ -510,10 +510,15 @@ func (tl *TaskList) isInArchiveSection(idx int) bool {
 }
 
 // restoreCursor finds the row matching currentRow in the rebuilt rows slice
-// and positions the cursor there.
-func (tl *TaskList) restoreCursor(target row) {
+// and positions the cursor there. inArchive restricts the search to the
+// archive section (or main section), preventing a project that exists in both
+// sections from matching the wrong header.
+func (tl *TaskList) restoreCursor(target row, inArchive bool) {
 	for i, r := range tl.rows {
 		if r.kind == target.kind && r.project == target.project {
+			if tl.isInArchiveSection(i) != inArchive {
+				continue
+			}
 			if r.kind == rowProject || r.task == target.task {
 				tl.scroll.SetCursor(i)
 				// Ensure offset is reasonable after cursor jump.

--- a/internal/ui/tasklist_test.go
+++ b/internal/ui/tasklist_test.go
@@ -909,3 +909,80 @@ func TestTaskList_ArchiveAutoExpandProjectSwitch(t *testing.T) {
 		t.Error("archive project should auto-expand when cursor moves to a different project")
 	}
 }
+
+// TestTaskList_ArchiveNavigation_SameProjectName tests that navigating within
+// the archive section does not jump to the main section when a project name
+// appears in both sections. This is the core bug: restoreCursor used to find
+// the first matching project header (in the main section) instead of the one
+// in the archive.
+func TestTaskList_ArchiveNavigation_SameProjectName(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
+	tasks := []*model.Task{
+		// "argus" has active tasks (appears in main section) AND archived tasks.
+		{ID: "t1", Name: "Active argus task", Project: "argus"},
+		{ID: "t2", Name: "Archived argus 1", Project: "argus", Archived: true},
+		{ID: "t3", Name: "Archived argus 2", Project: "argus", Archived: true},
+		// "cli" has only archived tasks (only appears in archive section).
+		{ID: "t4", Name: "Archived cli 1", Project: "cli", Archived: true},
+		{ID: "t5", Name: "Archived cli 2", Project: "cli", Archived: true},
+	}
+	tl.SetTasks(tasks)
+
+	// Navigate into the archive section.
+	for range 20 {
+		tl.CursorDown()
+	}
+
+	if !tl.archiveExpanded {
+		t.Fatal("expected archive to be expanded")
+	}
+
+	// Navigate through the archive to the "cli" project.
+	for range 20 {
+		tl.CursorDown()
+	}
+
+	sel := tl.Selected()
+	if sel == nil {
+		t.Fatal("expected a task selected")
+	}
+
+	// The cursor must be in the archive section — not in the main section.
+	c := tl.scroll.Cursor()
+	if !tl.isInArchiveSection(c) {
+		t.Errorf("cursor jumped out of archive section to main section (task %q, project %q)", sel.Name, sel.Project)
+	}
+}
+
+// TestTaskList_ArchiveLastItemNavigation verifies that pressing Down from the
+// last task in the archive does not move the cursor backward.
+func TestTaskList_ArchiveLastItemNavigation(t *testing.T) {
+	tl := NewTaskList(DefaultTheme())
+	tl.SetSize(80, 40)
+	tasks := []*model.Task{
+		{ID: "t1", Name: "Active", Project: "proj"},
+		{ID: "t2", Name: "Arch 1", Project: "proj", Archived: true},
+		{ID: "t3", Name: "Arch 2", Project: "proj", Archived: true},
+		{ID: "t4", Name: "Arch 3", Project: "proj", Archived: true},
+	}
+	tl.SetTasks(tasks)
+
+	// Navigate all the way down.
+	for range 30 {
+		tl.CursorDown()
+	}
+
+	sel := tl.Selected()
+	if sel == nil {
+		t.Fatal("expected a task selected at bottom")
+	}
+	lastCursor := tl.scroll.Cursor()
+
+	// Pressing down again from the last item must not move the cursor backward.
+	tl.CursorDown()
+	newCursor := tl.scroll.Cursor()
+	if newCursor < lastCursor {
+		t.Errorf("cursor moved backward from last item: was %d, now %d", lastCursor, newCursor)
+	}
+}


### PR DESCRIPTION
When a project has both active and archived tasks, its name appears as a rowProject header in both the main section and the archive section. restoreCursor was matching the first (kind, project) row — always the main-section header — jumping the cursor out of the archive when navigating between archive projects.

Fix: pass inArchive bool to restoreCursor and skip rows where isInArchiveSection(i) != inArchive, scoping the search to the correct section. Includes two new regression tests.

Co-Authored-By: Claude <noreply@anthropic.com>