### PR TITLE
Trim leading empty lines from vt10x terminal output

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -767,6 +767,12 @@ func (av *AgentView) renderIncremental(sess agent.SessionHandle, raw []byte, tot
 	if len(lines) > dispH {
 		lines = lines[len(lines)-dispH:]
 	}
+
+	// Trim leading empty lines (e.g. Codex positions its TUI content in the
+	// lower portion of the terminal, leaving the top rows blank).
+	for len(lines) > 0 && stripANSI(lines[0]) == "" {
+		lines = lines[1:]
+	}
 	for i, line := range lines {
 		lines[i] = ansi.Truncate(line, dispW, "\x1b[0m")
 	}

--- a/internal/ui/vtrender.go
+++ b/internal/ui/vtrender.go
@@ -49,6 +49,12 @@ func replayVT10X(raw []byte, vtCols, vtRows int, cursorVisible bool) []string {
 		lines = lines[:len(lines)-1]
 	}
 
+	// Trim leading empty lines (e.g. Codex positions its TUI content in the
+	// lower portion of the terminal, leaving the top rows blank).
+	for len(lines) > 0 && stripANSI(lines[0]) == "" {
+		lines = lines[1:]
+	}
+
 	return lines
 }
 

--- a/internal/ui/vtrender_test.go
+++ b/internal/ui/vtrender_test.go
@@ -1,0 +1,62 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReplayVT10X_TrimsLeadingEmptyLines(t *testing.T) {
+	// Codex-style TUI: positions content in the bottom portion of the terminal,
+	// leaving the top rows empty. replayVT10X should trim those leading empty rows.
+	// Use cursor-positioning to put text at row 5 of a 10-row terminal.
+	raw := []byte(
+		"\x1b[5;1H" + // move to row 5, col 1
+			"Hello from Codex" +
+			"\x1b[6;1H" + // row 6
+			"Second line",
+	)
+
+	lines := replayVT10X(raw, 40, 10, true)
+
+	if len(lines) == 0 {
+		t.Fatal("expected non-empty lines")
+	}
+
+	// Leading empty rows should be trimmed — first line should have content.
+	first := stripANSI(lines[0])
+	if strings.TrimSpace(first) == "" {
+		t.Errorf("leading empty line not trimmed: first line = %q", lines[0])
+	}
+	if !strings.Contains(first, "Hello from Codex") {
+		t.Errorf("expected first line to contain 'Hello from Codex', got %q", first)
+	}
+}
+
+func TestReplayVT10X_TrimsTrailingEmptyLines(t *testing.T) {
+	// Content only at top — trailing empty rows should be trimmed.
+	raw := []byte(
+		"\x1b[1;1H" + "Top line",
+	)
+
+	lines := replayVT10X(raw, 40, 10, true)
+
+	if len(lines) == 0 {
+		t.Fatal("expected non-empty lines")
+	}
+
+	// Should only have the one content line (trailing rows trimmed).
+	if len(lines) != 1 {
+		t.Errorf("expected 1 line after trailing trim, got %d", len(lines))
+	}
+	if !strings.Contains(stripANSI(lines[0]), "Top line") {
+		t.Errorf("expected 'Top line', got %q", lines[0])
+	}
+}
+
+func TestReplayVT10X_EmptyTerminal(t *testing.T) {
+	raw := []byte{}
+	lines := replayVT10X(raw, 40, 10, true)
+	if len(lines) != 0 {
+		t.Errorf("expected empty lines for empty input, got %d", len(lines))
+	}
+}


### PR DESCRIPTION
Codex positions its TUI content in the lower portion of the terminal, leaving the top rows empty. The panel showed large blank whitespace at the top because only trailing empty lines were trimmed.

Fix: trim leading empty lines after the tail window is taken, in both `renderIncremental` (live follow-tail mode) and `replayVT10X` (scrollback/finished sessions). Adds `vtrender_test.go` covering both trim directions.

Co-Authored-By: Claude <noreply@anthropic.com>