### PR TITLE
Wire up project and backend forms in settings tab

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -240,4 +240,6 @@
 
 - **Enter on a completed task in the task list is a no-op.** The `InputHandler` in `tasklist.go` guards `OnSelect` with `t.Status != model.StatusComplete`. Completed tasks can still be viewed via other means but pressing Enter won't re-enter the agent view for them. This prevents accidentally re-entering a finished task.
 
+- **Settings tab `n`/`e` keys open project/backend forms as modal overlays.** `SettingsView.HandleKey` dispatches `n` and `e` based on `currentSection()` — the row kind at the cursor. For project rows: `OnNewProject`/`OnEditProject` callbacks; for backend rows: `OnNewBackend`/`OnEditBackend`. The `App` wires these to `openProjectForm`/`openBackendForm` which use the same modal pattern as `modeNewTask` and `modeConfirmDelete`: set mode → `pages.AddPage` → `SwitchToPage` → `SetFocus`. Form key events are intercepted in `handleGlobalKey` before any other routing. On submit, the form validates (name and path/command non-empty), calls `db.SetProject`/`db.SetBackend`, refreshes settings, and returns to the settings page. On cancel (Esc), the form is dismissed. The `done` flag must be reset to `false` on validation failure to allow re-submission.
+
 ## Planned but Not Yet Implemented

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -30,6 +30,8 @@ const (
 	modeAgent
 	modeNewTask
 	modeConfirmDelete
+	modeProjectForm
+	modeBackendForm
 )
 
 // agentFocus tracks which panel has focus in the agent view.
@@ -69,6 +71,10 @@ type App struct {
 
 	// Confirm delete modal (created on demand)
 	confirmDeleteModal *ConfirmDeleteModal
+
+	// Settings forms (created on demand)
+	projectForm *ProjectForm
+	backendForm *BackendForm
 
 	// Layout containers
 	root      *tview.Flex
@@ -128,6 +134,10 @@ func New(database *db.DB, runner agent.SessionProvider, daemonConnected bool) *A
 		app.mu.Unlock()
 		go app.restartDaemon()
 	}
+	app.settings.OnNewProject = func() { app.openProjectForm(false, "", config.Project{}) }
+	app.settings.OnEditProject = func(name string, p config.Project) { app.openProjectForm(true, name, p) }
+	app.settings.OnNewBackend = func() { app.openBackendForm(false, "", config.Backend{}) }
+	app.settings.OnEditBackend = func(name string, b config.Backend) { app.openBackendForm(true, name, b) }
 	app.settingsPage = NewSettingsPage(app.settings)
 	app.buildUI()
 	app.refreshTasks()
@@ -570,6 +580,18 @@ func (a *App) handleGlobalKey(event *tcell.EventKey) *tcell.EventKey {
 	// Confirm delete modal — delegate everything to the modal
 	if a.mode == modeConfirmDelete && a.confirmDeleteModal != nil {
 		a.handleConfirmDeleteKey(event)
+		return nil
+	}
+
+	// Project form mode — delegate everything to the form
+	if a.mode == modeProjectForm && a.projectForm != nil {
+		a.handleProjectFormKey(event)
+		return nil
+	}
+
+	// Backend form mode — delegate everything to the form
+	if a.mode == modeBackendForm && a.backendForm != nil {
+		a.handleBackendFormKey(event)
 		return nil
 	}
 
@@ -1392,6 +1414,110 @@ func (a *App) closeConfirmDelete() {
 	a.pages.RemovePage("confirmdelete")
 	a.pages.SwitchToPage("tasks")
 	a.tapp.SetFocus(a.tasklist)
+}
+
+// --- Project form ---
+
+func (a *App) openProjectForm(edit bool, name string, p config.Project) {
+	a.projectForm = NewProjectForm()
+	if edit {
+		a.projectForm.LoadProject(name, p)
+	}
+	a.mode = modeProjectForm
+	a.pages.AddPage("projectform", a.projectForm, true, true)
+	a.pages.SwitchToPage("projectform")
+	a.tapp.SetFocus(a.projectForm)
+}
+
+func (a *App) handleProjectFormKey(event *tcell.EventKey) {
+	a.projectForm.HandleKey(event)
+
+	if a.projectForm.Canceled() {
+		a.closeProjectForm()
+		return
+	}
+
+	if a.projectForm.Done() {
+		name, proj := a.projectForm.Result()
+		if name == "" {
+			a.projectForm.SetError("Name cannot be empty")
+			a.projectForm.done = false
+			return
+		}
+		if proj.Path == "" {
+			a.projectForm.SetError("Path cannot be empty")
+			a.projectForm.done = false
+			return
+		}
+		if err := a.db.SetProject(name, proj); err != nil {
+			a.projectForm.SetError("Save error: " + err.Error())
+			a.projectForm.done = false
+			return
+		}
+		uxlog.Log("[settings] saved project %s (path=%s, branch=%s)", name, proj.Path, proj.Branch)
+		a.closeProjectForm()
+	}
+}
+
+func (a *App) closeProjectForm() {
+	a.mode = modeTaskList
+	a.projectForm = nil
+	a.pages.RemovePage("projectform")
+	a.settings.Refresh()
+	a.pages.SwitchToPage("settings")
+	a.tapp.SetFocus(a.settingsPage)
+}
+
+// --- Backend form ---
+
+func (a *App) openBackendForm(edit bool, name string, b config.Backend) {
+	a.backendForm = NewBackendForm()
+	if edit {
+		a.backendForm.LoadBackend(name, b)
+	}
+	a.mode = modeBackendForm
+	a.pages.AddPage("backendform", a.backendForm, true, true)
+	a.pages.SwitchToPage("backendform")
+	a.tapp.SetFocus(a.backendForm)
+}
+
+func (a *App) handleBackendFormKey(event *tcell.EventKey) {
+	a.backendForm.HandleKey(event)
+
+	if a.backendForm.Canceled() {
+		a.closeBackendForm()
+		return
+	}
+
+	if a.backendForm.Done() {
+		name, backend := a.backendForm.Result()
+		if name == "" {
+			a.backendForm.SetError("Name cannot be empty")
+			a.backendForm.done = false
+			return
+		}
+		if backend.Command == "" {
+			a.backendForm.SetError("Command cannot be empty")
+			a.backendForm.done = false
+			return
+		}
+		if err := a.db.SetBackend(name, backend); err != nil {
+			a.backendForm.SetError("Save error: " + err.Error())
+			a.backendForm.done = false
+			return
+		}
+		uxlog.Log("[settings] saved backend %s (cmd=%s)", name, backend.Command)
+		a.closeBackendForm()
+	}
+}
+
+func (a *App) closeBackendForm() {
+	a.mode = modeTaskList
+	a.backendForm = nil
+	a.pages.RemovePage("backendform")
+	a.settings.Refresh()
+	a.pages.SwitchToPage("settings")
+	a.tapp.SetFocus(a.settingsPage)
 }
 
 // deleteTask stops the agent, cleans up the worktree/branch, and removes the task from DB.

--- a/internal/tui2/settings.go
+++ b/internal/tui2/settings.go
@@ -75,6 +75,10 @@ type SettingsView struct {
 
 	// Callbacks.
 	OnRestartDaemon func()
+	OnNewProject    func()
+	OnEditProject   func(name string, p config.Project)
+	OnNewBackend    func()
+	OnEditBackend   func(name string, b config.Backend)
 
 	// DB reference for toggling values.
 	database *db.DB
@@ -332,6 +336,10 @@ func (sv *SettingsView) HandleKey(ev *tcell.EventKey) bool {
 			return true
 		case 'd':
 			return sv.handleSetDefault()
+		case 'n':
+			return sv.handleNew()
+		case 'e':
+			return sv.handleEdit()
 		}
 	}
 	return false
@@ -422,6 +430,46 @@ func (sv *SettingsView) handleSetDefault() bool {
 	uxlog.Log("[settings] default backend set to %s", be.Name)
 	sv.rebuildRows()
 	return true
+}
+
+// currentSection returns the section kind for the currently selected row.
+func (sv *SettingsView) currentSection() settingsRowKind {
+	if sv.cursor < 0 || sv.cursor >= len(sv.rows) {
+		return srSection
+	}
+	return sv.rows[sv.cursor].kind
+}
+
+func (sv *SettingsView) handleNew() bool {
+	switch sv.currentSection() {
+	case srProject:
+		if sv.OnNewProject != nil {
+			sv.OnNewProject()
+			return true
+		}
+	case srBackend:
+		if sv.OnNewBackend != nil {
+			sv.OnNewBackend()
+			return true
+		}
+	}
+	return false
+}
+
+func (sv *SettingsView) handleEdit() bool {
+	switch sv.currentSection() {
+	case srProject:
+		if pe := sv.SelectedProject(); pe != nil && sv.OnEditProject != nil {
+			sv.OnEditProject(pe.Name, pe.Project)
+			return true
+		}
+	case srBackend:
+		if be := sv.SelectedBackend(); be != nil && sv.OnEditBackend != nil {
+			sv.OnEditBackend(be.Name, be.Backend)
+			return true
+		}
+	}
+	return false
 }
 
 // --- Draw ---
@@ -622,6 +670,10 @@ func (sv *SettingsView) renderProjectDetail(screen tcell.Screen, x, y, w, h int,
 			drawText(screen, x, y+r, w, fmt.Sprintf("  %d%% complete", pct), StyleDimmed)
 		}
 	}
+
+	if h > 2 {
+		drawText(screen, x, y+h-1, w, "[n] new  [e] edit", StyleDimmed)
+	}
 }
 
 func (sv *SettingsView) renderBackendDetail(screen tcell.Screen, x, y, w, h int, row *settingsRow) {
@@ -650,9 +702,9 @@ func (sv *SettingsView) renderBackendDetail(screen tcell.Screen, x, y, w, h int,
 	drawText(screen, x, y+r, w, "  Prompt Flag: "+be.Backend.PromptFlag, StyleDimmed)
 	r += 2
 
-	hints := "[d] set as default"
+	hints := "[d] set as default  [n] new  [e] edit"
 	if be.Name == sv.defaultBackend {
-		hints = "(already default)"
+		hints = "(already default)  [n] new  [e] edit"
 	}
 	if r < h {
 		drawText(screen, x, y+r, w, hints, StyleDimmed)

--- a/internal/tui2/settings_test.go
+++ b/internal/tui2/settings_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 
 	"github.com/drn/argus/internal/config"
@@ -348,5 +349,121 @@ func TestSettingsView_LogScrollResetOnCursorMove(t *testing.T) {
 	}
 	if sv.logKey != "" {
 		t.Errorf("logKey not cleared: %q", sv.logKey)
+	}
+}
+
+func TestSettingsView_NewProjectCallback(t *testing.T) {
+	database, _ := db.OpenInMemory()
+	database.SetProject("test-proj", config.Project{Path: "/tmp/test", Branch: "main"})
+	sv := NewSettingsView(database)
+	sv.Refresh()
+
+	// Move cursor to a project row.
+	for i, row := range sv.rows {
+		if row.kind == srProject {
+			sv.cursor = i
+			break
+		}
+	}
+
+	called := false
+	sv.OnNewProject = func() { called = true }
+
+	ev := tcell.NewEventKey(tcell.KeyRune, 'n', 0)
+	handled := sv.HandleKey(ev)
+	if !handled {
+		t.Error("'n' key should be handled on project row")
+	}
+	if !called {
+		t.Error("OnNewProject callback not fired")
+	}
+}
+
+func TestSettingsView_EditProjectCallback(t *testing.T) {
+	database, _ := db.OpenInMemory()
+	database.SetProject("test-proj", config.Project{Path: "/tmp/test", Branch: "main"})
+	sv := NewSettingsView(database)
+	sv.Refresh()
+
+	// Move cursor to a project row.
+	for i, row := range sv.rows {
+		if row.kind == srProject && row.key == "test-proj" {
+			sv.cursor = i
+			break
+		}
+	}
+
+	var gotName string
+	sv.OnEditProject = func(name string, p config.Project) { gotName = name }
+
+	ev := tcell.NewEventKey(tcell.KeyRune, 'e', 0)
+	handled := sv.HandleKey(ev)
+	if !handled {
+		t.Error("'e' key should be handled on project row")
+	}
+	if gotName != "test-proj" {
+		t.Errorf("OnEditProject got name %q, want test-proj", gotName)
+	}
+}
+
+func TestSettingsView_NewBackendCallback(t *testing.T) {
+	sv := testSettingsView(t)
+
+	// Move cursor to a backend row.
+	for i, row := range sv.rows {
+		if row.kind == srBackend {
+			sv.cursor = i
+			break
+		}
+	}
+
+	called := false
+	sv.OnNewBackend = func() { called = true }
+
+	ev := tcell.NewEventKey(tcell.KeyRune, 'n', 0)
+	handled := sv.HandleKey(ev)
+	if !handled {
+		t.Error("'n' key should be handled on backend row")
+	}
+	if !called {
+		t.Error("OnNewBackend callback not fired")
+	}
+}
+
+func TestSettingsView_EditBackendCallback(t *testing.T) {
+	sv := testSettingsView(t)
+
+	// Move cursor to a backend row.
+	for i, row := range sv.rows {
+		if row.kind == srBackend {
+			sv.cursor = i
+			break
+		}
+	}
+
+	var gotName string
+	sv.OnEditBackend = func(name string, b config.Backend) { gotName = name }
+
+	ev := tcell.NewEventKey(tcell.KeyRune, 'e', 0)
+	handled := sv.HandleKey(ev)
+	if !handled {
+		t.Error("'e' key should be handled on backend row")
+	}
+	if gotName == "" {
+		t.Error("OnEditBackend callback not fired or got empty name")
+	}
+}
+
+func TestSettingsView_NKeyOnNonProjectRow(t *testing.T) {
+	sv := testSettingsView(t)
+
+	// Cursor should be on a non-project row (e.g., warning/status).
+	sv.OnNewProject = func() { t.Error("OnNewProject should not fire on non-project row") }
+	sv.OnNewBackend = func() { t.Error("OnNewBackend should not fire on non-backend row") }
+
+	ev := tcell.NewEventKey(tcell.KeyRune, 'n', 0)
+	handled := sv.HandleKey(ev)
+	if handled {
+		t.Error("'n' should not be handled on non-project/backend row")
 	}
 }


### PR DESCRIPTION
Connect n/e keys in the Settings tab to open ProjectForm/BackendForm modals for creating and editing projects and backends. Adds callbacks, modal lifecycle, validation, key hints in detail panels, and tests.

Co-Authored-By: Claude <noreply@anthropic.com>