### PR TITLE
Fix agent view text width smooshed to 80 columns

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -228,4 +228,7 @@
 
 - **In diff mode, Up/Down navigate between files — `j`/`k` scroll the diff.** `handleDiffKey` uses Up/Down arrows to move the file panel cursor (`CursorUp`/`CursorDown`) and immediately call `openFileDiff()` to fetch and display the new file's diff. Diff scrolling uses `j`/`k` (vim-style), `PgUp`/`PgDn`, and mouse scroll wheel. This matches the expected UX where arrow keys switch files while viewing diffs, similar to GitHub's PR review.
 
+- **PTY must be started at actual panel width, not hardcoded 80x24.** TUI agents (Claude Code, Codex) format their initial output for the PTY size at launch and don't reflow existing output on later resize. `startSession` in `internal/tui2/app.go` must query `agentPane.GetInnerRect()` for actual panel dimensions; when that returns zero (before first Draw), fall back to computing from `term.GetSize(os.Stdout)` and the 1:3:1 agent page layout ratio (center panel = 3/5 of terminal width; border is drawn outside the box rect so no deduction needed; height = terminal height minus header and statusbar). `SetSession` in `terminalpane.go` must NOT fall back to 80x24 when `GetInnerRect()` returns zero — leave `ptyCols/ptyRows` at 0 so `Draw()` sets them to match the actual panel width. Additionally, `SyncPTYSize()` runs in the 200ms `startAgentRedrawLoop` (not just the 1-second tick) to minimize the window where the PTY size is stale.
+
+
 ## Planned but Not Yet Implemented

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+	"golang.org/x/term"
 
 	"github.com/drn/argus/internal/agent"
 	"github.com/drn/argus/internal/app/agentview"
@@ -268,9 +269,8 @@ func (a *App) onTick() {
 	if taskID != "" {
 		sess := a.runner.Get(taskID)
 
-		// Sync PTY size from tick goroutine — this does RPC which must not
-		// happen on the tview main goroutine (Draw).
-		a.agentPane.SyncPTYSize()
+		// PTY size sync moved to startAgentRedrawLoop (200ms) for faster
+		// initial resize. The tick no longer calls SyncPTYSize.
 
 		a.tapp.QueueUpdateDraw(func() {
 			if sess != nil {
@@ -1147,8 +1147,31 @@ func (a *App) handleNewTaskKey(event *tcell.EventKey) {
 func (a *App) startSession(task *model.Task) {
 	cfg := a.db.Config()
 
-	// Use reasonable defaults — Draw() will resize to actual panel dimensions.
+	// Use actual panel dimensions so the agent process starts at the correct
+	// width — agents format their initial output for the PTY size at launch,
+	// and existing output isn't reflowed on later resize. GetInnerRect may
+	// return 0 before the first Draw(), so fall back to computing from the
+	// terminal size and the 1:3:1 agent page layout ratio.
 	rows, cols := uint16(24), uint16(80)
+	_, _, pw, ph := a.agentPane.GetInnerRect()
+	if pw > 0 && ph > 0 {
+		cols = uint16(max(pw, 20))
+		rows = uint16(max(ph, 5))
+	} else if tw, th, err := term.GetSize(int(os.Stdout.Fd())); err == nil && tw > 0 && th > 0 {
+		// Agent page is a 1:3:1 flex — center panel gets 3/5 of width.
+		// Border is drawn outside the box rect, so no deduction needed.
+		centerW := tw * 3 / 5
+		if centerW < 20 {
+			centerW = 20
+		}
+		// Height minus header(1) and statusbar(1).
+		centerH := th - 2
+		if centerH < 5 {
+			centerH = 5
+		}
+		cols = uint16(centerW)
+		rows = uint16(centerH)
+	}
 
 	resume := task.SessionID != ""
 	sess, err := a.runner.Start(task, cfg, rows, cols, resume)
@@ -1188,6 +1211,11 @@ func (a *App) startAgentRedrawLoop(taskID string, sess agent.SessionHandle) {
 			if !stillViewing {
 				return
 			}
+			// Sync PTY size on every redraw cycle — the 1-second tick is too
+			// slow and causes the agent to render at the wrong width (e.g., 80
+			// cols) until the first tick fires. This is an RPC call but runs on
+			// the background goroutine, not the tview main goroutine.
+			a.agentPane.SyncPTYSize()
 			a.tapp.QueueUpdateDraw(func() {})
 		}
 	}()

--- a/internal/tui2/terminalpane.go
+++ b/internal/tui2/terminalpane.go
@@ -127,15 +127,17 @@ func (tp *TerminalPane) SetSession(sess agentview.TerminalAdapter) {
 	tp.emu = nil
 	tp.emuFedTotal = 0
 	tp.scrollOffset = 0
-	// Seed PTY size from panel dimensions — SyncPTYSize will refine on next tick.
+	// Seed PTY size from panel dimensions — Draw() will refine on first render.
+	// Do NOT fall back to 80x24 when GetInnerRect returns zero (before first
+	// Draw); leave ptyCols/ptyRows at 0 so Draw() sets them to match the
+	// actual panel width. Falling back to 80 creates a mismatch with the PTY
+	// (which was started at the correct width), causing the emulator to wrap
+	// text at 80 cols even though the agent output is formatted wider.
 	if sess != nil {
 		_, _, w, h := tp.GetInnerRect()
 		if w > 0 && h > 0 {
 			tp.ptyCols = max(w, 20)
 			tp.ptyRows = max(h, 5)
-		} else {
-			tp.ptyCols = 80
-			tp.ptyRows = 24
 		}
 	}
 }

--- a/internal/tui2/terminalpane_test.go
+++ b/internal/tui2/terminalpane_test.go
@@ -30,6 +30,41 @@ func TestTerminalPane_SetSession(t *testing.T) {
 	}
 }
 
+func TestTerminalPane_SetSessionNoFallback(t *testing.T) {
+	// SetSession must NOT hardcode 80x24 — it should use GetInnerRect
+	// dimensions (or leave at 0 if unavailable). The old code had an
+	// explicit fallback to 80x24 which caused emulator/PTY mismatch.
+	tp := NewTerminalPane()
+	sess := &mockAdapter{alive: true, totalWritten: 100, output: make([]byte, 100)}
+	tp.SetSession(sess)
+	tp.mu.Lock()
+	cols, rows := tp.ptyCols, tp.ptyRows
+	tp.mu.Unlock()
+	// Must not be the old hardcoded 80x24 fallback.
+	if cols == 80 && rows == 24 {
+		t.Errorf("SetSession fell back to hardcoded 80x24; should use panel dimensions")
+	}
+}
+
+type mockAdapter struct {
+	alive        bool
+	totalWritten uint64
+	output       []byte
+}
+
+func (m *mockAdapter) WriteInput(p []byte) (int, error) { return len(p), nil }
+func (m *mockAdapter) Resize(rows, cols uint16) error    { return nil }
+func (m *mockAdapter) RecentOutput() []byte              { return m.output }
+func (m *mockAdapter) RecentOutputTail(n int) []byte {
+	if n >= len(m.output) {
+		return m.output
+	}
+	return m.output[len(m.output)-n:]
+}
+func (m *mockAdapter) TotalWritten() uint64          { return m.totalWritten }
+func (m *mockAdapter) Alive() bool                   { return m.alive }
+func (m *mockAdapter) PTYSize() (int, int)           { return 80, 24 }
+
 func TestTerminalPane_Scrollback(t *testing.T) {
 	tp := NewTerminalPane()
 	tp.ScrollUp(5)


### PR DESCRIPTION
## Summary
- Start PTY at actual panel dimensions instead of hardcoded 80x24
- Remove 80x24 fallback in `SetSession` to prevent emulator/PTY width mismatch
- Move `SyncPTYSize` to 200ms redraw loop for faster initial resize

## Test plan
- [ ] Create a new task and verify agent output fills the full center panel width
- [ ] Resize terminal window and verify agent output reflows on new input
- [ ] Verify finished session replay renders at correct width

🤖 Generated with [Claude Code](https://claude.com/claude-code)