### PR TITLE
Forward Shift+Tab to agent PTY

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -1083,6 +1083,8 @@ func tcellKeyToBytes(ev *tcell.EventKey) []byte {
 		return []byte{'\r'}
 	case tcell.KeyTab:
 		return []byte{'\t'}
+	case tcell.KeyBacktab:
+		return []byte("\x1b[Z")
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
 		if alt {
 			return []byte{0x1b, 0x7f}

--- a/internal/tui2/app_test.go
+++ b/internal/tui2/app_test.go
@@ -112,6 +112,7 @@ func TestTcellKeyToBytes(t *testing.T) {
 	}{
 		{"enter", tcell.KeyEnter, 0, 0, []byte{'\r'}},
 		{"tab", tcell.KeyTab, 0, 0, []byte{'\t'}},
+		{"shift-tab", tcell.KeyBacktab, 0, 0, []byte("\x1b[Z")},
 		{"backspace", tcell.KeyBackspace2, 0, 0, []byte{0x7f}},
 		{"up", tcell.KeyUp, 0, 0, []byte("\x1b[A")},
 		{"down", tcell.KeyDown, 0, 0, []byte("\x1b[B")},


### PR DESCRIPTION
Map tcell KeyBacktab to CSI Z escape sequence so Shift+Tab reaches the agent process instead of being silently dropped.

Co-Authored-By: Claude <noreply@anthropic.com>