### PR TITLE
Fix black background by using terminal default color

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -87,6 +87,9 @@ type App struct {
 
 // New creates the tui2 application shell.
 func New(database *db.DB, runner agent.SessionProvider, daemonConnected bool) *App {
+	// Use the terminal's default background instead of tview's hard-coded black.
+	tview.Styles.PrimitiveBackgroundColor = tcell.ColorDefault
+
 	app := &App{
 		tapp:            tview.NewApplication(),
 		db:              database,


### PR DESCRIPTION
Set tview.Styles.PrimitiveBackgroundColor to tcell.ColorDefault so all tview primitives inherit the terminal's background instead of hard-coded black.

Co-Authored-By: Claude <noreply@anthropic.com>