### PR TITLE
Fix agent view redraw: remove RPC from Draw, add 200ms loop

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -252,6 +252,11 @@ func (a *App) onTick() {
 	// Update agent pane session
 	if taskID != "" {
 		sess := a.runner.Get(taskID)
+
+		// Sync PTY size from tick goroutine — this does RPC which must not
+		// happen on the tview main goroutine (Draw).
+		a.agentPane.SyncPTYSize()
+
 		a.tapp.QueueUpdateDraw(func() {
 			if sess != nil {
 				a.agentPane.SetSession(sess)
@@ -975,6 +980,11 @@ func (a *App) onTaskSelect(task *model.Task) {
 	if a.worktreeDir != "" {
 		go a.fetchGitStatus(task.ID, a.worktreeDir)
 	}
+
+	// Start continuous redraw loop for existing running sessions.
+	if sess != nil && sess.Alive() {
+		a.startAgentRedrawLoop(task.ID, sess)
+	}
 }
 
 // onNewTask opens the new task form.
@@ -1061,19 +1071,29 @@ func (a *App) startSession(task *model.Task) {
 	// Now that the session exists, attach it to the terminal pane.
 	a.agentPane.SetSession(sess)
 
-	// Fast-poll for initial output. New sessions start with an empty ring buffer
-	// because the agent takes 2-3 seconds to initialize. The 1-second tick is too
-	// slow to catch the first output, so poll every 200ms for up to 10 seconds.
+	a.startAgentRedrawLoop(task.ID, sess)
+}
+
+// startAgentRedrawLoop runs a goroutine that triggers redraws every 200ms
+// while the session is alive and the agent view is active. The 1-second tick
+// is too slow for a live terminal. Self-terminates when the session exits or
+// the user leaves the agent view.
+func (a *App) startAgentRedrawLoop(taskID string, sess agent.SessionHandle) {
 	go func() {
-		for range 50 { // 50 * 200ms = 10 seconds max
+		for {
 			time.Sleep(200 * time.Millisecond)
-			if sess.TotalWritten() > 0 {
+			if !sess.Alive() {
+				// One final redraw to show the finished state.
 				a.tapp.QueueUpdateDraw(func() {})
 				return
 			}
-			if !sess.Alive() {
+			a.mu.Lock()
+			stillViewing := a.mode == modeAgent && a.agentState.TaskID == taskID
+			a.mu.Unlock()
+			if !stillViewing {
 				return
 			}
+			a.tapp.QueueUpdateDraw(func() {})
 		}
 	}()
 }

--- a/internal/tui2/terminalpane.go
+++ b/internal/tui2/terminalpane.go
@@ -42,6 +42,10 @@ type TerminalPane struct {
 	emuCols     int
 	emuRows     int
 
+	// Cached PTY size — updated from tick, never from Draw().
+	ptyCols int
+	ptyRows int
+
 	// Scrollback.
 	scrollOffset int
 
@@ -97,6 +101,17 @@ func (tp *TerminalPane) SetSession(sess agentview.TerminalAdapter) {
 	tp.emu = nil
 	tp.emuFedTotal = 0
 	tp.scrollOffset = 0
+	// Seed PTY size from panel dimensions — SyncPTYSize will refine on next tick.
+	if sess != nil {
+		_, _, w, h := tp.GetInnerRect()
+		if w > 0 && h > 0 {
+			tp.ptyCols = max(w, 20)
+			tp.ptyRows = max(h, 5)
+		} else {
+			tp.ptyCols = 80
+			tp.ptyRows = 24
+		}
+	}
 }
 
 // Session returns the current session (thread-safe).
@@ -133,6 +148,27 @@ func (tp *TerminalPane) loadSessionLog(taskID string) {
 // SetPRURL sets the PR URL for the current task.
 func (tp *TerminalPane) SetPRURL(url string) {
 	tp.taskPR = url
+}
+
+// SyncPTYSize resizes the PTY to match the panel and caches the result.
+// Called from the tick goroutine — RPC calls are safe here (not on UI thread).
+func (tp *TerminalPane) SyncPTYSize() {
+	tp.mu.Lock()
+	sess := tp.session
+	tp.mu.Unlock()
+	if sess == nil || !sess.Alive() {
+		return
+	}
+
+	_, _, width, height := tp.GetInnerRect()
+	wantRows := max(height, 5)
+	wantCols := max(width, 20)
+
+	if tp.ptyCols != wantCols || tp.ptyRows != wantRows {
+		sess.Resize(uint16(wantRows), uint16(wantCols))
+		tp.ptyCols = wantCols
+		tp.ptyRows = wantRows
+	}
 }
 
 // SetFocused sets the focus state for border rendering.
@@ -261,21 +297,14 @@ func (tp *TerminalPane) Draw(screen tcell.Screen) {
 	}
 
 	var raw []byte
-	var ptyCols, ptyRows int
 	alive := false
 
+	// Use cached PTY size — never do RPC in Draw().
+	ptyCols := tp.ptyCols
+	ptyRows := tp.ptyRows
+
 	if sess != nil {
-		ptyCols, ptyRows = sess.PTYSize()
 		alive = sess.Alive()
-
-		// Resize PTY to match panel dimensions if they've changed.
-		wantRows := max(height, 5)
-		wantCols := max(width, 20)
-		if alive && (ptyCols != wantCols || ptyRows != wantRows) {
-			sess.Resize(uint16(wantRows), uint16(wantCols))
-			ptyCols, ptyRows = wantCols, wantRows
-		}
-
 		raw = sess.RecentOutput()
 	} else if len(tp.replayData) > 0 {
 		raw = tp.replayData


### PR DESCRIPTION
Draw() called sess.PTYSize() (RPC) on every frame, blocking the tview main goroutine. Move PTY sync to tick goroutine, cache size on pane, add 200ms continuous redraw loop that self-terminates on session exit or view change.

Co-Authored-By: Claude <noreply@anthropic.com>