### PR TITLE
Add open links feature (o key) on ToDos tab

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -42,6 +42,7 @@ const (
 	modeForkTask
 	modeConfirmCleanupToDos
 	modeRenameTask
+	modeLinkPicker
 )
 
 // agentFocus tracks which panel has focus in the agent view.
@@ -89,6 +90,8 @@ type App struct {
 	// Launch to-do modal (created on demand)
 	launchToDoModal    *LaunchToDoModal
 	cleanupToDosModal *ConfirmCleanupToDosModal
+	linkPickerModal     *LinkPickerModal
+	linkPickerPrevPage  string
 
 	// Fork task modal (created on demand)
 	forkModal *ForkTaskModal
@@ -185,6 +188,9 @@ func New(database *db.DB, runner agent.SessionProvider, daemonConnected bool) *A
 	app.todos.SetVaultPath(vaultPath)
 	app.todos.OnLaunch = func(item ToDoItem) {
 		app.openLaunchToDoModal(item)
+	}
+	app.todos.OnOpenLinks = func(links []Link) {
+		app.openLinkPickerModal(links)
 	}
 	app.todos.OnStatusChange = func(t *model.Task) {
 		uxlog.Log("[todos] manual status change: task %s (%s) → %s", t.ID, t.Name, t.Status)
@@ -798,6 +804,12 @@ func (a *App) handleGlobalKey(event *tcell.EventKey) *tcell.EventKey {
 	// Cleanup to-dos confirmation modal
 	if a.mode == modeConfirmCleanupToDos && a.cleanupToDosModal != nil {
 		a.handleCleanupToDosKey(event)
+		return nil
+	}
+
+	// Link picker modal
+	if a.mode == modeLinkPicker && a.linkPickerModal != nil {
+		a.handleLinkPickerKey(event)
 		return nil
 	}
 
@@ -1832,6 +1844,45 @@ func (a *App) closeCleanupToDosModal() {
 	a.cleanupToDosModal = nil
 	a.pages.RemovePage("cleanuptodos")
 	a.pages.SwitchToPage("todos")
+}
+
+// openLinkPickerModal shows the link picker dialog.
+func (a *App) openLinkPickerModal(links []Link) {
+	// Remember the current page so we restore correctly on close.
+	name, _ := a.pages.GetFrontPage()
+	a.linkPickerPrevPage = name
+
+	a.linkPickerModal = NewLinkPickerModal(links)
+	a.mode = modeLinkPicker
+	a.pages.AddPage("linkpicker", a.linkPickerModal, true, true)
+	a.pages.SwitchToPage("linkpicker")
+	a.tapp.SetFocus(a.linkPickerModal)
+}
+
+// handleLinkPickerKey processes keys in the link picker modal.
+func (a *App) handleLinkPickerKey(event *tcell.EventKey) {
+	handler := a.linkPickerModal.InputHandler()
+	handler(event, func(p tview.Primitive) {})
+
+	if a.linkPickerModal.Canceled() {
+		a.closeLinkPickerModal()
+		return
+	}
+	if a.linkPickerModal.Selected() {
+		link := a.linkPickerModal.SelectedLink()
+		a.closeLinkPickerModal()
+		openURL(link.URL)
+	}
+}
+
+// closeLinkPickerModal closes the link picker modal.
+func (a *App) closeLinkPickerModal() {
+	a.mode = modeTaskList
+	a.linkPickerModal = nil
+	a.pages.RemovePage("linkpicker")
+	if a.linkPickerPrevPage != "" {
+		a.pages.SwitchToPage(a.linkPickerPrevPage)
+	}
 }
 
 // openConfirmDelete shows the confirm delete modal for the given task.

--- a/internal/tui2/todolinks.go
+++ b/internal/tui2/todolinks.go
@@ -1,0 +1,227 @@
+package tui2
+
+import (
+	"os/exec"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/drn/argus/internal/uxlog"
+)
+
+// Link represents a URL extracted from markdown content with optional label.
+type Link struct {
+	Label string // display text (markdown link text or the URL itself)
+	URL   string
+}
+
+// mdLinkRe matches markdown links: [text](url)
+var mdLinkRe = regexp.MustCompile(`\[([^\]]+)\]\((https?://[^\s)]+)\)`)
+
+// bareLinkRe matches bare URLs not already inside markdown link syntax.
+var bareLinkRe = regexp.MustCompile(`https?://[^\s)\]>]+`)
+
+// ExtractLinks extracts unique URLs from markdown content.
+// Markdown-style links [text](url) are preferred; bare URLs not already
+// captured by a markdown link are added with the URL as the label.
+func ExtractLinks(content string) []Link {
+	seen := make(map[string]bool)
+	var links []Link
+
+	// First pass: markdown links
+	for _, m := range mdLinkRe.FindAllStringSubmatch(content, -1) {
+		url := m[2]
+		if seen[url] {
+			continue
+		}
+		seen[url] = true
+		links = append(links, Link{Label: m[1], URL: url})
+	}
+
+	// Second pass: bare URLs not already captured
+	for _, url := range bareLinkRe.FindAllString(content, -1) {
+		if seen[url] {
+			continue
+		}
+		seen[url] = true
+		links = append(links, Link{Label: url, URL: url})
+	}
+
+	return links
+}
+
+// openURL opens the given URL in the default browser (macOS).
+// Only http:// and https:// schemes are allowed to prevent opening
+// file://, javascript:, or custom URI schemes from untrusted content.
+func openURL(url string) {
+	if !strings.HasPrefix(url, "https://") && !strings.HasPrefix(url, "http://") {
+		uxlog.Log("[todos] rejected non-http URL: %s", url)
+		return
+	}
+	exec.Command("open", url).Start() //nolint:errcheck
+	uxlog.Log("[todos] opened URL in browser: %s", url)
+}
+
+// ---------------------------------------------------------------------------
+// LinkPickerModal — selection dialog for multiple links
+// ---------------------------------------------------------------------------
+
+// LinkPickerModal presents a list of links for the user to choose from.
+type LinkPickerModal struct {
+	*tview.Box
+	links    []Link
+	cursor   int
+	selected bool
+	canceled bool
+}
+
+// NewLinkPickerModal creates a link picker dialog.
+func NewLinkPickerModal(links []Link) *LinkPickerModal {
+	return &LinkPickerModal{
+		Box:   tview.NewBox(),
+		links: links,
+	}
+}
+
+// Selected returns true if the user picked a link.
+func (m *LinkPickerModal) Selected() bool { return m.selected }
+
+// Canceled returns true if the user dismissed the modal.
+func (m *LinkPickerModal) Canceled() bool { return m.canceled }
+
+// SelectedLink returns the chosen link.
+func (m *LinkPickerModal) SelectedLink() Link {
+	if m.cursor >= 0 && m.cursor < len(m.links) {
+		return m.links[m.cursor]
+	}
+	return Link{}
+}
+
+// PasteHandler is a no-op — the link picker has no text input, but all
+// focused widgets must implement PasteHandler per project convention.
+func (m *LinkPickerModal) PasteHandler() func(string, func(tview.Primitive)) {
+	return m.WrapPasteHandler(func(_ string, _ func(tview.Primitive)) {})
+}
+
+// InputHandler handles key events for the link picker.
+func (m *LinkPickerModal) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+	return m.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+		switch event.Key() {
+		case tcell.KeyEscape:
+			m.canceled = true
+		case tcell.KeyEnter:
+			m.selected = true
+		case tcell.KeyUp:
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case tcell.KeyDown:
+			if m.cursor < len(m.links)-1 {
+				m.cursor++
+			}
+		case tcell.KeyRune:
+			switch event.Rune() {
+			case 'j':
+				if m.cursor < len(m.links)-1 {
+					m.cursor++
+				}
+			case 'k':
+				if m.cursor > 0 {
+					m.cursor--
+				}
+			}
+		}
+	})
+}
+
+// Draw renders the link picker as a centered modal.
+func (m *LinkPickerModal) Draw(screen tcell.Screen) {
+	m.Box.DrawForSubclass(screen, m)
+	x, y, width, height := m.GetInnerRect()
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	// Compute modal dimensions
+	maxLabelW := 0
+	for _, l := range m.links {
+		w := utf8.RuneCountInString(l.Label)
+		if w > maxLabelW {
+			maxLabelW = w
+		}
+	}
+
+	// modal width: label + padding + border
+	modalW := max(maxLabelW+6, 30)
+	modalW = min(modalW, width-4)
+	innerW := modalW - 4
+
+	// Height: border(1) + title padding(1) + items + padding(1) + help(1) + border(1)
+	maxVisible := max(min(len(m.links), height-6), 1)
+	modalH := maxVisible + 5 // border + gap + items + gap + help + border
+	if modalH > height {
+		return
+	}
+
+	mx := x + (width-modalW)/2
+	my := y + (height-modalH)/2
+
+	// Clear modal area
+	clearStyle := tcell.StyleDefault.Background(tcell.ColorDefault)
+	for row := my; row < my+modalH; row++ {
+		for col := mx; col < mx+modalW; col++ {
+			screen.SetContent(col, row, ' ', nil, clearStyle)
+		}
+	}
+
+	drawBorder(screen, mx, my, modalW, modalH, StyleFocusedBorder)
+
+	// Title
+	title := " Open Link "
+	titleX := mx + (modalW-utf8.RuneCountInString(title))/2
+	titleStyle := tcell.StyleDefault.Foreground(ColorTitle).Bold(true)
+	for i, r := range title {
+		screen.SetContent(titleX+i, my, r, nil, titleStyle)
+	}
+
+	innerX := mx + 2
+	row := my + 2
+
+	// Scrolling offset
+	offset := 0
+	if m.cursor >= maxVisible {
+		offset = m.cursor - maxVisible + 1
+	}
+
+	for i := 0; i < maxVisible; i++ {
+		idx := offset + i
+		if idx >= len(m.links) {
+			break
+		}
+		link := m.links[idx]
+		isCursor := idx == m.cursor
+
+		label := link.Label
+		if utf8.RuneCountInString(label) > innerW {
+			// Truncate
+			runes := []rune(label)
+			if innerW > 3 {
+				label = string(runes[:innerW-1]) + "…"
+			}
+		}
+
+		style := StyleNormal
+		if isCursor {
+			style = StyleSelected
+		}
+		drawText(screen, innerX, row+i, innerW, label, style)
+	}
+
+	// Help text
+	helpRow := my + modalH - 2
+	help := "↑/↓ select  Enter open  Esc cancel"
+	drawText(screen, innerX, helpRow, innerW, help, StyleDimmed)
+}

--- a/internal/tui2/todolinks_test.go
+++ b/internal/tui2/todolinks_test.go
@@ -1,0 +1,189 @@
+package tui2
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/drn/argus/internal/testutil"
+)
+
+func TestExtractLinks(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []Link
+	}{
+		{
+			name:    "no links",
+			content: "just plain text\nno urls here",
+			want:    nil,
+		},
+		{
+			name:    "single bare URL",
+			content: "check out https://example.com/page for details",
+			want:    []Link{{Label: "https://example.com/page", URL: "https://example.com/page"}},
+		},
+		{
+			name:    "single markdown link",
+			content: "see [Example](https://example.com/page) for info",
+			want:    []Link{{Label: "Example", URL: "https://example.com/page"}},
+		},
+		{
+			name:    "markdown link and bare URL",
+			content: "[Docs](https://docs.example.com)\nAlso see https://other.example.com",
+			want: []Link{
+				{Label: "Docs", URL: "https://docs.example.com"},
+				{Label: "https://other.example.com", URL: "https://other.example.com"},
+			},
+		},
+		{
+			name:    "duplicate URL in markdown and bare form",
+			content: "[My Site](https://example.com) and https://example.com",
+			want:    []Link{{Label: "My Site", URL: "https://example.com"}},
+		},
+		{
+			name:    "multiple markdown links",
+			content: "[A](https://a.com) and [B](https://b.com)",
+			want: []Link{
+				{Label: "A", URL: "https://a.com"},
+				{Label: "B", URL: "https://b.com"},
+			},
+		},
+		{
+			name:    "http scheme",
+			content: "link: http://insecure.example.com/path",
+			want:    []Link{{Label: "http://insecure.example.com/path", URL: "http://insecure.example.com/path"}},
+		},
+		{
+			name:    "URL with query parameters",
+			content: "see https://example.com/search?q=test&page=1",
+			want:    []Link{{Label: "https://example.com/search?q=test&page=1", URL: "https://example.com/search?q=test&page=1"}},
+		},
+		{
+			name:    "github PR URL",
+			content: "PR: https://github.com/org/repo/pull/123",
+			want:    []Link{{Label: "https://github.com/org/repo/pull/123", URL: "https://github.com/org/repo/pull/123"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractLinks(tt.content)
+			if tt.want == nil {
+				testutil.Equal(t, len(got), 0)
+				return
+			}
+			testutil.Equal(t, len(got), len(tt.want))
+			for i := range tt.want {
+				testutil.Equal(t, got[i].Label, tt.want[i].Label)
+				testutil.Equal(t, got[i].URL, tt.want[i].URL)
+			}
+		})
+	}
+}
+
+func TestLinkPickerModal_Navigation(t *testing.T) {
+	links := []Link{
+		{Label: "First", URL: "https://first.com"},
+		{Label: "Second", URL: "https://second.com"},
+		{Label: "Third", URL: "https://third.com"},
+	}
+
+	t.Run("initial state", func(t *testing.T) {
+		m := NewLinkPickerModal(links)
+		testutil.Equal(t, m.Selected(), false)
+		testutil.Equal(t, m.Canceled(), false)
+		testutil.Equal(t, m.SelectedLink().URL, "https://first.com")
+	})
+
+	t.Run("down arrow moves cursor", func(t *testing.T) {
+		m := NewLinkPickerModal(links)
+		handler := m.InputHandler()
+		handler(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone), func(p tview.Primitive) {})
+		testutil.Equal(t, m.SelectedLink().URL, "https://second.com")
+	})
+
+	t.Run("j key moves down", func(t *testing.T) {
+		m := NewLinkPickerModal(links)
+		handler := m.InputHandler()
+		handler(tcell.NewEventKey(tcell.KeyRune, 'j', tcell.ModNone), func(p tview.Primitive) {})
+		testutil.Equal(t, m.SelectedLink().URL, "https://second.com")
+	})
+
+	t.Run("k key moves up", func(t *testing.T) {
+		m := NewLinkPickerModal(links)
+		handler := m.InputHandler()
+		handler(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone), func(p tview.Primitive) {})
+		handler(tcell.NewEventKey(tcell.KeyRune, 'k', tcell.ModNone), func(p tview.Primitive) {})
+		testutil.Equal(t, m.SelectedLink().URL, "https://first.com")
+	})
+
+	t.Run("up at top stays at top", func(t *testing.T) {
+		m := NewLinkPickerModal(links)
+		handler := m.InputHandler()
+		handler(tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone), func(p tview.Primitive) {})
+		testutil.Equal(t, m.SelectedLink().URL, "https://first.com")
+	})
+
+	t.Run("down at bottom stays at bottom", func(t *testing.T) {
+		m := NewLinkPickerModal(links)
+		handler := m.InputHandler()
+		handler(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone), func(p tview.Primitive) {})
+		handler(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone), func(p tview.Primitive) {})
+		handler(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone), func(p tview.Primitive) {})
+		testutil.Equal(t, m.SelectedLink().URL, "https://third.com")
+	})
+
+	t.Run("enter selects", func(t *testing.T) {
+		m := NewLinkPickerModal(links)
+		handler := m.InputHandler()
+		handler(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone), func(p tview.Primitive) {})
+		handler(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone), func(p tview.Primitive) {})
+		testutil.Equal(t, m.Selected(), true)
+		testutil.Equal(t, m.SelectedLink().URL, "https://second.com")
+	})
+
+	t.Run("escape cancels", func(t *testing.T) {
+		m := NewLinkPickerModal(links)
+		handler := m.InputHandler()
+		handler(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone), func(p tview.Primitive) {})
+		testutil.Equal(t, m.Canceled(), true)
+		testutil.Equal(t, m.Selected(), false)
+	})
+}
+
+func TestOpenURL_RejectsNonHTTP(t *testing.T) {
+	// openURL should silently reject non-http schemes.
+	// We can't easily test exec.Command didn't fire, but we verify no panic.
+	openURL("file:///etc/passwd")
+	openURL("javascript:alert(1)")
+	openURL("")
+	// Valid schemes should not panic either.
+	// (We can't stop "open" from actually launching, so just verify no crash.)
+}
+
+func TestToDosView_OpenLinks_Callback(t *testing.T) {
+	v := NewToDosView()
+	items := []ToDoItem{
+		{
+			Name:    "multi-link",
+			Path:    "/tmp/multi.md",
+			Content: "[A](https://a.com) and [B](https://b.com)",
+		},
+	}
+	v.list.SetItems(items)
+
+	var receivedLinks []Link
+	v.OnOpenLinks = func(links []Link) {
+		receivedLinks = links
+	}
+
+	// Simulate pressing 'o'
+	v.HandleKey(tcell.NewEventKey(tcell.KeyRune, 'o', tcell.ModNone))
+
+	testutil.Equal(t, len(receivedLinks), 2)
+	testutil.Equal(t, receivedLinks[0].Label, "A")
+	testutil.Equal(t, receivedLinks[1].Label, "B")
+}

--- a/internal/tui2/todos.go
+++ b/internal/tui2/todos.go
@@ -31,6 +31,8 @@ type ToDosView struct {
 	OnLaunch func(item ToDoItem)
 	// Callback when the user changes a linked task's status via s/S keys.
 	OnStatusChange func(task *model.Task)
+	// Callback when the user presses 'o' and multiple links are found.
+	OnOpenLinks func(links []Link)
 }
 
 // NewToDosView creates the To Dos tab with three-panel layout.
@@ -175,9 +177,39 @@ func (v *ToDosView) HandleKey(event *tcell.EventKey) bool {
 				}
 			}
 			return true
+		case 'o':
+			v.openLinks()
+			return true
 		}
 	}
 	return false
+}
+
+// openLinks extracts links from the selected to-do and either opens the
+// single link directly or invokes OnOpenLinks for the user to pick one.
+func (v *ToDosView) openLinks() {
+	item := v.list.SelectedItem()
+	if item == nil {
+		return
+	}
+
+	// Collect links: PR URL from linked task + URLs from markdown content.
+	var links []Link
+	if t, ok := v.taskMap[item.Path]; ok && t.PRURL != "" {
+		links = append(links, Link{Label: "PR: " + t.PRURL, URL: t.PRURL})
+	}
+	links = append(links, ExtractLinks(item.Content)...)
+
+	if len(links) == 0 {
+		return
+	}
+	if len(links) == 1 {
+		openURL(links[0].URL)
+		return
+	}
+	if v.OnOpenLinks != nil {
+		v.OnOpenLinks(links)
+	}
 }
 
 // Draw renders the three-panel layout or an empty state.


### PR DESCRIPTION
Pressing 'o' on a todo item extracts URLs from the markdown content and linked task PR URL. Single link opens directly in the browser; multiple links show a picker dialog for selection. Includes URL scheme validation, PasteHandler per project convention, and proper page restore on modal close.

Co-Authored-By: Claude <noreply@anthropic.com>