### PR TITLE
Restore task status handling lost in tui2 migration

### DIFF
--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -637,5 +637,18 @@ The tui2 migration (Phase 11) ported individual task status icons but dropped:
 - `refreshTasksWithIDs(runningIDs, idleIDs []string)` — signature expanded to accept idle IDs. All three call sites updated: `onTick`, `handleSessionExitUI` goroutine, `refreshTasks`.
 - `handleSessionExitUI` now calls `exitAgentView()` when viewing a completed task's agent pane (not stopped — stopped tasks stay on agent view with cleared session).
 
+### Task Status Handling (2026-03-19)
+
+**Restored pre-tcell behavior for task status transitions and visual feedback:**
+
+- **Stopped agent → InReview**: `handleSessionExitUI` now sets `StatusInReview` (not Pending) when `stopped == true`. Matches the Bubble Tea `determinePostExitStatus` behavior where explicit stop = "needs human review".
+- **Idle+unvisited visual promotion**: `App` struct gains `idleUnvisited` and `viewedWhileAgent` maps. `refreshTasksWithIDs` diffs newly-idle tasks against `TaskListView.IdleSet()` to populate `idleUnvisited`. Entering agent view clears the flag via `onTaskSelect`. `drawTaskRow` renders idleUnvisited InProgress tasks with InReview icon (◎, cyan). `projectStatusIcon` counts them as InReview at project level.
+- **Manual status cycling**: `s`/`S` keys in task list call `Status.Next()`/`Prev()` via `OnStatusChange` callback → `db.Update` + `refreshTasks`.
+- **Task row animation**: `drawTaskRow` now checks `tickEven` for running InProgress tasks, alternating ● and ◉. Idle (visited) tasks show moon (☾). Idle+unvisited show ◎.
+
+**New fields on `TaskListView`**: `idleUnvisited map[string]bool`, `OnStatusChange func(task)`.
+**New methods**: `SetIdleUnvisited(ids)`, `IdleSet() map[string]bool`.
+**New fields on `App`**: `idleUnvisited map[string]bool`, `viewedWhileAgent map[string]bool`.
+
 ### Gotchas
 - Chevron state checks both `tl.expanded` and `tl.archiveProject` — same-named projects in main and archive sections will both show expanded chevrons. Acceptable given the BT code had the same behavior.

--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -230,4 +230,12 @@
 
 - **Stale in-progress tasks are reconciled to complete on every tick (daemon mode only).** `refreshTasksWithIDs` checks all tasks: if `StatusInProgress` but not in the daemon's running set, mark `Complete`. This catches cases where the `handleSessionExitUI` callback didn't fire (daemon restart with stale binary, TUI restart mid-session, stream loss without proper exit). Only runs when `daemonConnected` is true — in-process mode has its own `onFinish` callback. `restartDaemon` also wires `OnSessionExit` on the new client (was previously missing, causing all sessions started after a daemon restart to never fire exit callbacks).
 
+- **Stopped agent → `StatusInReview`, not Pending.** `handleSessionExitUI` in `app.go` sets `StatusInReview` when `stopped == true` (user explicitly stopped the agent). Normal clean exit → `StatusComplete`. This matches the pre-tcell Bubble Tea behavior: stopped means "needs human review", not "reset to pending".
+
+- **Idle+unvisited tasks are visually promoted to InReview in the task list.** `App` tracks `idleUnvisited` and `viewedWhileAgent` maps (same as pre-tcell). When an in-progress task becomes idle and the user hasn't visited its agent view since, `drawTaskRow` renders it with the InReview icon (◎) and cyan style. `projectStatusIcon` also counts these as InReview at the project level. Entering the agent view (`onTaskSelect`) clears the flag. `refreshTasksWithIDs` computes newly-idle tasks by diffing against `IdleSet()` (the previous idle map) and adds them to `idleUnvisited`; tasks no longer idle are removed. `viewedWhileAgent` suppresses false-positive re-adds for tasks the user was watching when they went idle.
+
+- **`s`/`S` keys cycle task status manually.** `s` advances via `Status.Next()`, `S` reverts via `Status.Prev()`. Wired through `OnStatusChange` callback → `db.Update` + `refreshTasks`. This allows manually cycling through all four states: Pending → InProgress → InReview → Complete.
+
+- **Task row icon animates between ● and ◉ for actively running tasks.** `drawTaskRow` checks `tickEven` for InProgress tasks that are running and not idle, alternating the icon on each tick. Idle tasks (visited) show moon (☾). Idle+unvisited show InReview icon (◎). This matches the pre-tcell 4-way branch: idleUnvisited → running/idle → running+tickEven → running+!tickEven.
+
 ## Planned but Not Yet Implemented

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -86,6 +86,10 @@ type App struct {
 	worktreeDir     string // resolved worktree dir for current agent view task
 	lastGitRefresh  time.Time
 
+	// Idle-unvisited tracking (for visual InReview promotion)
+	idleUnvisited    map[string]bool // task IDs idle since user last opened their agent view
+	viewedWhileAgent map[string]bool // tasks viewed in agent view; suppresses idleUnvisited re-add
+
 	// Daemon health
 	daemonFailures   int
 	daemonRestarting bool
@@ -102,12 +106,14 @@ func New(database *db.DB, runner agent.SessionProvider, daemonConnected bool) *A
 	tview.Styles.PrimitiveBackgroundColor = tcell.ColorDefault
 
 	app := &App{
-		tapp:            tview.NewApplication(),
-		db:              database,
-		runner:          runner,
-		daemonConnected: daemonConnected,
-		agentState:      agentview.New(),
-		tickDone:        make(chan struct{}),
+		tapp:             tview.NewApplication(),
+		db:               database,
+		runner:           runner,
+		daemonConnected:  daemonConnected,
+		agentState:       agentview.New(),
+		tickDone:         make(chan struct{}),
+		idleUnvisited:    make(map[string]bool),
+		viewedWhileAgent: make(map[string]bool),
 	}
 
 	if dc, ok := runner.(*dclient.Client); ok {
@@ -138,6 +144,11 @@ func (a *App) buildUI() {
 	a.tasklist.OnSelect = a.onTaskSelect
 	a.tasklist.OnNew = a.onNewTask
 	a.tasklist.OnCursorChange = a.onTaskCursorChange
+	a.tasklist.OnStatusChange = func(t *model.Task) {
+		uxlog.Log("[tui2] manual status change: task %s (%s) → %s", t.ID, t.Name, t.Status)
+		a.db.Update(t) //nolint:errcheck // best-effort; display is source of truth
+		a.refreshTasks()
+	}
 
 	a.taskGitPanel = NewGitPanel()
 	a.taskPreview = NewTaskPreviewPanel()
@@ -414,7 +425,7 @@ func (a *App) handleSessionExitUI(taskID string, stopped bool) {
 	for _, t := range tasks {
 		if t.ID == taskID && t.Status == model.StatusInProgress {
 			if stopped {
-				t.SetStatus(model.StatusPending)
+				t.SetStatus(model.StatusInReview)
 			} else {
 				t.SetStatus(model.StatusComplete)
 			}
@@ -425,7 +436,7 @@ func (a *App) handleSessionExitUI(taskID string, stopped bool) {
 	}
 
 	// If we're viewing this task's agent pane and it completed, navigate back
-	// to the task list. If stopped (reverted to pending), just clear the session.
+	// to the task list. If stopped (set to in-review), just clear the session.
 	a.mu.Lock()
 	viewing := a.mode == modeAgent && a.agentState.TaskID == taskID
 	a.mu.Unlock()
@@ -450,6 +461,17 @@ func (a *App) handleSessionExitUI(taskID string, stopped bool) {
 	}()
 }
 
+// syncIdleUnvisited pushes the current idleUnvisited set to the task list.
+// All access to idleUnvisited/viewedWhileAgent happens on the tview main goroutine
+// (via QueueUpdateDraw or direct calls from InputHandler), so no mutex is needed.
+func (a *App) syncIdleUnvisited() {
+	ids := make([]string, 0, len(a.idleUnvisited))
+	for id := range a.idleUnvisited {
+		ids = append(ids, id)
+	}
+	a.tasklist.SetIdleUnvisited(ids)
+}
+
 func (a *App) refreshTasks() {
 	// Fetch running/idle IDs OUTSIDE the lock — Running()/Idle() are RPC calls
 	// that can block for up to 5s on timeout. Holding a.mu during that blocks
@@ -472,6 +494,8 @@ func (a *App) refreshTasksWithIDs(runningIDs, idleIDs []string) {
 	// the exit callback didn't fire (daemon restart, TUI restart, etc.).
 	// Only reconcile when connected to a daemon — the daemon is the source of
 	// truth for running sessions. In-process mode has its own onFinish callback.
+	// Note: InReview tasks are intentionally non-running (set by handleSessionExitUI
+	// when the user stops an agent) and must NOT be reconciled to Complete.
 	if a.daemonConnected {
 		runningSet := make(map[string]bool, len(runningIDs))
 		for _, id := range runningIDs {
@@ -486,9 +510,38 @@ func (a *App) refreshTasksWithIDs(runningIDs, idleIDs []string) {
 		}
 	}
 
+	// Update idleUnvisited: add newly-idle tasks, remove tasks no longer idle.
+	newIdle := make(map[string]bool, len(idleIDs))
+	for _, id := range idleIDs {
+		newIdle[id] = true
+	}
+	prevIdle := a.tasklist.IdleSet()
+	for id := range newIdle {
+		if !prevIdle[id] {
+			// Newly idle — mark as unvisited until user opens the agent view.
+			a.idleUnvisited[id] = true
+		}
+	}
+	for id := range a.idleUnvisited {
+		if !newIdle[id] {
+			// No longer idle (agent produced output again) — clear unvisited.
+			delete(a.idleUnvisited, id)
+		}
+	}
+	// If the user recently viewed a task's agent view, suppress the
+	// idleUnvisited flag for it. Once the task goes active again (no longer
+	// idle), clear the guard — a new idle transition will re-add to
+	// idleUnvisited fresh.
+	for id := range a.viewedWhileAgent {
+		delete(a.idleUnvisited, id)
+		if !newIdle[id] {
+			delete(a.viewedWhileAgent, id)
+		}
+	}
 	a.tasklist.SetTasks(a.tasks)
 	a.tasklist.SetRunning(a.runningIDs)
 	a.tasklist.SetIdle(idleIDs)
+	a.syncIdleUnvisited()
 	a.tasklist.Tick()
 	a.statusbar.SetTasks(a.tasks)
 	a.statusbar.SetRunning(a.runningIDs)
@@ -1105,6 +1158,12 @@ func (a *App) isTaskRunning(taskID string) bool {
 // onTaskSelect handles Enter on a task — enters the agent view.
 func (a *App) onTaskSelect(task *model.Task) {
 	uxlog.Log("[tui2] entering agent view for task %s (%s)", task.ID, task.Name)
+
+	// User is viewing the agent — clear the "idle unvisited" flag so the task
+	// no longer displays as "in review" in the task list.
+	delete(a.idleUnvisited, task.ID)
+	a.viewedWhileAgent[task.ID] = true
+	a.syncIdleUnvisited()
 
 	a.mu.Lock()
 	a.mode = modeAgent

--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -30,11 +30,12 @@ type taskRow struct {
 // cursor skips headers, archive section at the bottom.
 type TaskListView struct {
 	*tview.Box
-	tasks   []*model.Task
-	rows    []taskRow
-	running map[string]bool
-	idle    map[string]bool
-	tickEven bool // toggles each tick for status icon animation
+	tasks         []*model.Task
+	rows          []taskRow
+	running       map[string]bool
+	idle          map[string]bool
+	idleUnvisited map[string]bool // task IDs idle since user last viewed the agent view
+	tickEven      bool            // toggles each tick for status icon animation
 
 	cursor   int
 	offset   int // scroll offset
@@ -48,14 +49,17 @@ type TaskListView struct {
 	OnNew func()
 	// Callback when cursor moves to a different task.
 	OnCursorChange func(task *model.Task)
+	// Callback when user changes task status via s/S keys.
+	OnStatusChange func(task *model.Task)
 }
 
 // NewTaskListView creates a task list view.
 func NewTaskListView() *TaskListView {
 	tl := &TaskListView{
-		Box:     tview.NewBox(),
-		running: make(map[string]bool),
-		idle:    make(map[string]bool),
+		Box:           tview.NewBox(),
+		running:       make(map[string]bool),
+		idle:          make(map[string]bool),
+		idleUnvisited: make(map[string]bool),
 	}
 	return tl
 }
@@ -80,6 +84,23 @@ func (tl *TaskListView) SetIdle(ids []string) {
 	tl.idle = make(map[string]bool, len(ids))
 	for _, id := range ids {
 		tl.idle[id] = true
+	}
+}
+
+// IdleSet returns a snapshot of the current idle map (for diffing newly-idle tasks).
+func (tl *TaskListView) IdleSet() map[string]bool {
+	cp := make(map[string]bool, len(tl.idle))
+	for id := range tl.idle {
+		cp[id] = true
+	}
+	return cp
+}
+
+// SetIdleUnvisited updates the set of idle+unvisited task IDs.
+func (tl *TaskListView) SetIdleUnvisited(ids []string) {
+	tl.idleUnvisited = make(map[string]bool, len(ids))
+	for _, id := range ids {
+		tl.idleUnvisited[id] = true
 	}
 }
 
@@ -334,6 +355,20 @@ func (tl *TaskListView) InputHandler() func(event *tcell.EventKey, setFocus func
 				if tl.OnNew != nil {
 					tl.OnNew()
 				}
+			case 's':
+				if t := tl.SelectedTask(); t != nil {
+					t.SetStatus(t.Status.Next())
+					if tl.OnStatusChange != nil {
+						tl.OnStatusChange(t)
+					}
+				}
+			case 'S':
+				if t := tl.SelectedTask(); t != nil {
+					t.SetStatus(t.Status.Prev())
+					if tl.OnStatusChange != nil {
+						tl.OnStatusChange(t)
+					}
+				}
 			}
 		}
 	})
@@ -395,9 +430,14 @@ func (tl *TaskListView) projectStatusIcon(tasks []*model.Task) (rune, tcell.Styl
 	for _, t := range tasks {
 		switch t.Status {
 		case model.StatusInProgress:
-			hasInProgress = true
-			if tl.running[t.ID] && !tl.idle[t.ID] {
-				allInProgressIdle = false
+			if tl.idleUnvisited[t.ID] {
+				// Idle+unvisited InProgress tasks count as InReview at project level.
+				hasInReview = true
+			} else {
+				hasInProgress = true
+				if tl.running[t.ID] && !tl.idle[t.ID] {
+					allInProgressIdle = false
+				}
 			}
 		case model.StatusInReview:
 			hasInReview = true
@@ -492,14 +532,21 @@ func (tl *TaskListView) drawTaskRow(screen tcell.Screen, x, y, w int, task *mode
 		statusChar = '○'
 		statusStyle = StylePending
 	case model.StatusInProgress:
-		if tl.running[task.ID] {
-			statusChar = '●'
+		if tl.idleUnvisited[task.ID] {
+			// Idle and not yet viewed since going idle — show as in-review.
+			statusChar = '◎'
+			statusStyle = StyleInReview
+		} else if !tl.running[task.ID] || tl.idle[task.ID] {
+			// Session absent or idle (waiting for input) — moon icon.
+			statusChar = '☾'
 			statusStyle = StyleInProgress
-		} else if tl.idle[task.ID] {
+		} else if tl.tickEven {
+			// Actively running — animated alternate frame.
 			statusChar = '◉'
-			statusStyle = tcell.StyleDefault.Foreground(tcell.Color78) // green
+			statusStyle = StyleInProgress
 		} else {
-			statusChar = '◉'
+			// Actively running — animated default frame.
+			statusChar = '●'
 			statusStyle = StyleInProgress
 		}
 	case model.StatusInReview:

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -3,6 +3,9 @@ package tui2
 import (
 	"testing"
 
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
 	"github.com/drn/argus/internal/model"
 )
 
@@ -298,5 +301,113 @@ func TestTaskListView_IsInArchive(t *testing.T) {
 	// Rows at or after archive header should be in archive
 	if !tl.isInArchive(archiveIdx) {
 		t.Error("archive header row should be in archive")
+	}
+}
+
+func TestTaskListView_SetIdleUnvisited(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetIdleUnvisited([]string{"1", "3"})
+	if !tl.idleUnvisited["1"] {
+		t.Error("task 1 should be idle-unvisited")
+	}
+	if tl.idleUnvisited["2"] {
+		t.Error("task 2 should not be idle-unvisited")
+	}
+	if !tl.idleUnvisited["3"] {
+		t.Error("task 3 should be idle-unvisited")
+	}
+}
+
+func TestTaskListView_IdleSet(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetIdle([]string{"a", "b"})
+	s := tl.IdleSet()
+	if !s["a"] || !s["b"] {
+		t.Error("IdleSet should return the current idle map")
+	}
+}
+
+func TestTaskListView_IdleUnvisitedPromotion(t *testing.T) {
+	tl := NewTaskListView()
+	tasks := []*model.Task{
+		{ID: "1", Status: model.StatusInProgress, Project: "p"},
+	}
+	tl.idleUnvisited = map[string]bool{"1": true}
+	tl.running = map[string]bool{"1": true}
+	tl.idle = map[string]bool{"1": true}
+	tl.tickEven = false
+
+	// Project icon should be InReview (◎) when the only InProgress task is idleUnvisited.
+	icon, _ := tl.projectStatusIcon(tasks)
+	if icon != '◎' {
+		t.Errorf("projectStatusIcon with idleUnvisited = %c, want ◎", icon)
+	}
+}
+
+func TestTaskListView_StatusCycleKeys(t *testing.T) {
+	tl := NewTaskListView()
+	var changed *model.Task
+	tl.OnStatusChange = func(task *model.Task) {
+		changed = task
+	}
+	tl.SetTasks([]*model.Task{
+		{ID: "1", Name: "task1", Status: model.StatusPending, Project: "p"},
+	})
+	tl.expanded = "p"
+	tl.buildRows()
+	// Move cursor to the task row (skip project header).
+	tl.CursorDown()
+
+	// Press 's' to advance status: Pending -> InProgress
+	handler := tl.InputHandler()
+	handler(tcell.NewEventKey(tcell.KeyRune, 's', tcell.ModNone), func(tview.Primitive) {})
+	if changed == nil {
+		t.Fatal("OnStatusChange should have been called")
+	}
+	if changed.Status != model.StatusInProgress {
+		t.Errorf("after 's': status = %v, want InProgress", changed.Status)
+	}
+
+	// Press 's' again: InProgress -> InReview
+	changed = nil
+	handler(tcell.NewEventKey(tcell.KeyRune, 's', tcell.ModNone), func(tview.Primitive) {})
+	if changed == nil {
+		t.Fatal("OnStatusChange should have been called")
+	}
+	if changed.Status != model.StatusInReview {
+		t.Errorf("after second 's': status = %v, want InReview", changed.Status)
+	}
+
+	// Press 'S' to revert: InReview -> InProgress
+	changed = nil
+	handler(tcell.NewEventKey(tcell.KeyRune, 'S', tcell.ModNone), func(tview.Primitive) {})
+	if changed == nil {
+		t.Fatal("OnStatusChange should have been called")
+	}
+	if changed.Status != model.StatusInProgress {
+		t.Errorf("after 'S': status = %v, want InProgress", changed.Status)
+	}
+}
+
+func TestTaskListView_RunningTaskAnimation(t *testing.T) {
+	tl := NewTaskListView()
+	tasks := []*model.Task{
+		{ID: "1", Status: model.StatusInProgress, Project: "p"},
+	}
+	tl.running = map[string]bool{"1": true}
+	tl.idle = map[string]bool{}
+
+	// tickEven=false: running task at project level should show ●
+	tl.tickEven = false
+	icon, _ := tl.projectStatusIcon(tasks)
+	if icon != '●' {
+		t.Errorf("tickEven=false: got %c, want ●", icon)
+	}
+
+	// tickEven=true: running task at project level should show ◉
+	tl.tickEven = true
+	icon, _ = tl.projectStatusIcon(tasks)
+	if icon != '◉' {
+		t.Errorf("tickEven=true: got %c, want ◉", icon)
 	}
 }


### PR DESCRIPTION
## Summary
- Stopped agent now transitions to **InReview** (was incorrectly going to Pending)
- Idle+unvisited tasks are visually promoted to InReview in the task list (display-only, not persisted)
- `s`/`S` keys cycle task status manually (Pending → InProgress → InReview → Complete)
- Task row icons animate between ● and ◉ for actively running tasks via `tickEven`

## Test plan
- [ ] Stop a running agent — verify task shows InReview status (◎ cyan icon)
- [ ] Let an agent go idle without visiting it — verify it shows ◎ icon
- [ ] Enter the agent view for an idle+unvisited task — verify icon reverts to moon (☾)
- [ ] Press `s` on a pending task — verify it cycles through all 4 states
- [ ] Press `S` to cycle backward
- [ ] Verify running tasks animate (icon alternates between ● and ◉ each second)
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)