### PR TITLE
Add diagnostic logging for task start hang debugging

### DIFF
--- a/internal/tui2/terminalpane.go
+++ b/internal/tui2/terminalpane.go
@@ -82,6 +82,11 @@ func NewTerminalPane() *TerminalPane {
 func (tp *TerminalPane) SetSession(sess agentview.TerminalAdapter) {
 	tp.mu.Lock()
 	defer tp.mu.Unlock()
+	if sess != nil {
+		uxlog.Log("[terminalpane] SetSession: sess=%p totalWritten=%d", sess, sess.TotalWritten())
+	} else {
+		uxlog.Log("[terminalpane] SetSession: nil")
+	}
 	tp.session = sess
 	tp.emu = nil
 	tp.emuFedTotal = 0
@@ -272,11 +277,16 @@ func (tp *TerminalPane) Draw(screen tcell.Screen) {
 
 	if len(raw) == 0 {
 		if sess != nil {
+			uxlog.Log("[terminalpane] Draw: sess=%p alive=%v ptyCols=%d ptyRows=%d raw=0 totalWritten=%d",
+				sess, alive, ptyCols, ptyRows, sess.TotalWritten())
 			msg := "Waiting for output..."
 			drawText(screen, x+(width-len(msg))/2, y+height/2, width, msg, StyleDimmed)
 		}
 		return
 	}
+
+	uxlog.Log("[terminalpane] Draw: rendering raw=%d ptyCols=%d ptyRows=%d alive=%v scroll=%d",
+		len(raw), ptyCols, ptyRows, alive, tp.scrollOffset)
 
 	if ptyCols < 20 {
 		ptyCols = width


### PR DESCRIPTION
Log SetSession, Draw() empty-output state, and render params in TerminalPane to diagnose persistent 'Waiting for output...' hangs.

Co-Authored-By: Claude <noreply@anthropic.com>