### PR TITLE
Remove (default) entry from new task backend selector

### DIFF
--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -415,7 +415,7 @@ Three bugs discovered in daemon lifecycle management:
 
 **fixupBackends**: Migrates old codex flags (`--yolo`, `--full-auto`) to `--dangerously-bypass-approvals-and-sandbox`. Scoped to `name == "codex"` — users who renamed their codex backend must update manually.
 
-**New task form**: Three fields — project → backend → prompt. Backend selector has `(default)` at index 0. When `(default)`, `Task().Backend` is empty string (inheritance).
+**New task form**: Three fields — project → backend → prompt. Backend selector shows sorted backend names only (no `(default)` entry). The configured default backend is pre-selected by name; `Task().Backend` is always an explicit backend name.
 
 **Settings**: BACKENDS section header shows `(default: <name>)`. Backend detail panel shows `★ Default backend`. Keys: `[e]` edit, `[n]` new, `[d]` set as default.
 

--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -138,7 +138,7 @@
 
 - **Backend form: `internal/ui/backendform.go`.** Mirrors `ProjectForm` pattern with 3 textinput fields: Name, Command, Prompt Flag. Supports edit mode (name read-only) and new mode. Wired via `viewNewBackend`/`viewEditBackend` in root.go. Settings view keys: `[n]` new backend, `[e]` edit backend, `[d]` set as default (on backend rows). The BACKENDS section header shows `(default: <name>)`.
 
-- **New task form has a backend selector.** Field order: project → backend → prompt. The backend selector has `(default)` at index 0 (inherits from project/global), followed by sorted backend names. When `(default)` is selected, `Task().Backend` is empty string (inheritance). The resolved default name is shown dimmed next to the selector.
+- **New task form has a backend selector.** Field order: project → backend → prompt. The backend selector shows sorted backend names only — no `(default)` entry. The configured default backend is pre-selected by name at open (`backendIdx` set by matching `defaultBackend` param, falls back to index 0). `SelectedBackend()` always returns the actual name at `backendIdx`; `Task().Backend` is always an explicit backend name (never empty string for "inherit").
 
 - **`fixupBackends()` migrates old codex flags to `--dangerously-bypass-approvals-and-sandbox`.** Detection: `name == "codex"` AND command doesn't contain `--dangerously-bypass-approvals-and-sandbox`. Covers `--yolo` and `--full-auto`. Scoped to `name == "codex"` — users who renamed their codex backend must update manually. The `resume_command` DB column exists for backward compat but is no longer read or written.
 

--- a/internal/ui/newtask.go
+++ b/internal/ui/newtask.go
@@ -16,20 +16,19 @@ import (
 
 // NewTaskForm handles the new task creation UI.
 type NewTaskForm struct {
-	promptInput        textarea.Model
-	projectNames       []string
-	projectIdx         int
-	backendNames       []string // sorted backend names; index 0 is "(default)"
-	backendIdx         int
-	defaultBackendName string // resolved name for the "(default)" entry
-	focused            int    // 0 = project, 1 = backend, 2 = prompt
-	theme              Theme
-	projects           map[string]config.Project
-	done               bool
-	canceled           bool
-	errMsg             string
-	width              int
-	height             int
+	promptInput  textarea.Model
+	projectNames []string
+	projectIdx   int
+	backendNames []string // sorted backend names
+	backendIdx   int
+	focused      int // 0 = project, 1 = backend, 2 = prompt
+	theme        Theme
+	projects     map[string]config.Project
+	done         bool
+	canceled     bool
+	errMsg       string
+	width        int
+	height       int
 	// autocomplete state
 	skills    []SkillItem
 	acOpen    bool
@@ -83,25 +82,31 @@ func NewNewTaskForm(theme Theme, projects map[string]config.Project, defaultProj
 		}
 	}
 
-	// Build sorted backend name list with "(default)" entry at index 0
-	backendNames := []string{"(default)"}
-	bNames := make([]string, 0, len(backends))
+	// Build sorted backend name list
+	backendNames := make([]string, 0, len(backends))
 	for name := range backends {
-		bNames = append(bNames, name)
+		backendNames = append(backendNames, name)
 	}
-	sort.Strings(bNames)
-	backendNames = append(backendNames, bNames...)
+	sort.Strings(backendNames)
+
+	// Pre-select the default backend
+	backendIdx := 0
+	for i, name := range backendNames {
+		if name == defaultBackend {
+			backendIdx = i
+			break
+		}
+	}
 
 	return NewTaskForm{
-		promptInput:        promptInput,
-		projectNames:       names,
-		projectIdx:         idx,
-		backendNames:       backendNames,
-		backendIdx:         0,
-		defaultBackendName: defaultBackend,
-		focused:            fieldPrompt,
-		theme:              theme,
-		projects:           projects,
+		promptInput:  promptInput,
+		projectNames: names,
+		projectIdx:   idx,
+		backendNames: backendNames,
+		backendIdx:   backendIdx,
+		focused:      fieldPrompt,
+		theme:        theme,
+		projects:     projects,
 	}
 }
 
@@ -351,10 +356,10 @@ func (f *NewTaskForm) SelectedProject() string {
 	return f.projectNames[f.projectIdx]
 }
 
-// SelectedBackend returns the selected backend name, or "" for "(default)".
+// SelectedBackend returns the selected backend name, or "" if no backends are configured.
 func (f *NewTaskForm) SelectedBackend() string {
-	if len(f.backendNames) == 0 || f.backendIdx == 0 {
-		return "" // "(default)" → inherit
+	if len(f.backendNames) == 0 {
+		return ""
 	}
 	return f.backendNames[f.backendIdx]
 }
@@ -480,13 +485,7 @@ func (f NewTaskForm) renderBackendSelector() string {
 	counter := f.theme.Dimmed.Render(
 		fmt.Sprintf(" (%d/%d)", f.backendIdx+1, len(f.backendNames)))
 
-	// Show resolved default name when "(default)" is selected
-	suffix := ""
-	if f.backendIdx == 0 && f.defaultBackendName != "" {
-		suffix = " " + f.theme.Dimmed.Render("→ "+f.defaultBackendName)
-	}
-
-	return "  " + left + name + right + counter + suffix
+	return "  " + left + name + right + counter
 }
 
 // renderAutocomplete renders the skill suggestion dropdown below the prompt input.

--- a/internal/ui/newtask_test.go
+++ b/internal/ui/newtask_test.go
@@ -212,15 +212,15 @@ func TestNewTaskForm_BackendSelectorDefaultsToDefault(t *testing.T) {
 	theme := DefaultTheme()
 	f := NewNewTaskForm(theme, testProjects(), "", testBackends(), "claude")
 
-	if got := f.SelectedBackend(); got != "" {
-		t.Errorf("SelectedBackend() = %q, want empty (default)", got)
+	if got := f.SelectedBackend(); got != "claude" {
+		t.Errorf("SelectedBackend() = %q, want claude", got)
 	}
-	// Backend names should be (default), claude, codex
-	if len(f.backendNames) != 3 {
-		t.Fatalf("expected 3 backend names, got %d: %v", len(f.backendNames), f.backendNames)
+	// Backend names should be claude, codex (sorted, no "(default)")
+	if len(f.backendNames) != 2 {
+		t.Fatalf("expected 2 backend names, got %d: %v", len(f.backendNames), f.backendNames)
 	}
-	if f.backendNames[0] != "(default)" {
-		t.Errorf("backendNames[0] = %q, want (default)", f.backendNames[0])
+	if f.backendNames[0] != "claude" {
+		t.Errorf("backendNames[0] = %q, want claude", f.backendNames[0])
 	}
 }
 
@@ -229,20 +229,15 @@ func TestNewTaskForm_BackendSelectorCycles(t *testing.T) {
 	f := NewNewTaskForm(theme, testProjects(), "", testBackends(), "claude")
 	f.focused = fieldBackend
 
-	// Right cycles: (default) → claude → codex → (default)
-	f.Update(tea.KeyMsg{Type: tea.KeyRight})
-	if got := f.SelectedBackend(); got != "claude" {
-		t.Errorf("after right: SelectedBackend() = %q, want claude", got)
-	}
-
+	// Right cycles: claude → codex → claude (wrap)
 	f.Update(tea.KeyMsg{Type: tea.KeyRight})
 	if got := f.SelectedBackend(); got != "codex" {
-		t.Errorf("after right x2: SelectedBackend() = %q, want codex", got)
+		t.Errorf("after right: SelectedBackend() = %q, want codex", got)
 	}
 
 	f.Update(tea.KeyMsg{Type: tea.KeyRight})
-	if got := f.SelectedBackend(); got != "" {
-		t.Errorf("after right x3 (wrap): SelectedBackend() = %q, want empty (default)", got)
+	if got := f.SelectedBackend(); got != "claude" {
+		t.Errorf("after right x2 (wrap): SelectedBackend() = %q, want claude", got)
 	}
 }
 
@@ -251,8 +246,7 @@ func TestNewTaskForm_TaskIncludesBackend(t *testing.T) {
 	f := NewNewTaskForm(theme, testProjects(), "", testBackends(), "claude")
 	f.focused = fieldBackend
 
-	// Select codex
-	f.Update(tea.KeyMsg{Type: tea.KeyRight}) // claude
+	// Select codex (starts at claude, one right moves to codex)
 	f.Update(tea.KeyMsg{Type: tea.KeyRight}) // codex
 
 	f.focused = fieldPrompt
@@ -264,7 +258,7 @@ func TestNewTaskForm_TaskIncludesBackend(t *testing.T) {
 	}
 }
 
-func TestNewTaskForm_TaskDefaultBackendEmpty(t *testing.T) {
+func TestNewTaskForm_TaskDefaultBackendIsPreselected(t *testing.T) {
 	theme := DefaultTheme()
 	f := NewNewTaskForm(theme, testProjects(), "", testBackends(), "claude")
 
@@ -272,8 +266,8 @@ func TestNewTaskForm_TaskDefaultBackendEmpty(t *testing.T) {
 	f.promptInput.SetValue("fix the bug")
 
 	task := f.Task()
-	if task.Backend != "" {
-		t.Errorf("task.Backend = %q, want empty (inherit)", task.Backend)
+	if task.Backend != "claude" {
+		t.Errorf("task.Backend = %q, want claude (pre-selected default)", task.Backend)
 	}
 }
 


### PR DESCRIPTION
Replace the synthetic "(default)" entry with pre-selection of the configured default backend by name. SelectedBackend() now always returns an explicit backend name.

Co-Authored-By: Claude <noreply@anthropic.com>