### PR TITLE
Suppress stray cursor block and fix Ink cursor color on input row

### DIFF
--- a/internal/ui/agentview.go
+++ b/internal/ui/agentview.go
@@ -773,17 +773,19 @@ func (av *AgentView) renderIncremental(sess agent.SessionHandle, raw []byte, tot
 	lines := make([]string, 0, ptyRows)
 	for y := 0; y < ptyRows; y++ {
 		cursorX := -1
-		if y == cur.Y {
+		// Only render the cursor block on the input row. When the cursor is
+		// parked on a different (empty) row — as Claude (Ink) does — rendering
+		// the cursor there produces a stray white block below the real input.
+		if y == cur.Y && cur.Y == inputRow {
 			cursorX = cur.X
 		}
 		lines = append(lines, renderLine(av.vtTerm, y, ptyCols, cursorX, y == inputRow))
 	}
 
-	// Trim trailing empty lines, but never trim the cursor line — TUI agents
-	// like Claude Code park the cursor at an empty bottom row after rendering,
-	// so stripANSI strips the colored-background cursor cell to "" and the
-	// trimmer would remove it, making the cursor invisible.
-	for len(lines) > 0 && len(lines)-1 != cur.Y && stripANSI(lines[len(lines)-1]) == "" {
+	// Trim trailing empty lines. The inputRow (where the highlight lives) has
+	// visible content so it will never be trimmed. The cursor parking row
+	// (cur.Y for Claude) is now empty and trimmed away — no stray blank row.
+	for len(lines) > 0 && stripANSI(lines[len(lines)-1]) == "" {
 		lines = lines[:len(lines)-1]
 	}
 
@@ -798,12 +800,8 @@ func (av *AgentView) renderIncremental(sess agent.SessionHandle, raw []byte, tot
 
 	// Trim leading empty lines (e.g. Codex positions its TUI content in the
 	// lower portion of the terminal, leaving the top rows blank).
-	// Track how many lines were removed from the front so we can protect the
-	// cursor line from being trimmed here too.
-	frontRemoved := 0
-	for len(lines) > 0 && frontRemoved != cur.Y && stripANSI(lines[0]) == "" {
+	for len(lines) > 0 && stripANSI(lines[0]) == "" {
 		lines = lines[1:]
-		frontRemoved++
 	}
 	for i, line := range lines {
 		lines[i] = ansi.Truncate(line, dispW, "\x1b[0m")

--- a/internal/ui/preview_test.go
+++ b/internal/ui/preview_test.go
@@ -97,6 +97,31 @@ func TestBuildSGRWithActiveLine_PreservesExplicitBackground(t *testing.T) {
 	}
 }
 
+func TestBuildSGRWithActiveLine_PreservesExplicitForeground(t *testing.T) {
+	// A cell with explicit FG (e.g. Claude Code's Ink cursor) must not be
+	// tinted — only completely default cells get the activeInputBG.
+	result := buildSGRWithActiveLine(vt10x.Color(7), vt10x.DefaultBG, 0, true)
+	if strings.Contains(result, "48;5;17") {
+		t.Fatalf("active-row tint should not apply when FG is explicit, got %q", result)
+	}
+}
+
+func TestBuildSGRWithActiveLine_PreservesMode(t *testing.T) {
+	// A reverse-video cell (e.g. a cursor indicator) must not be tinted.
+	result := buildSGRWithActiveLine(vt10x.DefaultFG, vt10x.DefaultBG, vtAttrReverse, true)
+	if strings.Contains(result, "48;5;17") {
+		t.Fatalf("active-row tint should not apply to reverse-video cells, got %q", result)
+	}
+}
+
+func TestBuildSGRWithActiveLine_TintsBlankCell(t *testing.T) {
+	// A completely default cell (blank background) should receive the tint.
+	result := buildSGRWithActiveLine(vt10x.DefaultFG, vt10x.DefaultBG, 0, true)
+	if !strings.Contains(result, "48;5;17") {
+		t.Fatalf("blank cell on active row should receive activeInputBG tint, got %q", result)
+	}
+}
+
 func TestStripANSI_NoEscapes(t *testing.T) {
 	result := stripANSI("hello world")
 	if result != "hello world" {

--- a/internal/ui/vtrender.go
+++ b/internal/ui/vtrender.go
@@ -46,27 +46,27 @@ func replayVT10X(raw []byte, vtCols, vtRows int, cursorVisible bool) []string {
 	var lines []string
 	for y := 0; y < vtRows; y++ {
 		cursorX := -1
-		if showCursor && y == cur.Y {
+		// Only render the cursor block on the input row. When the cursor is
+		// parked on a different (empty) row — as Claude (Ink) does — rendering
+		// the cursor there produces a stray white block below the real input.
+		if showCursor && y == cur.Y && cur.Y == inputRow {
 			cursorX = cur.X
 		}
 		line := renderLine(vt, y, vtCols, cursorX, y == inputRow)
 		lines = append(lines, line)
 	}
 
-	// Trim trailing empty lines, but preserve the cursor line — the cursor
-	// cell is a space with colored background that stripANSI collapses to "",
-	// so the trimmer would silently remove it and hide the cursor.
-	for len(lines) > 0 && !(showCursor && len(lines)-1 == cur.Y) && stripANSI(lines[len(lines)-1]) == "" {
+	// Trim trailing empty lines. The inputRow has visible content so it is
+	// never trimmed. The cursor parking row (cur.Y when cur.Y != inputRow) is
+	// now empty and trimmed away — no stray blank row below the input.
+	for len(lines) > 0 && stripANSI(lines[len(lines)-1]) == "" {
 		lines = lines[:len(lines)-1]
 	}
 
 	// Trim leading empty lines (e.g. Codex positions its TUI content in the
 	// lower portion of the terminal, leaving the top rows blank).
-	// Protect the cursor line here too.
-	frontRemoved := 0
-	for len(lines) > 0 && !(showCursor && frontRemoved == cur.Y) && stripANSI(lines[0]) == "" {
+	for len(lines) > 0 && stripANSI(lines[0]) == "" {
 		lines = lines[1:]
-		frontRemoved++
 	}
 
 	return lines
@@ -225,7 +225,10 @@ func buildSGRWithActiveLine(fg, bg vt10x.Color, mode int16, activeLine bool) str
 	if fg != vt10x.DefaultFG {
 		params = append(params, sgrColor(fg, 30))
 	}
-	if activeLine && bg == vt10x.DefaultBG {
+	// Only tint blank cells (no FG, no BG, no mode set). Cells with any
+	// explicit styling — including Claude Code's Ink cursor indicator — keep
+	// their original colors so they remain legible on the highlighted row.
+	if activeLine && fg == vt10x.DefaultFG && bg == vt10x.DefaultBG && mode == 0 {
 		bg = activeInputBG
 	}
 	if bg != vt10x.DefaultBG {

--- a/internal/ui/vtrender_test.go
+++ b/internal/ui/vtrender_test.go
@@ -58,25 +58,25 @@ func TestReplayVT10X_TrimsTrailingEmptyLines(t *testing.T) {
 func TestReplayVT10X_EmptyTerminal(t *testing.T) {
 	raw := []byte{}
 
-	// With cursor visible, the cursor line (row 0) must be preserved even
-	// though it has no content — that's the whole point of the fix.
+	// Empty terminal has no content anywhere. findInputRow falls back to
+	// curY=0, but after trimming (the rendered row is all spaces) we get 0
+	// lines — an empty panel is the right result.
 	lines := replayVT10X(raw, 40, 10, true)
-	if len(lines) != 1 {
-		t.Errorf("expected 1 line (cursor line) for empty input with cursor, got %d", len(lines))
+	if len(lines) != 0 {
+		t.Errorf("expected 0 lines for empty terminal, got %d", len(lines))
 	}
 
-	// Without cursor, there's nothing to preserve so output should be empty.
 	lines = replayVT10X(raw, 40, 10, false)
 	if len(lines) != 0 {
-		t.Errorf("expected empty lines for empty input without cursor, got %d", len(lines))
+		t.Errorf("expected 0 lines for empty terminal without cursor, got %d", len(lines))
 	}
 }
 
-func TestReplayVT10X_PreservesCursorOnEmptyBottomRow(t *testing.T) {
-	// Simulate Claude Code: content at top, cursor parked at an empty bottom
-	// row after rendering (Ink hides hardware cursor with \x1b[?25l and parks
-	// it below the TUI). The cursor line must NOT be trimmed even though
-	// stripANSI collapses its colored background to "".
+func TestReplayVT10X_CursorParkedBelowContent(t *testing.T) {
+	// Simulate Claude Code: content at row 0, cursor parked at an empty row
+	// below (Ink hides hardware cursor with \x1b[?25l and parks it below the
+	// TUI). findInputRow should find the content row; the empty parking rows
+	// should be trimmed away; no stray cursor block on the empty row.
 	raw := []byte(
 		"\x1b[1;1H" + "Hello" + // content at row 1
 			"\x1b[?25l" + // hide hardware cursor (Claude Code behavior)
@@ -85,15 +85,19 @@ func TestReplayVT10X_PreservesCursorOnEmptyBottomRow(t *testing.T) {
 
 	lines := replayVT10X(raw, 40, 10, true)
 
-	// Must have at least 5 lines (rows 1–5), with the cursor at the 5th.
-	if len(lines) < 5 {
-		t.Fatalf("cursor line was trimmed: expected ≥5 lines, got %d", len(lines))
+	// Empty rows below content are trimmed; only the content row remains.
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line (content row, empty rows trimmed), got %d", len(lines))
 	}
 
-	// The cursor line (index 4, row 5) should contain the cursor escape.
-	cursorLine := lines[len(lines)-1]
-	if !strings.Contains(cursorLine, "\x1b[0;38;5;17;48;5;153m") {
-		t.Errorf("cursor styling not found in last line: %q", cursorLine)
+	// The content row gets the inputRow highlight, not the cursor block.
+	contentLine := lines[0]
+	if !strings.Contains(contentLine, "Hello") {
+		t.Errorf("expected content line to contain 'Hello', got %q", contentLine)
+	}
+	// No cursor block — cursor is parked on a different (empty) row.
+	if strings.Contains(contentLine, "\x1b[0;38;5;17;48;5;153m") {
+		t.Errorf("cursor styling should not appear on content line when cursor is parked elsewhere: %q", contentLine)
 	}
 }
 


### PR DESCRIPTION
Two follow-up fixes for the Claude input highlight:

1. Suppress cursor block at the empty parking row: only render cursorX when cur.Y == inputRow. The empty trailing rows (including Claude's parking row) are now trimmed unconditionally.

2. Fix black cursor: buildSGRWithActiveLine now only applies activeInputBG to completely default cells (DefaultFG + DefaultBG + mode==0). Cells with explicit styling — including Claude Code's own Ink cursor indicator — keep their original colors.

Co-Authored-By: Claude <noreply@anthropic.com>