### PR TITLE
Fix test that opens browser on every test run

### DIFF
--- a/internal/tui2/reviews.go
+++ b/internal/tui2/reviews.go
@@ -454,7 +454,8 @@ func (rv *ReviewsView) handleEsc() {
 	}
 }
 
-func (rv *ReviewsView) openPRInBrowser() {
+// prURL returns the GitHub URL for the currently selected/cursored PR, or "".
+func (rv *ReviewsView) prURL() string {
 	var pr *github.PR
 	if rv.selectedPR != nil {
 		pr = rv.selectedPR
@@ -462,11 +463,18 @@ func (rv *ReviewsView) openPRInBrowser() {
 		pr = &rv.prs[rv.prCursor]
 	}
 	if pr == nil {
+		return ""
+	}
+	return fmt.Sprintf("https://github.com/%s/%s/pull/%d", pr.RepoOwner, pr.Repo, pr.Number)
+}
+
+func (rv *ReviewsView) openPRInBrowser() {
+	url := rv.prURL()
+	if url == "" {
 		return
 	}
-	url := fmt.Sprintf("https://github.com/%s/%s/pull/%d", pr.RepoOwner, pr.Repo, pr.Number)
 	exec.Command("open", url).Start() //nolint:errcheck
-	uxlog.Log("[reviews] opened PR #%d in browser: %s", pr.Number, url)
+	uxlog.Log("[reviews] opened PR in browser: %s", url)
 }
 
 func (rv *ReviewsView) handleRefresh(app *App) {

--- a/internal/tui2/reviews_test.go
+++ b/internal/tui2/reviews_test.go
@@ -228,23 +228,27 @@ func TestReviewsView_BackgroundRefresh(t *testing.T) {
 	}
 }
 
-func TestReviewsView_OpenPR_NoPanic(t *testing.T) {
+func TestReviewsView_PRURL(t *testing.T) {
 	rv := NewReviewsView()
 
-	// No PRs — should not panic.
-	rv.openPRInBrowser()
+	// No PRs — empty URL.
+	if got := rv.prURL(); got != "" {
+		t.Errorf("expected empty URL with no PRs, got %q", got)
+	}
 
 	// With PRs on the list (no selection).
 	rv.SetPRs([]github.PR{
 		{Number: 42, RepoOwner: "acme", Repo: "widgets"},
 	}, nil)
 	rv.prCursor = 0
-	// openPRInBrowser would call exec.Command("open", url).Start()
-	// which is a no-op on CI / headless. Just verify no panic.
-	rv.openPRInBrowser()
+	if got := rv.prURL(); got != "https://github.com/acme/widgets/pull/42" {
+		t.Errorf("unexpected URL from cursor: %q", got)
+	}
 
 	// With a selected PR.
 	pr := rv.prs[0]
 	rv.selectedPR = &pr
-	rv.openPRInBrowser()
+	if got := rv.prURL(); got != "https://github.com/acme/widgets/pull/42" {
+		t.Errorf("unexpected URL from selection: %q", got)
+	}
 }


### PR DESCRIPTION
Extract `prURL()` from `openPRInBrowser()` so the reviews test asserts the URL string instead of shelling out to `open`, which opened a real browser tab on macOS every time `go test` ran.

Co-Authored-By: Claude <noreply@anthropic.com>