### PR TITLE
Add Cmd+Up/Down to navigate between tasks in agent view

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -247,4 +247,6 @@
 
 - **`CreateWorktree` must return the branch name so callers can store it on `task.Branch`.** The branch created is `"argus/" + candidate` but was previously not returned — callers stored the base branch (e.g., `master`) in `task.Branch` instead of the actual worktree branch. This caused `removeWorktreeAndBranch` to attempt deleting the wrong branch (or skip deletion if empty), leaving stale `argus/*` branches behind. The fix: `CreateWorktree` returns `(wtPath, finalName, branchName, err)` and the caller in `app.go` sets `task.Branch = branchName` after worktree creation.
 
+- **Cmd+Up/Down navigates between tasks while in the agent view.** `handleAgentKey` intercepts `KeyUp`/`KeyDown` with `ModCtrl|ModAlt` (covers Cmd on macOS terminals) and calls `navigateAgentTask(direction)`. This finds the adjacent task via `TaskListView.AdjacentTask(currentID, direction)` which scans the full `tl.tasks` slice (not just visible rows), then calls `SelectByID` to sync the task list cursor (expanding the target project if collapsed), and `onTaskSelect` to switch the agent view. Allows cycling through tasks without returning to the task list.
+
 ## Planned but Not Yet Implemented

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -748,6 +748,16 @@ func (a *App) handleAgentKey(event *tcell.EventKey) *tcell.EventKey {
 			}
 			return nil
 		}
+	case tcell.KeyUp:
+		if event.Modifiers()&(tcell.ModCtrl|tcell.ModAlt) != 0 {
+			a.navigateAgentTask(-1)
+			return nil
+		}
+	case tcell.KeyDown:
+		if event.Modifiers()&(tcell.ModCtrl|tcell.ModAlt) != 0 {
+			a.navigateAgentTask(1)
+			return nil
+		}
 	}
 
 	// Diff mode keys
@@ -1618,6 +1628,20 @@ func (a *App) pruneCompletedTasks() {
 	}()
 
 	a.refreshTasks()
+}
+
+// navigateAgentTask switches to the next (+1) or previous (-1) task
+// while staying in the agent view.
+func (a *App) navigateAgentTask(direction int) {
+	next := a.tasklist.AdjacentTask(a.agentState.TaskID, direction)
+	if next == nil {
+		return
+	}
+	// Update the task list cursor so it stays in sync.
+	a.tasklist.SelectByID(next.ID)
+	// Enter the agent view for the new task (reuses onTaskSelect which
+	// resets all agent state, wires up the session, kicks off git status, etc.)
+	a.onTaskSelect(next)
 }
 
 // exitAgentView returns to the task list.

--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -748,6 +748,52 @@ func (tl *TaskListView) HasTasks() bool {
 	return len(tl.tasks) > 0
 }
 
+// AdjacentTask returns the next (+1) or previous (-1) task relative to the
+// given task ID. Scans the full task list (not just visible/expanded rows).
+// Returns nil if there is no adjacent task in that direction.
+func (tl *TaskListView) AdjacentTask(currentID string, direction int) *model.Task {
+	currentIdx := -1
+	for i, t := range tl.tasks {
+		if t.ID == currentID {
+			currentIdx = i
+			break
+		}
+	}
+	if currentIdx < 0 {
+		return nil
+	}
+	next := currentIdx + direction
+	if next < 0 || next >= len(tl.tasks) {
+		return nil
+	}
+	return tl.tasks[next]
+}
+
+// SelectByID moves the cursor to the row matching the given task ID.
+// If the task is in a collapsed project, expands it first.
+func (tl *TaskListView) SelectByID(id string) {
+	// Find the task to get its project, then expand it so the row exists.
+	for _, t := range tl.tasks {
+		if t.ID == id {
+			if t.Archived {
+				tl.archiveExpanded = true
+				tl.archiveProject = t.Project
+			} else {
+				tl.expanded = t.Project
+			}
+			tl.buildRows()
+			break
+		}
+	}
+	for i, r := range tl.rows {
+		if r.kind == rowTask && r.task.ID == id {
+			tl.cursor = i
+			tl.notifyCursorChange()
+			return
+		}
+	}
+}
+
 // SetExpanded sets which project is expanded.
 func (tl *TaskListView) SetExpanded(proj string) {
 	tl.expanded = proj

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -423,6 +423,71 @@ func TestTaskListView_StatusCycleKeys(t *testing.T) {
 	}
 }
 
+func TestTaskListView_AdjacentTask(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetTasks([]*model.Task{
+		{ID: "1", Name: "first", Project: "projA"},
+		{ID: "2", Name: "second", Project: "projA"},
+		{ID: "3", Name: "third", Project: "projB"},
+	})
+
+	// Next from first task
+	next := tl.AdjacentTask("1", 1)
+	if next == nil || next.ID != "2" {
+		t.Fatalf("expected task 2, got %v", next)
+	}
+
+	// Next across projects
+	next = tl.AdjacentTask("2", 1)
+	if next == nil || next.ID != "3" {
+		t.Fatalf("expected task 3, got %v", next)
+	}
+
+	// No next from last task
+	next = tl.AdjacentTask("3", 1)
+	if next != nil {
+		t.Fatalf("expected nil, got %v", next)
+	}
+
+	// Prev from second task
+	prev := tl.AdjacentTask("2", -1)
+	if prev == nil || prev.ID != "1" {
+		t.Fatalf("expected task 1, got %v", prev)
+	}
+
+	// No prev from first task
+	prev = tl.AdjacentTask("1", -1)
+	if prev != nil {
+		t.Fatalf("expected nil, got %v", prev)
+	}
+
+	// Unknown ID
+	if tl.AdjacentTask("unknown", 1) != nil {
+		t.Fatal("expected nil for unknown ID")
+	}
+}
+
+func TestTaskListView_SelectByID(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetTasks([]*model.Task{
+		{ID: "1", Name: "first", Project: "projA"},
+		{ID: "2", Name: "second", Project: "projA"},
+		{ID: "3", Name: "third", Project: "projB"},
+	})
+
+	tl.SelectByID("3")
+	sel := tl.SelectedTask()
+	if sel == nil || sel.ID != "3" {
+		t.Fatalf("expected task 3, got %v", sel)
+	}
+
+	tl.SelectByID("1")
+	sel = tl.SelectedTask()
+	if sel == nil || sel.ID != "1" {
+		t.Fatalf("expected task 1, got %v", sel)
+	}
+}
+
 func TestTaskListView_RunningTaskAnimation(t *testing.T) {
 	tl := NewTaskListView()
 	tasks := []*model.Task{


### PR DESCRIPTION
Navigate between tasks without leaving the agent view. Ctrl/Alt+Up/Down switches to the adjacent task, syncing the task list cursor and expanding collapsed projects as needed.

Co-Authored-By: Claude <noreply@anthropic.com>