### PR TITLE
Rewrite UI runtime to tcell/tview, fix empty tasklist panic

### DIFF
--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -303,7 +303,14 @@ func (tl *TaskListView) Draw(screen tcell.Screen) {
 		return
 	}
 
+	if len(tl.rows) == 0 {
+		return
+	}
+
 	// Ensure scroll offset keeps cursor visible
+	if tl.cursor < 0 {
+		tl.cursor = 0
+	}
 	if tl.cursor < tl.offset {
 		tl.offset = tl.cursor
 	}


### PR DESCRIPTION
Complete migration from Bubble Tea to tcell/tview runtime: port all views (task list, agent view, settings, reviews, forms), replace vt10x with x/vt, extract shared git utilities, delete BT runtime and dependencies. Fix startup panic when task list is empty.

Co-Authored-By: Claude <noreply@anthropic.com>