### PR TITLE
Add Agent label to terminal pane border

### DIFF
--- a/internal/tui2/terminalpane.go
+++ b/internal/tui2/terminalpane.go
@@ -391,7 +391,7 @@ func (tp *TerminalPane) Draw(screen tcell.Screen) {
 	if tp.focused {
 		borderStyle = StyleFocusedBorder
 	}
-	inner := drawBorderedPanel(screen, x, y, width, height, "", borderStyle)
+	inner := drawBorderedPanel(screen, x, y, width, height, " Agent ", borderStyle)
 	x, y, width, height = inner.X, inner.Y, inner.W, inner.H
 	if width <= 0 || height <= 0 {
 		return


### PR DESCRIPTION
Display 'Agent' title in the terminal pane's bordered panel, matching the labeling pattern used by Git Status, Files, Details, and other panels.

Co-Authored-By: Claude <noreply@anthropic.com>