### PR TITLE
Forward escape to PTY in agent view instead of exiting

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -165,7 +165,7 @@
 
 - **Inline diff viewer in `TerminalPane`.** `EnterDiffMode(diff, fileName)` parses raw unified diff into `[]diffLine` with types (added/removed/context/header) and renders with colored text. `ExitDiffMode()`, `ToggleDiffSplit()`, `DiffScrollUp/Down` for navigation. Diff is fetched asynchronously via `gitutil.FetchFileDiff` and rendered in the center panel, replacing the terminal view.
 
-- **Agent view key layering: 3-level exit.** `ctrl+q` and `esc` use: (1) if in diff mode → exit diff, refocus terminal; (2) if focused on files panel → refocus terminal; (3) otherwise → exit agent view. `updateFocusIndicators()` syncs border styles.
+- **Agent view key layering: `ctrl+q` exits, `esc` refocuses.** `ctrl+q` uses a 3-level exit: (1) diff → exit diff, refocus terminal; (2) files panel → refocus terminal; (3) terminal → exit agent view. `Escape` refocuses the terminal from diff/files (same first two levels) but does NOT exit agent view — when already on the terminal, escape is forwarded to the PTY as `0x1b` so agents receive it. `updateFocusIndicators()` syncs border styles.
 
 - **Session log loading for finished tasks.** `SetTaskID()` automatically reads `~/.argus/sessions/<taskID>.log` when no live session exists. The replay data is rendered via x/vt emulation painted directly to tcell.
 

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -715,7 +715,7 @@ func (a *App) updateFocusIndicators() {
 func (a *App) handleAgentKey(event *tcell.EventKey) *tcell.EventKey {
 	switch event.Key() {
 	case tcell.KeyEscape:
-		// 3-level exit: diff → files panel → agent view
+		// Escape refocuses terminal from diff/files, but does NOT exit agent view
 		if a.agentPane.InDiffMode() {
 			a.agentPane.ExitDiffMode()
 			a.agentFocus = focusTerminal
@@ -727,8 +727,7 @@ func (a *App) handleAgentKey(event *tcell.EventKey) *tcell.EventKey {
 			a.updateFocusIndicators()
 			return nil
 		}
-		a.exitAgentView()
-		return nil
+		// When focused on terminal, forward escape to PTY (handled by tcellKeyToBytes below)
 	case tcell.KeyCtrlP:
 		a.agentPane.OpenPR()
 		return nil


### PR DESCRIPTION
Escape in agent view no longer exits back to the task list. It refocuses the terminal from diff/files panels, or forwards to the PTY when on terminal. Ctrl+Q is now the only way to exit agent view.

Co-Authored-By: Claude <noreply@anthropic.com>