### PR TITLE
Add word-level navigation to rename task form

### DIFF
--- a/internal/tui2/forms_test.go
+++ b/internal/tui2/forms_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rivo/tview"
 
 	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/testutil"
 )
 
 // --- ProjectForm tests ---
@@ -354,4 +355,91 @@ func TestRenameTaskForm_Escape(t *testing.T) {
 	if !rf.Canceled() {
 		t.Error("should be canceled")
 	}
+}
+
+func TestRenameTaskForm_WordNavigation(t *testing.T) {
+	t.Run("alt+left jumps word left", func(t *testing.T) {
+		rf := NewRenameTaskForm("hello world")
+		// cursor at end (11)
+		rf.HandleKey(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModAlt))
+		testutil.Equal(t, rf.cursor, 6) // before "world"
+	})
+
+	t.Run("alt+right jumps word right", func(t *testing.T) {
+		rf := NewRenameTaskForm("hello world")
+		rf.cursor = 0
+		rf.HandleKey(tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModAlt))
+		testutil.Equal(t, rf.cursor, 5) // after "hello"
+	})
+
+	t.Run("alt+backspace deletes word left", func(t *testing.T) {
+		rf := NewRenameTaskForm("hello world")
+		rf.HandleKey(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModAlt))
+		testutil.Equal(t, rf.Name(), "hello ")
+		testutil.Equal(t, rf.cursor, 6)
+	})
+
+	t.Run("alt+b jumps word left", func(t *testing.T) {
+		rf := NewRenameTaskForm("hello world")
+		rf.HandleKey(tcell.NewEventKey(tcell.KeyRune, 'b', tcell.ModAlt))
+		testutil.Equal(t, rf.cursor, 6)
+	})
+
+	t.Run("alt+f jumps word right", func(t *testing.T) {
+		rf := NewRenameTaskForm("hello world")
+		rf.cursor = 0
+		rf.HandleKey(tcell.NewEventKey(tcell.KeyRune, 'f', tcell.ModAlt))
+		testutil.Equal(t, rf.cursor, 5)
+	})
+
+	t.Run("alt+d deletes word right", func(t *testing.T) {
+		rf := NewRenameTaskForm("hello world")
+		rf.cursor = 0
+		rf.HandleKey(tcell.NewEventKey(tcell.KeyRune, 'd', tcell.ModAlt))
+		testutil.Equal(t, rf.Name(), " world")
+		testutil.Equal(t, rf.cursor, 0)
+	})
+
+	t.Run("ctrl+a moves to start", func(t *testing.T) {
+		rf := NewRenameTaskForm("hello")
+		rf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlA, 0, 0))
+		testutil.Equal(t, rf.cursor, 0)
+	})
+
+	t.Run("ctrl+e moves to end", func(t *testing.T) {
+		rf := NewRenameTaskForm("hello")
+		rf.cursor = 0
+		rf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlE, 0, 0))
+		testutil.Equal(t, rf.cursor, 5)
+	})
+
+	t.Run("ctrl+w deletes word left", func(t *testing.T) {
+		rf := NewRenameTaskForm("hello world")
+		rf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlW, 0, 0))
+		testutil.Equal(t, rf.Name(), "hello ")
+	})
+
+	t.Run("ctrl+u deletes to start", func(t *testing.T) {
+		rf := NewRenameTaskForm("hello world")
+		rf.cursor = 5
+		rf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlU, 0, 0))
+		testutil.Equal(t, rf.Name(), " world")
+		testutil.Equal(t, rf.cursor, 0)
+	})
+
+	t.Run("ctrl+k deletes to end", func(t *testing.T) {
+		rf := NewRenameTaskForm("hello world")
+		rf.cursor = 5
+		rf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlK, 0, 0))
+		testutil.Equal(t, rf.Name(), "hello")
+		testutil.Equal(t, rf.cursor, 5)
+	})
+
+	t.Run("delete key removes char at cursor", func(t *testing.T) {
+		rf := NewRenameTaskForm("hello")
+		rf.cursor = 0
+		rf.HandleKey(tcell.NewEventKey(tcell.KeyDelete, 0, 0))
+		testutil.Equal(t, rf.Name(), "ello")
+		testutil.Equal(t, rf.cursor, 0)
+	})
 }

--- a/internal/tui2/renametask.go
+++ b/internal/tui2/renametask.go
@@ -34,26 +34,71 @@ func (rf *RenameTaskForm) ResetDone()          { rf.done = false }
 
 // HandleKey processes key events for the rename form.
 func (rf *RenameTaskForm) HandleKey(ev *tcell.EventKey) {
+	mod := ev.Modifiers()
+	hasAlt := mod&tcell.ModAlt != 0
+
 	switch ev.Key() {
 	case tcell.KeyEscape:
 		rf.canceled = true
 	case tcell.KeyEnter:
 		rf.done = true
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
+		if hasAlt {
+			rf.name, rf.cursor = deleteWordLeft(rf.name, rf.cursor)
+			return
+		}
 		if rf.cursor > 0 {
 			rf.name = append(rf.name[:rf.cursor-1], rf.name[rf.cursor:]...)
 			rf.cursor--
 		}
+	case tcell.KeyCtrlW:
+		rf.name, rf.cursor = deleteWordLeft(rf.name, rf.cursor)
+	case tcell.KeyDelete:
+		if hasAlt {
+			rf.name, rf.cursor = deleteWordRight(rf.name, rf.cursor)
+			return
+		}
+		if rf.cursor < len(rf.name) {
+			rf.name = append(rf.name[:rf.cursor], rf.name[rf.cursor+1:]...)
+		}
 	case tcell.KeyLeft:
+		if hasAlt {
+			rf.cursor = wordLeftPos(rf.name, rf.cursor)
+			return
+		}
 		if rf.cursor > 0 {
 			rf.cursor--
 		}
 	case tcell.KeyRight:
+		if hasAlt {
+			rf.cursor = wordRightPos(rf.name, rf.cursor)
+			return
+		}
 		if rf.cursor < len(rf.name) {
 			rf.cursor++
 		}
+	case tcell.KeyHome, tcell.KeyCtrlA:
+		rf.cursor = 0
+	case tcell.KeyEnd, tcell.KeyCtrlE:
+		rf.cursor = len(rf.name)
+	case tcell.KeyCtrlU:
+		rf.name = rf.name[rf.cursor:]
+		rf.cursor = 0
+	case tcell.KeyCtrlK:
+		rf.name = rf.name[:rf.cursor]
 	case tcell.KeyRune:
 		r := ev.Rune()
+		if hasAlt {
+			switch r {
+			case 'b', 'B':
+				rf.cursor = wordLeftPos(rf.name, rf.cursor)
+			case 'f', 'F':
+				rf.cursor = wordRightPos(rf.name, rf.cursor)
+			case 'd', 'D':
+				rf.name, rf.cursor = deleteWordRight(rf.name, rf.cursor)
+			}
+			return
+		}
 		rf.name = append(rf.name[:rf.cursor], append([]rune{r}, rf.name[rf.cursor:]...)...)
 		rf.cursor++
 	}
@@ -88,9 +133,7 @@ func (rf *RenameTaskForm) Draw(screen tcell.Screen) {
 	formH := 7
 	formX := x + (width-formW)/2
 	formY := y + (height-formH)/2
-	if formY < y {
-		formY = y
-	}
+	formY = max(formY, y)
 
 	drawBorder(screen, formX, formY, formW, formH, StyleFocusedBorder)
 	drawText(screen, formX+2, formY+1, formW-4, "Rename Task", StyleTitle)


### PR DESCRIPTION
Add option+delete, option+arrow, and emacs-style editing shortcuts (Ctrl+A/E/U/K/W, Alt+B/F/D) to the rename task modal, matching the new task form behavior.

Co-Authored-By: Claude <noreply@anthropic.com>