### PR TITLE
Restore three-panel layout for task list view

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -204,4 +204,6 @@
 
 - **tcell has no `KeyCtrlLeft`/`KeyCtrlRight` — use modifier checks.** Panel switching checks `event.Modifiers()&(tcell.ModCtrl|tcell.ModAlt) != 0` on arrow keys. Both Ctrl+arrow and Alt+arrow (macOS Cmd+arrow) work.
 
+- **Task list three-panel layout: tasks | preview | details.** The task list page (`taskPage` in `app.go`) uses a `tview.FlexColumn` with 1:3:1 ratio — `TaskListView` (left), `TaskPreviewPanel` (center), `TaskDetailPanel` (right). `TaskPreviewPanel` (`taskpreview.go`) renders a live terminal snapshot via `xvt.SafeEmulator` using `uvCellToTcellStyle` (same cell painting as `TerminalPane`), falling back to session log file for finished tasks. `TaskDetailPanel` (`taskdetail.go`) shows task metadata (name, status, project, branch, backend, PR URL, worktree, created date, elapsed time, prompt). Both panels update via `OnCursorChange` callback on `TaskListView` (fired from `CursorDown`/`CursorUp`) and from `refreshTasksLocked` to keep data current on ticks.
+
 ## Planned but Not Yet Implemented

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -45,12 +45,14 @@ type App struct {
 	mu     sync.Mutex
 
 	// Sub-views
-	header    *Header
-	statusbar *StatusBar
-	tasklist  *TaskListView
-	agentPane *TerminalPane
-	gitPanel  *GitPanel
-	filePanel *FilePanel
+	header       *Header
+	statusbar    *StatusBar
+	tasklist     *TaskListView
+	taskPreview  *TaskPreviewPanel
+	taskDetail   *TaskDetailPanel
+	agentPane    *TerminalPane
+	gitPanel     *GitPanel
+	filePanel    *FilePanel
 
 	// Reviews and settings tabs
 	reviews  *ReviewsView
@@ -119,6 +121,11 @@ func (a *App) buildUI() {
 	a.tasklist = NewTaskListView()
 	a.tasklist.OnSelect = a.onTaskSelect
 	a.tasklist.OnNew = a.onNewTask
+	a.tasklist.OnCursorChange = a.onTaskCursorChange
+
+	a.taskPreview = NewTaskPreviewPanel()
+	a.taskPreview.SetRunner(a.runner)
+	a.taskDetail = NewTaskDetailPanel()
 
 	a.gitPanel = NewGitPanel()
 	a.filePanel = NewFilePanel()
@@ -128,12 +135,11 @@ func (a *App) buildUI() {
 		go fn()
 	})
 
-	// Task list page
-	taskListCenter := tview.NewFlex().SetDirection(tview.FlexColumn).
-		AddItem(tview.NewBox(), 0, 1, false).
-		AddItem(a.tasklist, 0, 3, true).
-		AddItem(tview.NewBox(), 0, 1, false)
-	a.taskPage = taskListCenter
+	// Task list page — three-panel layout: tasks | preview | details
+	a.taskPage = tview.NewFlex().SetDirection(tview.FlexColumn).
+		AddItem(a.tasklist, 0, 1, true).
+		AddItem(a.taskPreview, 0, 3, false).
+		AddItem(a.taskDetail, 0, 1, false)
 
 	// Agent page — three-panel layout
 	a.agentPage = tview.NewFlex().SetDirection(tview.FlexColumn).
@@ -291,6 +297,7 @@ func (a *App) restartDaemon() {
 		a.daemonClient = newClient
 		a.runner = newClient
 		a.restartedClient = newClient
+		a.taskPreview.SetRunner(newClient)
 		a.mu.Unlock()
 
 		// Reset in-progress tasks to pending, preserving SessionID for resume.
@@ -340,6 +347,18 @@ func (a *App) refreshTasksLocked() {
 	a.tasklist.SetRunning(a.runningIDs)
 	a.statusbar.SetTasks(a.tasks)
 	a.statusbar.SetRunning(a.runningIDs)
+
+	// Keep side panels in sync with cursor
+	if a.mode == modeTaskList {
+		t := a.tasklist.SelectedTask()
+		if t != nil {
+			a.taskPreview.SetTaskID(t.ID)
+			a.taskDetail.SetTask(t, a.isTaskRunning(t.ID))
+		} else {
+			a.taskPreview.SetTaskID("")
+			a.taskDetail.SetTask(nil, false)
+		}
+	}
 }
 
 // handleGlobalKey processes key events at the application level.
@@ -806,6 +825,27 @@ func (a *App) switchTab(t Tab) {
 		a.settings.Refresh()
 		a.pages.SwitchToPage("settings")
 	}
+}
+
+// onTaskCursorChange updates the preview and detail panels when the task list cursor moves.
+func (a *App) onTaskCursorChange(task *model.Task) {
+	if task == nil {
+		a.taskPreview.SetTaskID("")
+		a.taskDetail.SetTask(nil, false)
+		return
+	}
+	a.taskPreview.SetTaskID(task.ID)
+	a.taskDetail.SetTask(task, a.isTaskRunning(task.ID))
+}
+
+// isTaskRunning checks if a task has a running session.
+func (a *App) isTaskRunning(taskID string) bool {
+	for _, id := range a.runningIDs {
+		if id == taskID {
+			return true
+		}
+	}
+	return false
 }
 
 // onTaskSelect handles Enter on a task — enters the agent view.

--- a/internal/tui2/taskdetail.go
+++ b/internal/tui2/taskdetail.go
@@ -1,0 +1,189 @@
+package tui2
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/drn/argus/internal/model"
+)
+
+// TaskDetailPanel displays metadata for the selected task in the right panel.
+type TaskDetailPanel struct {
+	*tview.Box
+	task    *model.Task
+	running bool
+}
+
+// NewTaskDetailPanel creates a task detail panel.
+func NewTaskDetailPanel() *TaskDetailPanel {
+	return &TaskDetailPanel{
+		Box: tview.NewBox(),
+	}
+}
+
+// SetTask updates the displayed task.
+func (td *TaskDetailPanel) SetTask(t *model.Task, running bool) {
+	td.task = t
+	td.running = running
+}
+
+// Draw renders the task detail panel.
+func (td *TaskDetailPanel) Draw(screen tcell.Screen) {
+	td.Box.DrawForSubclass(screen, td)
+	x, y, width, height := td.GetInnerRect()
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	// Draw border
+	drawBorder(screen, x-1, y-1, width+2, height+2, StyleBorder)
+
+	// Title in border
+	title := " Details "
+	for i, r := range title {
+		if x+i < x+width {
+			screen.SetContent(x+i, y-1, r, nil, StyleBorder.Bold(true))
+		}
+	}
+
+	if td.task == nil {
+		drawText(screen, x+1, y+1, width-2, "No task selected", StyleDimmed)
+		return
+	}
+
+	t := td.task
+	innerW := width - 2
+	row := y
+
+	// Task name (title)
+	name := t.Name
+	if len(name) > innerW-1 {
+		name = name[:innerW-4] + "..."
+	}
+	drawText(screen, x+1, row, innerW, name, StyleTitle)
+	row += 2
+
+	// Status
+	statusLabel := t.Status.DisplayName()
+	if t.Status == model.StatusInProgress {
+		if td.running {
+			statusLabel += " (running)"
+		} else {
+			statusLabel += " (idle)"
+		}
+	}
+	statusStyle := td.statusStyle(t.Status)
+	row = td.drawField(screen, x, row, innerW, "Status", statusLabel, statusStyle)
+
+	// Project
+	if t.Project != "" {
+		row = td.drawField(screen, x, row, innerW, "Project", t.Project, StyleNormal)
+	}
+
+	// Branch
+	if t.Branch != "" {
+		row = td.drawField(screen, x, row, innerW, "Branch", t.Branch, StyleNormal)
+	}
+
+	// Backend
+	if t.Backend != "" {
+		row = td.drawField(screen, x, row, innerW, "Backend", t.Backend, StyleNormal)
+	}
+
+	// PR URL
+	if t.PRURL != "" {
+		pr := t.PRURL
+		maxLen := innerW - 5
+		if maxLen > 3 && len(pr) > maxLen {
+			pr = "..." + pr[len(pr)-maxLen+3:]
+		}
+		row = td.drawField(screen, x, row, innerW, "PR", pr, StyleNormal)
+	}
+
+	// Worktree
+	if t.Worktree != "" {
+		wt := t.Worktree
+		maxLen := innerW - 11
+		if maxLen > 3 && len(wt) > maxLen {
+			wt = "..." + wt[len(wt)-maxLen+3:]
+		}
+		row = td.drawField(screen, x, row, innerW, "Worktree", wt, StyleNormal)
+	}
+
+	// Created date
+	if !t.CreatedAt.IsZero() {
+		row = td.drawField(screen, x, row, innerW, "Created", t.CreatedAt.Format(time.DateOnly), StyleNormal)
+	}
+
+	// Elapsed
+	if elapsed := t.ElapsedString(); elapsed != "" {
+		row = td.drawField(screen, x, row, innerW, "Elapsed", elapsed, tcell.StyleDefault.Foreground(ColorElapsed))
+	}
+
+	// Prompt
+	if t.Prompt != "" && row < y+height-1 {
+		row++
+		drawText(screen, x+1, row, innerW, "PROMPT", StyleTitle)
+		row++
+		remaining := y + height - row
+		promptLines := td.wrapText(t.Prompt, innerW-1)
+		for i, line := range promptLines {
+			if i >= remaining {
+				break
+			}
+			drawText(screen, x+1, row, innerW, line, StyleNormal)
+			row++
+		}
+	}
+}
+
+// drawField renders "  Label: Value" and returns the next row.
+func (td *TaskDetailPanel) drawField(screen tcell.Screen, x, row, innerW int, label, value string, valStyle tcell.Style) int {
+	labelStr := fmt.Sprintf("%s: ", label)
+	drawText(screen, x+1, row, len(labelStr), labelStr, StyleDimmed)
+	drawText(screen, x+1+len(labelStr), row, innerW-len(labelStr), value, valStyle)
+	return row + 1
+}
+
+// statusStyle returns the style for a given status.
+func (td *TaskDetailPanel) statusStyle(s model.Status) tcell.Style {
+	switch s {
+	case model.StatusPending:
+		return StylePending
+	case model.StatusInProgress:
+		return StyleInProgress
+	case model.StatusInReview:
+		return StyleInReview
+	case model.StatusComplete:
+		return StyleComplete
+	default:
+		return StyleNormal
+	}
+}
+
+// wrapText wraps text to fit within maxWidth at word boundaries.
+func (td *TaskDetailPanel) wrapText(text string, maxWidth int) []string {
+	if maxWidth <= 0 {
+		return nil
+	}
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return nil
+	}
+	var lines []string
+	line := words[0]
+	for _, w := range words[1:] {
+		if len(line)+1+len(w) > maxWidth {
+			lines = append(lines, line)
+			line = w
+		} else {
+			line += " " + w
+		}
+	}
+	lines = append(lines, line)
+	return lines
+}

--- a/internal/tui2/taskdetail_test.go
+++ b/internal/tui2/taskdetail_test.go
@@ -1,0 +1,83 @@
+package tui2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/drn/argus/internal/model"
+)
+
+func TestTaskDetailPanel_DrawNilTask(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	screen.SetSize(40, 20)
+
+	td := NewTaskDetailPanel()
+	td.SetRect(1, 1, 38, 18)
+	td.Draw(screen)
+	// Should not panic with nil task
+}
+
+func TestTaskDetailPanel_DrawWithTask(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	screen.SetSize(40, 20)
+
+	td := NewTaskDetailPanel()
+	td.SetRect(1, 1, 38, 18)
+
+	task := &model.Task{
+		ID:        "test-1",
+		Name:      "fix-the-bug",
+		Status:    model.StatusInProgress,
+		Project:   "argus",
+		Branch:    "argus/fix-the-bug",
+		Backend:   "claude",
+		Worktree:  "/Users/test/.argus/worktrees/argus/fix-the-bug",
+		Prompt:    "Fix the critical bug in the login flow",
+		CreatedAt: time.Now(),
+	}
+	task.SetStatus(model.StatusInProgress)
+
+	td.SetTask(task, true)
+	td.Draw(screen)
+	// Should render without panic
+}
+
+func TestTaskDetailPanel_ZeroDimensions(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	screen.SetSize(1, 1)
+
+	td := NewTaskDetailPanel()
+	td.SetRect(0, 0, 0, 0)
+	td.Draw(screen) // must not panic
+}
+
+func TestTaskDetailPanel_WrapText(t *testing.T) {
+	td := NewTaskDetailPanel()
+	lines := td.wrapText("the quick brown fox jumps over the lazy dog", 15)
+	if len(lines) < 2 {
+		t.Errorf("expected multiple lines, got %d", len(lines))
+	}
+
+	// Empty text
+	lines = td.wrapText("", 20)
+	if lines != nil {
+		t.Errorf("expected nil for empty text, got %v", lines)
+	}
+
+	// Zero width
+	lines = td.wrapText("hello", 0)
+	if lines != nil {
+		t.Errorf("expected nil for zero width, got %v", lines)
+	}
+}

--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -45,6 +45,8 @@ type TaskListView struct {
 	OnSelect func(task *model.Task)
 	// Callback when user presses 'n' (new task).
 	OnNew func()
+	// Callback when cursor moves to a different task.
+	OnCursorChange func(task *model.Task)
 }
 
 // NewTaskListView creates a task list view.
@@ -207,6 +209,7 @@ func (tl *TaskListView) CursorDown() {
 		tl.cursor = len(tl.rows) - 1
 	}
 	tl.autoExpand()
+	tl.notifyCursorChange()
 }
 
 // CursorUp moves the cursor up. When landing on a project header,
@@ -220,6 +223,14 @@ func (tl *TaskListView) CursorUp() {
 		tl.cursor = 0
 	}
 	tl.autoExpand()
+	tl.notifyCursorChange()
+}
+
+// notifyCursorChange fires the OnCursorChange callback with the current task.
+func (tl *TaskListView) notifyCursorChange() {
+	if tl.OnCursorChange != nil {
+		tl.OnCursorChange(tl.SelectedTask())
+	}
 }
 
 // autoExpand expands the project the cursor is in, collapses others.

--- a/internal/tui2/taskpreview.go
+++ b/internal/tui2/taskpreview.go
@@ -1,0 +1,164 @@
+package tui2
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	xvt "github.com/charmbracelet/x/vt"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/drn/argus/internal/agent"
+)
+
+// TaskPreviewPanel renders a small terminal snapshot of the selected task's agent output.
+type TaskPreviewPanel struct {
+	*tview.Box
+	mu     sync.Mutex
+	runner agent.SessionProvider
+	taskID string
+}
+
+// NewTaskPreviewPanel creates a task preview panel.
+func NewTaskPreviewPanel() *TaskPreviewPanel {
+	return &TaskPreviewPanel{
+		Box: tview.NewBox(),
+	}
+}
+
+// SetRunner sets the session provider for looking up task sessions.
+func (tp *TaskPreviewPanel) SetRunner(runner agent.SessionProvider) {
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+	tp.runner = runner
+}
+
+// SetTaskID sets which task to preview.
+func (tp *TaskPreviewPanel) SetTaskID(id string) {
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+	tp.taskID = id
+}
+
+// Draw renders the preview panel.
+func (tp *TaskPreviewPanel) Draw(screen tcell.Screen) {
+	tp.Box.DrawForSubclass(screen, tp)
+	x, y, width, height := tp.GetInnerRect()
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	// Draw border
+	drawBorder(screen, x-1, y-1, width+2, height+2, StyleBorder)
+
+	// Title in border
+	title := " Preview "
+	for i, r := range title {
+		if x+i < x+width {
+			screen.SetContent(x+i, y-1, r, nil, StyleBorder.Bold(true))
+		}
+	}
+
+	tp.mu.Lock()
+	taskID := tp.taskID
+	runner := tp.runner
+	tp.mu.Unlock()
+
+	if taskID == "" || runner == nil {
+		tp.drawCentered(screen, x, y, width, height, "No task selected")
+		return
+	}
+
+	sess := runner.Get(taskID)
+	if sess == nil {
+		// Try loading from session log file
+		logData := tp.loadSessionLog(taskID)
+		if len(logData) > 0 {
+			tp.renderVTOutput(screen, x, y, width, height, logData)
+			return
+		}
+		tp.drawCentered(screen, x, y, width, height, "No active agent")
+		return
+	}
+
+	raw := sess.RecentOutput()
+	if len(raw) == 0 {
+		tp.drawCentered(screen, x, y, width, height, "Waiting for output...")
+		return
+	}
+
+	tp.renderVTOutput(screen, x, y, width, height, raw)
+}
+
+// renderVTOutput replays raw PTY bytes through x/vt and paints the last h rows to screen.
+func (tp *TaskPreviewPanel) renderVTOutput(screen tcell.Screen, x, y, w, h int, raw []byte) {
+	cols := w
+	rows := h
+	if cols < 10 {
+		cols = 10
+	}
+	if rows < 3 {
+		rows = 3
+	}
+
+	emu := xvt.NewSafeEmulator(cols, rows)
+	emu.Write(raw)
+
+	renderCols := min(cols, w)
+	renderRows := min(rows, h)
+
+	for vy := 0; vy < renderRows; vy++ {
+		for vx := 0; vx < renderCols; vx++ {
+			cell := emu.CellAt(vx, vy)
+			ch := ' '
+			style := tcell.StyleDefault
+			if cell != nil {
+				if cell.Content != "" {
+					runes := []rune(cell.Content)
+					if len(runes) > 0 {
+						ch = runes[0]
+					}
+				}
+				style = uvCellToTcellStyle(cell)
+			}
+			screen.SetContent(x+vx, y+vy, ch, nil, style)
+		}
+	}
+}
+
+// drawCentered renders centered dimmed text in the panel.
+func (tp *TaskPreviewPanel) drawCentered(screen tcell.Screen, x, y, w, h int, msg string) {
+	lines := strings.Split(msg, "\n")
+	startY := y + (h-len(lines))/2
+	for i, line := range lines {
+		row := startY + i
+		if row < y || row >= y+h {
+			continue
+		}
+		startX := x + (w-len(line))/2
+		if startX < x {
+			startX = x
+		}
+		drawText(screen, startX, row, w-(startX-x), line, StyleDimmed)
+	}
+}
+
+// loadSessionLog reads the session log file for a finished task.
+func (tp *TaskPreviewPanel) loadSessionLog(taskID string) []byte {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	logPath := filepath.Join(home, ".argus", "sessions", taskID+".log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return nil
+	}
+	// Only use the last 64KB for preview rendering.
+	if len(data) > 64*1024 {
+		data = data[len(data)-64*1024:]
+	}
+	return data
+}

--- a/internal/tui2/taskpreview_test.go
+++ b/internal/tui2/taskpreview_test.go
@@ -1,0 +1,59 @@
+package tui2
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestTaskPreviewPanel_DrawEmpty(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	screen.SetSize(60, 20)
+
+	tp := NewTaskPreviewPanel()
+	tp.SetRect(1, 1, 58, 18)
+	tp.Draw(screen)
+	// Should render "No task selected" without panic
+}
+
+func TestTaskPreviewPanel_DrawNoSession(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	screen.SetSize(60, 20)
+
+	tp := NewTaskPreviewPanel()
+	tp.SetRect(1, 1, 58, 18)
+	tp.SetTaskID("nonexistent-task")
+	// No runner set — should show "No task selected"
+	tp.Draw(screen)
+}
+
+func TestTaskPreviewPanel_ZeroDimensions(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	screen.SetSize(1, 1)
+
+	tp := NewTaskPreviewPanel()
+	tp.SetRect(0, 0, 0, 0)
+	tp.Draw(screen) // must not panic
+}
+
+func TestTaskPreviewPanel_RenderVTOutput(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	screen.SetSize(40, 10)
+
+	tp := NewTaskPreviewPanel()
+	// Test renderVTOutput with simple text
+	tp.renderVTOutput(screen, 0, 0, 40, 10, []byte("Hello, World!\r\n"))
+	// Should render without panic
+}


### PR DESCRIPTION
Add TaskPreviewPanel (live terminal snapshot via x/vt) and TaskDetailPanel (task metadata) to the tcell task list page, replacing empty placeholder boxes. Wire OnCursorChange callback and tick-based refresh to keep panels in sync.

Co-Authored-By: Claude <noreply@anthropic.com>