### PR TITLE
Rewrite terminal passthrough plan with corrected framing

### DIFF
--- a/context/plans/2026-03-18-terminal-passthrough-plan.md
+++ b/context/plans/2026-03-18-terminal-passthrough-plan.md
@@ -1,4 +1,4 @@
-# Plan: Native Terminal Passthrough for Agent View
+# Plan: High-Fidelity Terminal Rendering + Bubble Tea Removal
 
 **Date:** 2026-03-18
 **Source:** Inline request: "research well-maintained libraries that do this cleanly. then write an implementation plan"
@@ -7,7 +7,25 @@
 
 ## Goal
 
-Replace the current replay-and-repaint terminal path in Argus with a native terminal surface for the live agent pane so upstream PTY UX, cursor behavior, and prompt styling render directly without manual row highlighting or cursor synthesis, using `tcell` for screen ownership and `tview` for higher-level shell primitives.
+Replace the current replay-and-repaint terminal path in Argus with high-fidelity emulated rendering for the live agent pane — upstream colors, cursor behavior, prompt styling, and escape sequences rendered faithfully via direct cell-to-cell painting — then delete the entire Bubble Tea runtime and ship a single tcell-based UI.
+
+## Why Emulation, Not True Passthrough
+
+**True passthrough** means PTY bytes go directly to the host terminal with no intermediary. This is what `attach` mode does (full-screen handoff via `tea.Exec`). It works perfectly but requires giving the agent the entire terminal — incompatible with the three-panel layout (git status | terminal | file explorer).
+
+**The only way to have panels + terminal content is emulated rendering.** This is what every terminal multiplexer does (tmux, screen, Zellij): feed PTY bytes to an emulator, read the resulting cells, paint them into a screen region. The quality depends on (a) the emulator's escape sequence coverage and (b) how faithfully cells reach the screen.
+
+The old Bubble Tea path failed on (b): cells were converted to ANSI strings for `View() string`, Bubble Tea parsed them back into cells, then rendered — a lossy round-trip that destroyed cursor position, prevented damage tracking, and required manual prompt-row hacks.
+
+The tcell path eliminates the string intermediary: emulator cells paint directly to `tcell.SetContent()`. x/vt (replacing vt10x) improves (a): actively maintained, better escape sequence coverage, native scrollback buffer, damage tracking via `Touched()`, hyperlink support.
+
+**x/vt is compatible with Bubble Tea** — it's just an emulator, it works with anything. But x/vt + BT would still have BT's string bottleneck. The value of tcell is the direct cell painting, not the emulator swap.
+
+| Path | Emulation | Cell → Screen | Damage Tracking | Cursor Fidelity |
+|------|-----------|---------------|-----------------|-----------------|
+| vt10x + BT (old) | Poor (unmaintained) | cells → ANSI strings → BT parses → renders | N/A (full repaint) | Lost in string conversion |
+| x/vt + BT (hypothetical) | Excellent | cells → ANSI strings → BT parses → renders | Available but useless (BT repaints every View()) | Lost in string conversion |
+| **x/vt + tcell (target)** | **Excellent** | **cells → tcell.SetContent() directly** | **Works — only repaint Touched() lines** | **Preserved natively** |
 
 ## Background
 
@@ -17,29 +35,29 @@ Argus currently runs agent sessions over a PTY and then re-renders the screen in
 - `internal/ui/agentview.go` reads recent bytes, replays them through `vt10x`, and converts the resulting screen back into ANSI strings for the center panel.
 - `internal/ui/vtrender.go` injects Argus-owned semantics such as the active input row tint, cursor repainting, and trimming of parked/empty rows.
 
-That architecture works for preview and normalized display, but it is not a true terminal passthrough. The live pane is a reconstructed view, not the agent's own terminal surface.
+That architecture works for preview and normalized display, but the live pane is a reconstructed view with lossy string conversion, not direct cell painting.
 
 Library research from primary sources points to the following:
 
-- Bubble Tea is mature and well-maintained, but its core model remains string-rendered (`View() string`), which makes true embedded-terminal passthrough awkward rather than natural.
+- Bubble Tea is mature and well-maintained, but its core model remains string-rendered (`View() string`), which makes high-fidelity terminal rendering impossible — every frame round-trips through ANSI string conversion.
 - `github.com/gdamore/tcell/v2` is the most mature low-level Go screen/event library. It gives the right primitives for screen ownership, cursor control, mouse handling, and event polling.
 - `github.com/rivo/tview` is a higher-level widget library built on `tcell` with layouts, lists, forms, tables, pages, and modals. It is the closest conservative replacement for the Bubble Tea shell primitives Argus uses today.
-- `github.com/charmbracelet/x/vt` is a modern Charm terminal emulator with `Write`, `Draw`, cursor, damage tracking, and alt-screen support. It is promising for emulation and preview, but by itself it is not a full application runtime.
+- `github.com/charmbracelet/x/vt` is a modern Charm terminal emulator with `Write`, `Draw`, cursor, damage tracking, scrollback buffer, and alt-screen support. It replaces `vt10x` as the emulation layer.
 - `github.com/creack/pty` remains the right PTY layer and should stay.
-- `github.com/hinshun/vt10x` is serviceable for replay, but it is older and should not be the long-term live-pane foundation.
+- `github.com/hinshun/vt10x` is unmaintained (last commit 2022), drops many modern escape sequences, and should be replaced.
 
 Recommendation:
 
-- Do not attempt a "true passthrough" center pane while Bubble Tea still owns the final screen rendering path for that pane.
-- Keep Bubble Tea only if we accept a semantic renderer, not real passthrough.
-- If true passthrough is the goal, migrate the UI runtime to `tcell` and use `tview` for the non-terminal shell while preserving existing Argus domain packages (`agent`, `daemon`, `db`, `github`).
+- Migrate the UI runtime to `tcell` + `tview` for direct cell painting.
+- Replace `vt10x` with `x/vt` for better emulation fidelity.
+- Delete the entire Bubble Tea runtime once all views are ported.
 
 ## Requirements
 
 ### Must Have
 
-- Preserve raw PTY semantics in the live agent pane: upstream colors, cursor, wrapped rows, alt-screen behavior, and prompt styling.
-- Remove manual prompt-row background injection from the live-pane path.
+- High-fidelity rendering of upstream PTY output: colors, cursor, wrapped rows, alt-screen behavior, and prompt styling.
+- No manual prompt-row background injection or cursor synthesis in the live-pane path.
 - Preserve existing task/session behavior in `internal/agent`, `internal/daemon`, and `internal/db`.
 - Preserve the current three-panel workflow: git status, agent terminal, file explorer.
 - Preserve task switching, detach flow, resize handling, and key forwarding to the PTY.
@@ -47,17 +65,17 @@ Recommendation:
 
 ### Should Have
 
-- Retain the existing preview/task-list ANSI rendering path with a smaller replay stack.
+- Damage tracking — only repaint lines that changed, not the full panel every frame.
+- Native scrollback via x/vt's `Scrollback()` buffer — no more replaying the entire ring buffer through a tall emulator.
 - Keep current keybindings and focus behavior as close as possible during migration.
-- Ship behind a runtime flag so Bubble Tea remains available as fallback during rollout.
-- Improve terminal correctness around cursor parking, scrollback, and wide-character handling.
+- Task list preview panel in tcell runtime (small terminal snapshot per task).
 
 ### Won't Do (this iteration)
 
 - Rebuild the daemon, agent session model, or worktree model.
 - Replace `creack/pty`.
-- Attempt a mixed ownership model where Bubble Tea and a live terminal pane both paint the same screen region.
-- Port every non-agent view to a new UI runtime in the first milestone.
+- True passthrough (raw PTY bytes to host terminal for a screen subregion) — fundamentally incompatible with panels.
+- Windows support — Unix-first, same as existing PTY behavior.
 
 ## Technical Approach
 
@@ -65,21 +83,20 @@ The clean path is a runtime split and staged migration:
 
 1. Extract a UI-agnostic application layer from the current Bubble Tea-heavy presentation code.
 2. Introduce a second UI runtime built on `tcell`, using `tview` for high-level application chrome and a custom PTY terminal primitive for the live agent pane.
-3. Keep the current replay renderer only for previews, snapshots, and fallback mode.
-4. Cut the live agent pane over first, then port the remaining screens to the new runtime once terminal ownership is proven out.
-
-This avoids trying to force a real terminal surface through a `View() string` API that was not designed for it.
+3. Replace `vt10x` with `x/vt` for modern emulation + damage tracking + native scrollback.
+4. Port all remaining views (Reviews, Settings, forms) to tcell.
+5. Delete the entire Bubble Tea runtime and all charmbracelet/bubbletea dependencies.
 
 ## Decisions
 
 | Decision | Rationale |
 |----------|-----------|
 | Use `tcell` as the target screen/runtime layer and `tview` as the shell/widget layer | This keeps the stack conservative: mature screen ownership plus common layout/widgets without betting on a smaller runtime ecosystem |
+| Use `x/vt` as the emulator, replacing `vt10x` | Actively maintained, damage tracking, scrollback buffer, hyperlinks, better escape sequence coverage |
+| Emulated rendering, not true passthrough | True passthrough requires full-screen handoff — incompatible with three-panel layout. x/vt + tcell gives high-fidelity emulation with direct cell painting |
 | Keep `creack/pty` for PTY allocation and resize | The PTY layer is already correct and independent of the renderer |
-| Keep a replay/emulation path for previews and finished-session output | Task-list preview and offline log rendering still benefit from deterministic replay |
-| Treat `x/vt` as a possible replacement for `vt10x` in replay code, not as the full live-pane solution | Emulation is only one part of the problem; the bigger issue is screen ownership |
-| Do not try to embed a native terminal pane inside Bubble Tea's string rendering model | Mixed ownership would be fragile around cursor placement, repaint order, focus, and alternate screen behavior |
-| Migrate the agent view first under a feature flag | It is the highest-value surface and isolates terminal correctness from the rest of the app |
+| Do not try to embed a native terminal pane inside Bubble Tea's string rendering model | The string intermediary is the bottleneck — x/vt + BT would still be lossy |
+| Delete BT entirely, not keep it as fallback | Two UI codebases in one binary is unsustainable. Once all views are ported, BT adds only maintenance burden |
 
 ## Implementation Steps
 
@@ -133,116 +150,202 @@ This avoids trying to force a real terminal surface through a `View() string` AP
 ### Phase 6: Replace vt10x with x/vt in TerminalPane
 **Status:** not started
 
+This is a significant architectural change. Currently scrollback replays the entire 256KB ring buffer through a tall vt10x instance every frame. x/vt's native `Scrollback()` buffer eliminates this entirely — no more `estimateVTRows()`, no more creating a throwaway emulator sized to total-output-lines.
+
+**Emulator swap:**
+- [ ] `go get github.com/charmbracelet/x/vt github.com/charmbracelet/ultraviolet`
 - [ ] Replace `vt10x.New(vt10x.WithSize(w, h))` → `vt.NewSafeEmulator(w, h)` in `internal/tui2/terminalpane.go`
-- [ ] Replace `vt.Cell(x, y)` → `emulator.CellAt(x, y)` (returns `*uv.Cell`)
-- [ ] Replace `cellStyle(vt10x.Glyph)` → new `uvCellToTcellStyle(*uv.Cell)` using `tcell.FromImageColor()`
+- [ ] Replace `vt.Cell(x, y)` → `emulator.CellAt(x, y)` (returns `*uv.Cell` with `.Content` string, `.Style` with fg/bg as `image/color.Color`, attrs as bitflags)
+- [ ] Replace `cellStyle(vt10x.Glyph)` → new `uvCellToTcellStyle(*uv.Cell)` using `tcell.FromImageColor(cell.Style.Fg)` for color conversion
 - [ ] Replace cursor access: `vt.Cursor()` → `emulator.CursorPosition()`
 - [ ] Remove `vt.Lock()/Unlock()` — SafeEmulator is thread-safe
-- [ ] Use `emulator.Scrollback()` for scrollback instead of replaying full buffer through a tall terminal
-- [ ] Use `emulator.Touched()` for incremental redraws — only repaint lines that changed
-- [ ] Update tests in `internal/tui2/terminalpane_test.go`
-- [ ] `go get github.com/charmbracelet/x/vt github.com/charmbracelet/ultraviolet`
+- [ ] Replace `rowHasContent` to check `cell.Content != "" && cell.Content != " "` (x/vt cells use string content, not rune)
+
+**Scrollback rewrite:**
+- [ ] Replace `renderReplay` (full-buffer replay through tall vt10x) with `emulator.Scrollback()` — native scrollback buffer with `.Len()` and `.CellAt(x, y)`
+- [ ] Delete `estimateVTRows()` from terminalpane.go — no longer needed
+- [ ] Scrollback rendering reads from `emulator.Scrollback()` for lines above the viewport and `emulator.CellAt()` for visible lines
+
+**Damage tracking:**
+- [ ] Use `emulator.Touched()` to get set of changed lines since last draw
+- [ ] Only repaint changed lines in `paintVT()` instead of full panel repaint
+
+**Log replay for finished sessions:**
+- [ ] Rewrite log replay in terminalpane.go to use x/vt instead of importing `ui.ReplayVT10X` + `ui.EstimateVTRows` — feed session log bytes to a local x/vt emulator, use its scrollback for navigation
+- [ ] Remove tui2's dependency on `internal/ui/vtrender.go` exports (`ReplayVT10X`, `EstimateVTRows`)
+
+**Tests:**
+- [ ] Update `internal/tui2/terminalpane_test.go` for x/vt API
+- [ ] Add tests for scrollback via `Scrollback()` buffer
+- [ ] Add tests for damage tracking (only changed lines repainted)
 
 ### Phase 7: Extract shared utilities from internal/ui/
 **Status:** not started
 
-New package: `internal/gitutil/`
+Two new packages: `internal/gitutil/` (git operations, diff parsing, changed files) and `internal/skills/` (skill loading — not git-related).
 
-Move pure-Go files with zero charmbracelet imports:
-- [ ] `internal/ui/gitcmd.go` → `internal/gitutil/gitcmd.go` (FetchGitStatus, FetchFileDiff, FetchDirFiles, message types)
+**Move to `internal/gitutil/` (pure Go, zero charmbracelet imports):**
+- [ ] `internal/ui/gitcmd.go` → `internal/gitutil/gitcmd.go` (FetchGitStatus, FetchFileDiff, FetchDirFiles, and their message types: `GitStatusRefreshMsg`, `DirFilesMsg`, `FileDiffMsg`)
 - [ ] `internal/ui/scrollstate.go` → `internal/gitutil/scrollstate.go` (ScrollState)
-- [ ] `internal/ui/diffparse.go` → `internal/gitutil/diffparse.go` (ParseUnifiedDiff, BuildSideBySide, types)
-- [ ] `internal/ui/skills.go` → `internal/gitutil/skills.go` (SkillItem, skill loading)
+- [ ] `internal/ui/diffparse.go` → `internal/gitutil/diffparse.go` (ParseUnifiedDiff, BuildSideBySide, DiffLine, DiffHunk types). Note: uses `charmbracelet/x/ansi` for `ansi.Hardwrap` and `ansi.StringWidth` — this dep stays in go.mod.
 - [ ] `internal/ui/worktree.go` → `internal/gitutil/worktree.go` (worktree discovery, cleanup)
-- [ ] Extract `ChangedFile`, `ParseGitStatus`, `ParseGitDiffNameStatus`, `MergeChangedFiles` from `internal/ui/fileexplorer.go` to `internal/gitutil/changedfiles.go`
-- [ ] Update all imports in `internal/tui2/` and `internal/ui/`
+- [ ] Extract `ChangedFile`, `ParseGitStatus`, `ParseGitDiffNameStatus`, `MergeChangedFiles` from `internal/ui/fileexplorer.go` → `internal/gitutil/changedfiles.go` (pure Go types and parsers only; the `FileExplorer` struct with lipgloss rendering stays in `internal/ui/` until Phase 11 deletion)
+
+**Move to `internal/skills/`:**
+- [ ] `internal/ui/skills.go` → `internal/skills/skills.go` (SkillItem, ScanSkills, LoadSkillsCmd — pure Go, no charmbracelet imports)
+
+**Update imports:**
+- [ ] `internal/tui2/app.go`: `ui.FetchGitStatus` → `gitutil.FetchGitStatus`, `ui.ParseGitStatus` → `gitutil.ParseGitStatus`, etc.
+- [ ] `internal/tui2/fileexplorer.go`: `ui.ChangedFile` → `gitutil.ChangedFile`
+- [ ] `internal/tui2/newtaskform.go`: skill loading → `skills.ScanSkills`
+- [ ] Keep `internal/ui/` files importing from `gitutil`/`skills` so BT runtime still compiles (deleted in Phase 11)
+
+**vtrender.go stays in `internal/ui/`** — after Phase 6 removes tui2's dependency on it, vtrender.go is only used by the BT runtime and will be deleted in Phase 11. No extraction needed.
 
 ### Phase 8: Port Reviews tab to tcell
 **Status:** not started
 
 New file: `internal/tui2/reviews.go`
 
-- [ ] Three-panel layout (PR list | diff | comments) using `tview.Flex`
-- [ ] PR list with "Review Requests" first, "My Open PRs" second, cursor navigation, status badges
-- [ ] Diff viewer with scroll, syntax highlighting (reuse `parseDiffLines` or `gitutil.ParseUnifiedDiff`)
-- [ ] Comments list + compose box
-- [ ] Data flow: `FetchPRList()` → goroutine → `QueueUpdateDraw`; PR select → fetch files + comments in parallel
-- [ ] Cooldown: 10-min PR list, 2-min comments TTL
-- [ ] Key bindings: up/down/j/k, Enter, tab focus, s split, c comment, a approve, r request changes, R refresh, esc back
+The BT reviews tab (`internal/ui/reviews.go`) has significant complexity that must be ported:
+
+**PR fetching (from `internal/github/github.go`):**
+- [ ] Cross-repo list via `gh search prs` → enrichment with `reviewDecision` via `gh pr list` grouped by repo (O(repos) not O(PRs))
+- [ ] `SetPRs` must sort review requests before "my PRs" — `prCursor` navigates a flat slice, order must match visual sections
+- [ ] 10-min cooldown (`prListCooldown`) gates refetch on tab entry; all tab-switch paths check `canFetchPRList()`
+- [ ] Show cached data during background refresh with dimmed "refreshing…" indicator
+
+**Three-panel layout using `tview.Flex`:**
+- [ ] Left: PR list with "Review Requests" section first, "My Open PRs" second. Cursor navigation, status badges (draft, review decision, CI status).
+- [ ] Center: Diff viewer using `gitutil.ParseUnifiedDiff` + `gitutil.BuildSideBySide` for split mode. Syntax highlighting via Chroma with `injectBg` for diff line backgrounds (Chroma resets after every token — must re-apply background after each `\033[0m`). Full diff cached per PR, re-sliced per file via `ExtractFileDiff`.
+- [ ] Right: Comments list with threading + compose box. Comments fetched via GitHub REST API. 2-min TTL for auto-refresh. Diff staleness checked against `PR.UpdatedAt`.
+
+**Key bindings:**
+- [ ] up/down/j/k navigate PR list or diff
+- [ ] Enter select PR → fetch files + comments in parallel
+- [ ] Tab cycle focus: list → diff → comment compose
+- [ ] s toggle split/unified diff view
+- [ ] c capture line number, open comment compose
+- [ ] a approve, r request changes via `github.SubmitReview()`
+- [ ] R manual refresh (subject to cooldown)
+- [ ] esc back (exit compose, exit diff, exit reviews)
 
 ### Phase 9: Port Settings tab to tcell
 **Status:** not started
 
 New file: `internal/tui2/settings.go`
 
-- [ ] Two-panel layout (section list | detail)
-- [ ] Sections: STATUS, SANDBOX, PROJECTS, BACKENDS, KNOWLEDGE BASE
-- [ ] Cursor skips section headers, detail panel shows selected item config
-- [ ] Key bindings: up/down navigate, 'n' new, 'e' edit, 'd' delete/default, Enter select
-- [ ] Forms as modal overlays via `tview.Pages.AddPage`
+The BT settings tab has more complexity than a simple list/detail view:
+
+**Two-panel layout (section list | detail):**
+- [ ] Left: Scrollable list of sections. Cursor skips section headers (same pattern as task list).
+- [ ] Right: Detail panel for selected item.
+
+**Sections and their detail views:**
+- [ ] STATUS — daemon connection state (`daemonConnected` flag drives "in-process mode" warning), sandbox availability (`IsSandboxAvailable()` cached via `sync.Once`)
+- [ ] SANDBOX — global sandbox enabled/disabled, deny-read paths (CSV), extra-write paths (CSV). Inline editing of path lists.
+- [ ] PROJECTS — project name, path, branch, backend, per-project sandbox overrides (`sandbox_enabled`: inherit/true/false, `sandbox_deny_read`, `sandbox_extra_write`). Detail shows all config fields.
+- [ ] BACKENDS — name, command, prompt flag. Shows `(default: <name>)` in section header. 'd' sets default.
+- [ ] KNOWLEDGE BASE — vault paths (`kb.argus_vault_path`, `kb.metis_vault_path`). Uses `NewKBVaultForm` pattern (accepts DB config key explicitly, not derived from label).
+- [ ] UX LOGS — display recent entries from `~/.argus/ux.log`
+
+**Key bindings:**
+- [ ] up/down navigate (cursor skips section headers)
+- [ ] 'n' new project/backend
+- [ ] 'e' edit selected item (opens modal form)
+- [ ] 'd' delete item or set default backend
+- [ ] Enter select/expand
+
+**Forms as modal overlays via `tview.Pages.AddPage`** — same pattern as `NewTaskForm`.
 
 ### Phase 10: Port remaining forms to tcell
 **Status:** not started
 
-- [ ] `internal/tui2/projectform.go` — add/edit project (name, path, branch, backend, sandbox settings)
-- [ ] `internal/tui2/backendform.go` — add/edit backend (name, command, prompt flag)
-- [ ] `internal/tui2/renametask.go` — rename task (single text input)
-- [ ] All follow modal pattern: `tview.Box` with `InputHandler`, added/removed as page
+- [ ] `internal/tui2/projectform.go` — add/edit project (name, path, branch, backend selector, per-project sandbox settings: enabled inherit/true/false, deny-read paths, extra-write paths). Auto-detect remote default branch on path entry (prefer `upstream` over `origin`).
+- [ ] `internal/tui2/backendform.go` — add/edit backend (name, command, prompt flag). Edit mode: name field read-only. Mirrors `internal/ui/backendform.go` pattern with 3 text input fields.
+- [ ] `internal/tui2/renametask.go` — rename task (single text input). Display-only rename: updates `t.Name` in DB, worktree dir/branch/session unchanged. Works while agent is running.
+- [ ] `internal/tui2/kbvaultform.go` — KB vault path editor. Takes DB config key explicitly (`"kb.metis_vault_path"`, `"kb.argus_vault_path"`), not derived from label string.
+- [ ] All follow modal pattern: `tview.Box` with `InputHandler`, added/removed as page on submit/cancel.
+
+### Phase 10.5: Task list preview panel
+**Status:** not started
+
+The BT task list shows a small terminal snapshot in the right panel when hovering over a task (`internal/ui/preview.go`). The tcell task list currently has no preview.
+
+- [ ] Add preview rendering to `TaskListView` right panel — small x/vt emulator sized to panel dimensions, fed from `session.RecentOutput()` or session log file
+- [ ] Preview updates on cursor movement (debounced, not every keystroke)
+- [ ] Finished tasks: replay from `~/.argus/sessions/<taskID>.log`
+- [ ] Active tasks: snapshot from `session.RecentOutputTail()`
 
 ### Phase 11: Delete Bubble Tea runtime + clean deps
 **Status:** not started
 
-- [ ] Delete `internal/ui/` entirely (~60 files)
-- [ ] Remove BT wiring from `cmd/argus/main.go` (delete `runTUI()`, remove runtime switch)
-- [ ] Delete `internal/app/agentview/runtime.go` and `runtime_test.go`
-- [ ] Remove from go.mod: `bubbletea`, `bubbles`, `lipgloss`, `hinshun/vt10x`
-- [ ] Keep: `charmbracelet/x/vt`, `charmbracelet/x/ansi`
-- [ ] `go mod tidy` → `go build ./... && go vet ./... && go test ./...`
+- [ ] Delete `internal/ui/` entirely (~60 files including vtrender.go, agentview.go, root.go, all forms, all views, all tests)
+- [ ] Remove BT wiring from `cmd/argus/main.go`: delete `runTUI()` function, delete `tea` and `internal/ui` imports, make `runTcell()` the only path (remove runtime switch and `ARGUS_UI_RUNTIME` env var)
+- [ ] Delete `internal/app/agentview/runtime.go` and `runtime_test.go` (no longer needed — single runtime)
+- [ ] Remove from go.mod: `github.com/charmbracelet/bubbletea`, `github.com/charmbracelet/bubbles`, `github.com/charmbracelet/lipgloss`, `github.com/hinshun/vt10x`
+- [ ] Keep in go.mod: `github.com/charmbracelet/x/vt` (emulator), `github.com/charmbracelet/x/ansi` (used by `internal/gitutil/diffparse.go` for `ansi.Hardwrap`/`ansi.StringWidth`), `github.com/charmbracelet/ultraviolet` (x/vt cell types)
+- [ ] `go mod tidy` to drop indirect deps (colorprofile, cellbuf, x/term, etc.)
+- [ ] `go build ./... && go vet ./... && go test ./...`
 - [ ] Verify: `grep -r "charmbracelet/bubbletea\|charmbracelet/bubbles\|charmbracelet/lipgloss\|hinshun/vt10x" go.mod` → zero matches
+- [ ] Verify: `grep -r "internal/ui" internal/tui2/ cmd/` → zero matches (only `internal/gitutil` and `internal/skills`)
 
 ### Phase 12: Wire daemon restart + in-process session exit
 **Status:** not started
 
-- [ ] `App.RestartedClient()` returns the new client after daemon restart
-- [ ] Wire `onFinish` callback in `runTcell()` for in-process mode
-- [ ] Daemon health check → auto-restart → reconnect sessions (mirror BT's `DaemonRestartedMsg` flow)
+The BT runtime has significant daemon lifecycle code that must be ported:
+
+**Daemon health check (mirror BT's `daemonFailures` counter):**
+- [ ] Tick handler pings daemon via `client.Ping()` (type-assert `runner` to `*dclient.Client`)
+- [ ] Three consecutive failures set `daemonRestarting = true` and trigger `restartDaemonCmd()`
+- [ ] Reset `daemonFailures = 0` on successful ping AND in restart-complete handler
+- [ ] Skip health check when `!daemonConnected` (in-process mode) or `daemonRestarting` (already restarting)
+
+**Daemon restart flow (mirror BT's `DaemonRestartedMsg`):**
+- [ ] `App.RestartedClient()` returns the new `*dclient.Client` after daemon restart (currently returns nil)
+- [ ] Restart handler: reset all InProgress tasks to Pending, **preserve SessionID** (Claude Code's `--session-id` persists conversation state — clearing it loses history)
+- [ ] Re-query sessions from new daemon, update `runner` reference
+
+**In-process session exit:**
+- [ ] Wire `onFinish` callback in `runTcell()` for in-process mode so session exits are detected immediately via `QueueUpdateDraw`, not on next 1s tick
+- [ ] `onFinish` must fire before session removal from runner (same ordering invariant as BT path)
+
+**Auto-start daemon:**
+- [ ] `autoStartDaemon()` forks current binary with `Setsid`, polls socket until ready (50ms intervals, 3s timeout)
+- [ ] Falls back to in-process mode if auto-start fails, with warning in Settings tab
 
 ## Testing Strategy
 
 - Keep `go test ./...` green throughout the extraction and migration.
 - Add focused adapter tests for PTY resize, key forwarding, scrollback, and session replay.
 - Create manual smoke scripts for terminal-specific behaviors that unit tests miss: alt-screen apps, mouse reporting, cursor visibility, long wrapped prompts, and Unicode/wide glyphs.
-- Test both runtimes behind the feature flag until cutover: Bubble Tea fallback and `tcell` target runtime.
+- Test both runtimes behind the feature flag until Phase 11 cutover.
 - Verify that task-list previews and completed-session output remain stable while live rendering changes underneath.
+- After Phase 11: verify no `internal/ui` imports remain in tui2 or cmd.
 
 ## Risks & Open Questions
 
 | Risk | Mitigation |
 |------|------------|
-| The `tcell` migration is materially larger than a renderer refactor | Ship in phases and cut over the agent pane first behind a runtime flag |
-| Reusing current UI logic is harder than expected because `internal/ui` mixes state and presentation | Extract agent/session state into runtime-agnostic packages before porting widgets |
-| Terminal behavior differs across macOS/Linux terminals in ways the current replay path hides | Add manual smoke coverage for resize, mouse, alternate screen, and Unicode cases early |
-| A mixed Bubble Tea/`tcell` runtime is tempting and causes dead-end complexity | Keep the separation explicit: Bubble Tea fallback runtime versus `tcell` target runtime |
-| Preview rendering drifts from live-pane rendering semantics | Deliberately treat preview as a separate product surface with its own acceptance criteria |
+| x/vt's API surface differs from vt10x more than expected | Phase 6 is isolated to terminalpane.go — if x/vt's cell/cursor API doesn't map cleanly, the blast radius is one file |
+| Reviews tab port is the largest single phase (complex data flow, Chroma highlighting, comment threading) | Port data fetching first (goroutines + QueueUpdateDraw), then layout, then interactions |
+| Settings forms have subtle validation and DB interaction | Mirror existing BT form logic closely, use same DB methods |
+| Damage tracking may not integrate cleanly with tview's own drawing | `tview.Box.Draw()` is called every frame by tview — may need to track dirty state ourselves and skip `SetContent` for untouched cells |
+| Task list preview requires a second x/vt emulator per visible task | Debounce heavily, only emulate for the currently-selected task, reuse emulator instance |
 
-- Is a runtime split with `cmd/argus-tcell` acceptable during migration, or must the switch stay inside one binary?
-- Do we want the task list and non-agent screens to remain Bubble Tea for a transitional period, or should the whole shell move once the agent pane works?
-- Should replay rendering stay on `vt10x` for stability, or should it move to `x/vt` once the live pane no longer depends on it?
-- Do we need Windows support for the terminal-surface migration, or can the first pass remain Unix-first like the existing PTY behavior?
+- Should the task list preview (Phase 10.5) use x/vt or a simpler approach (just show last N lines of raw output)?
+- Do we need Chroma syntax highlighting in the tcell diff viewer, or is colored +/- lines sufficient?
 
 ## Dependencies
 
-- Current PTY/session layer in [`internal/agent/session.go`](/Users/darrencheng/.argus/worktrees/argus/codex-prompt-line-manually/internal/agent/session.go)
-- Current Bubble Tea app shell in [`internal/ui/root.go`](/Users/darrencheng/.argus/worktrees/argus/codex-prompt-line-manually/internal/ui/root.go)
-- Current live-pane replay/render path in [`internal/ui/agentview.go`](/Users/darrencheng/.argus/worktrees/argus/codex-prompt-line-manually/internal/ui/agentview.go) and [`internal/ui/vtrender.go`](/Users/darrencheng/.argus/worktrees/argus/codex-prompt-line-manually/internal/ui/vtrender.go)
-- Bubble Tea package docs: https://pkg.go.dev/github.com/charmbracelet/bubbletea
-- Tview package docs: https://pkg.go.dev/github.com/rivo/tview
-- Tview repository: https://github.com/rivo/tview
+- Current PTY/session layer in `internal/agent/session.go`
+- Current Bubble Tea app shell in `internal/ui/root.go`
+- Current live-pane replay/render path in `internal/ui/agentview.go` and `internal/ui/vtrender.go`
 - Charm `x/vt` package docs: https://pkg.go.dev/github.com/charmbracelet/x/vt
+- Charm ultraviolet (cell types): https://pkg.go.dev/github.com/charmbracelet/ultraviolet
 - Tcell package docs: https://pkg.go.dev/github.com/gdamore/tcell/v2
-- Tcell repository: https://github.com/gdamore/tcell
+- Tview repository: https://github.com/rivo/tview
 - PTY package docs: https://pkg.go.dev/github.com/creack/pty
-- Current `vt10x` package docs: https://pkg.go.dev/github.com/hinshun/vt10x
 
 ## Errors Encountered
 
@@ -252,6 +355,6 @@ New file: `internal/tui2/settings.go`
 
 ## Estimated Scope
 
-**Phases:** 12
-**Tasks:** ~60
-**Files touched:** ~80+ (including ~60 deleted in Phase 11)
+**Phases:** 13 (including 10.5)
+**Tasks:** ~75
+**Files touched:** ~85+ (including ~60 deleted in Phase 11)


### PR DESCRIPTION
Reframe from 'true passthrough' to 'high-fidelity emulated rendering'. Expand Phases 6-12 with full specifications for x/vt migration, Reviews/Settings ports, daemon lifecycle, and task list preview.

Co-Authored-By: Claude <noreply@anthropic.com>