### PR TITLE
Show ARGUS banner as empty state when no tasks exist

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -208,4 +208,6 @@
 
 - **Task names with git-invalid characters must be sanitized before branch/dir creation.** `sanitizeBranchName()` in `internal/agent/worktree.go` strips characters forbidden by `git-check-ref-format`: spaces, control chars, `~ ^ : ? * [ ] { } \`, leading/trailing dots, consecutive dots, and `@{`. The sanitized name is used for both the branch (`argus/<safeName>`) and the worktree directory (`~/.argus/worktrees/<project>/<safeName>`). The task's display name (`t.Name`) is set to the sanitized+suffixed `finalName` returned by `CreateWorktree`. Worktree removal uses stored `t.Worktree` paths, not re-derived names, so no mismatch risk. Without sanitization, characters like `?` cause `git worktree add` to fail with exit status 255.
 
+- **Empty task list shows centered banner with hint.** `TaskPage` (`internal/tui2/taskpage.go`) wraps the 3-panel task list layout. When `tasklist.HasTasks()` is false, it draws the banner (reusing `drawBanner` from `banner.go`) centered vertically with "Press [n] to create your first task" below — same pattern as `SettingsPage`. When tasks exist, it delegates to the inner `tview.Flex` normally. `InputHandler` and `MouseHandler` always delegate to the inner flex.
+
 ## Planned but Not Yet Implemented

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -65,7 +65,7 @@ type App struct {
 
 	// Layout containers
 	root      *tview.Flex
-	taskPage  *tview.Flex
+	taskPage  *TaskPage
 	agentPage *tview.Flex
 	pages     *tview.Pages
 
@@ -145,10 +145,11 @@ func (a *App) buildUI() {
 	taskCenter := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(a.taskGitPanel, 0, 3, false).
 		AddItem(a.taskPreview, 0, 7, false)
-	a.taskPage = tview.NewFlex().SetDirection(tview.FlexColumn).
+	taskFlex := tview.NewFlex().SetDirection(tview.FlexColumn).
 		AddItem(a.tasklist, 0, 1, true).
 		AddItem(taskCenter, 0, 3, false).
 		AddItem(a.taskDetail, 0, 1, false)
+	a.taskPage = NewTaskPage(taskFlex, a.tasklist)
 
 	// Agent page — three-panel layout
 	a.agentPage = tview.NewFlex().SetDirection(tview.FlexColumn).

--- a/internal/tui2/taskpage.go
+++ b/internal/tui2/taskpage.go
@@ -1,0 +1,62 @@
+package tui2
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+const emptyHint = "Press [n] to create your first task"
+
+// TaskPage wraps the task list 3-panel layout and shows the banner
+// as an empty state when there are no tasks.
+type TaskPage struct {
+	*tview.Box
+	inner    *tview.Flex // the 3-panel layout
+	tasklist *TaskListView
+}
+
+// NewTaskPage creates a task page wrapping the given layout and task list.
+func NewTaskPage(inner *tview.Flex, tasklist *TaskListView) *TaskPage {
+	return &TaskPage{
+		Box:      tview.NewBox(),
+		inner:    inner,
+		tasklist: tasklist,
+	}
+}
+
+func (tp *TaskPage) Draw(screen tcell.Screen) {
+	tp.Box.DrawForSubclass(screen, tp)
+	x, y, width, height := tp.GetInnerRect()
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	if tp.tasklist.HasTasks() {
+		tp.inner.SetRect(x, y, width, height)
+		tp.inner.Draw(screen)
+		return
+	}
+
+	// Empty state: draw banner centered vertically.
+	bh := bannerHeight()
+	hintRow := 1 // "Press [n]..." line
+	totalH := bh + hintRow
+	topPad := max((height-totalH)/2, 0)
+
+	drawBanner(screen, x, y+topPad, width)
+
+	// Draw hint below the banner.
+	hintY := y + topPad + bh
+	hintPad := max((width-len(emptyHint))/2, 0)
+	drawText(screen, x+hintPad, hintY, width-hintPad, emptyHint, tcell.StyleDefault.Foreground(ColorDimmed))
+}
+
+// Children returns the inner flex for tview focus routing.
+func (tp *TaskPage) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+	return tp.inner.InputHandler()
+}
+
+// MouseHandler delegates to the inner flex.
+func (tp *TaskPage) MouseHandler() func(action tview.MouseAction, event *tcell.EventMouse, setFocus func(p tview.Primitive)) (bool, tview.Primitive) {
+	return tp.inner.MouseHandler()
+}

--- a/internal/tui2/taskpage_test.go
+++ b/internal/tui2/taskpage_test.go
@@ -1,0 +1,104 @@
+package tui2
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/drn/argus/internal/model"
+)
+
+func TestTaskPage_EmptyState(t *testing.T) {
+	tl := NewTaskListView()
+	flex := tview.NewFlex()
+	tp := NewTaskPage(flex, tl)
+
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(120, 40)
+
+	tp.SetRect(0, 0, 120, 40)
+	// Should draw banner + hint without panic.
+	tp.Draw(screen)
+
+	// Verify the hint text is present somewhere on screen.
+	found := screenContains(screen, emptyHint)
+	if !found {
+		t.Error("empty state should render hint text")
+	}
+}
+
+func TestTaskPage_WithTasks(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetTasks([]*model.Task{{ID: "1", Name: "test", Project: "proj"}})
+
+	flex := tview.NewFlex().AddItem(tl, 0, 1, true)
+	tp := NewTaskPage(flex, tl)
+
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(120, 40)
+
+	tp.SetRect(0, 0, 120, 40)
+	// Should draw the inner flex (task list), not the banner.
+	tp.Draw(screen)
+
+	// Hint should NOT be present.
+	if screenContains(screen, emptyHint) {
+		t.Error("task page with tasks should not show empty hint")
+	}
+}
+
+func TestTaskPage_ZeroDimensions(t *testing.T) {
+	tl := NewTaskListView()
+	flex := tview.NewFlex()
+	tp := NewTaskPage(flex, tl)
+
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(1, 1)
+
+	tp.SetRect(0, 0, 0, 0)
+	// Must not panic.
+	tp.Draw(screen)
+}
+
+// screenContains checks if a string appears anywhere on the simulation screen.
+func screenContains(screen tcell.SimulationScreen, needle string) bool {
+	w, h := screen.Size()
+	for row := 0; row < h; row++ {
+		var line []rune
+		for col := 0; col < w; col++ {
+			r, _, _, _ := screen.GetContent(col, row)
+			line = append(line, r)
+		}
+		if containsRunes(line, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsRunes(line []rune, needle string) bool {
+	s := string(line)
+	return len(needle) > 0 && len(s) >= len(needle) && contains(s, needle)
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
TaskPage wraps the 3-panel task list layout and renders the centered banner with a hint when the task list is empty, reusing drawBanner from the settings page.

Co-Authored-By: Claude <noreply@anthropic.com>