### PR TITLE
Show iterative progress in prune modal during worktree cleanup

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -1805,6 +1805,11 @@ func (a *App) pruneCompletedTasks() {
 				uxlog.Log("[tui2] prune cleanup: task=%s name=%q worktree=%q branch=%q repoDir=%q project=%q",
 					t.ID, t.Name, t.Worktree, t.Branch, repoDir, t.Project)
 				removeWorktreeAndBranch(t.Worktree, t.Branch, repoDir)
+				a.tapp.QueueUpdateDraw(func() {
+					if a.pruneModal != nil {
+						a.pruneModal.Increment()
+					}
+				})
 			}(t)
 		}
 
@@ -1815,6 +1820,11 @@ func (a *App) pruneCompletedTasks() {
 				defer wg.Done()
 				swept := sweepOrphanedWorktrees(a.wtRoot, knownPaths, projects)
 				uxlog.Log("[tui2] orphan sweep cleaned %d directories", swept)
+				a.tapp.QueueUpdateDraw(func() {
+					if a.pruneModal != nil {
+						a.pruneModal.Increment()
+					}
+				})
 			}()
 		}
 

--- a/internal/tui2/prunemodal.go
+++ b/internal/tui2/prunemodal.go
@@ -15,8 +15,12 @@ const pruneModalWidth = 50
 type PruneModal struct {
 	*tview.Box
 	total    int
+	current  int  // number completed so far (0 = starting)
 	tickEven bool // toggles for animated dots
 }
+
+// Increment marks one more worktree as cleaned.
+func (m *PruneModal) Increment() { m.current++ }
 
 // NewPruneModal creates a prune progress modal.
 func NewPruneModal(total int) *PruneModal {
@@ -64,6 +68,11 @@ func (m *PruneModal) Draw(screen tcell.Screen) {
 	if m.tickEven {
 		dots = ".. "
 	}
-	msg := fmt.Sprintf("Cleaning up %d worktree(s)%s", m.total, dots)
+	var msg string
+	if m.current == 0 {
+		msg = fmt.Sprintf("Cleaning up %d worktree(s)%s", m.total, dots)
+	} else {
+		msg = fmt.Sprintf("Cleaning up worktrees (%d/%d)%s", m.current, m.total, dots)
+	}
 	drawText(screen, formX+2, formY+2, formW-4, msg, StyleNormal)
 }

--- a/internal/tui2/prunemodal_test.go
+++ b/internal/tui2/prunemodal_test.go
@@ -1,6 +1,7 @@
 package tui2
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
@@ -55,4 +56,59 @@ func TestPruneModalTick(t *testing.T) {
 	if m.tickEven {
 		t.Error("tickEven should be false after second Tick")
 	}
+}
+
+func TestPruneModalIncrement(t *testing.T) {
+	m := NewPruneModal(5)
+	if m.current != 0 {
+		t.Errorf("current should start at 0, got %d", m.current)
+	}
+	m.Increment()
+	if m.current != 1 {
+		t.Errorf("current should be 1 after Increment, got %d", m.current)
+	}
+	m.Increment()
+	if m.current != 2 {
+		t.Errorf("current should be 2 after second Increment, got %d", m.current)
+	}
+}
+
+func TestPruneModalProgressDisplay(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	screen.Init() //nolint:errcheck
+	screen.SetSize(80, 24)
+
+	m := NewPruneModal(5)
+	m.SetRect(0, 0, 80, 24)
+
+	// Before any increments — shows static count.
+	m.Draw(screen)
+	all := readAllScreenText(screen, 80, 24)
+	if !strings.Contains(all, "Cleaning up 5 worktree(s)") {
+		t.Errorf("expected static count message, got %q", all)
+	}
+
+	// After increments — shows progress format.
+	m.Increment()
+	m.Increment()
+	screen.Clear()
+	m.Draw(screen)
+	all = readAllScreenText(screen, 80, 24)
+	if !strings.Contains(all, "(2/5)") {
+		t.Errorf("expected progress (2/5), got %q", all)
+	}
+}
+
+// readAllScreenText reads all text from the simulation screen.
+func readAllScreenText(screen tcell.SimulationScreen, width, height int) string {
+	var lines []string
+	for row := range height {
+		var runes []rune
+		for col := range width {
+			r, _, _, _ := screen.GetContent(col, row)
+			runes = append(runes, r)
+		}
+		lines = append(lines, string(runes))
+	}
+	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
Instead of a static worktree count, the prune modal now displays incremental progress (e.g. "2/5") as each worktree is cleaned. Each cleanup goroutine calls Increment() via QueueUpdateDraw, updating the display in real time.

Co-Authored-By: Claude <noreply@anthropic.com>