### PR TITLE
Style header tab bar with tmux powerline separators

### DIFF
--- a/internal/tui2/header.go
+++ b/internal/tui2/header.go
@@ -19,7 +19,19 @@ const (
 var tabLabels = [...]string{"Tasks", "Reviews", "Settings"}
 var tabKeys = [...]string{"1", "2", "3"}
 
-// Header renders the top tab bar.
+// Powerline separator (right-facing filled chevron).
+const powerlineSep = '\ue0b0'
+
+// Colors matching the tmux status bar palette.
+var (
+	headerBaseBG     = tcell.Color236 // dark bar background (C3)
+	headerActiveBG   = tcell.Color103 // lavender — active segment (C1)
+	headerActiveFG   = tcell.Color236 // dark text on active
+	headerInactiveBG = tcell.Color239 // medium gray — inactive segment (C2)
+	headerInactiveFG = tcell.Color253 // light text on inactive
+)
+
+// Header renders the top tab bar with tmux-style powerline separators.
 type Header struct {
 	*tview.Box
 	activeTab Tab
@@ -44,7 +56,7 @@ func (h *Header) ActiveTab() Tab {
 	return h.activeTab
 }
 
-// Draw renders the tab bar.
+// Draw renders the tab bar with powerline-style segments.
 func (h *Header) Draw(screen tcell.Screen) {
 	h.Box.DrawForSubclass(screen, h)
 	x, y, width, _ := h.GetInnerRect()
@@ -52,42 +64,65 @@ func (h *Header) Draw(screen tcell.Screen) {
 		return
 	}
 
-	// Draw "argus" title
-	titleStyle := tcell.StyleDefault.Foreground(ColorTitle).Bold(true)
-	title := " argus "
-	for i, r := range title {
-		if x+i >= x+width {
-			break
-		}
-		screen.SetContent(x+i, y, r, nil, titleStyle)
+	// Fill entire row with base background
+	baseStyle := tcell.StyleDefault.Background(headerBaseBG)
+	for i := 0; i < width; i++ {
+		screen.SetContent(x+i, y, ' ', nil, baseStyle)
 	}
-	col := x + len(title) + 1
+
+	col := x
+
+	// Draw "argus" segment (always active/C1 style)
+	col = h.drawSegment(screen, col, y, x+width, " argus ", headerActiveBG, headerActiveFG, true)
+
+	// One space gap between title and tabs
+	col++
 
 	// Draw tabs
 	for i, label := range tabLabels {
 		if col >= x+width {
 			break
 		}
-
 		text := fmt.Sprintf(" %s %s ", tabKeys[i], label)
-		var style tcell.Style
 		if Tab(i) == h.activeTab {
-			style = tcell.StyleDefault.Foreground(ColorTitle).Bold(true)
+			col = h.drawSegment(screen, col, y, x+width, text, headerActiveBG, headerActiveFG, true)
 		} else {
-			style = tcell.StyleDefault.Foreground(ColorDimmed)
-		}
-
-		for _, r := range text {
-			if col >= x+width {
-				break
-			}
-			screen.SetContent(col, y, r, nil, style)
-			col++
-		}
-		// Separator
-		if i < len(tabLabels)-1 && col < x+width {
-			screen.SetContent(col, y, '|', nil, tcell.StyleDefault.Foreground(ColorBorder))
-			col++
+			col = h.drawSegment(screen, col, y, x+width, text, headerInactiveBG, headerInactiveFG, false)
 		}
 	}
+}
+
+// drawSegment renders a powerline-style segment: opening chevron, text, closing chevron.
+// Returns the column position after the segment.
+func (h *Header) drawSegment(screen tcell.Screen, col, y, maxCol int, text string, bg, fg tcell.Color, bold bool) int {
+	if col >= maxCol {
+		return col
+	}
+
+	// Opening separator: transition from base → segment
+	sepStyle := tcell.StyleDefault.Foreground(headerBaseBG).Background(bg)
+	screen.SetContent(col, y, powerlineSep, nil, sepStyle)
+	col++
+
+	// Text
+	textStyle := tcell.StyleDefault.Foreground(fg).Background(bg)
+	if bold {
+		textStyle = textStyle.Bold(true)
+	}
+	for _, r := range text {
+		if col >= maxCol {
+			return col
+		}
+		screen.SetContent(col, y, r, nil, textStyle)
+		col++
+	}
+
+	// Closing separator: transition from segment → base
+	if col < maxCol {
+		sepStyle = tcell.StyleDefault.Foreground(bg).Background(headerBaseBG)
+		screen.SetContent(col, y, powerlineSep, nil, sepStyle)
+		col++
+	}
+
+	return col
 }


### PR DESCRIPTION
Replace flat pipe-separated tab labels with powerline-style segments using the same color palette as the tmux status bar (colour103 active, colour239 inactive, colour236 base with chevron transitions).

Co-Authored-By: Claude <noreply@anthropic.com>