### PR TITLE
DRY up cursor highlight logic in settings renderList

### DIFF
--- a/internal/tui2/settings.go
+++ b/internal/tui2/settings.go
@@ -419,13 +419,9 @@ func (sv *SettingsView) renderList(screen tcell.Screen, x, y, w, h int) {
 			style = tcell.StyleDefault.Foreground(ColorTitle).Bold(true)
 		case srWarning:
 			style = tcell.StyleDefault.Foreground(ColorInProgress)
-			if rowIdx == sv.cursor {
-				style = style.Background(ColorHighlight)
-			}
-		default:
-			if rowIdx == sv.cursor {
-				style = style.Background(ColorHighlight)
-			}
+		}
+		if row.kind != srSection && rowIdx == sv.cursor {
+			style = style.Background(ColorHighlight)
 		}
 
 		label := row.label


### PR DESCRIPTION
Extract duplicated cursor highlight check from srWarning and default switch cases into a single post-switch conditional.

Co-Authored-By: Claude <noreply@anthropic.com>