### PR TITLE
Add Logs section to settings tab

### DIFF
--- a/internal/tui2/settings.go
+++ b/internal/tui2/settings.go
@@ -2,6 +2,7 @@ package tui2
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -218,6 +219,11 @@ func (sv *SettingsView) rebuildRows() {
 		kbLabel = "  Enabled"
 	}
 	sv.rows = append(sv.rows, settingsRow{kind: srKB, label: kbLabel, key: "_kb"})
+
+	// Logs section.
+	sv.rows = append(sv.rows, settingsRow{kind: srSection, label: "Logs"})
+	sv.rows = append(sv.rows, settingsRow{kind: srLogs, label: "  UX Log", key: "ux"})
+	sv.rows = append(sv.rows, settingsRow{kind: srLogs, label: "  Daemon Log", key: "daemon"})
 
 	// Clamp cursor.
 	if sv.cursor >= len(sv.rows) {
@@ -459,6 +465,8 @@ func (sv *SettingsView) renderDetail(screen tcell.Screen, x, y, w, h int) {
 		sv.renderBackendDetail(screen, innerX, innerY, innerW, innerH, row)
 	case srKB:
 		sv.renderKBDetail(screen, innerX, innerY, innerW, innerH)
+	case srLogs:
+		sv.renderLogsDetail(screen, innerX, innerY, innerW, innerH, row)
 	}
 }
 
@@ -637,6 +645,56 @@ func (sv *SettingsView) renderKBDetail(screen tcell.Screen, x, y, w, h int) {
 	if r < h {
 		drawText(screen, x, y+r, w, "[enter] toggle KB", StyleDimmed)
 	}
+}
+
+func (sv *SettingsView) renderLogsDetail(screen tcell.Screen, x, y, w, h int, row *settingsRow) {
+	dataDir := db.DataDir()
+	var title, logPath string
+	switch row.key {
+	case "ux":
+		title = "UX Log"
+		logPath = uxlog.Path(dataDir)
+	case "daemon":
+		title = "Daemon Log"
+		logPath = dataDir + "/daemon.log"
+	default:
+		return
+	}
+
+	drawText(screen, x, y, w, title, StyleTitle)
+	drawText(screen, x, y+2, w, logPath, StyleDimmed)
+
+	// Show tail of the log file.
+	lines := tailFile(logPath, h-4)
+	for i, line := range lines {
+		if y+4+i >= y+h {
+			break
+		}
+		if len(line) > w {
+			line = line[:w]
+		}
+		drawText(screen, x, y+4+i, w, line, tcell.StyleDefault)
+	}
+}
+
+// tailFile reads the last n lines from a file.
+func tailFile(path string, n int) []string {
+	if n <= 0 {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return []string{"(file not found)"}
+	}
+	text := strings.TrimRight(string(data), "\n")
+	if text == "" {
+		return []string{"(empty)"}
+	}
+	lines := strings.Split(text, "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return lines
 }
 
 // --- Helpers ---

--- a/internal/tui2/settings_test.go
+++ b/internal/tui2/settings_test.go
@@ -1,6 +1,8 @@
 package tui2
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/drn/argus/internal/config"
@@ -171,5 +173,54 @@ func TestSettingsView_KBToggle(t *testing.T) {
 
 	if sv.kbEnabled == initialKB {
 		t.Error("KB should have toggled")
+	}
+}
+
+func TestSettingsView_LogsSection(t *testing.T) {
+	sv := testSettingsView(t)
+	var logsRows []settingsRow
+	for _, row := range sv.rows {
+		if row.kind == srLogs {
+			logsRows = append(logsRows, row)
+		}
+	}
+	if len(logsRows) != 2 {
+		t.Fatalf("expected 2 log rows, got %d", len(logsRows))
+	}
+	if logsRows[0].key != "ux" {
+		t.Errorf("first log row key = %q, want ux", logsRows[0].key)
+	}
+	if logsRows[1].key != "daemon" {
+		t.Errorf("second log row key = %q, want daemon", logsRows[1].key)
+	}
+}
+
+func TestTailFile(t *testing.T) {
+	// Non-existent file.
+	lines := tailFile("/nonexistent/path", 10)
+	if len(lines) != 1 || lines[0] != "(file not found)" {
+		t.Errorf("expected '(file not found)', got %v", lines)
+	}
+
+	// Write a temp file with known content.
+	f, err := os.CreateTemp(t.TempDir(), "log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range 20 {
+		fmt.Fprintf(f, "line %d\n", i)
+	}
+	f.Close()
+
+	// Tail last 5 lines.
+	lines = tailFile(f.Name(), 5)
+	if len(lines) != 5 {
+		t.Fatalf("expected 5 lines, got %d", len(lines))
+	}
+	if lines[0] != "line 15" {
+		t.Errorf("first tail line = %q, want 'line 15'", lines[0])
+	}
+	if lines[4] != "line 19" {
+		t.Errorf("last tail line = %q, want 'line 19'", lines[4])
 	}
 }


### PR DESCRIPTION
Adds a Logs section with UX Log and Daemon Log rows. Detail panel shows the file path and a tail of recent log lines. Includes tailFile helper and tests.

Co-Authored-By: Claude <noreply@anthropic.com>