### PR TITLE
Add mouse wheel scrolling to agent view

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -220,4 +220,6 @@
 
 - **`ctrl+d` must exit agent view when session is dead.** When a Claude/Codex session finishes (Ctrl+D sends EOF to the agent), the PTY process exits and `sess.Alive()` returns false. But pressing Ctrl+D again in the agent view did nothing — `tcellKeyToBytes` converts it to `{0x04}` which reaches the "Forward to PTY" block, but with no alive session the key is silently dropped. Fix: in `handleAgentKey`, check for `KeyCtrlD` when `sess == nil || !sess.Alive()` and call `exitAgentView()`. This mirrors the existing `'o'` key guard pattern for dead sessions.
 
+- **`TerminalPane.MouseHandler()` enables mouse wheel scrolling in the agent view.** tview dispatches mouse events via `MouseHandler()` on primitives — the default `Box.MouseHandler()` does nothing with scroll events. `TerminalPane` overrides it using `WrapMouseHandler` (which checks bounds) to handle `tview.MouseScrollUp` and `tview.MouseScrollDown`. In diff mode, scroll events go to `DiffScrollUp`/`DiffScrollDown`; otherwise to `ScrollUp`/`ScrollDown`. Scroll step is 3 lines per wheel tick. `WrapMouseHandler` requires the box to have a valid rect and the event coordinates to be inside it — tests must call `SetRect()` and pass a `tcell.EventMouse` with coordinates inside the rect.
+
 ## Planned but Not Yet Implemented

--- a/internal/tui2/terminalpane.go
+++ b/internal/tui2/terminalpane.go
@@ -94,6 +94,9 @@ const (
 	diffHeader
 )
 
+// mouseScrollStep is the number of lines scrolled per mouse wheel tick.
+const mouseScrollStep = 3
+
 // NewTerminalPane creates a native terminal rendering pane.
 func NewTerminalPane() *TerminalPane {
 	return &TerminalPane{
@@ -223,6 +226,29 @@ func (tp *TerminalPane) ScrollDown(n int) {
 	if tp.scrollOffset < 0 {
 		tp.scrollOffset = 0
 	}
+}
+
+// MouseHandler handles mouse wheel scrolling in the terminal pane.
+func (tp *TerminalPane) MouseHandler() func(action tview.MouseAction, event *tcell.EventMouse, setFocus func(p tview.Primitive)) (bool, tview.Primitive) {
+	return tp.WrapMouseHandler(func(action tview.MouseAction, event *tcell.EventMouse, setFocus func(p tview.Primitive)) (bool, tview.Primitive) {
+		switch action {
+		case tview.MouseScrollUp:
+			if tp.diffMode {
+				tp.DiffScrollUp(mouseScrollStep)
+			} else {
+				tp.ScrollUp(mouseScrollStep)
+			}
+			return true, nil
+		case tview.MouseScrollDown:
+			if tp.diffMode {
+				tp.DiffScrollDown(mouseScrollStep)
+			} else {
+				tp.ScrollDown(mouseScrollStep)
+			}
+			return true, nil
+		}
+		return false, nil
+	})
 }
 
 // --- Diff mode ---

--- a/internal/tui2/terminalpane_test.go
+++ b/internal/tui2/terminalpane_test.go
@@ -8,6 +8,7 @@ import (
 	xvt "github.com/charmbracelet/x/vt"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
 )
 
 func TestTerminalPane_SetSession(t *testing.T) {
@@ -47,6 +48,51 @@ func TestTerminalPane_Scrollback(t *testing.T) {
 	tp.ResetScroll()
 	if tp.ScrollOffset() != 0 {
 		t.Errorf("after reset scrollOffset = %d, want 0", tp.ScrollOffset())
+	}
+}
+
+func TestTerminalPane_MouseScroll(t *testing.T) {
+	tp := NewTerminalPane()
+	tp.SetRect(0, 0, 80, 24)
+	handler := tp.MouseHandler()
+	setFocus := func(p tview.Primitive) {}
+	// Mouse event inside the box.
+	ev := tcell.NewEventMouse(5, 5, tcell.ButtonNone, tcell.ModNone)
+
+	// Scroll up via mouse wheel.
+	consumed, _ := handler(tview.MouseScrollUp, ev, setFocus)
+	if !consumed {
+		t.Error("MouseScrollUp should be consumed")
+	}
+	if tp.ScrollOffset() != 3 {
+		t.Errorf("after scroll up: offset = %d, want 3", tp.ScrollOffset())
+	}
+
+	// Scroll down via mouse wheel.
+	consumed, _ = handler(tview.MouseScrollDown, ev, setFocus)
+	if !consumed {
+		t.Error("MouseScrollDown should be consumed")
+	}
+	if tp.ScrollOffset() != 0 {
+		t.Errorf("after scroll down: offset = %d, want 0", tp.ScrollOffset())
+	}
+
+	// Diff mode scrolling.
+	tp.EnterDiffMode("+line1\n+line2\n context", "test.go")
+	tp.diffScroll = 0
+	consumed, _ = handler(tview.MouseScrollDown, ev, setFocus)
+	if !consumed {
+		t.Error("MouseScrollDown in diff mode should be consumed")
+	}
+	if tp.diffScroll != 3 {
+		t.Errorf("diff scroll after down = %d, want 3", tp.diffScroll)
+	}
+	consumed, _ = handler(tview.MouseScrollUp, ev, setFocus)
+	if !consumed {
+		t.Error("MouseScrollUp in diff mode should be consumed")
+	}
+	if tp.diffScroll != 0 {
+		t.Errorf("diff scroll after up = %d, want 0", tp.diffScroll)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `MouseHandler()` override on `TerminalPane` to handle mouse wheel scroll events
- Routes scroll to terminal scrollback or diff scrollback depending on current mode
- Scroll step of 3 lines per wheel tick (extracted as `mouseScrollStep` constant)

## Test plan
- [x] `TestTerminalPane_MouseScroll` covers both terminal and diff mode scrolling
- [x] All existing tests pass (`go test ./...`)
- [ ] Manual: mouse wheel scrolls terminal output up/down in agent view
- [ ] Manual: mouse wheel scrolls diff content when viewing a file diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)