### PR TITLE
Show restart-required hint for API settings toggle

### DIFF
--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -1216,3 +1216,19 @@ When the daemon crashed, one task was incorrectly marked Complete despite its ag
 - `len(raw)` is NOT a valid cache key for ring buffer content — once full (256KB), length is constant but content changes on every wrap. Use `TotalWritten()` instead.
 - `refreshPreview` is called from both tick goroutine and `onTaskCursorChange` goroutine — any shared state must be mutex-protected.
 - `readLoop` data alias (`tmp[:n]`) requires all writers to copy synchronously. An async writer storing a reference to `p` would corrupt data.
+
+## API Settings Restart Hint: 2026-03-23
+
+### Data Model
+- `apiEnabledAtBoot bool` — snapshot of `cfg.API.Enabled` on first `Refresh()` after daemon (re)start
+- `apiBootRecorded bool` — true after boot value captured; reset to false by `SetDaemonRestarting(false)`
+
+### Flow
+1. First `Refresh()` → captures `apiEnabledAtBoot`, sets `apiBootRecorded = true`
+2. User toggles API → `apiEnabled` changes → `rebuildRows` appends "(restart required)" when `apiEnabled != apiEnabledAtBoot`
+3. Double-toggle back to boot value → hint disappears (values match again)
+4. Any daemon restart completion → `SetDaemonRestarting(false)` resets `apiBootRecorded = false` → next `Refresh()` re-anchors
+
+### Gotchas
+- `SetDaemonRestarting(false)` is the single reset point for both manual and auto-restart paths — do not add a redundant reset in `handleEnter`
+- `rebuildRows` guards with `apiBootRecorded &&` to suppress the hint during the window between restart and next `Refresh()`

--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -179,3 +179,4 @@ Non-obvious invariants and gotchas. For architecture, see CLAUDE.md. For feature
 - **Headless task creation uses default 24x80 PTY dimensions.** Agents format initial output for the PTY size at launch. The TUI resizes the PTY when a user opens the agent view, so headless tasks auto-correct on attach.
 - **API server binds to `0.0.0.0` (not `127.0.0.1`) for Tailscale access.** MCP server uses `127.0.0.1` (local-only), but the API must be reachable over Tailscale's network interface. Auth is via bearer token from `~/.argus/api-token`.
 - **`HeadlessCreateTask` must revert task to Pending on `runner.Start` failure.** Clear SessionID and zero StartedAt — same revert pattern as `startSession` in `app.go`.
+- **API server only starts during daemon `Serve()` init — toggling `api.enabled` in Settings requires a daemon restart.** `SetDaemonRestarting(false)` resets `apiBootRecorded` so the "(restart required)" hint re-anchors after any restart path (manual or auto).

--- a/internal/tui2/settings.go
+++ b/internal/tui2/settings.go
@@ -67,8 +67,10 @@ type SettingsView struct {
 	kbTaskSync     bool
 
 	// API.
-	apiEnabled bool
-	apiPort    int
+	apiEnabled       bool
+	apiEnabledAtBoot bool // value when daemon started; used to show "restart required"
+	apiBootRecorded  bool // true after first Refresh captures boot value
+	apiPort          int
 
 	// ToDo defaults.
 	todoProject  string   // current default todo project
@@ -165,6 +167,10 @@ func (sv *SettingsView) Refresh() {
 	sv.kbTaskSync = cfg.KB.AutoCreateTasks
 
 	// API.
+	if !sv.apiBootRecorded {
+		sv.apiEnabledAtBoot = cfg.API.Enabled
+		sv.apiBootRecorded = true
+	}
 	sv.apiEnabled = cfg.API.Enabled
 	sv.apiPort = cfg.API.HTTPPort
 	if sv.apiPort == 0 {
@@ -271,6 +277,9 @@ func (sv *SettingsView) rebuildRows() {
 	apiLabel := "  Disabled"
 	if sv.apiEnabled {
 		apiLabel = fmt.Sprintf("  Enabled (port %d)", sv.apiPort)
+	}
+	if sv.apiBootRecorded && sv.apiEnabled != sv.apiEnabledAtBoot {
+		apiLabel += " (restart required)"
 	}
 	sv.rows = append(sv.rows, settingsRow{kind: srAPI, label: apiLabel, key: "_api"})
 
@@ -882,6 +891,10 @@ func (sv *SettingsView) renderDaemonDetail(screen tcell.Screen, x, y, w, h int) 
 // SetDaemonRestarting updates the restarting state from the app.
 func (sv *SettingsView) SetDaemonRestarting(restarting bool) {
 	sv.daemonRestarting = restarting
+	if !restarting {
+		// Daemon just came back — re-capture boot state on next Refresh.
+		sv.apiBootRecorded = false
+	}
 	sv.rebuildRows()
 }
 

--- a/internal/tui2/settings_test.go
+++ b/internal/tui2/settings_test.go
@@ -3,6 +3,7 @@ package tui2
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
@@ -440,6 +441,78 @@ func TestSettingsView_DaemonRestart(t *testing.T) {
 	if sv.daemonRestarting {
 		t.Error("daemonRestarting should be false after SetDaemonRestarting(false)")
 	}
+}
+
+func TestSettingsView_APIRestartHint(t *testing.T) {
+	sv := testSettingsView(t)
+
+	// After first Refresh, boot state is recorded.
+	testutil.Equal(t, sv.apiBootRecorded, true)
+	testutil.Equal(t, sv.apiEnabledAtBoot, false) // default is disabled
+
+	apiLabel := func() string {
+		for _, row := range sv.rows {
+			if row.kind == srAPI {
+				return row.label
+			}
+		}
+		return ""
+	}
+
+	t.Run("no hint when state matches boot", func(t *testing.T) {
+		testutil.Equal(t, apiLabel(), "  Disabled")
+	})
+
+	t.Run("hint appears after toggle", func(t *testing.T) {
+		// Toggle API on.
+		for i, row := range sv.rows {
+			if row.kind == srAPI {
+				sv.cursor = i
+				sv.handleEnter()
+				break
+			}
+		}
+		testutil.Contains(t, apiLabel(), "(restart required)")
+	})
+
+	t.Run("hint disappears after double toggle", func(t *testing.T) {
+		for i, row := range sv.rows {
+			if row.kind == srAPI {
+				sv.cursor = i
+				sv.handleEnter()
+				break
+			}
+		}
+		label := apiLabel()
+		if strings.Contains(label, "(restart required)") {
+			t.Errorf("hint should disappear after toggling back, got %q", label)
+		}
+	})
+
+	t.Run("hint clears after daemon restart completes", func(t *testing.T) {
+		// Toggle API on again to show hint.
+		for i, row := range sv.rows {
+			if row.kind == srAPI {
+				sv.cursor = i
+				sv.handleEnter()
+				break
+			}
+		}
+		testutil.Contains(t, apiLabel(), "(restart required)")
+
+		// Simulate daemon restart completion (covers both manual and auto paths).
+		sv.SetDaemonRestarting(false)
+		testutil.Equal(t, sv.apiBootRecorded, false)
+
+		// Next Refresh re-anchors boot state — hint should clear.
+		sv.Refresh()
+		testutil.Equal(t, sv.apiBootRecorded, true)
+		testutil.Equal(t, sv.apiEnabledAtBoot, true) // now matches toggled state
+		label := apiLabel()
+		if strings.Contains(label, "(restart required)") {
+			t.Errorf("hint should clear after restart + refresh, got %q", label)
+		}
+	})
 }
 
 func TestSettingsView_LogScrollResetOnCursorMove(t *testing.T) {


### PR DESCRIPTION
Show '(restart required)' in Settings API row when toggle state differs from daemon boot state. Covers both manual and auto-restart paths via SetDaemonRestarting reset.

Co-Authored-By: Claude <noreply@anthropic.com>