### PR TITLE
Fix task start hang from invisible panel PTY sizing

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -1000,18 +1000,18 @@ func (a *App) handleNewTaskKey(event *tcell.EventKey) {
 		a.closeNewTaskForm()
 		a.refreshTasks()
 
-		// Start the agent session
-		a.startAndAttach(task)
+		// Enter agent view FIRST so panel has real dimensions for PTY sizing.
+		a.onTaskSelect(task)
+		a.startSession(task)
 	}
 }
 
-// startAndAttach starts a session for the task and enters agent view.
-func (a *App) startAndAttach(task *model.Task) {
+// startSession starts a session for the current task (agent view must already be active).
+func (a *App) startSession(task *model.Task) {
 	cfg := a.db.Config()
 
-	// Compute PTY size from agent pane dimensions
-	_, _, w, h := a.agentPane.GetInnerRect()
-	rows, cols := uint16(max(h-2, 5)), uint16(max(w-4, 20))
+	// Use reasonable defaults — Draw() will resize to actual panel dimensions.
+	rows, cols := uint16(24), uint16(80)
 
 	resume := task.SessionID != ""
 	sess, err := a.runner.Start(task, cfg, rows, cols, resume)
@@ -1025,7 +1025,8 @@ func (a *App) startAndAttach(task *model.Task) {
 	task.AgentPID = sess.PID()
 	a.db.Update(task)
 
-	a.onTaskSelect(task)
+	// Now that the session exists, attach it to the terminal pane.
+	a.agentPane.SetSession(sess)
 }
 
 func (a *App) closeNewTaskForm() {

--- a/internal/tui2/terminalpane.go
+++ b/internal/tui2/terminalpane.go
@@ -256,6 +256,15 @@ func (tp *TerminalPane) Draw(screen tcell.Screen) {
 	if sess != nil {
 		ptyCols, ptyRows = sess.PTYSize()
 		alive = sess.Alive()
+
+		// Resize PTY to match panel dimensions if they've changed.
+		wantRows := max(height, 5)
+		wantCols := max(width, 20)
+		if alive && (ptyCols != wantCols || ptyRows != wantRows) {
+			sess.Resize(uint16(wantRows), uint16(wantCols))
+			ptyCols, ptyRows = wantCols, wantRows
+		}
+
 		raw = sess.RecentOutput()
 	} else if len(tp.replayData) > 0 {
 		raw = tp.replayData


### PR DESCRIPTION
startAndAttach read panel dimensions before the agent page was visible (0x0 clamped to 5x20). Claude Code can't render in 5x20, producing zero output and leaving the view stuck on 'Waiting for output...' Enter agent view first, start with 80x24 defaults, and add PTY resize in Draw() to sync with actual panel size.

Co-Authored-By: Claude <noreply@anthropic.com>