### PR TITLE
Add mouse wheel scrolling for settings log viewer

### DIFF
--- a/internal/tui2/settings.go
+++ b/internal/tui2/settings.go
@@ -63,6 +63,11 @@ type SettingsView struct {
 	argusVaultPath string
 	kbTaskSync     bool
 
+	// Logs detail scroll.
+	logScrollOff int
+	logLines     []string // cached lines for current log
+	logKey       string   // which log is cached ("ux" or "daemon")
+
 	// DB reference for toggling values.
 	database *db.DB
 }
@@ -316,6 +321,25 @@ func (sv *SettingsView) HandleKey(ev *tcell.EventKey) bool {
 	return false
 }
 
+// HandleMouse handles mouse events (scroll wheel on logs detail).
+func (sv *SettingsView) HandleMouse(action tview.MouseAction) bool {
+	row := sv.SelectedRow()
+	if row == nil || row.kind != srLogs {
+		return false
+	}
+	switch action {
+	case tview.MouseScrollUp:
+		if sv.logScrollOff > 0 {
+			sv.logScrollOff--
+		}
+		return true
+	case tview.MouseScrollDown:
+		sv.logScrollOff++
+		return true
+	}
+	return false
+}
+
 func (sv *SettingsView) moveCursor(dir int) {
 	sv.cursor += dir
 	if sv.cursor < 0 {
@@ -325,6 +349,12 @@ func (sv *SettingsView) moveCursor(dir int) {
 		sv.cursor = len(sv.rows) - 1
 	}
 	sv.skipToSelectable(dir)
+	// Reset log scroll when leaving a log row or switching logs.
+	if row := sv.SelectedRow(); row == nil || row.kind != srLogs || row.key != sv.logKey {
+		sv.logScrollOff = 0
+		sv.logLines = nil
+		sv.logKey = ""
+	}
 }
 
 func (sv *SettingsView) handleEnter() bool {
@@ -664,12 +694,39 @@ func (sv *SettingsView) renderLogsDetail(screen tcell.Screen, x, y, w, h int, ro
 	drawText(screen, x, y, w, title, StyleTitle)
 	drawText(screen, x, y+2, w, logPath, StyleDimmed)
 
-	// Show tail of the log file.
-	lines := tailFile(logPath, h-4)
-	for i, line := range lines {
-		if y+4+i >= y+h {
+	// Load/cache log lines.
+	if sv.logKey != row.key {
+		sv.logLines = readLogLines(logPath)
+		sv.logKey = row.key
+		// Auto-scroll to bottom on first load.
+		visibleRows := h - 4
+		if len(sv.logLines) > visibleRows {
+			sv.logScrollOff = len(sv.logLines) - visibleRows
+		} else {
+			sv.logScrollOff = 0
+		}
+	}
+
+	// Clamp scroll offset.
+	visibleRows := h - 4
+	if visibleRows <= 0 {
+		return
+	}
+	maxScroll := len(sv.logLines) - visibleRows
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if sv.logScrollOff > maxScroll {
+		sv.logScrollOff = maxScroll
+	}
+
+	// Render visible lines.
+	for i := range visibleRows {
+		lineIdx := sv.logScrollOff + i
+		if lineIdx >= len(sv.logLines) {
 			break
 		}
+		line := sv.logLines[lineIdx]
 		if len(line) > w {
 			line = line[:w]
 		}
@@ -677,11 +734,8 @@ func (sv *SettingsView) renderLogsDetail(screen tcell.Screen, x, y, w, h int, ro
 	}
 }
 
-// tailFile reads the last n lines from a file.
-func tailFile(path string, n int) []string {
-	if n <= 0 {
-		return nil
-	}
+// readLogLines reads all lines from a log file.
+func readLogLines(path string) []string {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return []string{"(file not found)"}
@@ -690,11 +744,7 @@ func tailFile(path string, n int) []string {
 	if text == "" {
 		return []string{"(empty)"}
 	}
-	lines := strings.Split(text, "\n")
-	if len(lines) > n {
-		lines = lines[len(lines)-n:]
-	}
-	return lines
+	return strings.Split(text, "\n")
 }
 
 // --- Helpers ---

--- a/internal/tui2/settings_test.go
+++ b/internal/tui2/settings_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/rivo/tview"
+
 	"github.com/drn/argus/internal/config"
 	"github.com/drn/argus/internal/db"
 )
@@ -195,9 +197,9 @@ func TestSettingsView_LogsSection(t *testing.T) {
 	}
 }
 
-func TestTailFile(t *testing.T) {
+func TestReadLogLines(t *testing.T) {
 	// Non-existent file.
-	lines := tailFile("/nonexistent/path", 10)
+	lines := readLogLines("/nonexistent/path")
 	if len(lines) != 1 || lines[0] != "(file not found)" {
 		t.Errorf("expected '(file not found)', got %v", lines)
 	}
@@ -212,15 +214,77 @@ func TestTailFile(t *testing.T) {
 	}
 	f.Close()
 
-	// Tail last 5 lines.
-	lines = tailFile(f.Name(), 5)
-	if len(lines) != 5 {
-		t.Fatalf("expected 5 lines, got %d", len(lines))
+	lines = readLogLines(f.Name())
+	if len(lines) != 20 {
+		t.Fatalf("expected 20 lines, got %d", len(lines))
 	}
-	if lines[0] != "line 15" {
-		t.Errorf("first tail line = %q, want 'line 15'", lines[0])
+	if lines[0] != "line 0" {
+		t.Errorf("first line = %q, want 'line 0'", lines[0])
 	}
-	if lines[4] != "line 19" {
-		t.Errorf("last tail line = %q, want 'line 19'", lines[4])
+	if lines[19] != "line 19" {
+		t.Errorf("last line = %q, want 'line 19'", lines[19])
+	}
+}
+
+func TestSettingsView_LogScroll(t *testing.T) {
+	sv := testSettingsView(t)
+
+	// Find a log row.
+	for i, row := range sv.rows {
+		if row.kind == srLogs {
+			sv.cursor = i
+			break
+		}
+	}
+
+	// Simulate loading some lines.
+	sv.logLines = make([]string, 100)
+	for i := range sv.logLines {
+		sv.logLines[i] = fmt.Sprintf("line %d", i)
+	}
+	sv.logKey = sv.SelectedRow().key
+	sv.logScrollOff = 50
+
+	// Scroll up.
+	sv.HandleMouse(tview.MouseScrollUp)
+	if sv.logScrollOff != 49 {
+		t.Errorf("scroll up: offset = %d, want 49", sv.logScrollOff)
+	}
+
+	// Scroll down.
+	sv.HandleMouse(tview.MouseScrollDown)
+	if sv.logScrollOff != 50 {
+		t.Errorf("scroll down: offset = %d, want 50", sv.logScrollOff)
+	}
+
+	// Scroll up at 0 stays at 0.
+	sv.logScrollOff = 0
+	sv.HandleMouse(tview.MouseScrollUp)
+	if sv.logScrollOff != 0 {
+		t.Errorf("scroll up at 0: offset = %d, want 0", sv.logScrollOff)
+	}
+}
+
+func TestSettingsView_LogScrollResetOnCursorMove(t *testing.T) {
+	sv := testSettingsView(t)
+
+	// Find a log row and set scroll state.
+	for i, row := range sv.rows {
+		if row.kind == srLogs {
+			sv.cursor = i
+			sv.logScrollOff = 42
+			sv.logKey = row.key
+			sv.logLines = []string{"test"}
+			break
+		}
+	}
+
+	// Move cursor away — should reset scroll.
+	sv.moveCursor(1)
+	if sv.logScrollOff != 0 {
+		t.Errorf("scroll offset not reset after cursor move: %d", sv.logScrollOff)
+	}
+	if sv.logKey != "" {
+		t.Errorf("logKey not cleared: %q", sv.logKey)
 	}
 }

--- a/internal/tui2/settingspage.go
+++ b/internal/tui2/settingspage.go
@@ -53,3 +53,13 @@ func (sp *SettingsPage) Draw(screen tcell.Screen) {
 	sp.settings.SetRect(x+marginW, settingsY, innerW, settingsH)
 	sp.settings.Draw(screen)
 }
+
+// MouseHandler delegates mouse events to the settings view.
+func (sp *SettingsPage) MouseHandler() func(action tview.MouseAction, event *tcell.EventMouse, setFocus func(p tview.Primitive)) (bool, tview.Primitive) {
+	return sp.WrapMouseHandler(func(action tview.MouseAction, event *tcell.EventMouse, setFocus func(p tview.Primitive)) (bool, tview.Primitive) {
+		if sp.settings.HandleMouse(action) {
+			return true, nil
+		}
+		return false, nil
+	})
+}


### PR DESCRIPTION
Logs detail panel now supports mouse wheel scrolling. Auto-scrolls to bottom on first load, resets scroll when navigating away. SettingsPage wires mouse events through to SettingsView.

Co-Authored-By: Claude <noreply@anthropic.com>