### PR TITLE
Add branch selector to new project modal

### DIFF
--- a/internal/gitutil/gitcmd.go
+++ b/internal/gitutil/gitcmd.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -136,6 +137,67 @@ func FetchDirFiles(taskID, worktree, dirPath string) DirFilesMsg {
 	}
 
 	return msg
+}
+
+// ListRemoteBranches returns remote-tracking branch names (e.g. "origin/main")
+// sorted with priority branches first. Returns nil if the path is not a git repo.
+func ListRemoteBranches(repoDir string) []string {
+	if repoDir == "" {
+		return nil
+	}
+	out, err := runGit(repoDir, "for-each-ref", "--format=%(refname:short)", "refs/remotes/")
+	if err != nil {
+		return nil
+	}
+	var branches []string
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasSuffix(line, "/HEAD") {
+			continue
+		}
+		branches = append(branches, line)
+	}
+	return sortBranchesWithPriority(branches)
+}
+
+// priorityBranches defines the preferred ordering for branch selection.
+// upstream first for fork workflows where upstream is the canonical remote.
+var priorityBranches = []string{
+	"upstream/master",
+	"origin/master",
+	"upstream/main",
+	"origin/main",
+}
+
+// sortBranchesWithPriority returns branches with priority entries first (in
+// order), followed by the remaining branches sorted alphabetically.
+func sortBranchesWithPriority(branches []string) []string {
+	if len(branches) == 0 {
+		return nil
+	}
+	prioritySet := make(map[string]bool, len(priorityBranches))
+	for _, b := range priorityBranches {
+		prioritySet[b] = true
+	}
+
+	var result []string
+	for _, pb := range priorityBranches {
+		for _, b := range branches {
+			if b == pb {
+				result = append(result, b)
+				break
+			}
+		}
+	}
+
+	var rest []string
+	for _, b := range branches {
+		if !prioritySet[b] {
+			rest = append(rest, b)
+		}
+	}
+	sort.Strings(rest)
+	return append(result, rest...)
 }
 
 func runGit(dir string, args ...string) (string, error) {

--- a/internal/gitutil/gitcmd_test.go
+++ b/internal/gitutil/gitcmd_test.go
@@ -1,0 +1,61 @@
+package gitutil
+
+import (
+	"testing"
+
+	"github.com/drn/argus/internal/testutil"
+)
+
+func TestSortBranchesWithPriority(t *testing.T) {
+	t.Run("priority branches first", func(t *testing.T) {
+		branches := []string{"origin/dev", "origin/main", "upstream/master", "origin/feature-a"}
+		got := sortBranchesWithPriority(branches)
+		testutil.DeepEqual(t, got, []string{
+			"upstream/master",
+			"origin/main",
+			"origin/dev",
+			"origin/feature-a",
+		})
+	})
+
+	t.Run("all priority branches in order", func(t *testing.T) {
+		branches := []string{"origin/main", "origin/master", "upstream/main", "upstream/master"}
+		got := sortBranchesWithPriority(branches)
+		testutil.DeepEqual(t, got, []string{
+			"upstream/master",
+			"origin/master",
+			"upstream/main",
+			"origin/main",
+		})
+	})
+
+	t.Run("no priority branches", func(t *testing.T) {
+		branches := []string{"origin/dev", "origin/feature-b", "origin/feature-a"}
+		got := sortBranchesWithPriority(branches)
+		testutil.DeepEqual(t, got, []string{
+			"origin/dev",
+			"origin/feature-a",
+			"origin/feature-b",
+		})
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		got := sortBranchesWithPriority(nil)
+		testutil.Nil(t, got)
+	})
+
+	t.Run("single branch", func(t *testing.T) {
+		got := sortBranchesWithPriority([]string{"origin/main"})
+		testutil.DeepEqual(t, got, []string{"origin/main"})
+	})
+}
+
+func TestListRemoteBranches_EmptyPath(t *testing.T) {
+	got := ListRemoteBranches("")
+	testutil.Nil(t, got)
+}
+
+func TestListRemoteBranches_InvalidPath(t *testing.T) {
+	got := ListRemoteBranches("/nonexistent/path")
+	testutil.Nil(t, got)
+}

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -1594,6 +1594,16 @@ func (a *App) closeConfirmDelete() {
 
 func (a *App) openProjectForm(edit bool, name string, p config.Project) {
 	a.projectForm = NewProjectForm()
+	a.projectForm.OnBranchFocus = func(path string) {
+		go func() {
+			branches := gitutil.ListRemoteBranches(path)
+			a.tapp.QueueUpdateDraw(func() {
+				if a.projectForm != nil {
+					a.projectForm.SetBranchOptions(branches)
+				}
+			})
+		}()
+	}
 	if edit {
 		a.projectForm.LoadProject(name, p)
 	}

--- a/internal/tui2/forms_test.go
+++ b/internal/tui2/forms_test.go
@@ -86,6 +86,143 @@ func TestProjectForm_Escape(t *testing.T) {
 	}
 }
 
+func TestProjectForm_BranchSelector(t *testing.T) {
+	// syncBranchLoader simulates the async OnBranchFocus pattern used in
+	// production (goroutine + QueueUpdateDraw) by calling SetBranchOptions
+	// synchronously within the callback. This is safe in tests since there
+	// is no tview event loop.
+	syncBranchLoader := func(pf *ProjectForm, branches []string) {
+		pf.OnBranchFocus = func(path string) {
+			pf.SetBranchOptions(branches)
+		}
+	}
+
+	t.Run("loads branches on tab to branch field", func(t *testing.T) {
+		pf := NewProjectForm()
+		syncBranchLoader(pf, []string{"upstream/master", "origin/main", "origin/feature"})
+		// Type a path.
+		pf.focused = pfFieldPath
+		pf.fields[pfFieldPath] = []rune("/tmp/repo")
+		// Tab to branch field.
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyTab, 0, 0))
+		if pf.focused != pfFieldBranch {
+			t.Fatalf("focused = %d, want %d", pf.focused, pfFieldBranch)
+		}
+		if len(pf.branchOptions) != 3 {
+			t.Fatalf("branchOptions = %d, want 3", len(pf.branchOptions))
+		}
+		if pf.branchIdx != 0 {
+			t.Errorf("branchIdx = %d, want 0", pf.branchIdx)
+		}
+	})
+
+	t.Run("left/right cycles branch options", func(t *testing.T) {
+		pf := NewProjectForm()
+		syncBranchLoader(pf, []string{"origin/master", "origin/main", "origin/dev"})
+		pf.focused = pfFieldPath
+		pf.fields[pfFieldPath] = []rune("/repo")
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyTab, 0, 0)) // → branch
+
+		// Right cycles forward.
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyRight, 0, 0))
+		if pf.branchIdx != 1 {
+			t.Errorf("after right: branchIdx = %d, want 1", pf.branchIdx)
+		}
+		// Left cycles back.
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyLeft, 0, 0))
+		if pf.branchIdx != 0 {
+			t.Errorf("after left: branchIdx = %d, want 0", pf.branchIdx)
+		}
+		// Left wraps to end.
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyLeft, 0, 0))
+		if pf.branchIdx != 2 {
+			t.Errorf("after wrap left: branchIdx = %d, want 2", pf.branchIdx)
+		}
+	})
+
+	t.Run("result returns selected branch", func(t *testing.T) {
+		pf := NewProjectForm()
+		syncBranchLoader(pf, []string{"origin/master", "origin/main"})
+		pf.fields[pfFieldName] = []rune("proj")
+		pf.fields[pfFieldPath] = []rune("/repo")
+		pf.focused = pfFieldPath
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyTab, 0, 0)) // → branch
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyRight, 0, 0))
+
+		_, proj := pf.Result()
+		if proj.Branch != "origin/main" {
+			t.Errorf("branch = %q, want origin/main", proj.Branch)
+		}
+	})
+
+	t.Run("pre-selects existing branch on edit", func(t *testing.T) {
+		pf := NewProjectForm()
+		syncBranchLoader(pf, []string{"origin/master", "origin/main", "origin/dev"})
+		pf.LoadProject("test", config.Project{Path: "/repo", Branch: "origin/main"})
+		// Tab from path → branch.
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyTab, 0, 0))
+		if pf.branchIdx != 1 {
+			t.Errorf("branchIdx = %d, want 1 (origin/main)", pf.branchIdx)
+		}
+	})
+
+	t.Run("no callback falls back to text input", func(t *testing.T) {
+		pf := NewProjectForm()
+		// No OnBranchFocus set.
+		pf.focused = pfFieldPath
+		pf.fields[pfFieldPath] = []rune("/repo")
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyTab, 0, 0)) // → branch
+		if pf.branchIsSelector() {
+			t.Error("should not be in selector mode without callback")
+		}
+		// Typing should still work.
+		for _, r := range "main" {
+			pf.HandleKey(tcell.NewEventKey(tcell.KeyRune, r, 0))
+		}
+		_, proj := pf.Result()
+		if proj.Branch != "main" {
+			t.Errorf("branch = %q, want main", proj.Branch)
+		}
+	})
+
+	t.Run("enter from path loads branches", func(t *testing.T) {
+		pf := NewProjectForm()
+		syncBranchLoader(pf, []string{"origin/main"})
+		pf.focused = pfFieldPath
+		pf.fields[pfFieldPath] = []rune("/repo")
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyEnter, 0, 0)) // → branch
+		if len(pf.branchOptions) != 1 {
+			t.Errorf("branchOptions = %d, want 1", len(pf.branchOptions))
+		}
+	})
+
+	t.Run("paste ignored in selector mode", func(t *testing.T) {
+		pf := NewProjectForm()
+		syncBranchLoader(pf, []string{"origin/main"})
+		pf.focused = pfFieldPath
+		pf.fields[pfFieldPath] = []rune("/repo")
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyTab, 0, 0)) // → branch
+		paste := pf.PasteHandler()
+		paste("garbage", func(p tview.Primitive) {})
+		_, proj := pf.Result()
+		if proj.Branch != "origin/main" {
+			t.Errorf("branch = %q, want origin/main (paste should be ignored)", proj.Branch)
+		}
+	})
+
+	t.Run("SetBranchOptions updates state", func(t *testing.T) {
+		pf := NewProjectForm()
+		pf.fields[pfFieldBranch] = []rune("origin/dev")
+		pf.SetBranchOptions([]string{"origin/master", "origin/dev", "origin/main"})
+		if pf.branchIdx != 1 {
+			t.Errorf("branchIdx = %d, want 1 (pre-selected origin/dev)", pf.branchIdx)
+		}
+		if !pf.branchIsSelector() {
+			t.Error("should be in selector mode after SetBranchOptions")
+		}
+	})
+}
+
 // --- BackendForm tests ---
 
 func TestBackendForm_New(t *testing.T) {

--- a/internal/tui2/projectform.go
+++ b/internal/tui2/projectform.go
@@ -19,13 +19,23 @@ const (
 // ProjectForm is a modal form for adding/editing projects.
 type ProjectForm struct {
 	*tview.Box
-	fields   [4][]rune // name, path, branch, backend
+	fields   [4][]rune // name, path, branch (fallback text), backend
 	cursors  [4]int
 	focused  int
 	editMode bool // true = editing (name read-only)
 	done     bool
 	canceled bool
 	errMsg   string
+
+	// Branch selector state
+	branchOptions []string // populated via SetBranchOptions
+	branchIdx     int
+	branchPath    string // path for which branches were last loaded
+
+	// OnBranchFocus is called when the branch field gains focus and the
+	// path has changed since the last load. The caller should fetch branches
+	// in a background goroutine and call SetBranchOptions with the results.
+	OnBranchFocus func(path string)
 }
 
 // NewProjectForm creates a new project form.
@@ -45,17 +55,54 @@ func (pf *ProjectForm) LoadProject(name string, p config.Project) {
 	pf.focused = pfFieldPath // skip name in edit mode
 }
 
-func (pf *ProjectForm) Done() bool     { return pf.done }
-func (pf *ProjectForm) Canceled() bool { return pf.canceled }
+func (pf *ProjectForm) Done() bool          { return pf.done }
+func (pf *ProjectForm) Canceled() bool      { return pf.canceled }
 func (pf *ProjectForm) SetError(msg string) { pf.errMsg = msg }
+
+// branchIsSelector returns true when the branch field should render as a
+// left/right selector instead of a text input.
+func (pf *ProjectForm) branchIsSelector() bool {
+	return len(pf.branchOptions) > 0
+}
+
+// SetBranchOptions sets the branch dropdown options. Called from a background
+// goroutine via QueueUpdateDraw after fetching branches.
+func (pf *ProjectForm) SetBranchOptions(options []string) {
+	pf.branchOptions = options
+	pf.branchIdx = 0
+
+	// Pre-select the current branch value if it matches an option.
+	cur := string(pf.fields[pfFieldBranch])
+	for i, b := range pf.branchOptions {
+		if b == cur {
+			pf.branchIdx = i
+			break
+		}
+	}
+}
 
 // Result returns the form values.
 func (pf *ProjectForm) Result() (name string, p config.Project) {
+	branch := string(pf.fields[pfFieldBranch])
+	if pf.branchIsSelector() && pf.branchIdx < len(pf.branchOptions) {
+		branch = pf.branchOptions[pf.branchIdx]
+	}
 	return string(pf.fields[pfFieldName]), config.Project{
 		Path:    string(pf.fields[pfFieldPath]),
-		Branch:  string(pf.fields[pfFieldBranch]),
+		Branch:  branch,
 		Backend: string(pf.fields[pfFieldBackend]),
 	}
+}
+
+// maybeLoadBranches fires OnBranchFocus when the path has changed since
+// the last load. The actual git call happens in a background goroutine.
+func (pf *ProjectForm) maybeLoadBranches() {
+	path := string(pf.fields[pfFieldPath])
+	if path == pf.branchPath || pf.OnBranchFocus == nil {
+		return
+	}
+	pf.branchPath = path
+	pf.OnBranchFocus(path)
 }
 
 // HandleKey processes key events for the form.
@@ -68,7 +115,10 @@ func (pf *ProjectForm) HandleKey(ev *tcell.EventKey) {
 		if pf.focused < pfFieldBackend {
 			pf.focused++
 			if pf.editMode && pf.focused == pfFieldName {
-				pf.focused++ // skip name in edit mode
+				pf.focused++
+			}
+			if pf.focused == pfFieldBranch {
+				pf.maybeLoadBranches()
 			}
 		} else {
 			pf.done = true
@@ -79,13 +129,29 @@ func (pf *ProjectForm) HandleKey(ev *tcell.EventKey) {
 		if pf.editMode && pf.focused == pfFieldName {
 			pf.focused++
 		}
+		if pf.focused == pfFieldBranch {
+			pf.maybeLoadBranches()
+		}
 		return
 	case tcell.KeyBacktab:
 		pf.focused = (pf.focused + 3) % 4
 		if pf.editMode && pf.focused == pfFieldName {
 			pf.focused = pfFieldBackend
 		}
+		if pf.focused == pfFieldBranch {
+			pf.maybeLoadBranches()
+		}
 		return
+	}
+
+	// Branch selector mode — left/right cycles options.
+	if pf.focused == pfFieldBranch && pf.branchIsSelector() {
+		pf.handleBranchSelector(ev)
+		return
+	}
+
+	// Text field input.
+	switch ev.Key() {
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
 		f := pf.focused
 		if pf.editMode && f == pfFieldName {
@@ -116,7 +182,20 @@ func (pf *ProjectForm) HandleKey(ev *tcell.EventKey) {
 		pf.cursors[f]++
 		return
 	}
-	_ = utf8.RuneError // ensure import
+}
+
+// handleBranchSelector processes keys when the branch field is in selector mode.
+func (pf *ProjectForm) handleBranchSelector(ev *tcell.EventKey) {
+	n := len(pf.branchOptions)
+	if n == 0 {
+		return
+	}
+	switch ev.Key() {
+	case tcell.KeyLeft:
+		pf.branchIdx = (pf.branchIdx - 1 + n) % n
+	case tcell.KeyRight:
+		pf.branchIdx = (pf.branchIdx + 1) % n
+	}
 }
 
 // PasteHandler handles bracketed paste events, inserting pasted text into the
@@ -125,6 +204,10 @@ func (pf *ProjectForm) PasteHandler() func(pastedText string, setFocus func(p tv
 	return pf.WrapPasteHandler(func(pastedText string, setFocus func(p tview.Primitive)) {
 		f := pf.focused
 		if pf.editMode && f == pfFieldName {
+			return
+		}
+		// Ignore paste on branch selector.
+		if f == pfFieldBranch && pf.branchIsSelector() {
 			return
 		}
 		runes := []rune(pastedText)
@@ -171,6 +254,7 @@ func (pf *ProjectForm) Draw(screen tcell.Screen) {
 	}
 
 	labels := [4]string{"Name:", "Path:", "Branch:", "Backend:"}
+	maxW := formW - 14
 	for i := range 4 {
 		ly := formY + 2 + i*2
 		if ly >= formY+formH-1 {
@@ -182,10 +266,15 @@ func (pf *ProjectForm) Draw(screen tcell.Screen) {
 		}
 		drawText(screen, formX+2, ly, 10, labels[i], style)
 
-		// Field value.
+		// Branch selector mode.
+		if i == pfFieldBranch && pf.branchIsSelector() {
+			pf.drawBranchSelector(screen, formX+12, ly, maxW)
+			continue
+		}
+
+		// Field value (text input).
 		val := string(pf.fields[i])
 		if i == pf.focused {
-			// Insert cursor.
 			before := string(pf.fields[i][:pf.cursors[i]])
 			after := string(pf.fields[i][pf.cursors[i]:])
 			val = before + "█" + after
@@ -195,7 +284,6 @@ func (pf *ProjectForm) Draw(screen tcell.Screen) {
 		} else {
 			style = tcell.StyleDefault
 		}
-		maxW := formW - 14
 		if len(val) > maxW {
 			val = val[len(val)-maxW:]
 		}
@@ -204,5 +292,28 @@ func (pf *ProjectForm) Draw(screen tcell.Screen) {
 
 	if pf.errMsg != "" {
 		drawText(screen, formX+2, formY+formH-2, formW-4, pf.errMsg, StyleError)
+	}
+}
+
+// drawBranchSelector renders the branch field as a ◀/▶ selector.
+func (pf *ProjectForm) drawBranchSelector(screen tcell.Screen, x, y, w int) {
+	if len(pf.branchOptions) == 0 {
+		drawText(screen, x, y, w, "(none)", StyleDimmed)
+		return
+	}
+
+	name := pf.branchOptions[pf.branchIdx]
+	selector := "◀ " + name + " ▶"
+	st := StyleNormal
+	if pf.focused == pfFieldBranch {
+		st = StyleSelected
+	}
+	drawText(screen, x, y, w, selector, st)
+
+	// Position indicator.
+	posText := "(" + itoa(pf.branchIdx+1) + "/" + itoa(len(pf.branchOptions)) + ")"
+	posX := x + w - utf8.RuneCountInString(posText)
+	if posX > x+utf8.RuneCountInString(selector)+1 {
+		drawText(screen, posX, y, utf8.RuneCountInString(posText), posText, StyleDimmed)
 	}
 }


### PR DESCRIPTION
## Summary
- Converts the branch field in the new project modal from a text input to a dropdown selector
- Fetches remote branches asynchronously via `git for-each-ref` when the field gains focus
- Priority branches (`upstream/master`, `origin/master`, `upstream/main`, `origin/main`) appear first if they exist
- Falls back to text input when no `OnBranchFocus` callback is set or no branches are found
- Left/Right arrow keys cycle through options; paste is ignored in selector mode

## Test plan
- [x] `TestSortBranchesWithPriority` — verifies priority ordering, alphabetical rest, edge cases
- [x] `TestProjectForm_BranchSelector` — 8 subtests covering load on tab/enter, cycling, result, pre-selection on edit, text fallback, paste ignore
- [x] `make build && make vet` clean
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)