### PR TITLE
Pre-select project in new task form based on task list cursor

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -1384,7 +1384,7 @@ func (a *App) onNewTask() {
 	cfg := a.db.Config()
 
 	a.newTaskForm = NewNewTaskForm(
-		cfg.Projects, "", // TODO: default to currently selected project
+		cfg.Projects, a.tasklist.SelectedProject(),
 		cfg.Backends, cfg.Defaults.Backend,
 	)
 

--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -126,6 +126,15 @@ func (tl *TaskListView) SelectedTask() *model.Task {
 	return r.task
 }
 
+// SelectedProject returns the project name at the current cursor position,
+// whether the cursor is on a task row or a project header row.
+func (tl *TaskListView) SelectedProject() string {
+	if tl.cursor < 0 || tl.cursor >= len(tl.rows) {
+		return ""
+	}
+	return tl.rows[tl.cursor].project
+}
+
 // buildRows flattens tasks into display rows grouped by project.
 func (tl *TaskListView) buildRows() {
 	tl.rows = nil

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -753,3 +753,27 @@ func TestTaskListView_OpenPRKey(t *testing.T) {
 		t.Error("OnOpenPR should NOT fire for task without PR URL")
 	}
 }
+
+func TestTaskListView_SelectedProject(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetTasks(makeTasks())
+
+	// Starts on alpha's first task — SelectedProject should return "alpha".
+	if got := tl.SelectedProject(); got != "alpha" {
+		t.Errorf("SelectedProject = %q, want 'alpha'", got)
+	}
+
+	// Navigate down into beta.
+	for i := 0; i < 10; i++ {
+		tl.CursorDown()
+	}
+	if got := tl.SelectedProject(); got != "beta" {
+		t.Errorf("SelectedProject after navigating to beta = %q, want 'beta'", got)
+	}
+
+	// Empty list — should return "".
+	tl2 := NewTaskListView()
+	if got := tl2.SelectedProject(); got != "" {
+		t.Errorf("SelectedProject on empty list = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
When pressing 'n' in the task list, the project dropdown now defaults to the project the cursor is currently hovering over, instead of requiring manual selection.

Co-Authored-By: Claude <noreply@anthropic.com>