### PR TITLE
Restore semantic task naming lost in tui2 migration

### DIFF
--- a/internal/tui2/newtaskform.go
+++ b/internal/tui2/newtaskform.go
@@ -109,12 +109,13 @@ func (f *NewTaskForm) Task() *model.Task {
 		}
 	}
 
+	prompt := strings.TrimSpace(string(f.prompt))
 	return &model.Task{
-		Name:    strings.TrimSpace(string(f.prompt)),
+		Name:    model.GenerateNameFromPrompt(prompt),
 		Status:  model.StatusPending,
 		Project: proj,
 		Branch:  branch,
-		Prompt:  strings.TrimSpace(string(f.prompt)),
+		Prompt:  prompt,
 		Backend: backend,
 	}
 }


### PR DESCRIPTION
The BT→tcell migration passed raw prompt text as task name instead of calling GenerateNameFromPrompt(). This restores the kebab-case slug generation (e.g. fix-auth-token-refresh) that existed in the old Bubble Tea form.

Co-Authored-By: Claude <noreply@anthropic.com>