### PR TITLE
Fix premature task reconciliation on daemon RPC failure

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -1,5 +1,7 @@
 ## Key Learnings
 
+- **Reconciliation must distinguish RPC failure from empty running set.** `Client.Running()` returns `nil` on RPC error vs. `[]string{}` when the daemon confirms no sessions. `refreshTasksWithIDs` checks `runningIDs != nil` before reconciling — without this, a transient RPC timeout causes ALL InProgress tasks to be marked Complete, prematurely killing active workflows.
+
 - **`ctrl+c` only exits Argus from the root (task list) view.** The global `handleGlobalKey` processes `KeyCtrlC` before mode-specific handlers. In agent mode, `ctrl+c` is always consumed: if the session is alive, `0x03` is written to the PTY; if dead, it's a no-op. Only in non-agent modes does `ctrl+c` call `tapp.Stop()`. This prevents accidentally killing Argus when trying to interrupt an agent process.
 
 - **`ctrl+q` in diff mode must both exit diff mode AND refocus the agent panel.** When a file diff is open, pressing `ctrl+q` calls `exitDiffMode()` but must also refocus the terminal panel — without this, the user lands back on the files panel and needs a second keypress to reach the terminal. The global `ctrl+q` handler runs before the diff key handler, so the fix belongs there.

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -567,7 +567,9 @@ func (a *App) refreshTasksWithIDs(runningIDs, idleIDs []string) {
 	// truth for running sessions. In-process mode has its own onFinish callback.
 	// Note: InReview tasks are intentionally non-running (set by handleSessionExitUI
 	// when the user stops an agent) and must NOT be reconciled to Complete.
-	if a.daemonConnected {
+	// IMPORTANT: runningIDs is nil when the daemon RPC failed — skip reconciliation
+	// to avoid marking all active tasks as Complete due to a transient error.
+	if a.daemonConnected && runningIDs != nil {
 		runningSet := make(map[string]bool, len(runningIDs))
 		for _, id := range runningIDs {
 			runningSet[id] = true

--- a/internal/tui2/app_test.go
+++ b/internal/tui2/app_test.go
@@ -698,6 +698,51 @@ func TestCtrlRPrunesCompleted(t *testing.T) {
 	}
 }
 
+func TestReconcileSkipsOnNilRunning(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false)
+
+	// Simulate daemon mode
+	app.daemonConnected = true
+
+	d.Add(&model.Task{ID: "t1", Name: "active-agent", Status: model.StatusInProgress, Project: "p", CreatedAt: time.Now()})
+	d.Add(&model.Task{ID: "t2", Name: "also-active", Status: model.StatusInProgress, Project: "p", CreatedAt: time.Now()})
+
+	// Pass nil runningIDs (simulates RPC failure) — should NOT reconcile
+	app.refreshTasksWithIDs(nil, nil)
+
+	for _, task := range app.tasks {
+		if task.Status == model.StatusComplete {
+			t.Errorf("task %q was wrongly reconciled to Complete on nil runningIDs", task.Name)
+		}
+	}
+}
+
+func TestReconcileWorksOnEmptyRunning(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false)
+
+	// Simulate daemon mode
+	app.daemonConnected = true
+
+	d.Add(&model.Task{ID: "t1", Name: "stale-task", Status: model.StatusInProgress, Project: "p", CreatedAt: time.Now()})
+
+	// Pass empty non-nil runningIDs (daemon confirmed nothing running) — should reconcile
+	app.refreshTasksWithIDs([]string{}, []string{})
+
+	found := false
+	for _, task := range app.tasks {
+		if task.ID == "t1" && task.Status == model.StatusComplete {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("stale task should have been reconciled to Complete with empty (non-nil) runningIDs")
+	}
+}
+
 func TestWorktreeSubdir(t *testing.T) {
 	tests := []struct {
 		path string


### PR DESCRIPTION
Client.Running() returns nil on RPC error, which reconciliation treated as "no sessions running" — marking all InProgress tasks Complete. Added nil guard so transient failures skip reconciliation. Includes two new tests.

Co-Authored-By: Claude <noreply@anthropic.com>