### PR TITLE
Add daemon restart option to settings tab

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -226,4 +226,6 @@
 
 - **Project headers in the task list show an aggregated status icon with chevron and task count.** `drawProjectRow` in `internal/tui2/tasklist.go` renders: icon + chevron + project name + (count). `projectStatusIcon()` computes the icon from all tasks in that project with priority: in_progress > in_review > all_complete > mixed > all_pending. When all in-progress tasks are idle, shows a moon icon (☾). The `tickEven` field toggles on each tick for icon animation (alternates between ● and ◉ for active in-progress). `refreshTasksWithIDs` in `app.go` passes both `runningIDs` and `idleIDs` from the runner, calling `SetIdle()` and `Tick()` on every refresh cycle.
 
+- **Daemon restart from Settings tab via `srDaemon` row.** When `daemonConnected` is true, the Status section shows a "Restart Daemon" row (`srDaemon` kind). Enter triggers `OnRestartDaemon` callback → `App.restartDaemon()` in a goroutine. During restart, the row label changes to "Restarting..." and Enter is a no-op. `SetDaemonRestarting(false)` is called from `restartDaemon()`'s success and error `QueueUpdateDraw` callbacks to reset the label. The detail panel shows daemon status and `[enter] restart daemon` hint. The row only appears in daemon mode — not in in-process mode.
+
 ## Planned but Not Yet Implemented

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -116,6 +116,12 @@ func New(database *db.DB, runner agent.SessionProvider, daemonConnected bool) *A
 
 	app.settings = NewSettingsView(database)
 	app.settings.SetDaemonConnected(daemonConnected)
+	app.settings.OnRestartDaemon = func() {
+		app.mu.Lock()
+		app.daemonRestarting = true
+		app.mu.Unlock()
+		go app.restartDaemon()
+	}
 	app.settingsPage = NewSettingsPage(app.settings)
 	app.buildUI()
 	app.refreshTasks()
@@ -335,6 +341,7 @@ func (a *App) restartDaemon() {
 			a.daemonRestarting = false
 			a.daemonFailures = 0
 			a.mu.Unlock()
+			a.settings.SetDaemonRestarting(false)
 			a.statusbar.SetError("Daemon restart failed: " + err.Error())
 		})
 		return
@@ -349,6 +356,8 @@ func (a *App) restartDaemon() {
 		a.runner = newClient
 		a.restartedClient = newClient
 		a.mu.Unlock()
+
+		a.settings.SetDaemonRestarting(false)
 
 		// Reset in-progress tasks to pending, preserving SessionID for resume.
 		for _, t := range a.db.Tasks() {

--- a/internal/tui2/settings.go
+++ b/internal/tui2/settings.go
@@ -27,6 +27,7 @@ const (
 	srSandbox
 	srLogs
 	srKB
+	srDaemon
 )
 
 // settingsRow is a single row in the settings section list.
@@ -67,6 +68,13 @@ type SettingsView struct {
 	logScrollOff int
 	logLines     []string // cached lines for current log
 	logKey       string   // which log is cached ("ux" or "daemon")
+
+	// Daemon.
+	daemonConnected  bool
+	daemonRestarting bool
+
+	// Callbacks.
+	OnRestartDaemon func()
 
 	// DB reference for toggling values.
 	database *db.DB
@@ -150,6 +158,7 @@ func (sv *SettingsView) Refresh() {
 }
 
 func (sv *SettingsView) SetDaemonConnected(connected bool) {
+	sv.daemonConnected = connected
 	if !connected {
 		sv.warnings = []string{"Running in-process mode (daemon not connected)"}
 	} else {
@@ -187,6 +196,13 @@ func (sv *SettingsView) rebuildRows() {
 		for i, w := range sv.warnings {
 			sv.rows = append(sv.rows, settingsRow{kind: srWarning, label: "  ⚠ " + w, key: fmt.Sprintf("_warn_%d", i)})
 		}
+	}
+	if sv.daemonConnected {
+		label := "  Restart Daemon"
+		if sv.daemonRestarting {
+			label = "  Restarting..."
+		}
+		sv.rows = append(sv.rows, settingsRow{kind: srDaemon, label: label, key: "_daemon_restart"})
 	}
 
 	// Sandbox section.
@@ -385,6 +401,13 @@ func (sv *SettingsView) handleEnter() bool {
 		uxlog.Log("[settings] KB toggled to %s", val)
 		sv.rebuildRows()
 		return true
+	case srDaemon:
+		if !sv.daemonRestarting && sv.OnRestartDaemon != nil {
+			sv.daemonRestarting = true
+			sv.rebuildRows()
+			sv.OnRestartDaemon()
+		}
+		return true
 	}
 	return false
 }
@@ -497,6 +520,8 @@ func (sv *SettingsView) renderDetail(screen tcell.Screen, x, y, w, h int) {
 		sv.renderKBDetail(screen, innerX, innerY, innerW, innerH)
 	case srLogs:
 		sv.renderLogsDetail(screen, innerX, innerY, innerW, innerH, row)
+	case srDaemon:
+		sv.renderDaemonDetail(screen, innerX, innerY, innerW, innerH)
 	}
 }
 
@@ -675,6 +700,25 @@ func (sv *SettingsView) renderKBDetail(screen tcell.Screen, x, y, w, h int) {
 	if r < h {
 		drawText(screen, x, y+r, w, "[enter] toggle KB", StyleDimmed)
 	}
+}
+
+func (sv *SettingsView) renderDaemonDetail(screen tcell.Screen, x, y, w, h int) {
+	drawText(screen, x, y, w, "Daemon", StyleTitle)
+	r := 2
+
+	if sv.daemonRestarting {
+		drawText(screen, x, y+r, w, "Restarting daemon...", tcell.StyleDefault.Foreground(ColorInProgress))
+	} else {
+		drawText(screen, x, y+r, w, "Daemon is running", tcell.StyleDefault.Foreground(ColorComplete))
+		r += 2
+		drawText(screen, x, y+r, w, "[enter] restart daemon", StyleDimmed)
+	}
+}
+
+// SetDaemonRestarting updates the restarting state from the app.
+func (sv *SettingsView) SetDaemonRestarting(restarting bool) {
+	sv.daemonRestarting = restarting
+	sv.rebuildRows()
 }
 
 func (sv *SettingsView) renderLogsDetail(screen tcell.Screen, x, y, w, h int, row *settingsRow) {

--- a/internal/tui2/settings_test.go
+++ b/internal/tui2/settings_test.go
@@ -265,6 +265,68 @@ func TestSettingsView_LogScroll(t *testing.T) {
 	}
 }
 
+func TestSettingsView_DaemonRestart(t *testing.T) {
+	sv := testSettingsView(t)
+
+	// Not connected — no daemon row.
+	sv.SetDaemonConnected(false)
+	for _, row := range sv.rows {
+		if row.kind == srDaemon {
+			t.Fatal("daemon row should not appear when not connected")
+		}
+	}
+
+	// Connected — daemon row should appear.
+	sv.SetDaemonConnected(true)
+	found := false
+	for _, row := range sv.rows {
+		if row.kind == srDaemon {
+			found = true
+			if row.label != "  Restart Daemon" {
+				t.Errorf("daemon row label = %q, want '  Restart Daemon'", row.label)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("daemon row should appear when connected")
+	}
+
+	// Enter on daemon row fires callback.
+	called := false
+	sv.OnRestartDaemon = func() { called = true }
+	for i, row := range sv.rows {
+		if row.kind == srDaemon {
+			sv.cursor = i
+			break
+		}
+	}
+	sv.handleEnter()
+	if !called {
+		t.Error("OnRestartDaemon should be called on enter")
+	}
+	if !sv.daemonRestarting {
+		t.Error("daemonRestarting should be true after enter")
+	}
+
+	// While restarting, label changes and enter is a no-op.
+	called = false
+	sv.handleEnter()
+	if called {
+		t.Error("OnRestartDaemon should not fire while restarting")
+	}
+	for _, row := range sv.rows {
+		if row.kind == srDaemon && row.label != "  Restarting..." {
+			t.Errorf("daemon row label during restart = %q, want '  Restarting...'", row.label)
+		}
+	}
+
+	// Clear restarting state.
+	sv.SetDaemonRestarting(false)
+	if sv.daemonRestarting {
+		t.Error("daemonRestarting should be false after SetDaemonRestarting(false)")
+	}
+}
+
 func TestSettingsView_LogScrollResetOnCursorMove(t *testing.T) {
 	sv := testSettingsView(t)
 


### PR DESCRIPTION
Shows a 'Restart Daemon' row in the Settings Status section when in daemon mode. Enter triggers restart with visual feedback. Also fixes a pre-existing paintEmu test compile error.

Co-Authored-By: Claude <noreply@anthropic.com>