### PR TITLE
Add /skill autocomplete to new task form

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -1,5 +1,7 @@
 ## Key Learnings
 
+- **New task form has `/skill` autocomplete.** `internal/ui/skills.go` scans `~/.claude/skills/*/SKILL.md` frontmatter to build a `[]SkillItem` list. The form stores this list and when the prompt value starts with `/` and contains no spaces, shows a filtered dropdown below the textarea (`acOpen`, `acMatches`, `acIdx`, `acScroll`). Up/Down navigate the list, Enter selects (sets value to `/<name> ` and closes without submitting), Esc closes the dropdown (second Esc cancels the form). `updateAutocomplete()` is called after every `textarea.Update()` to recompute matches. The dropdown uses `acMaxVisible = 6` visible rows with scroll indicators when the list is longer.
+
 - PTY child processes need a real terminal size at launch (`pty.StartWithSize`), not 0x0. TUI apps like claude won't render with zero dimensions.
 - Use `charmbracelet/x/term` for raw mode (cross-platform) instead of platform-specific ioctls (`TIOCGETA` is macOS-only, `TCGETS` is Linux-only).
 - `tea.ExecCommand.SetStdin/SetStdout` must capture and use Bubble Tea's `p.input`/`p.output` — don't hardcode `os.Stdin`/`os.Stdout`.

--- a/internal/ui/newtask.go
+++ b/internal/ui/newtask.go
@@ -9,26 +9,33 @@ import (
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/drn/argus/internal/config"
 	"github.com/drn/argus/internal/model"
 )
 
 // NewTaskForm handles the new task creation UI.
 type NewTaskForm struct {
-	promptInput  textarea.Model
-	projectNames []string
-	projectIdx   int
-	backendNames []string // sorted backend names; index 0 is "(default)"
-	backendIdx   int
+	promptInput        textarea.Model
+	projectNames       []string
+	projectIdx         int
+	backendNames       []string // sorted backend names; index 0 is "(default)"
+	backendIdx         int
 	defaultBackendName string // resolved name for the "(default)" entry
-	focused      int // 0 = project, 1 = backend, 2 = prompt
-	theme        Theme
-	projects     map[string]config.Project
-	done         bool
-	canceled     bool
-	errMsg       string
-	width        int
-	height       int
+	focused            int    // 0 = project, 1 = backend, 2 = prompt
+	theme              Theme
+	projects           map[string]config.Project
+	done               bool
+	canceled           bool
+	errMsg             string
+	width              int
+	height             int
+	// autocomplete state
+	skills    []SkillItem
+	acOpen    bool
+	acMatches []SkillItem
+	acIdx     int
+	acScroll  int
 }
 
 const (
@@ -98,6 +105,17 @@ func NewNewTaskForm(theme Theme, projects map[string]config.Project, defaultProj
 	}
 }
 
+// skillsLoadedMsg carries the result of an async skill scan.
+type skillsLoadedMsg []SkillItem
+
+// loadSkillsCmd returns a Cmd that scans ~/.claude/skills/ in a background
+// goroutine, keeping the UI responsive during filesystem discovery.
+func loadSkillsCmd() tea.Cmd {
+	return func() tea.Msg {
+		return skillsLoadedMsg(LoadSkills(nil))
+	}
+}
+
 func (f *NewTaskForm) Update(msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
@@ -105,6 +123,10 @@ func (f *NewTaskForm) Update(msg tea.Msg) tea.Cmd {
 		f.errMsg = ""
 		switch msg.String() {
 		case "esc":
+			if f.acOpen {
+				f.acOpen = false
+				return nil
+			}
 			f.canceled = true
 			return nil
 		case "tab":
@@ -151,6 +173,10 @@ func (f *NewTaskForm) Update(msg tea.Msg) tea.Cmd {
 				return nil
 			}
 		case "up":
+			if f.acOpen && f.focused == fieldPrompt {
+				f.acMoveUp()
+				return nil
+			}
 			if f.focused == fieldProject {
 				f.focused = fieldPrompt
 				return f.promptInput.Focus()
@@ -168,6 +194,10 @@ func (f *NewTaskForm) Update(msg tea.Msg) tea.Cmd {
 			}
 			// Otherwise let textarea handle up arrow for multi-line navigation
 		case "down":
+			if f.acOpen && f.focused == fieldPrompt {
+				f.acMoveDown()
+				return nil
+			}
 			if f.focused == fieldProject {
 				f.focused = fieldBackend
 				return nil
@@ -193,6 +223,14 @@ func (f *NewTaskForm) Update(msg tea.Msg) tea.Cmd {
 				f.focused = fieldPrompt
 				return f.promptInput.Focus()
 			}
+			// Select autocomplete suggestion if open
+			if f.acOpen && len(f.acMatches) > 0 {
+				f.promptInput.SetValue("/" + f.acMatches[f.acIdx].Name + " ")
+				f.promptInput.CursorEnd()
+				f.acOpen = false
+				f.adjustPromptHeight()
+				return nil
+			}
 			// Submit on enter at prompt field
 			if strings.TrimSpace(f.promptInput.Value()) != "" {
 				f.done = true
@@ -217,6 +255,7 @@ func (f *NewTaskForm) Update(msg tea.Msg) tea.Cmd {
 		f.promptInput, cmd = f.promptInput.Update(msg)
 		// Shrink height back to fit the actual visual line count
 		f.adjustPromptHeight()
+		f.updateAutocomplete()
 		return cmd
 	}
 
@@ -249,6 +288,60 @@ func (f *NewTaskForm) visualLineCount() int {
 		return maxPromptLines
 	}
 	return f.promptInput.LineInfo().Height
+}
+
+// updateAutocomplete recomputes the autocomplete matches based on the current
+// prompt value. Autocomplete is active when the value starts with "/" and
+// contains no spaces (the user is still typing the skill name).
+func (f *NewTaskForm) updateAutocomplete() {
+	val := f.promptInput.Value()
+	// Close once the user moves past the skill name (typed a space to add args).
+	if !strings.HasPrefix(val, "/") || strings.ContainsRune(val[1:], ' ') {
+		f.acOpen = false
+		return
+	}
+	filter := val[1:]
+	f.acMatches = filterSkills(f.skills, filter)
+	if len(f.acMatches) == 0 {
+		f.acOpen = false
+		return
+	}
+	f.acOpen = true
+	if f.acIdx >= len(f.acMatches) {
+		f.acIdx = 0
+		f.acScroll = 0
+	}
+}
+
+// acMoveDown moves the autocomplete cursor down one item (wraps around).
+func (f *NewTaskForm) acMoveDown() {
+	if len(f.acMatches) == 0 {
+		return
+	}
+	f.acIdx = (f.acIdx + 1) % len(f.acMatches)
+	if f.acIdx == 0 {
+		f.acScroll = 0
+	} else if f.acIdx >= f.acScroll+acMaxVisible {
+		f.acScroll = f.acIdx - acMaxVisible + 1
+	}
+}
+
+// acMoveUp moves the autocomplete cursor up one item (wraps around).
+func (f *NewTaskForm) acMoveUp() {
+	if len(f.acMatches) == 0 {
+		return
+	}
+	if f.acIdx == 0 {
+		f.acIdx = len(f.acMatches) - 1
+		if f.acIdx >= acMaxVisible {
+			f.acScroll = f.acIdx - acMaxVisible + 1
+		}
+	} else {
+		f.acIdx--
+		if f.acIdx < f.acScroll {
+			f.acScroll = f.acIdx
+		}
+	}
 }
 
 func (f *NewTaskForm) SelectedProject() string {
@@ -347,7 +440,11 @@ func (f NewTaskForm) View() string {
 		promptStyle = f.theme.Selected
 	}
 	b.WriteString(promptStyle.Render("Prompt:") + "\n")
-	b.WriteString(f.promptInput.View() + "\n\n")
+	b.WriteString(f.promptInput.View() + "\n")
+	if f.acOpen { // acOpen is only true when acMatches is non-empty
+		b.WriteString(f.renderAutocomplete() + "\n")
+	}
+	b.WriteString("\n")
 
 	if f.errMsg != "" {
 		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
@@ -390,6 +487,71 @@ func (f NewTaskForm) renderBackendSelector() string {
 	}
 
 	return "  " + left + name + right + counter + suffix
+}
+
+// renderAutocomplete renders the skill suggestion dropdown below the prompt input.
+func (f NewTaskForm) renderAutocomplete() string {
+	inputW := f.modalWidth() - 4 // matches textarea width
+
+	// Compute the longest skill name for alignment
+	maxName := 0
+	end := f.acScroll + acMaxVisible
+	if end > len(f.acMatches) {
+		end = len(f.acMatches)
+	}
+	for i := f.acScroll; i < end; i++ {
+		n := ansi.StringWidth("/" + f.acMatches[i].Name)
+		if n > maxName {
+			maxName = n
+		}
+	}
+
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("87"))
+	var rows []string
+	for i := f.acScroll; i < end; i++ {
+		skill := f.acMatches[i]
+		isSelected := i == f.acIdx
+
+		indicator := "  "
+		nameStr := "/" + skill.Name
+		if isSelected {
+			indicator = "▶ "
+			nameStr = selectedStyle.Render(nameStr)
+		} else {
+			nameStr = f.theme.Dimmed.Render(nameStr)
+		}
+
+		// Pad name to maxName display columns for alignment.
+		// Use ansi.StringWidth for multibyte/wide-character safety.
+		plainNameW := ansi.StringWidth("/" + skill.Name)
+		padding := strings.Repeat(" ", maxName-plainNameW+2)
+
+		// Truncate description to fit remaining display width.
+		// Guard descW <= 0 explicitly — avoids negative slice index when
+		// the modal is very narrow (zero-dimension invariant).
+		descW := inputW - ansi.StringWidth(indicator) - maxName - 2
+		desc := skill.Description
+		if descW <= 0 {
+			desc = ""
+		} else {
+			runes := []rune(desc)
+			if len(runes) > descW {
+				desc = string(runes[:descW-1]) + "…"
+			}
+		}
+		descStr := f.theme.Dimmed.Render(desc)
+
+		rows = append(rows, indicator+nameStr+padding+descStr)
+	}
+
+	// Scroll indicator when list is longer than visible window
+	if len(f.acMatches) > acMaxVisible {
+		count := f.theme.Dimmed.Render(
+			fmt.Sprintf("  (%d/%d)", f.acIdx+1, len(f.acMatches)))
+		rows = append(rows, count)
+	}
+
+	return strings.Join(rows, "\n")
 }
 
 func (f NewTaskForm) renderProjectSelector() string {

--- a/internal/ui/newtask_test.go
+++ b/internal/ui/newtask_test.go
@@ -353,6 +353,243 @@ func TestNewTaskForm_WordWrapHeightTransitions(t *testing.T) {
 	}
 }
 
+func TestFilterSkills(t *testing.T) {
+	skills := []SkillItem{
+		{Name: "bisect", Description: "Bisect commits"},
+		{Name: "changelog", Description: "Generate changelog"},
+		{Name: "debug", Description: "Debug issue"},
+		{Name: "deploy", Description: "Deploy app"},
+	}
+
+	tests := []struct {
+		prefix string
+		want   []string
+	}{
+		{"", []string{"bisect", "changelog", "debug", "deploy"}},
+		{"d", []string{"debug", "deploy"}},
+		{"de", []string{"debug", "deploy"}},
+		{"dep", []string{"deploy"}},
+		{"ch", []string{"changelog"}},
+		{"z", nil},
+	}
+	for _, tt := range tests {
+		got := filterSkills(skills, tt.prefix)
+		if len(got) != len(tt.want) {
+			t.Errorf("filterSkills(%q): got %d results, want %d", tt.prefix, len(got), len(tt.want))
+			continue
+		}
+		for i, s := range got {
+			if s.Name != tt.want[i] {
+				t.Errorf("filterSkills(%q)[%d] = %q, want %q", tt.prefix, i, s.Name, tt.want[i])
+			}
+		}
+	}
+}
+
+func testFormWithSkills(skills []SkillItem) NewTaskForm {
+	theme := DefaultTheme()
+	f := NewNewTaskForm(theme, testProjects(), "", testBackends(), "claude")
+	f.skills = skills
+	f.SetSize(80, 40)
+	return f
+}
+
+func testSkills() []SkillItem {
+	return []SkillItem{
+		{Name: "debug", Description: "Debug issue"},
+		{Name: "deploy", Description: "Deploy app"},
+		{Name: "deps", Description: "Audit dependencies"},
+		{Name: "pr", Description: "Open a PR"},
+	}
+}
+
+func TestNewTaskForm_AutocompleteOpensOnSlash(t *testing.T) {
+	f := testFormWithSkills(testSkills())
+
+	// Type "/" — should open autocomplete with all skills
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+
+	if !f.acOpen {
+		t.Error("acOpen should be true after typing '/'")
+	}
+	if len(f.acMatches) != 4 {
+		t.Errorf("acMatches = %d, want 4", len(f.acMatches))
+	}
+}
+
+func TestNewTaskForm_AutocompleteFiltersOnType(t *testing.T) {
+	f := testFormWithSkills(testSkills())
+
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+
+	if !f.acOpen {
+		t.Error("acOpen should be true after '/d'")
+	}
+	// debug, deploy, deps — 3 matches
+	if len(f.acMatches) != 3 {
+		t.Errorf("acMatches = %d, want 3", len(f.acMatches))
+	}
+}
+
+func TestNewTaskForm_AutocompleteClosesOnSpace(t *testing.T) {
+	f := testFormWithSkills(testSkills())
+
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+
+	if f.acOpen {
+		t.Error("acOpen should be false after space")
+	}
+}
+
+func TestNewTaskForm_AutocompleteClosesOnNoMatch(t *testing.T) {
+	f := testFormWithSkills(testSkills())
+
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+
+	if f.acOpen {
+		t.Error("acOpen should be false when no matches")
+	}
+}
+
+func TestNewTaskForm_AutocompleteNavigationDown(t *testing.T) {
+	f := testFormWithSkills(testSkills())
+
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	if f.acIdx != 0 {
+		t.Fatalf("initial acIdx = %d, want 0", f.acIdx)
+	}
+
+	f.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if f.acIdx != 1 {
+		t.Errorf("after down: acIdx = %d, want 1", f.acIdx)
+	}
+
+	f.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if f.acIdx != 2 {
+		t.Errorf("after down x2: acIdx = %d, want 2", f.acIdx)
+	}
+}
+
+func TestNewTaskForm_AutocompleteNavigationWrap(t *testing.T) {
+	f := testFormWithSkills(testSkills())
+
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+
+	// Wrap down past last item (4 skills)
+	for i := 0; i < 4; i++ {
+		f.Update(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if f.acIdx != 0 {
+		t.Errorf("after 4 downs (wrap): acIdx = %d, want 0", f.acIdx)
+	}
+
+	// Wrap up past first item
+	f.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if f.acIdx != 3 {
+		t.Errorf("after up from 0 (wrap): acIdx = %d, want 3", f.acIdx)
+	}
+}
+
+func TestNewTaskForm_AutocompleteSelectOnEnter(t *testing.T) {
+	f := testFormWithSkills(testSkills())
+
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	f.Update(tea.KeyMsg{Type: tea.KeyDown}) // select deploy (index 1)
+
+	f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Should close autocomplete
+	if f.acOpen {
+		t.Error("acOpen should be false after enter")
+	}
+	// Should not submit form (enter with autocomplete just selects)
+	if f.Done() {
+		t.Error("Done() should be false — enter on autocomplete selects, not submits")
+	}
+	// Value should be the selected skill name
+	val := f.promptInput.Value()
+	if !strings.HasPrefix(val, "/deploy") {
+		t.Errorf("prompt value = %q, want '/deploy ...'", val)
+	}
+}
+
+func TestNewTaskForm_AutocompleteEscClosesDropdown(t *testing.T) {
+	f := testFormWithSkills(testSkills())
+
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	if !f.acOpen {
+		t.Fatal("acOpen should be true")
+	}
+
+	f.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if f.acOpen {
+		t.Error("acOpen should be false after esc")
+	}
+	// Form should NOT be canceled — esc on autocomplete only closes it
+	if f.Canceled() {
+		t.Error("form should not be canceled when esc closes autocomplete")
+	}
+}
+
+func TestNewTaskForm_AutocompleteEscTwiceCancels(t *testing.T) {
+	f := testFormWithSkills(testSkills())
+
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	f.Update(tea.KeyMsg{Type: tea.KeyEsc}) // close autocomplete
+	f.Update(tea.KeyMsg{Type: tea.KeyEsc}) // cancel form
+
+	if !f.Canceled() {
+		t.Error("form should be canceled after second esc")
+	}
+}
+
+func TestNewTaskForm_AutocompleteViewRendersDropdown(t *testing.T) {
+	f := testFormWithSkills(testSkills())
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+
+	view := f.View()
+	if !strings.Contains(view, "/pr") {
+		t.Errorf("View() missing '/pr' in autocomplete: %q", view)
+	}
+}
+
+func TestNewTaskForm_AutocompleteScrolling(t *testing.T) {
+	// Create more skills than acMaxVisible (6)
+	skills := []SkillItem{
+		{Name: "a1", Description: "A1"},
+		{Name: "a2", Description: "A2"},
+		{Name: "a3", Description: "A3"},
+		{Name: "a4", Description: "A4"},
+		{Name: "a5", Description: "A5"},
+		{Name: "a6", Description: "A6"},
+		{Name: "a7", Description: "A7"},
+	}
+	f := testFormWithSkills(skills)
+
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	if len(f.acMatches) != 7 {
+		t.Fatalf("acMatches = %d, want 7", len(f.acMatches))
+	}
+
+	// Scroll down past visible window
+	for i := 0; i < acMaxVisible; i++ {
+		f.Update(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	// acIdx = 6, acScroll should have moved
+	if f.acIdx != acMaxVisible {
+		t.Errorf("acIdx = %d, want %d", f.acIdx, acMaxVisible)
+	}
+	if f.acScroll == 0 {
+		t.Error("acScroll should be > 0 after scrolling past visible window")
+	}
+}
+
 func TestNewTaskForm_VisualLineCount(t *testing.T) {
 	theme := DefaultTheme()
 	f := NewNewTaskForm(theme, testProjects(), "", testBackends(), "claude")

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -704,6 +704,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case skillsLoadedMsg:
+		m.newtask.skills = []SkillItem(msg)
+		return m, nil
+
 	case tea.KeyMsg:
 		m.statusbar.ClearError()
 		return m.handleKey(msg)
@@ -854,7 +858,7 @@ func (m Model) handleTaskListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.newtask = NewNewTaskForm(m.theme, m.db.Projects(), defaultProject, cfg.Backends, cfg.Defaults.Backend)
 		m.newtask.SetSize(m.width, m.height)
 		m.current = viewNewTask
-		return m, nil
+		return m, loadSkillsCmd()
 
 	case key.Matches(msg, m.keys.StatusFwd):
 		if t := m.tasklist.Selected(); t != nil {

--- a/internal/ui/skills.go
+++ b/internal/ui/skills.go
@@ -1,0 +1,95 @@
+package ui
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// acMaxVisible is the maximum number of autocomplete rows shown at once.
+const acMaxVisible = 6
+
+// SkillItem represents a discovered Claude Code skill.
+type SkillItem struct {
+	Name        string
+	Description string
+}
+
+// LoadSkills scans ~/.claude/skills/ and any extraDirs for skill directories.
+// Skills in extraDirs take precedence (earlier dirs win on name collision).
+func LoadSkills(extraDirs []string) []SkillItem {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+
+	dirs := make([]string, 0, len(extraDirs)+1)
+	dirs = append(dirs, extraDirs...)
+	dirs = append(dirs, filepath.Join(home, ".claude", "skills"))
+
+	seen := make(map[string]bool)
+	var skills []SkillItem
+
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() || seen[e.Name()] {
+				continue
+			}
+			seen[e.Name()] = true
+			desc := readSkillDesc(filepath.Join(dir, e.Name(), "SKILL.md"))
+			skills = append(skills, SkillItem{Name: e.Name(), Description: desc})
+		}
+	}
+
+	sort.Slice(skills, func(i, j int) bool {
+		return skills[i].Name < skills[j].Name
+	})
+	return skills
+}
+
+// readSkillDesc reads the description field from a SKILL.md frontmatter block.
+func readSkillDesc(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	inFrontmatter := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "---" {
+			if !inFrontmatter {
+				inFrontmatter = true
+				continue
+			}
+			break
+		}
+		if inFrontmatter && strings.HasPrefix(line, "description:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "description:"))
+		}
+	}
+	return ""
+}
+
+// filterSkills returns skills whose names have the given prefix.
+// If prefix is empty, all skills are returned.
+func filterSkills(skills []SkillItem, prefix string) []SkillItem {
+	if prefix == "" {
+		return skills
+	}
+	var out []SkillItem
+	for _, s := range skills {
+		if strings.HasPrefix(s.Name, prefix) {
+			out = append(out, s)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
When typing '/' in the new task prompt, a dropdown appears below the textarea showing matching skills from ~/.claude/skills/. Up/Down navigate, Enter selects (sets prompt to '/<name> ' without submitting), Esc closes the dropdown (second Esc cancels the form). Skills are loaded asynchronously to keep the UI responsive.

Co-Authored-By: Claude <noreply@anthropic.com>