### PR TITLE
Add 'o' key to open PR in browser from reviews tab

### DIFF
--- a/internal/tui2/reviews.go
+++ b/internal/tui2/reviews.go
@@ -2,6 +2,7 @@ package tui2
 
 import (
 	"fmt"
+	"os/exec"
 	"sort"
 	"strings"
 	"sync"
@@ -299,6 +300,9 @@ func (rv *ReviewsView) handleNormalKey(ev *tcell.EventKey, app *App) bool {
 		case 'k':
 			rv.cursorUp()
 			return true
+		case 'o':
+			rv.openPRInBrowser()
+			return true
 		case 'R':
 			rv.handleRefresh(app)
 			return true
@@ -448,6 +452,21 @@ func (rv *ReviewsView) handleEsc() {
 		rv.focus = rfList
 		return
 	}
+}
+
+func (rv *ReviewsView) openPRInBrowser() {
+	var pr *github.PR
+	if rv.selectedPR != nil {
+		pr = rv.selectedPR
+	} else if rv.prCursor >= 0 && rv.prCursor < len(rv.prs) {
+		pr = &rv.prs[rv.prCursor]
+	}
+	if pr == nil {
+		return
+	}
+	url := fmt.Sprintf("https://github.com/%s/%s/pull/%d", pr.RepoOwner, pr.Repo, pr.Number)
+	exec.Command("open", url).Start() //nolint:errcheck
+	uxlog.Log("[reviews] opened PR #%d in browser: %s", pr.Number, url)
 }
 
 func (rv *ReviewsView) handleRefresh(app *App) {

--- a/internal/tui2/reviews_test.go
+++ b/internal/tui2/reviews_test.go
@@ -227,3 +227,24 @@ func TestReviewsView_BackgroundRefresh(t *testing.T) {
 		t.Errorf("cursor = %d, want 1 (preserved)", rv.prCursor)
 	}
 }
+
+func TestReviewsView_OpenPR_NoPanic(t *testing.T) {
+	rv := NewReviewsView()
+
+	// No PRs — should not panic.
+	rv.openPRInBrowser()
+
+	// With PRs on the list (no selection).
+	rv.SetPRs([]github.PR{
+		{Number: 42, RepoOwner: "acme", Repo: "widgets"},
+	}, nil)
+	rv.prCursor = 0
+	// openPRInBrowser would call exec.Command("open", url).Start()
+	// which is a no-op on CI / headless. Just verify no panic.
+	rv.openPRInBrowser()
+
+	// With a selected PR.
+	pr := rv.prs[0]
+	rv.selectedPR = &pr
+	rv.openPRInBrowser()
+}


### PR DESCRIPTION
Pressing 'o' in the reviews view opens the GitHub PR under the cursor (or the selected PR) in the default web browser. Works from both the PR list and the file/diff view.

Co-Authored-By: Claude <noreply@anthropic.com>