### PR TITLE
Reimplement task list navigation with header skipping and archive toggle

### DIFF
--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -17,3 +17,4 @@ Which context files are captured in knowledge:
 | context/research/daemon-lifecycle-flows.md | code-quality.md (Daemon Cleanup Race section) | All startup/shutdown/restart flows, goroutine ordering, race analysis |
 | context/research/terminal-runtime-notes.md | key-learnings.md (tui2 entries) | Library evaluation (tcell, tview, x/vt), migration complete |
 | context/plans/2026-03-18-terminal-passthrough-plan.md | key-learnings.md (tui2 entries), code-quality.md (Phase 2 section) | All phases complete: tcell/tview runtime is sole UI |
+| context/knowledge/reference-bt-migration.md | reference-bt-migration.md | Pre-tcell BT reference commit (5b8d560), old file listing |

--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -81,6 +81,7 @@
 - `context/knowledge/index.md` is the knowledge graph index — read it when you need project history or domain context
 - `context/research/` holds investigation notes and spike results
 - `context/plans/` holds strategic plans and proposals
+- **All project memories go in `context/knowledge/`** (checked into repo), NOT in `~/.claude/projects/.../memory/`. This ensures memories are versioned, visible in worktrees, and shared across branches.
 
 - **`git worktree add` requires a valid local ref or remote-tracking ref as the start point.** If the project config stores just `"master"` but the repo only has `origin/master` (no local branch), `git worktree add -b argus/task <path> master` fails with `fatal: not a valid object name: 'master'`. `resolveStartPoint()` in `worktree.go` resolves this by checking `git rev-parse --verify` and falling back to `upstream/<branch>` then `origin/<branch>`. The new project form also auto-detects the remote default branch (preferring `upstream` over `origin`) when the user enters a repo path, so new projects get the full ref like `upstream/master` by default.
 

--- a/context/knowledge/reference-bt-migration.md
+++ b/context/knowledge/reference-bt-migration.md
@@ -1,0 +1,15 @@
+## Pre-tcell Bubble Tea Reference Commit
+
+The last commit before the tcell/tview migration is `5b8d560`. The old Bubble Tea UI lived in `internal/ui/` and was deleted in commit `4f7ae62` (Phase 11: Delete Bubble Tea runtime).
+
+To view old implementations: `git show 5b8d560:internal/ui/<file>`
+
+Key old files:
+- `internal/ui/tasklist.go` — task list with navigation, archive, auto-expand
+- `internal/ui/root.go` — key bindings, callbacks, app-level wiring
+- `internal/ui/newtask.go` — new task form with autocomplete
+- `internal/ui/agentpane.go` — agent view
+- `internal/ui/wordboundary.go` — word navigation helpers
+- `internal/ui/worktree.go` — worktree cleanup helpers
+
+When checking for missing functionality from the old UI, diff or read files at this commit to see the original behavior.

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -159,6 +159,11 @@ func (a *App) buildUI() {
 		a.db.Update(t) //nolint:errcheck // best-effort; display is source of truth
 		a.refreshTasks()
 	}
+	a.tasklist.OnArchive = func(t *model.Task) {
+		uxlog.Log("[tui2] archive toggle: task %s (%s) archived=%v", t.ID, t.Name, t.Archived)
+		a.db.Update(t) //nolint:errcheck // best-effort; display is source of truth
+		a.refreshTasks()
+	}
 
 	a.taskGitPanel = NewGitPanel()
 	a.taskPreview = NewTaskPreviewPanel()

--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -51,6 +51,8 @@ type TaskListView struct {
 	OnCursorChange func(task *model.Task)
 	// Callback when user changes task status via s/S keys.
 	OnStatusChange func(task *model.Task)
+	// Callback when user toggles archive on a task via 'a' key.
+	OnArchive func(task *model.Task)
 }
 
 // NewTaskListView creates a task list view.
@@ -225,32 +227,138 @@ func (tl *TaskListView) skipToTask(dir int) {
 	}
 }
 
-// CursorDown moves the cursor down. When landing on a project header,
-// autoExpand will expand it and advance the cursor to the first task.
+// CursorDown moves the cursor down, skipping headers.
 func (tl *TaskListView) CursorDown() {
+	tl.moveCursor(1)
+}
+
+// CursorUp moves the cursor up, skipping headers.
+func (tl *TaskListView) CursorUp() {
+	tl.moveCursor(-1)
+}
+
+// moveCursor moves the cursor in the given direction (+1 down, -1 up),
+// skipping project header and archive header rows so the cursor always
+// lands on a task. When navigating up past a project header, the cursor
+// lands on the last task of the previous project.
+func (tl *TaskListView) moveCursor(dir int) {
 	if len(tl.rows) == 0 {
 		return
 	}
-	tl.cursor++
+
+	prev := tl.cursor
+
+	// Step 1: Move one position in the given direction.
+	tl.cursor += dir
+	if tl.cursor < 0 {
+		tl.cursor = 0
+	}
 	if tl.cursor >= len(tl.rows) {
 		tl.cursor = len(tl.rows) - 1
 	}
 	tl.autoExpand()
+
+	c := tl.cursor
+	if c < 0 || c >= len(tl.rows) {
+		tl.notifyCursorChange()
+		return
+	}
+
+	// Already on a task row — done.
+	if tl.rows[c].kind == rowTask {
+		tl.notifyCursorChange()
+		return
+	}
+
+	// On the archive header — skip it like a project header.
+	if tl.rows[c].kind == rowArchiveHeader {
+		if dir > 0 {
+			if c+1 < len(tl.rows) {
+				tl.cursor++
+				tl.autoExpand()
+				c = tl.cursor
+				// May have landed on a project header within archive — skip that too.
+				if c >= 0 && c < len(tl.rows) && tl.rows[c].kind == rowProject {
+					if c+1 < len(tl.rows) && tl.rows[c+1].kind == rowTask {
+						tl.cursor++
+					}
+				}
+			}
+		} else {
+			tl.skipUpPastHeader(prev)
+		}
+		tl.notifyCursorChange()
+		return
+	}
+
+	// On a project header — skip it.
+	if dir > 0 {
+		// Going down: move to the first task below this header.
+		if c+1 < len(tl.rows) && tl.rows[c+1].kind == rowTask {
+			tl.cursor++
+		}
+	} else {
+		if c > 0 {
+			tl.skipUpPastHeader(prev)
+		} else {
+			// At the top (row 0) and it's a header — stay on the previous task.
+			tl.cursor = prev
+		}
+	}
 	tl.notifyCursorChange()
 }
 
-// CursorUp moves the cursor up. When landing on a project header,
-// autoExpand will expand it and move the cursor to the last task.
-func (tl *TaskListView) CursorUp() {
-	if len(tl.rows) == 0 {
-		return
-	}
+// skipUpPastHeader moves the cursor up past a header row (project or archive),
+// landing on the last task of the previous expanded project. If it lands on
+// another header (e.g., archive header above a project header), it chains
+// through one additional header. Falls back to prev if no task is reachable.
+func (tl *TaskListView) skipUpPastHeader(prev int) {
 	tl.cursor--
 	if tl.cursor < 0 {
-		tl.cursor = 0
+		tl.cursor = prev
+		return
 	}
 	tl.autoExpand()
-	tl.notifyCursorChange()
+	c := tl.cursor
+
+	if c >= 0 && c < len(tl.rows) && tl.rows[c].kind == rowProject {
+		tl.landOnLastTask(c, prev)
+		return
+	}
+
+	// Landed on archive header after skipping a project header — skip it too.
+	if c >= 0 && c < len(tl.rows) && tl.rows[c].kind == rowArchiveHeader {
+		tl.cursor--
+		if tl.cursor < 0 {
+			tl.cursor = prev
+			return
+		}
+		tl.autoExpand()
+		c = tl.cursor
+		if c >= 0 && c < len(tl.rows) && tl.rows[c].kind == rowProject {
+			tl.landOnLastTask(c, prev)
+			return
+		}
+	}
+
+	// Couldn't find a task — revert.
+	if c < 0 || c >= len(tl.rows) || tl.rows[c].kind != rowTask {
+		tl.cursor = prev
+	}
+}
+
+// landOnLastTask sets the cursor to the last consecutive task row after
+// the project header at idx. Falls back to prev if no tasks follow.
+func (tl *TaskListView) landOnLastTask(idx, prev int) {
+	lastTask := -1
+	for i := idx + 1; i < len(tl.rows) && tl.rows[i].kind == rowTask; i++ {
+		lastTask = i
+	}
+	if lastTask >= 0 {
+		tl.cursor = lastTask
+	} else {
+		tl.cursor = prev
+	}
 }
 
 // notifyCursorChange fires the OnCursorChange callback with the current task.
@@ -260,52 +368,57 @@ func (tl *TaskListView) notifyCursorChange() {
 	}
 }
 
-// autoExpand expands the project the cursor is in, collapses others.
+// autoExpand checks if the cursor moved to a different project and rebuilds
+// the row list with that project expanded. Also auto-expands the archive
+// section when the cursor enters it and auto-collapses when the cursor leaves.
 func (tl *TaskListView) autoExpand() {
-	if tl.cursor < 0 || tl.cursor >= len(tl.rows) {
+	if len(tl.rows) == 0 {
 		return
 	}
-	row := tl.rows[tl.cursor]
+	c := tl.cursor
+	if c < 0 || c >= len(tl.rows) {
+		return
+	}
+	r := tl.rows[c]
 
-	switch row.kind {
-	case rowProject:
-		// Cursor landed on a project header — expand it
-		inArchive := tl.isInArchive(tl.cursor)
-		if inArchive {
-			tl.archiveExpanded = true
-			if row.project != tl.archiveProject {
-				tl.archiveProject = row.project
-				tl.buildRows()
-				// Move cursor to the first task in this project
-				tl.skipToTask(1)
-			}
-		} else {
-			if row.project != tl.expanded {
-				tl.expanded = row.project
-				tl.buildRows()
-				// Move cursor to the first task in this project
-				tl.skipToTask(1)
-			}
-		}
-	case rowArchiveHeader:
-		tl.archiveExpanded = !tl.archiveExpanded
+	// Determine if cursor is in the archive section.
+	inArchive := tl.isInArchive(c)
+
+	// Auto-expand/collapse archive section based on cursor position.
+	if inArchive && !tl.archiveExpanded {
+		tl.archiveExpanded = true
 		tl.buildRows()
-	case rowTask:
-		inArchive := tl.isInArchive(tl.cursor)
-		if inArchive {
-			tl.archiveExpanded = true
-			if row.project != tl.archiveProject {
-				tl.archiveProject = row.project
-				tl.buildRows()
-				tl.restoreCursorToTask(row.task)
-			}
-		} else {
-			tl.archiveExpanded = false
-			if row.project != tl.expanded {
-				tl.expanded = row.project
-				tl.buildRows()
-				tl.restoreCursorToTask(row.task)
-			}
+		// Cursor stays valid — archive rows are appended after current position.
+		c = tl.cursor
+		if c >= 0 && c < len(tl.rows) {
+			r = tl.rows[c]
+		}
+	} else if !inArchive && tl.archiveExpanded {
+		tl.archiveExpanded = false
+		tl.buildRows()
+		// Cursor is above archive section — rows above haven't changed.
+	}
+
+	// Archive header — don't change project expansion.
+	if r.kind == rowArchiveHeader {
+		return
+	}
+
+	if inArchive {
+		// Expand the project within the archive section.
+		if r.project != tl.archiveProject {
+			currentRow := tl.rows[c]
+			tl.archiveProject = r.project
+			tl.buildRows()
+			tl.restoreCursor(currentRow, true)
+		}
+	} else {
+		// Expand the project in the active section.
+		if r.project != tl.expanded {
+			currentRow := tl.rows[c]
+			tl.expanded = r.project
+			tl.buildRows()
+			tl.restoreCursor(currentRow, false)
 		}
 	}
 }
@@ -320,17 +433,23 @@ func (tl *TaskListView) isInArchive(idx int) bool {
 	return false
 }
 
-// restoreCursorToTask moves the cursor to the row matching the given task.
-func (tl *TaskListView) restoreCursorToTask(task *model.Task) {
-	if task == nil {
-		return
-	}
+// restoreCursor finds the row matching target in the rebuilt rows slice
+// and positions the cursor there. inArchive restricts the search to the
+// archive section (or main section), preventing a project that exists in both
+// sections from matching the wrong header.
+func (tl *TaskListView) restoreCursor(target taskRow, inArchive bool) {
 	for i, r := range tl.rows {
-		if r.kind == rowTask && r.task != nil && r.task.ID == task.ID {
-			tl.cursor = i
-			return
+		if r.kind == target.kind && r.project == target.project {
+			if tl.isInArchive(i) != inArchive {
+				continue
+			}
+			if r.kind == rowProject || (r.task != nil && target.task != nil && r.task.ID == target.task.ID) {
+				tl.cursor = i
+				return
+			}
 		}
 	}
+	tl.clampCursor()
 }
 
 // InputHandler handles key events for the task list.
@@ -367,6 +486,13 @@ func (tl *TaskListView) InputHandler() func(event *tcell.EventKey, setFocus func
 					t.SetStatus(t.Status.Prev())
 					if tl.OnStatusChange != nil {
 						tl.OnStatusChange(t)
+					}
+				}
+			case 'a':
+				if t := tl.SelectedTask(); t != nil {
+					t.Archived = !t.Archived
+					if tl.OnArchive != nil {
+						tl.OnArchive(t)
 					}
 				}
 			}

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -445,3 +445,170 @@ func TestTaskListView_RunningTaskAnimation(t *testing.T) {
 		t.Errorf("tickEven=true: got %c, want ◉", icon)
 	}
 }
+
+func TestTaskListView_ArchiveToggle(t *testing.T) {
+	tl := NewTaskListView()
+	var archived *model.Task
+	tl.OnArchive = func(task *model.Task) {
+		archived = task
+	}
+	tl.SetTasks([]*model.Task{
+		{ID: "1", Name: "task1", Status: model.StatusPending, Project: "p"},
+	})
+	tl.expanded = "p"
+	tl.buildRows()
+	tl.clampCursor()
+
+	// Press 'a' to archive the task
+	handler := tl.InputHandler()
+	handler(tcell.NewEventKey(tcell.KeyRune, 'a', tcell.ModNone), func(tview.Primitive) {})
+	if archived == nil {
+		t.Fatal("OnArchive should have been called")
+	}
+	if !archived.Archived {
+		t.Error("task should be archived after pressing 'a'")
+	}
+
+	// Press 'a' again to unarchive
+	archived = nil
+	handler(tcell.NewEventKey(tcell.KeyRune, 'a', tcell.ModNone), func(tview.Primitive) {})
+	if archived == nil {
+		t.Fatal("OnArchive should have been called again")
+	}
+	if archived.Archived {
+		t.Error("task should be unarchived after pressing 'a' again")
+	}
+}
+
+func TestTaskListView_CursorAlwaysOnTask(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetTasks(makeTasks())
+
+	// Navigate through all rows — cursor should always be on a task.
+	for i := 0; i < 20; i++ {
+		task := tl.SelectedTask()
+		if task == nil {
+			t.Errorf("step %d down: cursor not on a task (cursor=%d)", i, tl.cursor)
+		}
+		tl.CursorDown()
+	}
+	for i := 0; i < 20; i++ {
+		task := tl.SelectedTask()
+		if task == nil {
+			t.Errorf("step %d up: cursor not on a task (cursor=%d)", i, tl.cursor)
+		}
+		tl.CursorUp()
+	}
+}
+
+func TestTaskListView_SkipProjectHeaders(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetTasks([]*model.Task{
+		{ID: "1", Name: "t1", Project: "alpha", Status: model.StatusPending},
+		{ID: "2", Name: "t2", Project: "beta", Status: model.StatusPending},
+	})
+
+	// Start on alpha's task
+	if tl.SelectedTask() == nil || tl.SelectedTask().ID != "1" {
+		t.Fatalf("expected to start on task 1, got %v", tl.SelectedTask())
+	}
+
+	// Move down — should skip beta's project header and land on task 2
+	tl.CursorDown()
+	task := tl.SelectedTask()
+	if task == nil || task.ID != "2" {
+		t.Errorf("after down: expected task 2, got %v", task)
+	}
+
+	// Move back up — should skip alpha's project header and land on task 1
+	tl.CursorUp()
+	task = tl.SelectedTask()
+	if task == nil || task.ID != "1" {
+		t.Errorf("after up: expected task 1, got %v", task)
+	}
+}
+
+func TestTaskListView_UpLandsOnLastTask(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetTasks([]*model.Task{
+		{ID: "1", Name: "t1", Project: "alpha", Status: model.StatusPending},
+		{ID: "2", Name: "t2", Project: "alpha", Status: model.StatusPending},
+		{ID: "3", Name: "t3", Project: "beta", Status: model.StatusPending},
+	})
+
+	// Navigate to beta's task
+	for i := 0; i < 10; i++ {
+		tl.CursorDown()
+	}
+	task := tl.SelectedTask()
+	if task == nil || task.ID != "3" {
+		t.Fatalf("expected to be on task 3, got %v", task)
+	}
+
+	// Move up — should land on last task of alpha (task 2), not first (task 1)
+	tl.CursorUp()
+	task = tl.SelectedTask()
+	if task == nil || task.ID != "2" {
+		t.Errorf("after up from beta: expected task 2 (last in alpha), got %v", task)
+	}
+}
+
+func TestTaskListView_ArchiveAutoExpand(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetTasks([]*model.Task{
+		{ID: "1", Name: "active", Project: "proj", Status: model.StatusPending},
+		{ID: "2", Name: "archived", Project: "proj", Status: model.StatusPending, Archived: true},
+	})
+
+	// Archive should start collapsed
+	if tl.archiveExpanded {
+		t.Error("archive should start collapsed")
+	}
+
+	// Navigate down past all active tasks — should enter archive
+	for i := 0; i < 10; i++ {
+		tl.CursorDown()
+	}
+
+	// Should have auto-expanded archive and landed on the archived task
+	task := tl.SelectedTask()
+	if task == nil || task.ID != "2" {
+		t.Errorf("expected to land on archived task 2, got %v", task)
+	}
+	if !tl.archiveExpanded {
+		t.Error("archive should be expanded after navigating into it")
+	}
+
+	// Navigate back up out of archive — should auto-collapse
+	tl.CursorUp()
+	task = tl.SelectedTask()
+	if task == nil || task.ID != "1" {
+		t.Errorf("expected to land on task 1 after leaving archive, got %v", task)
+	}
+	if tl.archiveExpanded {
+		t.Error("archive should be collapsed after leaving it")
+	}
+}
+
+func TestTaskListView_ArchiveSectionAwareCursor(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetTasks([]*model.Task{
+		{ID: "1", Name: "active", Project: "shared", Status: model.StatusPending},
+		{ID: "2", Name: "archived", Project: "shared", Status: model.StatusPending, Archived: true},
+	})
+
+	// Navigate into archive section
+	for i := 0; i < 10; i++ {
+		tl.CursorDown()
+	}
+
+	task := tl.SelectedTask()
+	if task == nil || task.ID != "2" {
+		t.Errorf("expected archived task 2, got %v", task)
+	}
+
+	// The cursor should be in the archive section, not on the main "shared" project
+	if !tl.isInArchive(tl.cursor) {
+		t.Error("cursor should be in archive section")
+	}
+}


### PR DESCRIPTION
Port pre-tcell Bubble Tea task list behavior: cursor skips project/archive headers, navigating up lands on last task of previous project, archive auto-expands/collapses based on cursor position, section-aware cursor restoration. Add 'a' key to toggle archived state. Store BT reference commit in context/knowledge/.

Co-Authored-By: Claude <noreply@anthropic.com>