### PR TITLE
Fix task list unresponsiveness from synchronous git on tick loop

### DIFF
--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -67,6 +67,7 @@ Non-obvious invariants and gotchas. For architecture, see CLAUDE.md. For feature
 - **Never call `GetInnerRect()` from the tick goroutine.** tview is not thread-safe. Store pending values under mutex in `Draw()`, read from tick goroutine.
 - **`refreshTasks()` must not do RPC while holding `a.mu`.** Fetch `runningIDs` OUTSIDE the lock.
 - **`TaskPreviewPanel.Draw()` must never call `runner.Get()` or create a VT emulator.** Pre-render in `RefreshOutput()` on tick goroutine; `Draw()` only paints cached cells.
+- **Never run synchronous git commands on the tick goroutine.** Blocking the tick goroutine prevents `QueueUpdateDraw` from firing, freezing the UI. Use `go` + cooldown (e.g., `lastTaskGitRefresh` with 3s interval). The agent view already follows this pattern — the task list must too.
 
 ### Sandbox (macOS sandbox-exec)
 

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -111,7 +111,8 @@ type App struct {
 	runningIDs      []string
 	idleIDs         []string
 	worktreeDir     string // resolved worktree dir for current agent view task
-	lastGitRefresh  time.Time
+	lastGitRefresh     time.Time
+	lastTaskGitRefresh time.Time
 
 	// Idle-unvisited tracking (for visual InReview promotion)
 	idleUnvisited    map[string]bool // task IDs idle since user last opened their agent view
@@ -360,12 +361,13 @@ func (a *App) onTick() {
 		}
 	}
 
-	// Refresh task list side panels (runs on tick goroutine — blocking is OK here).
+	// Refresh task list side panels.
 	if previewTaskID := a.taskPreview.TaskID(); previewTaskID != "" && a.mode == modeTaskList {
 		a.refreshPreview(previewTaskID)
 		// Also refresh git status for the selected task periodically.
-		if sel := a.tasklist.SelectedTask(); sel != nil && sel.Worktree != "" {
-			a.fetchTaskGitStatus(sel.ID, sel.Worktree)
+		if sel := a.tasklist.SelectedTask(); sel != nil && sel.Worktree != "" && time.Since(a.lastTaskGitRefresh) > 3*time.Second {
+			a.lastTaskGitRefresh = time.Now()
+			go a.fetchTaskGitStatus(sel.ID, sel.Worktree)
 		}
 	}
 


### PR DESCRIPTION
fetchTaskGitStatus was called synchronously on the tick goroutine every second with no cooldown, blocking the UI. Made it async with a 3-second cooldown, matching the agent view pattern.

Co-Authored-By: Claude <noreply@anthropic.com>