### PR TITLE
Phase 10: Port remaining forms to tcell

### DIFF
--- a/internal/tui2/backendform.go
+++ b/internal/tui2/backendform.go
@@ -1,0 +1,172 @@
+package tui2
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/drn/argus/internal/config"
+)
+
+const (
+	bfFieldName      = 0
+	bfFieldCommand   = 1
+	bfFieldPromptFlag = 2
+)
+
+// BackendForm is a modal form for adding/editing backends.
+type BackendForm struct {
+	*tview.Box
+	fields   [3][]rune // name, command, prompt flag
+	cursors  [3]int
+	focused  int
+	editMode bool // true = editing (name read-only)
+	done     bool
+	canceled bool
+	errMsg   string
+}
+
+// NewBackendForm creates a new backend form.
+func NewBackendForm() *BackendForm {
+	return &BackendForm{
+		Box: tview.NewBox(),
+	}
+}
+
+// LoadBackend populates the form for editing an existing backend.
+func (bf *BackendForm) LoadBackend(name string, b config.Backend) {
+	bf.fields[bfFieldName] = []rune(name)
+	bf.fields[bfFieldCommand] = []rune(b.Command)
+	bf.fields[bfFieldPromptFlag] = []rune(b.PromptFlag)
+	bf.editMode = true
+	bf.focused = bfFieldCommand // skip name in edit mode
+}
+
+func (bf *BackendForm) Done() bool     { return bf.done }
+func (bf *BackendForm) Canceled() bool { return bf.canceled }
+func (bf *BackendForm) SetError(msg string) { bf.errMsg = msg }
+
+// Result returns the form values.
+func (bf *BackendForm) Result() (name string, b config.Backend) {
+	return string(bf.fields[bfFieldName]), config.Backend{
+		Command:    string(bf.fields[bfFieldCommand]),
+		PromptFlag: string(bf.fields[bfFieldPromptFlag]),
+	}
+}
+
+// HandleKey processes key events for the form.
+func (bf *BackendForm) HandleKey(ev *tcell.EventKey) {
+	switch ev.Key() {
+	case tcell.KeyEscape:
+		bf.canceled = true
+		return
+	case tcell.KeyEnter:
+		if bf.focused < bfFieldPromptFlag {
+			bf.focused++
+			if bf.editMode && bf.focused == bfFieldName {
+				bf.focused++
+			}
+		} else {
+			bf.done = true
+		}
+		return
+	case tcell.KeyTab:
+		bf.focused = (bf.focused + 1) % 3
+		if bf.editMode && bf.focused == bfFieldName {
+			bf.focused++
+		}
+		return
+	case tcell.KeyBacktab:
+		bf.focused = (bf.focused + 2) % 3
+		if bf.editMode && bf.focused == bfFieldName {
+			bf.focused = bfFieldPromptFlag
+		}
+		return
+	case tcell.KeyBackspace, tcell.KeyBackspace2:
+		f := bf.focused
+		if bf.editMode && f == bfFieldName {
+			return
+		}
+		if bf.cursors[f] > 0 {
+			bf.fields[f] = append(bf.fields[f][:bf.cursors[f]-1], bf.fields[f][bf.cursors[f]:]...)
+			bf.cursors[f]--
+		}
+		return
+	case tcell.KeyLeft:
+		if bf.cursors[bf.focused] > 0 {
+			bf.cursors[bf.focused]--
+		}
+		return
+	case tcell.KeyRight:
+		if bf.cursors[bf.focused] < len(bf.fields[bf.focused]) {
+			bf.cursors[bf.focused]++
+		}
+		return
+	case tcell.KeyRune:
+		if bf.editMode && bf.focused == bfFieldName {
+			return
+		}
+		f := bf.focused
+		r := ev.Rune()
+		bf.fields[f] = append(bf.fields[f][:bf.cursors[f]], append([]rune{r}, bf.fields[f][bf.cursors[f]:]...)...)
+		bf.cursors[f]++
+		return
+	}
+}
+
+// Draw renders the backend form as a modal.
+func (bf *BackendForm) Draw(screen tcell.Screen) {
+	bf.Box.DrawForSubclass(screen, bf)
+	x, y, width, height := bf.GetInnerRect()
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	formW := min(60, width-4)
+	formH := 12
+	formX := x + (width-formW)/2
+	formY := y + (height-formH)/2
+	if formY < y {
+		formY = y
+	}
+
+	drawBorder(screen, formX, formY, formW, formH, StyleFocusedBorder)
+
+	title := "New Backend"
+	if bf.editMode {
+		title = "Edit Backend"
+	}
+	drawText(screen, formX+2, formY+1, formW-4, title, StyleTitle)
+
+	labels := [3]string{"Name:", "Command:", "Prompt Flag:"}
+	for i := range 3 {
+		ly := formY + 3 + i*2
+		if ly >= formY+formH-1 {
+			break
+		}
+		style := StyleDimmed
+		if i == bf.focused {
+			style = tcell.StyleDefault.Foreground(ColorTitle)
+		}
+		drawText(screen, formX+2, ly, 14, labels[i], style)
+
+		val := string(bf.fields[i])
+		if i == bf.focused {
+			before := string(bf.fields[i][:bf.cursors[i]])
+			after := string(bf.fields[i][bf.cursors[i]:])
+			val = before + "█" + after
+		}
+		fieldStyle := tcell.StyleDefault
+		if bf.editMode && i == bfFieldName {
+			fieldStyle = StyleDimmed
+		}
+		maxW := formW - 18
+		if len(val) > maxW {
+			val = val[len(val)-maxW:]
+		}
+		drawText(screen, formX+16, ly, maxW, val, fieldStyle)
+	}
+
+	if bf.errMsg != "" {
+		drawText(screen, formX+2, formY+formH-2, formW-4, bf.errMsg, StyleError)
+	}
+}

--- a/internal/tui2/forms_test.go
+++ b/internal/tui2/forms_test.go
@@ -1,0 +1,172 @@
+package tui2
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/drn/argus/internal/config"
+)
+
+// --- ProjectForm tests ---
+
+func TestProjectForm_New(t *testing.T) {
+	pf := NewProjectForm()
+	if pf.editMode {
+		t.Error("should not be in edit mode")
+	}
+	if pf.Done() || pf.Canceled() {
+		t.Error("should not be done or canceled initially")
+	}
+}
+
+func TestProjectForm_LoadProject(t *testing.T) {
+	pf := NewProjectForm()
+	pf.LoadProject("test", config.Project{Path: "/tmp", Branch: "main", Backend: "claude"})
+	if !pf.editMode {
+		t.Error("should be in edit mode")
+	}
+	if string(pf.fields[pfFieldName]) != "test" {
+		t.Errorf("name = %q, want test", string(pf.fields[pfFieldName]))
+	}
+	if pf.focused != pfFieldPath {
+		t.Error("should focus path field in edit mode")
+	}
+}
+
+func TestProjectForm_KeyNavigation(t *testing.T) {
+	pf := NewProjectForm()
+	// Tab to next field.
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyTab, 0, 0))
+	if pf.focused != 1 {
+		t.Errorf("focused = %d, want 1", pf.focused)
+	}
+	// Back-tab.
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyBacktab, 0, 0))
+	if pf.focused != 0 {
+		t.Errorf("focused = %d, want 0", pf.focused)
+	}
+}
+
+func TestProjectForm_TypeAndResult(t *testing.T) {
+	pf := NewProjectForm()
+	// Type a name.
+	for _, r := range "myproj" {
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyRune, r, 0))
+	}
+	// Enter → next field.
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
+	// Type a path.
+	for _, r := range "/tmp/test" {
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyRune, r, 0))
+	}
+	// Skip to done.
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyEnter, 0, 0)) // → branch
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyEnter, 0, 0)) // → backend
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyEnter, 0, 0)) // → done
+
+	if !pf.Done() {
+		t.Error("should be done")
+	}
+	name, proj := pf.Result()
+	if name != "myproj" {
+		t.Errorf("name = %q", name)
+	}
+	if proj.Path != "/tmp/test" {
+		t.Errorf("path = %q", proj.Path)
+	}
+}
+
+func TestProjectForm_Escape(t *testing.T) {
+	pf := NewProjectForm()
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyEscape, 0, 0))
+	if !pf.Canceled() {
+		t.Error("should be canceled")
+	}
+}
+
+// --- BackendForm tests ---
+
+func TestBackendForm_New(t *testing.T) {
+	bf := NewBackendForm()
+	if bf.editMode || bf.Done() || bf.Canceled() {
+		t.Error("bad initial state")
+	}
+}
+
+func TestBackendForm_LoadBackend(t *testing.T) {
+	bf := NewBackendForm()
+	bf.LoadBackend("claude", config.Backend{Command: "claude --dangerously-skip-permissions", PromptFlag: "--"})
+	if !bf.editMode {
+		t.Error("should be in edit mode")
+	}
+	if string(bf.fields[bfFieldCommand]) != "claude --dangerously-skip-permissions" {
+		t.Error("command not loaded")
+	}
+}
+
+func TestBackendForm_TypeAndSubmit(t *testing.T) {
+	bf := NewBackendForm()
+	for _, r := range "test-be" {
+		bf.HandleKey(tcell.NewEventKey(tcell.KeyRune, r, 0))
+	}
+	bf.HandleKey(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
+	for _, r := range "echo hello" {
+		bf.HandleKey(tcell.NewEventKey(tcell.KeyRune, r, 0))
+	}
+	bf.HandleKey(tcell.NewEventKey(tcell.KeyEnter, 0, 0)) // → prompt flag
+	bf.HandleKey(tcell.NewEventKey(tcell.KeyEnter, 0, 0)) // → done
+
+	if !bf.Done() {
+		t.Error("should be done")
+	}
+	name, be := bf.Result()
+	if name != "test-be" {
+		t.Errorf("name = %q", name)
+	}
+	if be.Command != "echo hello" {
+		t.Errorf("command = %q", be.Command)
+	}
+}
+
+// --- RenameTaskForm tests ---
+
+func TestRenameTaskForm_New(t *testing.T) {
+	rf := NewRenameTaskForm("old-name")
+	if rf.Name() != "old-name" {
+		t.Errorf("name = %q, want old-name", rf.Name())
+	}
+	if rf.cursor != 8 {
+		t.Errorf("cursor = %d, want 8", rf.cursor)
+	}
+}
+
+func TestRenameTaskForm_TypeAndSubmit(t *testing.T) {
+	rf := NewRenameTaskForm("")
+	for _, r := range "new-name" {
+		rf.HandleKey(tcell.NewEventKey(tcell.KeyRune, r, 0))
+	}
+	rf.HandleKey(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
+	if !rf.Done() {
+		t.Error("should be done")
+	}
+	if rf.Name() != "new-name" {
+		t.Errorf("name = %q", rf.Name())
+	}
+}
+
+func TestRenameTaskForm_Backspace(t *testing.T) {
+	rf := NewRenameTaskForm("abc")
+	rf.HandleKey(tcell.NewEventKey(tcell.KeyBackspace2, 0, 0))
+	if rf.Name() != "ab" {
+		t.Errorf("name = %q, want ab", rf.Name())
+	}
+}
+
+func TestRenameTaskForm_Escape(t *testing.T) {
+	rf := NewRenameTaskForm("test")
+	rf.HandleKey(tcell.NewEventKey(tcell.KeyEscape, 0, 0))
+	if !rf.Canceled() {
+		t.Error("should be canceled")
+	}
+}

--- a/internal/tui2/projectform.go
+++ b/internal/tui2/projectform.go
@@ -1,0 +1,182 @@
+package tui2
+
+import (
+	"unicode/utf8"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/drn/argus/internal/config"
+)
+
+const (
+	pfFieldName    = 0
+	pfFieldPath    = 1
+	pfFieldBranch  = 2
+	pfFieldBackend = 3
+)
+
+// ProjectForm is a modal form for adding/editing projects.
+type ProjectForm struct {
+	*tview.Box
+	fields   [4][]rune // name, path, branch, backend
+	cursors  [4]int
+	focused  int
+	editMode bool // true = editing (name read-only)
+	done     bool
+	canceled bool
+	errMsg   string
+}
+
+// NewProjectForm creates a new project form.
+func NewProjectForm() *ProjectForm {
+	return &ProjectForm{
+		Box: tview.NewBox(),
+	}
+}
+
+// LoadProject populates the form for editing an existing project.
+func (pf *ProjectForm) LoadProject(name string, p config.Project) {
+	pf.fields[pfFieldName] = []rune(name)
+	pf.fields[pfFieldPath] = []rune(p.Path)
+	pf.fields[pfFieldBranch] = []rune(p.Branch)
+	pf.fields[pfFieldBackend] = []rune(p.Backend)
+	pf.editMode = true
+	pf.focused = pfFieldPath // skip name in edit mode
+}
+
+func (pf *ProjectForm) Done() bool     { return pf.done }
+func (pf *ProjectForm) Canceled() bool { return pf.canceled }
+func (pf *ProjectForm) SetError(msg string) { pf.errMsg = msg }
+
+// Result returns the form values.
+func (pf *ProjectForm) Result() (name string, p config.Project) {
+	return string(pf.fields[pfFieldName]), config.Project{
+		Path:    string(pf.fields[pfFieldPath]),
+		Branch:  string(pf.fields[pfFieldBranch]),
+		Backend: string(pf.fields[pfFieldBackend]),
+	}
+}
+
+// HandleKey processes key events for the form.
+func (pf *ProjectForm) HandleKey(ev *tcell.EventKey) {
+	switch ev.Key() {
+	case tcell.KeyEscape:
+		pf.canceled = true
+		return
+	case tcell.KeyEnter:
+		if pf.focused < pfFieldBackend {
+			pf.focused++
+			if pf.editMode && pf.focused == pfFieldName {
+				pf.focused++ // skip name in edit mode
+			}
+		} else {
+			pf.done = true
+		}
+		return
+	case tcell.KeyTab:
+		pf.focused = (pf.focused + 1) % 4
+		if pf.editMode && pf.focused == pfFieldName {
+			pf.focused++
+		}
+		return
+	case tcell.KeyBacktab:
+		pf.focused = (pf.focused + 3) % 4
+		if pf.editMode && pf.focused == pfFieldName {
+			pf.focused = pfFieldBackend
+		}
+		return
+	case tcell.KeyBackspace, tcell.KeyBackspace2:
+		f := pf.focused
+		if pf.editMode && f == pfFieldName {
+			return
+		}
+		if pf.cursors[f] > 0 {
+			pf.fields[f] = append(pf.fields[f][:pf.cursors[f]-1], pf.fields[f][pf.cursors[f]:]...)
+			pf.cursors[f]--
+		}
+		return
+	case tcell.KeyLeft:
+		if pf.cursors[pf.focused] > 0 {
+			pf.cursors[pf.focused]--
+		}
+		return
+	case tcell.KeyRight:
+		if pf.cursors[pf.focused] < len(pf.fields[pf.focused]) {
+			pf.cursors[pf.focused]++
+		}
+		return
+	case tcell.KeyRune:
+		if pf.editMode && pf.focused == pfFieldName {
+			return
+		}
+		f := pf.focused
+		r := ev.Rune()
+		pf.fields[f] = append(pf.fields[f][:pf.cursors[f]], append([]rune{r}, pf.fields[f][pf.cursors[f]:]...)...)
+		pf.cursors[f]++
+		return
+	}
+	_ = utf8.RuneError // ensure import
+}
+
+// Draw renders the project form as a modal.
+func (pf *ProjectForm) Draw(screen tcell.Screen) {
+	pf.Box.DrawForSubclass(screen, pf)
+	x, y, width, height := pf.GetInnerRect()
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	// Center the form.
+	formW := min(60, width-4)
+	formH := 14
+	formX := x + (width-formW)/2
+	formY := y + (height-formH)/2
+	if formY < y {
+		formY = y
+	}
+
+	drawBorder(screen, formX, formY, formW, formH, StyleFocusedBorder)
+
+	title := "New Project"
+	if pf.editMode {
+		title = "Edit Project"
+	}
+	drawText(screen, formX+2, formY+1, formW-4, title, StyleTitle)
+
+	labels := [4]string{"Name:", "Path:", "Branch:", "Backend:"}
+	for i := range 4 {
+		ly := formY + 3 + i*2
+		if ly >= formY+formH-1 {
+			break
+		}
+		style := StyleDimmed
+		if i == pf.focused {
+			style = tcell.StyleDefault.Foreground(ColorTitle)
+		}
+		drawText(screen, formX+2, ly, 10, labels[i], style)
+
+		// Field value.
+		val := string(pf.fields[i])
+		if i == pf.focused {
+			// Insert cursor.
+			before := string(pf.fields[i][:pf.cursors[i]])
+			after := string(pf.fields[i][pf.cursors[i]:])
+			val = before + "█" + after
+		}
+		if pf.editMode && i == pfFieldName {
+			style = StyleDimmed
+		} else {
+			style = tcell.StyleDefault
+		}
+		maxW := formW - 14
+		if len(val) > maxW {
+			val = val[len(val)-maxW:]
+		}
+		drawText(screen, formX+12, ly, maxW, val, style)
+	}
+
+	if pf.errMsg != "" {
+		drawText(screen, formX+2, formY+formH-2, formW-4, pf.errMsg, StyleError)
+	}
+}

--- a/internal/tui2/renametask.go
+++ b/internal/tui2/renametask.go
@@ -1,0 +1,93 @@
+package tui2
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// RenameTaskForm is a single-field modal for renaming a task.
+// Rename is display-only — worktree dir, branch, and session ID are preserved.
+type RenameTaskForm struct {
+	*tview.Box
+	name     []rune
+	cursor   int
+	done     bool
+	canceled bool
+	errMsg   string
+}
+
+// NewRenameTaskForm creates a rename form pre-populated with the current name.
+func NewRenameTaskForm(currentName string) *RenameTaskForm {
+	runes := []rune(currentName)
+	return &RenameTaskForm{
+		Box:    tview.NewBox(),
+		name:   runes,
+		cursor: len(runes),
+	}
+}
+
+func (rf *RenameTaskForm) Done() bool      { return rf.done }
+func (rf *RenameTaskForm) Canceled() bool  { return rf.canceled }
+func (rf *RenameTaskForm) Name() string    { return string(rf.name) }
+func (rf *RenameTaskForm) SetError(msg string) { rf.errMsg = msg }
+
+// HandleKey processes key events for the rename form.
+func (rf *RenameTaskForm) HandleKey(ev *tcell.EventKey) {
+	switch ev.Key() {
+	case tcell.KeyEscape:
+		rf.canceled = true
+	case tcell.KeyEnter:
+		rf.done = true
+	case tcell.KeyBackspace, tcell.KeyBackspace2:
+		if rf.cursor > 0 {
+			rf.name = append(rf.name[:rf.cursor-1], rf.name[rf.cursor:]...)
+			rf.cursor--
+		}
+	case tcell.KeyLeft:
+		if rf.cursor > 0 {
+			rf.cursor--
+		}
+	case tcell.KeyRight:
+		if rf.cursor < len(rf.name) {
+			rf.cursor++
+		}
+	case tcell.KeyRune:
+		r := ev.Rune()
+		rf.name = append(rf.name[:rf.cursor], append([]rune{r}, rf.name[rf.cursor:]...)...)
+		rf.cursor++
+	}
+}
+
+// Draw renders the rename form as a modal.
+func (rf *RenameTaskForm) Draw(screen tcell.Screen) {
+	rf.Box.DrawForSubclass(screen, rf)
+	x, y, width, height := rf.GetInnerRect()
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	formW := min(50, width-4)
+	formH := 7
+	formX := x + (width-formW)/2
+	formY := y + (height-formH)/2
+	if formY < y {
+		formY = y
+	}
+
+	drawBorder(screen, formX, formY, formW, formH, StyleFocusedBorder)
+	drawText(screen, formX+2, formY+1, formW-4, "Rename Task", StyleTitle)
+
+	// Name field with cursor.
+	before := string(rf.name[:rf.cursor])
+	after := string(rf.name[rf.cursor:])
+	val := before + "█" + after
+	maxW := formW - 4
+	if len(val) > maxW {
+		val = val[len(val)-maxW:]
+	}
+	drawText(screen, formX+2, formY+3, maxW, val, tcell.StyleDefault)
+
+	if rf.errMsg != "" {
+		drawText(screen, formX+2, formY+5, formW-4, rf.errMsg, StyleError)
+	}
+}


### PR DESCRIPTION
Add ProjectForm, BackendForm, and RenameTaskForm as modal overlays. All follow the tview.Box modal pattern with cursor, tab navigation, escape/enter. 12 tests.

Co-Authored-By: Claude <noreply@anthropic.com>