### PR TITLE
Hide tab header in agent view and fix new task form

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -1131,6 +1131,8 @@ func (a *App) onTaskSelect(task *model.Task) {
 	a.agentPane.SetFocused(true)
 	a.filePanel.SetFocused(false)
 
+	// Hide the tab header in agent view — only the agent header is shown.
+	a.root.ResizeItem(a.header, 0, 0)
 	a.pages.SwitchToPage("agent")
 	a.tapp.SetFocus(a.agentPane)
 
@@ -1440,6 +1442,8 @@ func (a *App) exitAgentView() {
 	a.agentPane.ExitDiffMode()
 	a.agentPane.ResetVT()
 	a.worktreeDir = ""
+	// Restore the tab header when returning to root views.
+	a.root.ResizeItem(a.header, 1, 0)
 	a.pages.SwitchToPage("tasks")
 	a.tapp.SetFocus(a.tasklist)
 	a.statusbar.ClearError()


### PR DESCRIPTION
Hide the Tasks/Reviews/Settings tab header when in agent view so only the task name header is displayed. Also includes new task form fixes for word wrapping, cursor visibility, and input background.

Co-Authored-By: Claude <noreply@anthropic.com>