### PR TITLE
Fix task list not interactable after tcell refactor

### DIFF
--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -108,6 +108,12 @@ func (tl *TaskListView) buildRows() {
 
 	// Group active tasks by project
 	projectOrder, projectTasks := groupByProject(active)
+
+	// Auto-expand first project if none is expanded
+	if tl.expanded == "" && len(projectOrder) > 0 {
+		tl.expanded = projectOrder[0]
+	}
+
 	for _, proj := range projectOrder {
 		tl.rows = append(tl.rows, taskRow{kind: rowProject, project: proj})
 		if proj == tl.expanded {
@@ -190,7 +196,8 @@ func (tl *TaskListView) skipToTask(dir int) {
 	}
 }
 
-// CursorDown moves the cursor down, skipping non-task rows.
+// CursorDown moves the cursor down. When landing on a project header,
+// autoExpand will expand it and advance the cursor to the first task.
 func (tl *TaskListView) CursorDown() {
 	if len(tl.rows) == 0 {
 		return
@@ -199,11 +206,11 @@ func (tl *TaskListView) CursorDown() {
 	if tl.cursor >= len(tl.rows) {
 		tl.cursor = len(tl.rows) - 1
 	}
-	tl.skipToTask(1)
 	tl.autoExpand()
 }
 
-// CursorUp moves the cursor up, skipping non-task rows.
+// CursorUp moves the cursor up. When landing on a project header,
+// autoExpand will expand it and move the cursor to the last task.
 func (tl *TaskListView) CursorUp() {
 	if len(tl.rows) == 0 {
 		return
@@ -212,7 +219,6 @@ func (tl *TaskListView) CursorUp() {
 	if tl.cursor < 0 {
 		tl.cursor = 0
 	}
-	tl.skipToTask(-1)
 	tl.autoExpand()
 }
 
@@ -222,25 +228,46 @@ func (tl *TaskListView) autoExpand() {
 		return
 	}
 	row := tl.rows[tl.cursor]
-	if row.kind != rowTask {
-		return
-	}
 
-	inArchive := tl.isInArchive(tl.cursor)
-
-	if inArchive {
-		tl.archiveExpanded = true
-		if row.project != tl.archiveProject {
-			tl.archiveProject = row.project
-			tl.buildRows()
-			tl.restoreCursorToTask(row.task)
+	switch row.kind {
+	case rowProject:
+		// Cursor landed on a project header — expand it
+		inArchive := tl.isInArchive(tl.cursor)
+		if inArchive {
+			tl.archiveExpanded = true
+			if row.project != tl.archiveProject {
+				tl.archiveProject = row.project
+				tl.buildRows()
+				// Move cursor to the first task in this project
+				tl.skipToTask(1)
+			}
+		} else {
+			if row.project != tl.expanded {
+				tl.expanded = row.project
+				tl.buildRows()
+				// Move cursor to the first task in this project
+				tl.skipToTask(1)
+			}
 		}
-	} else {
-		tl.archiveExpanded = false
-		if row.project != tl.expanded {
-			tl.expanded = row.project
-			tl.buildRows()
-			tl.restoreCursorToTask(row.task)
+	case rowArchiveHeader:
+		tl.archiveExpanded = !tl.archiveExpanded
+		tl.buildRows()
+	case rowTask:
+		inArchive := tl.isInArchive(tl.cursor)
+		if inArchive {
+			tl.archiveExpanded = true
+			if row.project != tl.archiveProject {
+				tl.archiveProject = row.project
+				tl.buildRows()
+				tl.restoreCursorToTask(row.task)
+			}
+		} else {
+			tl.archiveExpanded = false
+			if row.project != tl.expanded {
+				tl.expanded = row.project
+				tl.buildRows()
+				tl.restoreCursorToTask(row.task)
+			}
 		}
 	}
 }

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -130,6 +130,52 @@ func TestGroupByProject(t *testing.T) {
 	}
 }
 
+func TestTaskListView_AutoExpandFirstProject(t *testing.T) {
+	tl := NewTaskListView()
+	// expanded is "" — should auto-expand first project
+	tl.SetTasks(makeTasks())
+
+	if tl.expanded != "alpha" {
+		t.Errorf("expanded = %q, want 'alpha' (first project auto-expanded)", tl.expanded)
+	}
+
+	// Should have task rows visible
+	task := tl.SelectedTask()
+	if task == nil {
+		t.Fatal("cursor should be on a task row after auto-expand")
+	}
+	if task.Project != "alpha" {
+		t.Errorf("selected task project = %q, want 'alpha'", task.Project)
+	}
+}
+
+func TestTaskListView_CursorNavigatesCrossProject(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetTasks(makeTasks())
+
+	// Should start in alpha
+	if tl.expanded != "alpha" {
+		t.Fatalf("expanded = %q, want alpha", tl.expanded)
+	}
+
+	// Navigate down past alpha tasks into beta
+	for i := 0; i < 10; i++ {
+		tl.CursorDown()
+	}
+
+	// Should have auto-expanded beta
+	task := tl.SelectedTask()
+	if task == nil {
+		t.Fatal("cursor should be on a task after navigating down")
+	}
+	if task.Project != "beta" {
+		t.Errorf("after navigating down, project = %q, want 'beta'", task.Project)
+	}
+	if tl.expanded != "beta" {
+		t.Errorf("expanded = %q, want 'beta' after navigating into it", tl.expanded)
+	}
+}
+
 func TestTaskListView_IsInArchive(t *testing.T) {
 	tl := NewTaskListView()
 	tl.archiveExpanded = true


### PR DESCRIPTION
The tcell task list had a deadlock where no project was auto-expanded on initial load, making the entire view non-interactable. Fixes: auto-expand first project in buildRows(), handle project/archive headers in autoExpand(), and allow cursor to land on headers for navigation.

Co-Authored-By: Claude <noreply@anthropic.com>