### PR TITLE
Remove debug logging from tui2 blank terminal fix

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -1126,14 +1126,12 @@ func (a *App) startSession(task *model.Task) {
 // is too slow for a live terminal. Self-terminates when the session exits or
 // the user leaves the agent view.
 func (a *App) startAgentRedrawLoop(taskID string, sess agent.SessionHandle) {
-	uxlog.Log("[tui2] startAgentRedrawLoop: taskID=%s sessAlive=%v", taskID, sess.Alive())
+	uxlog.Log("[tui2] startAgentRedrawLoop: taskID=%s", taskID)
 	go func() {
-		iter := 0
 		for {
 			time.Sleep(200 * time.Millisecond)
-			iter++
 			if !sess.Alive() {
-				uxlog.Log("[tui2] redrawLoop: session dead, exiting iter=%d", iter)
+				// One final redraw to show the finished state.
 				a.tapp.QueueUpdateDraw(func() {})
 				return
 			}
@@ -1141,11 +1139,7 @@ func (a *App) startAgentRedrawLoop(taskID string, sess agent.SessionHandle) {
 			stillViewing := a.mode == modeAgent && a.agentState.TaskID == taskID
 			a.mu.Unlock()
 			if !stillViewing {
-				uxlog.Log("[tui2] redrawLoop: no longer viewing, exiting iter=%d", iter)
 				return
-			}
-			if iter <= 10 || iter%50 == 0 {
-				uxlog.Log("[tui2] redrawLoop: iter=%d totalWritten=%d", iter, sess.TotalWritten())
 			}
 			a.tapp.QueueUpdateDraw(func() {})
 		}

--- a/internal/tui2/xvt_hang_test.go
+++ b/internal/tui2/xvt_hang_test.go
@@ -1,42 +1,9 @@
 package tui2
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
-
-	xvt "github.com/charmbracelet/x/vt"
 )
-
-func TestXVTDAHang(t *testing.T) {
-	sequences := map[string][]byte{
-		"DA1":       []byte("\x1b[c"),
-		"DA2":       []byte("\x1b[>c"),
-		"DA3":       []byte("\x1b[=c"),
-		"XTVERSION": []byte("\x1b[>0q"),
-		"DSR_pos":   []byte("\x1b[6n"),
-		"DSR_dev":   []byte("\x1b[5n"),
-	}
-
-	for name, seq := range sequences {
-		t.Run(name, func(t *testing.T) {
-			done := make(chan struct{})
-			go func() {
-				emu := xvt.NewSafeEmulator(80, 24)
-				emu.Write(seq)
-				close(done)
-			}()
-
-			select {
-			case <-done:
-				t.Logf("%s: OK (no hang)", name)
-			case <-time.After(2 * time.Second):
-				t.Logf("%s: HANG (expected for DA1/DA2/DSR)", name)
-			}
-		})
-	}
-}
 
 func TestDrainedEmulatorNoHang(t *testing.T) {
 	sequences := map[string][]byte{
@@ -62,33 +29,5 @@ func TestDrainedEmulatorNoHang(t *testing.T) {
 				t.Fatalf("%s: HANG — drain goroutine did not prevent blocking", name)
 			}
 		})
-	}
-}
-
-func TestDrainedEmulatorWithSessionData(t *testing.T) {
-	home, _ := os.UserHomeDir()
-	logPath := filepath.Join(home, ".argus", "sessions", "1773949319275631000.log")
-	data, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Skipf("session log not found: %v", err)
-	}
-
-	if len(data) > 2300 {
-		data = data[:2300]
-	}
-	t.Logf("feeding %d bytes to drained emulator(192, 84)", len(data))
-
-	done := make(chan struct{})
-	go func() {
-		emu := newDrainedEmulator(192, 84)
-		emu.Write(data)
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		t.Log("Write completed successfully with drained emulator")
-	case <-time.After(5 * time.Second):
-		t.Fatal("HANG: drained emulator still hangs on Claude output")
 	}
 }


### PR DESCRIPTION
Clean up diagnostic iter counters, periodic uxlog calls, and test cases added during the blank terminal investigation. Keeps the regression test for newDrainedEmulator.

Co-Authored-By: Claude <noreply@anthropic.com>