### PR TITLE
Prevent entering agent view for completed tasks

### DIFF
--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -672,3 +672,12 @@ Three visual fixes to the `NewTaskForm` modal:
 ### Gotchas
 - `cursorWrappedPos` can no longer use division — must iterate `wrapPrompt` result. This means `wrapPrompt` is called more often (once per cursor position query), but the prompt is small so this is negligible.
 - Word wrap includes trailing space on the broken line (e.g., "hello " not "hello"). This keeps cursor positions contiguous across the prompt rune slice with no gaps.
+
+## Enter Guard on Completed Tasks: 2026-03-19
+
+### Flow
+- `TaskListView.InputHandler()` in `tasklist.go` checks `t.Status != model.StatusComplete` before calling `OnSelect`
+- Single-line guard — no new types, fields, or DB changes
+
+### Gotchas
+- The guard is on the tasklist side, not `onTaskSelect` — so any programmatic calls to `onTaskSelect` (e.g., from new task form) are unaffected

--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -238,4 +238,6 @@
 
 - **Task row icon animates between ● and ◉ for actively running tasks.** `drawTaskRow` checks `tickEven` for InProgress tasks that are running and not idle, alternating the icon on each tick. Idle tasks (visited) show moon (☾). Idle+unvisited show InReview icon (◎). This matches the pre-tcell 4-way branch: idleUnvisited → running/idle → running+tickEven → running+!tickEven.
 
+- **Enter on a completed task in the task list is a no-op.** The `InputHandler` in `tasklist.go` guards `OnSelect` with `t.Status != model.StatusComplete`. Completed tasks can still be viewed via other means but pressing Enter won't re-enter the agent view for them. This prevents accidentally re-entering a finished task.
+
 ## Planned but Not Yet Implemented

--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -342,7 +342,7 @@ func (tl *TaskListView) InputHandler() func(event *tcell.EventKey, setFocus func
 		case tcell.KeyDown:
 			tl.CursorDown()
 		case tcell.KeyEnter:
-			if t := tl.SelectedTask(); t != nil && tl.OnSelect != nil {
+			if t := tl.SelectedTask(); t != nil && t.Status != model.StatusComplete && tl.OnSelect != nil {
 				tl.OnSelect(t)
 			}
 		case tcell.KeyRune:

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -3,10 +3,9 @@ package tui2
 import (
 	"testing"
 
+	"github.com/drn/argus/internal/model"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
-
-	"github.com/drn/argus/internal/model"
 )
 
 func makeTasks() []*model.Task {
@@ -272,6 +271,41 @@ func TestTaskListView_ProjectStatusIcon(t *testing.T) {
 				t.Errorf("projectStatusIcon() = %c, want %c", icon, tt.wantChar)
 			}
 		})
+	}
+}
+
+func TestTaskListView_EnterSkipsCompleted(t *testing.T) {
+	tl := NewTaskListView()
+	tl.expanded = "beta"
+	tl.SetTasks([]*model.Task{
+		{ID: "1", Name: "done-task", Project: "beta", Status: model.StatusComplete},
+		{ID: "2", Name: "active-task", Project: "beta", Status: model.StatusInProgress},
+	})
+
+	var selected *model.Task
+	tl.OnSelect = func(task *model.Task) { selected = task }
+
+	// Navigate to the completed task
+	for tl.SelectedTask() == nil || tl.SelectedTask().Status != model.StatusComplete {
+		tl.CursorDown()
+	}
+
+	// Enter on completed task should NOT fire OnSelect
+	handler := tl.InputHandler()
+	handler(tcell.NewEventKey(tcell.KeyEnter, 0, 0), func(p tview.Primitive) {})
+	if selected != nil {
+		t.Error("Enter on completed task should not fire OnSelect")
+	}
+
+	// Navigate to the in-progress task
+	for tl.SelectedTask() == nil || tl.SelectedTask().Status != model.StatusInProgress {
+		tl.CursorDown()
+	}
+
+	// Enter on in-progress task should fire OnSelect
+	handler(tcell.NewEventKey(tcell.KeyEnter, 0, 0), func(p tview.Primitive) {})
+	if selected == nil || selected.ID != "2" {
+		t.Error("Enter on in-progress task should fire OnSelect")
 	}
 }
 


### PR DESCRIPTION
Enter on a completed task in the task list is now a no-op, preventing accidental re-entry into finished agent sessions.

Co-Authored-By: Claude <noreply@anthropic.com>