### PR TITLE
Add Cmd+O shortcut to open PR from agent view

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -1,5 +1,7 @@
 ## Key Learnings
 
+- **Cmd+O in agent view opens the associated PR URL in the browser.** macOS terminals send Cmd+O as Alt+O (`msg.Alt=true`, `msg.Type=tea.KeyRunes`, `string(msg.Runes)=="o"`). Handled in `handleAgentViewKey` in `root.go` before the key reaches the PTY. The PR URL is stored in `AgentView.taskPRURL` (set via `SetPRURL`). Three places keep it current: (1) `enterAgentView` looks up the task from DB at view entry; (2) `PRDetectedMsg` handler pushes new URLs while the agent view is active; (3) `handleAgentFinished` pushes URLs discovered from the final output. The `⌘O open PR` hint appears in the agent view status bar only when `taskPRURL != ""`.
+
 - **New task form has `/skill` autocomplete.** `internal/ui/skills.go` scans `~/.claude/skills/*/SKILL.md` frontmatter to build a `[]SkillItem` list. The form stores this list and when the prompt value starts with `/` and contains no spaces, shows a filtered dropdown below the textarea (`acOpen`, `acMatches`, `acIdx`, `acScroll`). Up/Down navigate the list, Enter selects (sets value to `/<name> ` and closes without submitting), Esc closes the dropdown (second Esc cancels the form). `updateAutocomplete()` is called after every `textarea.Update()` to recompute matches. The dropdown uses `acMaxVisible = 6` visible rows with scroll indicators when the list is longer.
 
 - PTY child processes need a real terminal size at launch (`pty.StartWithSize`), not 0x0. TUI apps like claude won't render with zero dimensions.

--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -41,6 +41,7 @@ type AgentView struct {
 	sessionsDir string // directory where session logs are stored
 	taskID      string
 	taskName    string
+	taskPRURL   string
 	focus       AgentPanel
 	layout      PanelLayout
 	width       int
@@ -106,6 +107,7 @@ func NewAgentView(theme Theme, runner agent.SessionProvider, sessionsDir string)
 func (av *AgentView) Enter(taskID, taskName string) {
 	av.taskID = taskID
 	av.taskName = taskName
+	av.taskPRURL = ""
 	av.focus = panelAgent
 	av.gitstatus.SetTask(taskID)
 	av.lastGitRefresh = time.Time{}
@@ -143,6 +145,24 @@ func (av *AgentView) LoadSessionLogCmd(taskID string) tea.Cmd {
 			return nil
 		}
 		return SessionLogLoadedMsg{TaskID: taskID, Data: data}
+	}
+}
+
+// SetPRURL updates the PR URL associated with the current task.
+func (av *AgentView) SetPRURL(url string) {
+	av.taskPRURL = url
+}
+
+// OpenPR opens the task's PR URL in the default browser.
+// Returns a tea.Cmd that runs the open command, or nil if no PR URL is set.
+func (av *AgentView) OpenPR() tea.Cmd {
+	if av.taskPRURL == "" {
+		return nil
+	}
+	url := av.taskPRURL
+	return func() tea.Msg {
+		exec.Command("open", url).Start() //nolint:errcheck
+		return nil
 	}
 }
 
@@ -833,6 +853,9 @@ func (av AgentView) renderStatusBar() string {
 			{"⇧↑/↓", "scroll"},
 			{"C-←/→", "panel"},
 			{"^q", "detach"},
+		}
+		if av.taskPRURL != "" {
+			keys = append(keys, struct{ key, label string }{"⌘O", "open PR"})
 		}
 	}
 	var parts []string

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -544,6 +544,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			_ = m.db.Update(t)
 			m.refreshTasks()
 		}
+		if m.current == viewAgent && m.agentview.taskID == msg.TaskID {
+			m.agentview.SetPRURL(msg.URL)
+		}
 		return m, nil
 
 	case PruneProgressMsg:
@@ -803,6 +806,11 @@ func (m Model) handleAgentViewKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m.switchAgentTask(-1)
 		case tea.KeyDown:
 			return m.switchAgentTask(+1)
+		case tea.KeyRunes:
+			// Cmd+O (sent as Alt+O by macOS terminals) opens the associated PR in browser.
+			if string(msg.Runes) == "o" {
+				return m, m.agentview.OpenPR()
+			}
 		}
 	}
 
@@ -1090,6 +1098,9 @@ func (m *Model) enterAgentView(taskID, taskName string) tea.Cmd {
 	}
 	m.tasklist.SetIdleUnvisited(idleUnvisited)
 	m.agentview.Enter(taskID, taskName)
+	if t, err := m.db.Get(taskID); err == nil {
+		m.agentview.SetPRURL(t.PRURL)
+	}
 	m.agentview.SetSize(m.width, m.height)
 	if dir, ok := m.resolvedDirs[taskID]; ok && dir != "" {
 		m.agentview.SetWorktreeDir(dir)
@@ -1169,6 +1180,7 @@ func (m Model) handleAgentFinished(msg AgentFinishedMsg) (tea.Model, tea.Cmd) {
 
 	if m.current == viewAgent && m.agentview.taskID == msg.TaskID {
 		m.agentview.SetLastOutput(msg.LastOutput)
+		m.agentview.SetPRURL(t.PRURL)
 	}
 
 	if m.current == viewAgent && m.agentview.taskID == msg.TaskID && !quickExit {

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -1997,6 +1997,43 @@ func TestHandleTaskListKey_OpenPR_NoURL(t *testing.T) {
 	}
 }
 
+func TestAgentView_CmdO_OpensPR(t *testing.T) {
+	task := &model.Task{
+		ID: "t1", Name: "pr task", Status: model.StatusPending, Project: "proj",
+		PRURL: "https://github.com/owner/repo/pull/42",
+	}
+	m := testModel(t, task)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+	m.current = viewAgent
+	m.agentview.Enter("t1", "pr task")
+	m.agentview.SetPRURL(task.PRURL)
+
+	// Alt+O (Cmd+O on macOS terminals) should return a non-nil cmd to open PR.
+	// We test that cmd is non-nil (not that it executes), to avoid opening a real browser in tests.
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}, Alt: true}
+	_, cmd := m.Update(msg)
+	if cmd == nil {
+		t.Error("expected non-nil cmd when task has PRURL")
+	}
+}
+
+func TestAgentView_CmdO_NoPR(t *testing.T) {
+	task := &model.Task{ID: "t1", Name: "no pr task", Status: model.StatusPending, Project: "proj"}
+	m := testModel(t, task)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+	m.current = viewAgent
+	m.agentview.Enter("t1", "no pr task")
+
+	// Alt+O with no PRURL should return nil cmd.
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}, Alt: true}
+	_, cmd := m.Update(msg)
+	if cmd != nil {
+		t.Error("expected nil cmd when task has no PRURL")
+	}
+}
+
 func TestRenameKey_OpensForm(t *testing.T) {
 	task := &model.Task{ID: "t1", Name: "old-name", Status: model.StatusPending, Project: "proj"}
 	m := testModel(t, task)


### PR DESCRIPTION
Pressing Cmd+O (sent as Alt+O by macOS terminals) in the agent view now opens the task's associated PR URL in the default browser. Shows a ⌘O hint in the status bar when a PR URL is detected. PR URL is kept in sync at view entry, on detection, and on agent finish.

Co-Authored-By: Claude <noreply@anthropic.com>