### PR TITLE
Add left/right arrow tab navigation in root view

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -407,6 +407,22 @@ func (a *App) handleGlobalKey(event *tcell.EventKey) *tcell.EventKey {
 			a.exitAgentView()
 			return nil
 		}
+	case tcell.KeyLeft:
+		if a.mode != modeAgent {
+			cur := a.header.ActiveTab()
+			if cur > TabTasks {
+				a.switchTab(cur - 1)
+			}
+			return nil
+		}
+	case tcell.KeyRight:
+		if a.mode != modeAgent {
+			cur := a.header.ActiveTab()
+			if cur < TabSettings {
+				a.switchTab(cur + 1)
+			}
+			return nil
+		}
 	case tcell.KeyRune:
 		switch event.Rune() {
 		case 'q':

--- a/internal/tui2/app_test.go
+++ b/internal/tui2/app_test.go
@@ -140,6 +140,77 @@ func TestTcellKeyToBytes(t *testing.T) {
 	}
 }
 
+func TestArrowTabNavigation(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false)
+
+	// Start on Tasks tab
+	if app.header.ActiveTab() != TabTasks {
+		t.Fatalf("initial tab = %v, want TabTasks", app.header.ActiveTab())
+	}
+
+	// Right arrow → Reviews
+	ev := tcell.NewEventKey(tcell.KeyRight, 0, 0)
+	result := app.handleGlobalKey(ev)
+	if result != nil {
+		t.Error("right arrow should be consumed (return nil)")
+	}
+	if app.header.ActiveTab() != TabReviews {
+		t.Errorf("tab = %v, want TabReviews", app.header.ActiveTab())
+	}
+
+	// Right arrow → Settings
+	result = app.handleGlobalKey(ev)
+	if app.header.ActiveTab() != TabSettings {
+		t.Errorf("tab = %v, want TabSettings", app.header.ActiveTab())
+	}
+
+	// Right arrow at Settings — stays on Settings (no wrap)
+	result = app.handleGlobalKey(ev)
+	if app.header.ActiveTab() != TabSettings {
+		t.Errorf("tab = %v, want TabSettings (no wrap)", app.header.ActiveTab())
+	}
+
+	// Left arrow → Reviews
+	ev = tcell.NewEventKey(tcell.KeyLeft, 0, 0)
+	result = app.handleGlobalKey(ev)
+	if result != nil {
+		t.Error("left arrow should be consumed")
+	}
+	if app.header.ActiveTab() != TabReviews {
+		t.Errorf("tab = %v, want TabReviews", app.header.ActiveTab())
+	}
+
+	// Left arrow → Tasks
+	result = app.handleGlobalKey(ev)
+	if app.header.ActiveTab() != TabTasks {
+		t.Errorf("tab = %v, want TabTasks", app.header.ActiveTab())
+	}
+
+	// Left arrow at Tasks — stays on Tasks (no wrap)
+	result = app.handleGlobalKey(ev)
+	if app.header.ActiveTab() != TabTasks {
+		t.Errorf("tab = %v, want TabTasks (no wrap)", app.header.ActiveTab())
+	}
+}
+
+func TestArrowsIgnoredInAgentMode(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false)
+
+	app.mode = modeAgent
+	app.agentState.Reset("t1", "test")
+
+	// Right arrow should NOT switch tabs in agent mode
+	ev := tcell.NewEventKey(tcell.KeyRight, 0, 0)
+	app.handleGlobalKey(ev)
+	if app.header.ActiveTab() != TabTasks {
+		t.Errorf("tab changed in agent mode: %v", app.header.ActiveTab())
+	}
+}
+
 // ptySizeForPanel is tested inline below.
 
 func TestRefreshTasks(t *testing.T) {


### PR DESCRIPTION
Allow plain left/right arrow keys to switch between tabs (Tasks, Reviews, Settings) when not in agent mode. Arrows clamp at edges without wrapping.

Co-Authored-By: Claude <noreply@anthropic.com>