### PR TITLE
Fix prune modal double-counting worktrees as orphans (#328)

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -1709,6 +1709,12 @@ func (a *App) pruneCompletedTasks() {
 	if err != nil {
 		uxlog.Log("[tui2] WorktreePaths failed, skipping orphan sweep: %v", err)
 	} else {
+		// PruneCompleted already deleted these from the DB, so their
+		// worktree dirs would be misidentified as orphans. Mark them
+		// known so they aren't double-counted.
+		for _, t := range toClean {
+			knownPaths[t.Worktree] = true
+		}
 		orphanCount = countOrphanedWorktrees(a.wtRoot, knownPaths)
 	}
 

--- a/internal/tui2/app_test.go
+++ b/internal/tui2/app_test.go
@@ -1,6 +1,8 @@
 package tui2
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -698,6 +700,43 @@ func TestPruneCompletedTasks(t *testing.T) {
 		if task.Status == model.StatusComplete {
 			t.Errorf("completed task %q should have been pruned", task.Name)
 		}
+	}
+}
+
+func TestPruneDoesNotDoubleCountWorktrees(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false)
+	wtRoot := t.TempDir()
+	app.wtRoot = wtRoot
+
+	// Create a worktree directory on disk for the completed task.
+	wtPath := filepath.Join(wtRoot, "p", "done-task")
+	if err := os.MkdirAll(wtPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	d.Add(&model.Task{
+		ID: "t1", Name: "done-task", Status: model.StatusComplete,
+		Project: "p", Worktree: wtPath, CreatedAt: time.Now(),
+	})
+	d.Add(&model.Task{
+		ID: "t2", Name: "active", Status: model.StatusPending,
+		Project: "p", CreatedAt: time.Now(),
+	})
+	app.refreshTasks()
+
+	app.pruneCompletedTasks()
+
+	// The prune modal total should be 1 (the completed task), not 2.
+	// Before the fix, the worktree was counted once as a pruned task
+	// AND once as an orphan (because PruneCompleted deletes the DB
+	// record before WorktreePaths runs).
+	if app.pruneModal == nil {
+		t.Fatal("expected prune modal to be shown")
+	}
+	if app.pruneModal.total != 1 {
+		t.Errorf("prune modal total = %d, want 1 (worktree double-counted as orphan)", app.pruneModal.total)
 	}
 }
 


### PR DESCRIPTION
PruneCompleted() deletes DB records before WorktreePaths() queries them, so the pruned worktree is misidentified as an orphan and double-counted. Adds pruned paths to knownPaths before counting orphans.

Co-Authored-By: Claude <noreply@anthropic.com>