### PR TITLE
Add debug logging for tui2 agent view rendering

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -1126,11 +1126,14 @@ func (a *App) startSession(task *model.Task) {
 // is too slow for a live terminal. Self-terminates when the session exits or
 // the user leaves the agent view.
 func (a *App) startAgentRedrawLoop(taskID string, sess agent.SessionHandle) {
+	uxlog.Log("[tui2] startAgentRedrawLoop: taskID=%s sessAlive=%v", taskID, sess.Alive())
 	go func() {
+		iter := 0
 		for {
 			time.Sleep(200 * time.Millisecond)
+			iter++
 			if !sess.Alive() {
-				// One final redraw to show the finished state.
+				uxlog.Log("[tui2] redrawLoop: session dead, exiting iter=%d", iter)
 				a.tapp.QueueUpdateDraw(func() {})
 				return
 			}
@@ -1138,7 +1141,11 @@ func (a *App) startAgentRedrawLoop(taskID string, sess agent.SessionHandle) {
 			stillViewing := a.mode == modeAgent && a.agentState.TaskID == taskID
 			a.mu.Unlock()
 			if !stillViewing {
+				uxlog.Log("[tui2] redrawLoop: no longer viewing, exiting iter=%d", iter)
 				return
+			}
+			if iter <= 10 || iter%50 == 0 {
+				uxlog.Log("[tui2] redrawLoop: iter=%d totalWritten=%d", iter, sess.TotalWritten())
 			}
 			a.tapp.QueueUpdateDraw(func() {})
 		}

--- a/internal/tui2/terminalpane.go
+++ b/internal/tui2/terminalpane.go
@@ -329,9 +329,14 @@ func (tp *TerminalPane) Draw(screen tcell.Screen) {
 		raw = tp.replayData
 	}
 
-	if tp.drawLogCounter%50 == 0 {
-		uxlog.Log("[terminalpane] Draw: sess=%v alive=%v rawLen=%d ptyCols=%d ptyRows=%d panelW=%d panelH=%d scrollOff=%d",
-			sess != nil, alive, len(raw), ptyCols, ptyRows, width, height, tp.scrollOffset)
+	// Log frequently during startup (first 20 draws), then every 50th.
+	if tp.drawLogCounter < 20 || tp.drawLogCounter%50 == 0 {
+		tw := uint64(0)
+		if sess != nil {
+			tw = sess.TotalWritten()
+		}
+		uxlog.Log("[terminalpane] Draw #%d: sess=%v alive=%v rawLen=%d totalWritten=%d ptyCols=%d ptyRows=%d panelW=%d panelH=%d scrollOff=%d",
+			tp.drawLogCounter, sess != nil, alive, len(raw), tw, ptyCols, ptyRows, width, height, tp.scrollOffset)
 	}
 	tp.drawLogCounter++
 


### PR DESCRIPTION
Add startup-phase debug logging to TerminalPane Draw and agent redraw loop to diagnose blank terminal pane issue. Logs Draw call frequency, totalWritten, rawLen, and redraw loop iteration state during first 20 draws and every 50th thereafter.

Co-Authored-By: Claude <noreply@anthropic.com>