### PR TITLE
Fix PTY race condition between Resize and process exit

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -32,6 +32,7 @@ Non-obvious invariants and gotchas. For architecture, see CLAUDE.md. For feature
 
 ### PTY & Terminal Rendering
 
+- **`pty.Setsize` (which calls `os.File.Fd()`) races with `os.File.Close()`.** `Fd()` reads the internal fd field without synchronization, while `Close()` modifies it. `Read()`/`Write()` are safe (they use internal `fdMutex`). Fix: `ptmxClosed` bool flag under Session mutex; `waitLoop` sets flag + closes under lock; `Resize` checks flag under lock before calling `Setsize`.
 - **PTY needs real terminal size at launch** (`pty.StartWithSize`), not 0x0. TUI apps won't render with zero dimensions. Start at actual panel width, not 80x24 — agents format initial output for launch PTY size.
 - **Single-reader-tee pattern is critical.** Two goroutines reading the same fd causes data loss.
 - **`AddWriter` must replay before registering.** Register first → live bytes arrive before replay → duplicate data → rendering corruption.

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -39,6 +39,7 @@ type Session struct {
 	ptyCols    uint16    // current PTY width
 	ptyRows    uint16    // current PTY height
 	lastOutput time.Time // last time output was received from PTY
+	ptmxClosed bool      // true after waitLoop closes ptmx; guards Resize/WriteInput
 
 	logFile *os.File // PTY output log for post-session scrollback; nil if unavailable
 }
@@ -145,7 +146,10 @@ func (s *Session) readLoop() {
 // waitLoop waits for the process to exit and cleans up.
 func (s *Session) waitLoop() {
 	s.err = s.Cmd.Wait()
+	s.mu.Lock()
+	s.ptmxClosed = true
 	s.ptmx.Close()
+	s.mu.Unlock()
 	close(s.done)
 }
 
@@ -352,9 +356,12 @@ func (s *Session) WorkDir() string {
 // Resize sets the PTY window size.
 func (s *Session) Resize(rows, cols uint16) error {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.ptyCols = cols
 	s.ptyRows = rows
-	s.mu.Unlock()
+	if s.ptmxClosed {
+		return nil
+	}
 	return pty.Setsize(s.ptmx, &pty.Winsize{
 		Rows: rows,
 		Cols: cols,


### PR DESCRIPTION
Guard ptmx.Close() in waitLoop with Session mutex and a ptmxClosed flag so that Resize (which calls pty.Setsize → os.File.Fd()) cannot race with Close on the file descriptor.

Co-Authored-By: Claude <noreply@anthropic.com>