### PR TITLE
Reconcile stale in-progress tasks and fix daemon restart exit wiring

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -228,4 +228,6 @@
 
 - **Daemon restart from Settings tab via `srDaemon` row.** When `daemonConnected` is true, the Status section shows a "Restart Daemon" row (`srDaemon` kind). Enter triggers `OnRestartDaemon` callback → `App.restartDaemon()` in a goroutine. During restart, the row label changes to "Restarting..." and Enter is a no-op. `SetDaemonRestarting(false)` is called from `restartDaemon()`'s success and error `QueueUpdateDraw` callbacks to reset the label. The detail panel shows daemon status and `[enter] restart daemon` hint. The row only appears in daemon mode — not in in-process mode.
 
+- **Stale in-progress tasks are reconciled to complete on every tick (daemon mode only).** `refreshTasksWithIDs` checks all tasks: if `StatusInProgress` but not in the daemon's running set, mark `Complete`. This catches cases where the `handleSessionExitUI` callback didn't fire (daemon restart with stale binary, TUI restart mid-session, stream loss without proper exit). Only runs when `daemonConnected` is true — in-process mode has its own `onFinish` callback. `restartDaemon` also wires `OnSessionExit` on the new client (was previously missing, causing all sessions started after a daemon restart to never fire exit callbacks).
+
 ## Planned but Not Yet Implemented

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -348,6 +348,12 @@ func (a *App) restartDaemon() {
 	}
 
 	uxlog.Log("[tui2] daemon restarted, reconnected")
+
+	// Wire up session exit callback on the new client.
+	newClient.OnSessionExit(func(taskID string, info daemon.ExitInfo) {
+		a.HandleSessionExit(taskID, info)
+	})
+
 	a.tapp.QueueUpdateDraw(func() {
 		a.mu.Lock()
 		a.daemonRestarting = false
@@ -461,6 +467,25 @@ func (a *App) refreshTasks() {
 func (a *App) refreshTasksWithIDs(runningIDs, idleIDs []string) {
 	a.tasks = a.db.Tasks()
 	a.runningIDs = runningIDs
+
+	// Reconcile stale in-progress tasks: if a task is InProgress in the DB
+	// but has no running session, mark it Complete. This handles cases where
+	// the exit callback didn't fire (daemon restart, TUI restart, etc.).
+	// Only reconcile when connected to a daemon — the daemon is the source of
+	// truth for running sessions. In-process mode has its own onFinish callback.
+	if a.daemonConnected {
+		runningSet := make(map[string]bool, len(runningIDs))
+		for _, id := range runningIDs {
+			runningSet[id] = true
+		}
+		for _, t := range a.tasks {
+			if t.Status == model.StatusInProgress && !runningSet[t.ID] {
+				t.SetStatus(model.StatusComplete)
+				a.db.Update(t) //nolint:errcheck
+				uxlog.Log("[tui2] reconciled stale task %s (%s) → complete (no running session)", t.ID, t.Name)
+			}
+		}
+	}
 
 	a.tasklist.SetTasks(a.tasks)
 	a.tasklist.SetRunning(a.runningIDs)
@@ -1217,12 +1242,17 @@ func (a *App) startSession(task *model.Task) {
 	if err != nil {
 		uxlog.Log("[tui2] failed to start session: %v", err)
 		a.statusbar.SetError("Start failed: " + err.Error())
+		// Revert to pending so the task isn't left in a ghost state.
+		task.SetStatus(model.StatusPending)
+		task.SessionID = ""
+		task.StartedAt = time.Time{}
+		a.db.Update(task) //nolint:errcheck
 		return
 	}
 
-	task.Status = model.StatusInProgress
+	task.SetStatus(model.StatusInProgress)
 	task.AgentPID = sess.PID()
-	a.db.Update(task)
+	a.db.Update(task) //nolint:errcheck
 
 	// Now that the session exists, attach it to the terminal pane.
 	a.agentPane.SetSession(sess)


### PR DESCRIPTION
Tasks stuck as in-progress with no running daemon session are now auto-reconciled to complete on each tick. Daemon restart wires OnSessionExit on the new client. startSession reverts to pending on failure.

Co-Authored-By: Claude <noreply@anthropic.com>