### PR TITLE
Fix phantom cursor at bottom-left of agent terminal pane

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -35,13 +35,14 @@ Non-obvious invariants and gotchas. For architecture, see CLAUDE.md. For feature
 - **`AddWriter` must replay before registering.** Register first → live bytes arrive before replay → duplicate data → rendering corruption.
 - **x/vt `SafeEmulator` hangs on terminal query sequences.** Use `newDrainedEmulator()` which starts `go io.Copy(io.Discard, emu)` to drain the response pipe. Never use bare `xvt.NewSafeEmulator()` in tui2.
 - **x/vt can panic on replay from differently-sized terminals.** Use `safeEmuWrite()` which wraps with `recover()`.
-- **Always render cursor regardless of `CursorVisible()`.** TUI agents hide the hardware cursor — irrelevant for Argus's use case.
+- **Cursor rendering respects `CursorVisibility` callback.** Tracked via `cursorVisible` field, updated by x/vt callback. Defaults to `false` on emulator creation.
 - **Ring buffer must be bounded (256KB).** Unbounded causes CPU spikes and OOM. Session log file provides full scrollback.
 - **Live scrollback reads from session log file, not ring buffer.** `readLogTail` seeks from EOF — gives infinite scrollback while live follow-tail stays on the fast ring buffer path.
 - **Anchor-lock keeps scrolled-up content pinned when new output arrives.** Track `anchorTotalLines`; bump `scrollOffset` by the delta. Reset to 0 on scroll-to-bottom.
 - **Replay emulator is cached and reused when only scroll offset changes.** Rebuild only when input size or dimensions change.
 - **Agent view replay must use current panel dimensions, not stale PTY size.** Override `ptyCols/ptyRows` with current dimensions for dead/nil sessions.
 - **Preview panel must use PTY width, not panel width, for VT emulation.** Otherwise text double-wraps.
+- **New emulators must default `cursorVisible` to `false`.** Agents send `\e[?25l` early, but after ring buffer wrap or emu rebuild, that sequence is lost. Defaulting to `true` causes a phantom cursor at bottom-left. Also, `lastContentRow` must not extend to cursor position when cursor is hidden.
 
 ### UI Threading
 

--- a/internal/tui2/terminalpane.go
+++ b/internal/tui2/terminalpane.go
@@ -564,7 +564,10 @@ func (tp *TerminalPane) paintEmu(screen tcell.Screen, x, y, w, h int, emu *xvt.S
 	sbLen := emu.ScrollbackLen()
 	// Find content bounds in the main screen area.
 	lastContentRow := findLastContentRowEmu(emu, emuCols, emuRows)
-	if cur.Y > lastContentRow {
+	// Only extend content area to include cursor when it's visible.
+	// Without this guard, a hidden cursor at (0, bottom) inflates the
+	// content region with empty rows, causing a phantom cursor artifact.
+	if cursorVisible && cur.Y > lastContentRow {
 		lastContentRow = cur.Y
 	}
 
@@ -682,8 +685,13 @@ func (tp *TerminalPane) newTrackedEmulatorWithCallback(cols, rows int, onCursorV
 			CursorVisibility: onCursorVisible,
 		})
 	}
+	// Default cursor to hidden — agents (Claude Code, Codex) hide the hardware
+	// cursor via \e[?25l. When the ring buffer wraps or the emulator is rebuilt,
+	// the hide sequence may no longer be in the replay data. Defaulting to false
+	// prevents a stale cursor from appearing (typically bottom-left) until the
+	// emulator processes an explicit \e[?25h show-cursor sequence.
 	if onCursorVisible != nil {
-		onCursorVisible(true)
+		onCursorVisible(false)
 	}
 	return emu
 }

--- a/internal/tui2/terminalpane_test.go
+++ b/internal/tui2/terminalpane_test.go
@@ -297,6 +297,44 @@ func TestScrollbackLen(t *testing.T) {
 	}
 }
 
+func TestNewTrackedEmulator_DefaultCursorHidden(t *testing.T) {
+	tp := NewTerminalPane()
+	cursorVisible := true // will be overwritten by callback
+	_ = tp.newTrackedEmulatorWithCallback(20, 5, func(visible bool) {
+		cursorVisible = visible
+	})
+	if cursorVisible {
+		t.Fatal("new emulator should default cursor to hidden (agents hide cursor)")
+	}
+}
+
+func TestPaintEmu_HiddenCursorNoContentExtension(t *testing.T) {
+	// When cursor is hidden and at (0, lastRow), paintEmu should NOT extend
+	// lastContentRow to include the cursor — otherwise a phantom cursor cell
+	// appears at the bottom-left.
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	screen.SetSize(20, 10)
+
+	tp := NewTerminalPane()
+	emu := tp.newTrackedEmulatorWithCallback(20, 10, func(visible bool) {})
+	// Write one line of content, then move cursor to bottom-left.
+	emu.Write([]byte("hello\x1b[10;1H"))
+
+	// Paint with cursorVisible=false — the cursor at (0,9) should NOT
+	// cause content to extend to row 9.
+	tp.paintEmu(screen, 0, 0, 20, 10, emu, 20, 10, true, false)
+
+	// Row 9 col 0 should NOT have cursor styling.
+	_, _, style, _ := screen.GetContent(0, 9)
+	fg, bg, _ := style.Decompose()
+	if fg == cursorFG || bg == cursorBG {
+		t.Fatalf("hidden cursor at bottom-left should not be painted: fg=%v bg=%v", fg, bg)
+	}
+}
+
 func TestPaintEmu_HiddenCursorNotRendered(t *testing.T) {
 	screen := tcell.NewSimulationScreen("UTF-8")
 	if err := screen.Init(); err != nil {


### PR DESCRIPTION
Default cursorVisible to false when creating new x/vt emulators so lost cursor-hide sequences after ring buffer wrap don't cause a stale cursor. Guard lastContentRow extension with cursorVisible check to prevent hidden cursors from inflating content region.

Co-Authored-By: Claude <noreply@anthropic.com>