### PR TITLE
Fix blank terminal: strip DA/DSR queries that hang x/vt

### DIFF
--- a/internal/tui2/taskpreview.go
+++ b/internal/tui2/taskpreview.go
@@ -85,8 +85,9 @@ func (tp *TaskPreviewPanel) RefreshOutput(raw []byte, cols, rows int) {
 	}
 
 	// Run VT emulation off the UI thread.
+	// Strip terminal query sequences that cause x/vt to hang (DA, DSR).
 	emu := xvt.NewSafeEmulator(cols, rows)
-	emu.Write(raw)
+	emu.Write(stripTerminalQueries(raw))
 
 	grid := make([][]previewCell, rows)
 	for vy := 0; vy < rows; vy++ {

--- a/internal/tui2/terminalpane.go
+++ b/internal/tui2/terminalpane.go
@@ -1,6 +1,7 @@
 package tui2
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,6 +19,83 @@ import (
 	"github.com/drn/argus/internal/app/agentview"
 	"github.com/drn/argus/internal/uxlog"
 )
+
+// stripTerminalQueries removes terminal query sequences that cause x/vt to hang.
+// These are sequences where the terminal application asks the host terminal
+// for information (device attributes, cursor position, etc.). x/vt blocks
+// waiting for a response that never comes since we're not a real terminal.
+//
+// Stripped sequences:
+//   - \x1b[c   (DA1 — Primary Device Attributes)
+//   - \x1b[>c  (DA2 — Secondary Device Attributes)
+//   - \x1b[5n  (DSR — Device Status Report)
+//   - \x1b[6n  (DSR — Cursor Position Report)
+func stripTerminalQueries(data []byte) []byte {
+	// Fast path: no ESC means no queries to strip.
+	if !bytes.ContainsRune(data, 0x1b) {
+		return data
+	}
+
+	out := make([]byte, 0, len(data))
+	i := 0
+	for i < len(data) {
+		if data[i] != 0x1b || i+1 >= len(data) || data[i+1] != '[' {
+			out = append(out, data[i])
+			i++
+			continue
+		}
+
+		// We have ESC[ — scan for the specific query sequences.
+		// Format: ESC [ <optional params> <final byte>
+		j := i + 2 // skip ESC [
+		for j < len(data) && ((data[j] >= '0' && data[j] <= '9') || data[j] == ';' || data[j] == '>' || data[j] == '=') {
+			j++
+		}
+		if j >= len(data) {
+			// Incomplete sequence at end of buffer — keep it.
+			out = append(out, data[i:]...)
+			break
+		}
+
+		seq := data[i : j+1] // full sequence including final byte
+		if isTerminalQuery(seq) {
+			// Skip this sequence entirely.
+			i = j + 1
+			continue
+		}
+
+		// Not a query — keep the byte and advance.
+		out = append(out, data[i])
+		i++
+	}
+	return out
+}
+
+// isTerminalQuery returns true if the sequence is a known terminal query.
+func isTerminalQuery(seq []byte) bool {
+	// Minimum: ESC [ <final> = 3 bytes
+	if len(seq) < 3 || seq[0] != 0x1b || seq[1] != '[' {
+		return false
+	}
+	body := seq[2:]
+	// DA1: ESC [ c  or  ESC [ 0 c
+	if bytes.Equal(body, []byte("c")) || bytes.Equal(body, []byte("0c")) {
+		return true
+	}
+	// DA2: ESC [ > c  or  ESC [ > 0 c
+	if bytes.Equal(body, []byte(">c")) || bytes.Equal(body, []byte(">0c")) {
+		return true
+	}
+	// DSR device status: ESC [ 5 n
+	if bytes.Equal(body, []byte("5n")) {
+		return true
+	}
+	// DSR cursor position: ESC [ 6 n
+	if bytes.Equal(body, []byte("6n")) {
+		return true
+	}
+	return false
+}
 
 // Cursor colors — high-contrast, theme-independent.
 var (
@@ -388,16 +466,19 @@ func (tp *TerminalPane) renderLive(screen tcell.Screen, x, y, w, h int, raw []by
 	if newBytes > uint64(len(raw)) {
 		// Ring buffer wrapped — full reset and replay.
 		tp.emu = xvt.NewSafeEmulator(ptyCols, ptyRows)
-		n, err := tp.emu.Write(raw)
+		clean := stripTerminalQueries(raw)
+		n, err := tp.emu.Write(clean)
 		if tp.drawLogCounter < 20 || tp.drawLogCounter%50 == 1 {
-			uxlog.Log("[terminalpane] renderLive #%d: WRAPPED totalWritten=%d emuFedTotal=%d rawLen=%d wrote=%d err=%v",
-				tp.drawLogCounter, totalWritten, tp.emuFedTotal, len(raw), n, err)
+			uxlog.Log("[terminalpane] renderLive #%d: WRAPPED totalWritten=%d emuFedTotal=%d rawLen=%d clean=%d wrote=%d err=%v",
+				tp.drawLogCounter, totalWritten, tp.emuFedTotal, len(raw), len(clean), n, err)
 		}
 	} else if newBytes > 0 {
-		n, err := tp.emu.Write(raw[len(raw)-int(newBytes):])
+		chunk := raw[len(raw)-int(newBytes):]
+		clean := stripTerminalQueries(chunk)
+		n, err := tp.emu.Write(clean)
 		if tp.drawLogCounter < 20 || tp.drawLogCounter%50 == 1 {
-			uxlog.Log("[terminalpane] renderLive #%d: INCR newBytes=%d rawLen=%d wrote=%d err=%v totalWritten=%d",
-				tp.drawLogCounter, newBytes, len(raw), n, err, totalWritten)
+			uxlog.Log("[terminalpane] renderLive #%d: INCR newBytes=%d rawLen=%d clean=%d wrote=%d err=%v totalWritten=%d",
+				tp.drawLogCounter, newBytes, len(raw), len(clean), n, err, totalWritten)
 		}
 	}
 	if tp.drawLogCounter < 20 {
@@ -412,7 +493,7 @@ func (tp *TerminalPane) renderLive(screen tcell.Screen, x, y, w, h int, raw []by
 // Feeds full buffer into a fresh emulator and uses scrollback for history.
 func (tp *TerminalPane) renderReplay(screen tcell.Screen, x, y, w, h int, raw []byte, ptyCols, ptyRows int) {
 	emu := xvt.NewSafeEmulator(ptyCols, ptyRows)
-	emu.Write(raw)
+	emu.Write(stripTerminalQueries(raw))
 
 	tp.paintEmu(screen, x, y, w, h, emu, ptyCols, ptyRows, tp.scrollOffset == 0)
 }

--- a/internal/tui2/xvt_hang_test.go
+++ b/internal/tui2/xvt_hang_test.go
@@ -1,0 +1,101 @@
+package tui2
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	xvt "github.com/charmbracelet/x/vt"
+)
+
+func TestXVTDAHang(t *testing.T) {
+	sequences := map[string][]byte{
+		"DA1":       []byte("\x1b[c"),
+		"DA2":       []byte("\x1b[>c"),
+		"DA3":       []byte("\x1b[=c"),
+		"XTVERSION": []byte("\x1b[>0q"),
+		"DSR_pos":   []byte("\x1b[6n"),
+		"DSR_dev":   []byte("\x1b[5n"),
+	}
+
+	for name, seq := range sequences {
+		t.Run(name, func(t *testing.T) {
+			done := make(chan struct{})
+			go func() {
+				emu := xvt.NewSafeEmulator(80, 24)
+				emu.Write(seq)
+				close(done)
+			}()
+
+			select {
+			case <-done:
+				t.Logf("%s: OK (no hang)", name)
+			case <-time.After(2 * time.Second):
+				t.Logf("%s: HANG (expected for DA1/DA2/DSR)", name)
+			}
+		})
+	}
+}
+
+func TestStripTerminalQueries(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+		want  []byte
+	}{
+		{"no queries", []byte("hello world"), []byte("hello world")},
+		{"DA1", []byte("before\x1b[cafter"), []byte("beforeafter")},
+		{"DA1 with 0", []byte("before\x1b[0cafter"), []byte("beforeafter")},
+		{"DA2", []byte("before\x1b[>cafter"), []byte("beforeafter")},
+		{"DA2 with 0", []byte("before\x1b[>0cafter"), []byte("beforeafter")},
+		{"DSR5", []byte("before\x1b[5nafter"), []byte("beforeafter")},
+		{"DSR6", []byte("before\x1b[6nafter"), []byte("beforeafter")},
+		{"non-query CSI", []byte("before\x1b[38;5;174mafter"), []byte("before\x1b[38;5;174mafter")},
+		{"multiple queries", []byte("\x1b[c\x1b[6nhello"), []byte("hello")},
+		{"XTVERSION kept", []byte("before\x1b[>0qafter"), []byte("before\x1b[>0qafter")},
+		{"DA3 kept", []byte("before\x1b[=cafter"), []byte("before\x1b[=cafter")},
+		{"empty", []byte{}, []byte{}},
+		{"incomplete ESC at end", []byte("hello\x1b"), []byte("hello\x1b")},
+		{"incomplete CSI at end", []byte("hello\x1b["), []byte("hello\x1b[")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripTerminalQueries(tt.input)
+			if string(got) != string(tt.want) {
+				t.Errorf("stripTerminalQueries(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripTerminalQueriesFixesHang(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	logPath := filepath.Join(home, ".argus", "sessions", "1773949319275631000.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Skipf("session log not found: %v", err)
+	}
+
+	if len(data) > 2300 {
+		data = data[:2300]
+	}
+
+	clean := stripTerminalQueries(data)
+	t.Logf("original: %d bytes, stripped: %d bytes (removed %d)", len(data), len(clean), len(data)-len(clean))
+
+	done := make(chan struct{})
+	go func() {
+		emu := xvt.NewSafeEmulator(192, 84)
+		emu.Write(clean)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Log("Write completed successfully after stripping queries")
+	case <-time.After(5 * time.Second):
+		t.Fatal("HANG: emu.Write still hangs after stripping queries")
+	}
+}


### PR DESCRIPTION
x/vt blocks indefinitely on terminal query sequences (DA1, DA2, DSR) that Claude Code sends to detect capabilities. stripTerminalQueries() removes these before feeding to x/vt. Fixes blank agent view and task preview panel.

Co-Authored-By: Claude <noreply@anthropic.com>