### PR TITLE
Skip file I/O during scroll to eliminate UI thread blocking

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -41,7 +41,7 @@ Non-obvious invariants and gotchas. For architecture, see CLAUDE.md. For feature
 - **Ring buffer must be bounded (256KB).** Unbounded causes CPU spikes and OOM. Session log file provides full scrollback.
 - **Live scrollback reads from session log file, not ring buffer.** `readLogTail` seeks from EOF — gives infinite scrollback while live follow-tail stays on the fast ring buffer path.
 - **Anchor-lock keeps scrolled-up content pinned when new output arrives.** Track `anchorTotalLines`; bump `scrollOffset` by the delta. Reset to 0 on scroll-to-bottom.
-- **Replay emulator is cached and reused when only scroll offset changes.** Rebuild only when input size or dimensions change.
+- **Replay emulator is cached and reused when only scroll offset changes.** Rebuild only when input size or dimensions change. `Draw()` must stat the log file (not read it) to check cache validity — `readLogTail()` does open+stat+seek+read of 1MB+ per call, which blocks the UI thread and makes scrolling laggy.
 - **Agent view replay must use current panel dimensions, not stale PTY size.** Override `ptyCols/ptyRows` with current dimensions for dead/nil sessions.
 - **Preview panel must use PTY width, not panel width, for VT emulation.** Otherwise text double-wraps.
 - **New emulators must default `cursorVisible` to `false`.** Agents send `\e[?25l` early, but after ring buffer wrap or emu rebuild, that sequence is lost. Defaulting to `true` causes a phantom cursor at bottom-left. Also, `lastContentRow` must not extend to cursor position when cursor is hidden.

--- a/internal/tui2/terminalpane.go
+++ b/internal/tui2/terminalpane.go
@@ -255,6 +255,18 @@ func (tp *TerminalPane) ScrollDown(n int) {
 	}
 }
 
+// statLogSize returns the current size of the session log file without reading it.
+// Returns 0 if the file doesn't exist or can't be stat'd. This is a cheap syscall
+// (~1μs) used to check replay emulator cache validity without the cost of a full read.
+func (tp *TerminalPane) statLogSize() int64 {
+	logPath := agent.SessionLogPath(tp.taskID)
+	fi, err := os.Stat(logPath)
+	if err != nil {
+		return 0
+	}
+	return fi.Size()
+}
+
 // readLogTail reads the last `size` bytes from the session log file.
 // Returns nil if the file doesn't exist or is empty. The log file is
 // concurrently appended by readLoop; using Open+Seek+Read (not ReadFile)
@@ -471,8 +483,33 @@ func (tp *TerminalPane) Draw(screen tcell.Screen) {
 	}
 
 	if tp.scrollOffset > 0 || !alive {
-		// Scrollback or finished session: use log file for full history,
-		// falling back to ring buffer or cached replay data.
+		// Fast path: if we have a cached replay emulator with matching
+		// dimensions and the log file hasn't grown, skip file I/O entirely
+		// and just repaint from the cache with the new scroll offset.
+		// This is the hot path during scrolling — stat (~1μs) vs read (~1-10ms).
+		// Mirrors renderReplay's needRebuild logic as an early-out before readLogTail.
+		if tp.replayEmu != nil && tp.replayEmuCols == ptyCols && tp.replayEmuRows == ptyRows {
+			cacheValid := false
+			if tp.taskID != "" {
+				logSize := tp.statLogSize()
+				if logSize > 0 && logSize == tp.replayEmuLogSize {
+					cacheValid = true
+				}
+			} else if tp.replayEmuLogSize == 0 {
+				// Non-log-backed: check ring buffer or replayData size.
+				if sess != nil {
+					cacheValid = tp.replayEmuBytes == sess.TotalWritten()
+				} else {
+					cacheValid = tp.replayEmuBytes == uint64(len(tp.replayData))
+				}
+			}
+			if cacheValid {
+				tp.paintEmu(screen, x, y, width, height, tp.replayEmu, ptyCols, ptyRows, tp.scrollOffset == 0, tp.replayEmuCursorVisible)
+				return
+			}
+		}
+
+		// Slow path: cache miss — read log file and rebuild emulator.
 		var raw []byte
 		var logSize int64
 

--- a/internal/tui2/terminalpane_test.go
+++ b/internal/tui2/terminalpane_test.go
@@ -700,6 +700,105 @@ func TestTerminalPane_RenderLiveSkipsCopyWhenIdle(t *testing.T) {
 	testutil.Equal(t, tp.emuFedTotal, uint64(len(newOutput)))
 }
 
+func TestTerminalPane_StatLogSize(t *testing.T) {
+	tp := NewTerminalPane()
+
+	// No taskID → should return 0.
+	tp.taskID = ""
+	size := tp.statLogSize()
+	testutil.Equal(t, size, int64(0))
+
+	// Non-existent task → should return 0.
+	tp.taskID = "nonexistent-task-id-99999"
+	size = tp.statLogSize()
+	testutil.Equal(t, size, int64(0))
+}
+
+func TestTerminalPane_ScrollCacheFastPath(t *testing.T) {
+	// When a cached replay emulator exists and the data source hasn't changed,
+	// scrolling (changing scrollOffset) should NOT rebuild the emulator.
+	// This is the fast path that avoids file I/O during scroll events.
+	tp := NewTerminalPane()
+	screen := tcell.NewSimulationScreen("UTF-8")
+	screen.Init() //nolint:errcheck
+	screen.SetSize(80, 24)
+
+	// Generate enough content to create scrollback.
+	var raw []byte
+	for i := 0; i < 50; i++ {
+		raw = append(raw, []byte("line of scrollable content here!\n")...)
+	}
+
+	// First render builds the emulator (non-log-backed: logSize=0).
+	tp.renderReplay(screen, 0, 0, 40, 10, raw, 0, 40, 10)
+	if tp.replayEmu == nil {
+		t.Fatal("replayEmu should be set after first render")
+	}
+	firstEmu := tp.replayEmu
+	testutil.Equal(t, tp.replayEmuBytes, uint64(len(raw)))
+
+	// Simulate scrolling up — only scrollOffset changes.
+	tp.scrollOffset = 5
+	tp.renderReplay(screen, 0, 0, 40, 10, raw, 0, 40, 10)
+	if tp.replayEmu != firstEmu {
+		t.Error("replayEmu should be reused when only scrollOffset changed (non-log path)")
+	}
+
+	// Scroll further up — still cached.
+	tp.scrollOffset = 20
+	tp.renderReplay(screen, 0, 0, 40, 10, raw, 0, 40, 10)
+	if tp.replayEmu != firstEmu {
+		t.Error("replayEmu should be reused on deeper scroll (non-log path)")
+	}
+
+	// Same test for log-backed path (logSize > 0).
+	tp.replayEmu = nil // force rebuild
+	tp.renderReplay(screen, 0, 0, 40, 10, raw, 5000, 40, 10)
+	logEmu := tp.replayEmu
+	if logEmu == nil {
+		t.Fatal("replayEmu should be set for log-backed render")
+	}
+
+	// Scroll with same logSize — should reuse.
+	tp.scrollOffset = 10
+	tp.renderReplay(screen, 0, 0, 40, 10, raw, 5000, 40, 10)
+	if tp.replayEmu != logEmu {
+		t.Error("replayEmu should be reused when logSize unchanged (scroll-only)")
+	}
+
+	// Different logSize (new output) — should rebuild.
+	tp.renderReplay(screen, 0, 0, 40, 10, raw, 6000, 40, 10)
+	if tp.replayEmu == logEmu {
+		t.Error("replayEmu should rebuild when logSize changes")
+	}
+}
+
+func TestTerminalPane_ScrollCacheDimensionChange(t *testing.T) {
+	// Changing terminal dimensions must invalidate the replay cache.
+	tp := NewTerminalPane()
+	screen := tcell.NewSimulationScreen("UTF-8")
+	screen.Init() //nolint:errcheck
+	screen.SetSize(80, 24)
+
+	raw := []byte("hello world\nline two\nline three\n")
+
+	tp.renderReplay(screen, 0, 0, 40, 10, raw, 0, 40, 10)
+	firstEmu := tp.replayEmu
+
+	// Change cols → must rebuild.
+	tp.renderReplay(screen, 0, 0, 60, 10, raw, 0, 60, 10)
+	if tp.replayEmu == firstEmu {
+		t.Error("replayEmu should rebuild when cols change")
+	}
+	secondEmu := tp.replayEmu
+
+	// Change rows → must rebuild.
+	tp.renderReplay(screen, 0, 0, 60, 15, raw, 0, 60, 15)
+	if tp.replayEmu == secondEmu {
+		t.Error("replayEmu should rebuild when rows change")
+	}
+}
+
 func TestDrawBorder(t *testing.T) {
 	screen := tcell.NewSimulationScreen("UTF-8")
 	screen.Init()


### PR DESCRIPTION
## Summary
- Adds `statLogSize()` — stat-only check (~1μs) for replay emulator cache validity
- Adds fast path in `Draw()` that skips `readLogTail()` (open+stat+seek+read 1MB+) when cache is valid
- Scrolling now only stats the file instead of reading it, eliminating per-scroll-event UI thread blocking

## Test plan
- [x] `TestTerminalPane_StatLogSize` — returns 0 for missing/empty taskID
- [x] `TestTerminalPane_ScrollCacheFastPath` — cache hit on scroll-only, miss on file growth
- [x] `TestTerminalPane_ScrollCacheDimensionChange` — cache invalidated on resize
- [x] Full tui2 test suite passes with race detector
- [ ] Manual: scroll up/down in agent view while agent is running — should be smooth with anchor-lock preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)