### PR TITLE
Fix todo status loss after pruning and daemon restart

### DIFF
--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -69,7 +69,6 @@ func runTUI() {
 	client, err := dclient.Connect(sockPath)
 	if err != nil {
 		uxlog.Log("no daemon at %s, auto-starting...", sockPath)
-		daemonFreshStart = true // fresh daemon has no prior sessions
 		client, err = dclient.AutoStart(sockPath)
 	}
 
@@ -86,6 +85,7 @@ func runTUI() {
 	} else {
 		uxlog.Log("connected to daemon at %s", sockPath)
 		daemonConnected = true
+		daemonFreshStart = client.FreshStart() // true when daemon was auto-started (no prior sessions)
 		runner = client
 		defer client.Close()
 	}

--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -63,11 +63,13 @@ func runTUI() {
 
 	var runner agent.SessionProvider
 	var daemonConnected bool
+	var daemonFreshStart bool
 
 	sockPath := daemon.DefaultSocketPath()
 	client, err := dclient.Connect(sockPath)
 	if err != nil {
 		uxlog.Log("no daemon at %s, auto-starting...", sockPath)
+		daemonFreshStart = true // fresh daemon has no prior sessions
 		client, err = dclient.AutoStart(sockPath)
 	}
 
@@ -99,7 +101,7 @@ func runTUI() {
 		})
 	}
 
-	app := tui2.New(database, runner, daemonConnected)
+	app := tui2.New(database, runner, daemonConnected, daemonFreshStart)
 	appRef = app
 	appRef2 = app
 	if err := app.Run(); err != nil {

--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -30,6 +30,7 @@ Non-obvious invariants and gotchas. For architecture, see CLAUDE.md. For feature
 - **`startOrAttach` must revert all state on Start failure.** Reset to Pending, clear SessionID, zero StartedAt. `SetStatus(StatusPending)` doesn't clear StartedAt — explicit zero required.
 - **Daemon session exits must be wired to TUI via `client.OnSessionExit`.** Without this, tasks stay InProgress forever in daemon mode.
 - **`restartDaemon` must re-wire `OnSessionExit` on the new client.**
+- **Fresh daemon auto-start must reconcile InProgress → InReview, not Complete.** When the TUI auto-starts a daemon (no prior daemon running), `daemonRestarting` is `false` but the daemon has zero sessions. Without `daemonFreshStart`, reconciliation marks all InProgress tasks Complete — losing todo status indicators. The flag is cleared after the first reconciliation so subsequent ticks use normal Complete behavior.
 - **SessionID must be populated before first `runner.Start` for Claude backends, and captured post-exit for Codex.** Claude uses `--session-id <uuid>` on first run and `--resume <uuid>` on subsequent runs. Codex captures its ID from `~/.codex/state_5.sqlite` after exit. Without a SessionID, `resume` is always false and every start is a fresh conversation.
 - **Codex session ID capture (`CaptureCodexSessionID`) must run off the tview main goroutine.** It opens a SQLite connection which can block. Use a background goroutine + `QueueUpdateDraw` to persist.
 
@@ -137,6 +138,7 @@ Non-obvious invariants and gotchas. For architecture, see CLAUDE.md. For feature
 ### Todo-Task Association
 
 - **`TodoPath` links a task to its source vault `.md` file.** Set only during `handleLaunchToDoKey`. `TasksByTodoPath()` returns most-recent task per path (ORDER BY created_at ASC, last wins).
+- **`PruneCompleted` must skip tasks with `todo_path` set.** Without the `AND todo_path = ''` filter, pruning deletes todo-linked completed tasks. The vault files survive but the association is lost — todo bullets revert to "not started" on next scan. Todo-linked tasks should only be cleaned up via the ToDo cleanup flow (Ctrl+R on ToDos tab), which removes vault files and tasks together.
 - **Ctrl+R cleanup on ToDos tab deletes vault files, not tasks.** Only `.md` files for todos with completed linked tasks are removed. Tasks remain in Argus history.
 - **`taskColumns`/`scanTask`/`Add`/`Update` lockstep includes `todo_path`.** Column position is after `pr_url`, before `archived`. Missing any site causes runtime panics.
 

--- a/internal/daemon/client/client.go
+++ b/internal/daemon/client/client.go
@@ -33,10 +33,11 @@ var _ agent.SessionProvider = (*Client)(nil)
 
 // Client connects to the daemon and implements agent.SessionProvider.
 type Client struct {
-	rpc      *rpc.Client
-	sockPath string
-	sessions map[string]*RemoteSession
-	mu       sync.Mutex
+	rpc        *rpc.Client
+	sockPath   string
+	sessions   map[string]*RemoteSession
+	freshStart bool // true when the daemon was auto-started (no prior sessions)
+	mu         sync.Mutex
 
 	// leakedCalls tracks goroutines from timed-out RPC calls that are still
 	// blocked in rpc.Call. Logged for observability — drain goroutines
@@ -46,6 +47,12 @@ type Client struct {
 	// onSessionExit is called when a session's stream EOF is detected.
 	// Includes exit info (error, stopped flag, last output) from the daemon.
 	onSessionExit func(taskID string, info daemon.ExitInfo)
+}
+
+// FreshStart returns true when this client connected to a freshly auto-started
+// daemon that has no prior sessions (as opposed to an already-running daemon).
+func (c *Client) FreshStart() bool {
+	return c.freshStart
 }
 
 // Connect dials the daemon socket and returns a Client.
@@ -327,6 +334,7 @@ func AutoStart(sockPath string) (*Client, error) {
 	for time.Now().Before(deadline) {
 		time.Sleep(pollInterval)
 		if client, err := Connect(sockPath); err == nil {
+			client.freshStart = true
 			return client, nil
 		}
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1416,6 +1416,36 @@ func TestDB_PruneCompleted_AllStatuses(t *testing.T) {
 	}
 }
 
+func TestDB_PruneCompleted_PreservesToDoLinked(t *testing.T) {
+	d := testDB(t)
+
+	_ = d.Add(&model.Task{Name: "regular-done", Status: model.StatusComplete})
+	_ = d.Add(&model.Task{Name: "todo-done", Status: model.StatusComplete, TodoPath: "/vault/task.md"})
+	_ = d.Add(&model.Task{Name: "pending", Status: model.StatusPending})
+
+	pruned, err := d.PruneCompleted()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pruned) != 1 {
+		t.Errorf("expected 1 pruned (regular only), got %d", len(pruned))
+	}
+	if len(pruned) > 0 && pruned[0].Name != "regular-done" {
+		t.Errorf("pruned wrong task: %q", pruned[0].Name)
+	}
+
+	remaining := d.Tasks()
+	if len(remaining) != 2 {
+		t.Errorf("expected 2 remaining (todo-done + pending), got %d", len(remaining))
+	}
+
+	// The todo-linked task should still be retrievable via TasksByTodoPath.
+	todoMap := d.TasksByTodoPath()
+	if _, ok := todoMap["/vault/task.md"]; !ok {
+		t.Error("todo-linked completed task should be preserved after prune")
+	}
+}
+
 func TestMigration_OnlyRunsOnce(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "data.sql")
 

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -146,8 +146,10 @@ func (d *DB) PruneCompleted() ([]*model.Task, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	// Fetch completed tasks first
-	rows, err := d.conn.Query(`SELECT ` + taskColumns + ` FROM tasks WHERE status='complete'`)
+	// Fetch completed tasks first. Skip tasks with a todo_path — those are
+	// linked to vault files and should only be cleaned up via the ToDo
+	// cleanup flow (which removes the vault file + association together).
+	rows, err := d.conn.Query(`SELECT ` + taskColumns + ` FROM tasks WHERE status='complete' AND todo_path = ''`)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +166,7 @@ func (d *DB) PruneCompleted() ([]*model.Task, error) {
 		return nil, nil
 	}
 
-	_, err = d.conn.Exec(`DELETE FROM tasks WHERE status='complete'`)
+	_, err = d.conn.Exec(`DELETE FROM tasks WHERE status='complete' AND todo_path = ''`)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -131,9 +131,9 @@ type App struct {
 	viewedWhileAgent map[string]bool // tasks viewed in agent view; suppresses idleUnvisited re-add
 
 	// Daemon health
-	daemonFailures    int
-	daemonRestarting  bool
-	daemonFreshStart  bool // daemon was auto-started (no prior sessions)
+	daemonFailures   int
+	daemonRestarting bool
+	daemonFreshStart bool            // daemon was auto-started (no prior sessions)
 	daemonClient     *dclient.Client
 	restartedClient  *dclient.Client // set after daemon restart
 
@@ -149,8 +149,9 @@ type App struct {
 }
 
 // New creates the tui2 application shell.
-// daemonFreshStart indicates the daemon was just auto-started (no prior sessions),
-// so InProgress tasks should be reconciled to InReview instead of Complete.
+// daemonFreshStart indicates this daemon instance has no prior sessions (freshly
+// auto-started or restarted), so InProgress tasks should be reconciled to
+// InReview instead of Complete on the first tick.
 func New(database *db.DB, runner agent.SessionProvider, daemonConnected bool, daemonFreshStart bool) *App {
 	// Use the terminal's default background instead of tview's hard-coded black.
 	tview.Styles.PrimitiveBackgroundColor = tcell.ColorDefault
@@ -742,9 +743,13 @@ func (a *App) refreshTasksWithIDs(runningIDs, idleIDs []string) {
 				}
 			}
 		}
-		// Clear fresh-start flag after first reconciliation — subsequent ticks
-		// should use normal Complete reconciliation for tasks that truly finished.
-		a.daemonFreshStart = false
+		// Clear fresh-start flag after first reconciliation with tasks present —
+		// subsequent ticks use normal Complete reconciliation for tasks that truly
+		// finished. Only clear when tasks were loaded to avoid a race where a slow
+		// or empty first read clears the flag before InProgress tasks are seen.
+		if len(a.tasks) > 0 {
+			a.daemonFreshStart = false
+		}
 	}
 
 	// Update idleUnvisited: add newly-idle tasks, remove tasks no longer idle.

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -131,8 +131,9 @@ type App struct {
 	viewedWhileAgent map[string]bool // tasks viewed in agent view; suppresses idleUnvisited re-add
 
 	// Daemon health
-	daemonFailures   int
-	daemonRestarting bool
+	daemonFailures    int
+	daemonRestarting  bool
+	daemonFreshStart  bool // daemon was auto-started (no prior sessions)
 	daemonClient     *dclient.Client
 	restartedClient  *dclient.Client // set after daemon restart
 
@@ -148,7 +149,9 @@ type App struct {
 }
 
 // New creates the tui2 application shell.
-func New(database *db.DB, runner agent.SessionProvider, daemonConnected bool) *App {
+// daemonFreshStart indicates the daemon was just auto-started (no prior sessions),
+// so InProgress tasks should be reconciled to InReview instead of Complete.
+func New(database *db.DB, runner agent.SessionProvider, daemonConnected bool, daemonFreshStart bool) *App {
 	// Use the terminal's default background instead of tview's hard-coded black.
 	tview.Styles.PrimitiveBackgroundColor = tcell.ColorDefault
 
@@ -157,6 +160,7 @@ func New(database *db.DB, runner agent.SessionProvider, daemonConnected bool) *A
 		db:               database,
 		runner:           runner,
 		daemonConnected:  daemonConnected,
+		daemonFreshStart: daemonFreshStart,
 		agentState:       agentview.New(),
 		tickDone:         make(chan struct{}),
 		idleUnvisited:    make(map[string]bool),
@@ -724,11 +728,23 @@ func (a *App) refreshTasksWithIDs(runningIDs, idleIDs []string) {
 		}
 		for _, t := range a.tasks {
 			if t.Status == model.StatusInProgress && !runningSet[t.ID] {
-				t.SetStatus(model.StatusComplete)
-				a.db.Update(t) //nolint:errcheck
-				uxlog.Log("[tui2] reconciled stale task %s (%s) → complete (no running session)", t.ID, t.Name)
+				if a.daemonFreshStart {
+					// Daemon was just auto-started — agent sessions were lost
+					// (daemon died or system restarted), not finished normally.
+					// Mark as InReview so the user can decide what to do.
+					t.SetStatus(model.StatusInReview)
+					a.db.Update(t) //nolint:errcheck
+					uxlog.Log("[tui2] reconciled stale task %s (%s) → in_review (daemon fresh start, session lost)", t.ID, t.Name)
+				} else {
+					t.SetStatus(model.StatusComplete)
+					a.db.Update(t) //nolint:errcheck
+					uxlog.Log("[tui2] reconciled stale task %s (%s) → complete (no running session)", t.ID, t.Name)
+				}
 			}
 		}
+		// Clear fresh-start flag after first reconciliation — subsequent ticks
+		// should use normal Complete reconciliation for tasks that truly finished.
+		a.daemonFreshStart = false
 	}
 
 	// Update idleUnvisited: add newly-idle tasks, remove tasks no longer idle.

--- a/internal/tui2/app_test.go
+++ b/internal/tui2/app_test.go
@@ -28,7 +28,7 @@ func testDB(t *testing.T) *db.DB {
 func TestNew(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	if app.tapp == nil {
 		t.Error("tview.Application should not be nil")
@@ -53,7 +53,7 @@ func TestNew(t *testing.T) {
 func TestSwitchTab(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	app.switchTab(TabReviews)
 	if app.header.ActiveTab() != TabReviews {
@@ -74,7 +74,7 @@ func TestSwitchTab(t *testing.T) {
 func TestOnTaskSelect(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	task := &model.Task{
 		ID:   "test-1",
@@ -94,7 +94,7 @@ func TestOnTaskSelect(t *testing.T) {
 func TestExitAgentView(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	app.mode = modeAgent
 	app.exitAgentView()
@@ -149,7 +149,7 @@ func TestTcellKeyToBytes(t *testing.T) {
 func TestArrowTabNavigation(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	// Start on Tasks tab
 	if app.header.ActiveTab() != TabTasks {
@@ -216,7 +216,7 @@ func TestArrowTabNavigation(t *testing.T) {
 func TestCtrlCForwardsToAgentPTY(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	// Start a real process so we have a live session.
 	task := &model.Task{
@@ -258,7 +258,7 @@ func TestCtrlCForwardsToAgentPTY(t *testing.T) {
 func TestCtrlCNoopInAgentViewDeadSession(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	// Agent mode with no session — ctrl+c should be consumed but not exit
 	app.mode = modeAgent
@@ -277,7 +277,7 @@ func TestCtrlCNoopInAgentViewDeadSession(t *testing.T) {
 func TestCtrlDExitsAgentViewWhenSessionDead(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	app.mode = modeAgent
 	app.agentState.Reset("t1", "test")
@@ -294,7 +294,7 @@ func TestCtrlDExitsAgentViewWhenSessionDead(t *testing.T) {
 func TestEscapeStaysInAgentView(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	app.mode = modeAgent
 	app.agentState.Reset("t1", "test")
@@ -315,7 +315,7 @@ func TestEscapeStaysInAgentView(t *testing.T) {
 func TestFilePanelKeyRouting(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	// Enter agent mode with file panel focused
 	app.mode = modeAgent
@@ -363,7 +363,7 @@ func TestFilePanelKeyRouting(t *testing.T) {
 func TestDiffModeArrowsNavigateFiles(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	// Enter agent mode
 	app.mode = modeAgent
@@ -414,7 +414,7 @@ func TestDiffModeArrowsNavigateFiles(t *testing.T) {
 func TestFilePanelMouseFocus(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	// Enter agent mode with terminal focused (default)
 	app.mode = modeAgent
@@ -466,7 +466,7 @@ func TestFilePanelMouseFocus(t *testing.T) {
 func TestArrowsIgnoredInAgentMode(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	app.mode = modeAgent
 	app.agentState.Reset("t1", "test")
@@ -484,7 +484,7 @@ func TestArrowsIgnoredInAgentMode(t *testing.T) {
 func TestRefreshTasks(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	// Add a task
 	task := &model.Task{
@@ -558,7 +558,7 @@ func TestConfirmDeleteModal(t *testing.T) {
 func TestOpenConfirmDelete(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	task := &model.Task{
 		ID:        "t1",
@@ -583,7 +583,7 @@ func TestOpenConfirmDelete(t *testing.T) {
 func TestCloseConfirmDelete(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	task := &model.Task{
 		ID:        "t1",
@@ -610,7 +610,7 @@ func TestCloseConfirmDelete(t *testing.T) {
 func TestDeleteTask(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	task := &model.Task{
 		ID:        "t1",
@@ -642,7 +642,7 @@ func TestDeleteTask(t *testing.T) {
 func TestRefreshTasksLocal(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	d.Add(&model.Task{ID: "t1", Name: "task1", Status: model.StatusPending, Project: "p", CreatedAt: time.Now()})
 	d.Add(&model.Task{ID: "t2", Name: "task2", Status: model.StatusPending, Project: "p", CreatedAt: time.Now()})
@@ -667,7 +667,7 @@ func TestRefreshTasksLocal(t *testing.T) {
 func TestCtrlDOpensConfirmDelete(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	task := &model.Task{
 		ID:        "t1",
@@ -694,7 +694,7 @@ func TestCtrlDOpensConfirmDelete(t *testing.T) {
 func TestCtrlDDoesNotDeleteInAgentMode(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	app.mode = modeAgent
 	app.agentState.Reset("t1", "test")
@@ -712,7 +712,7 @@ func TestCtrlDDoesNotDeleteInAgentMode(t *testing.T) {
 func TestPruneCompletedTasks(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 	app.wtRoot = t.TempDir() // isolate from real worktrees
 
 	// Add tasks with various statuses
@@ -743,7 +743,7 @@ func TestPruneCompletedTasks(t *testing.T) {
 func TestPruneDoesNotDoubleCountWorktrees(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 	wtRoot := t.TempDir()
 	app.wtRoot = wtRoot
 
@@ -780,7 +780,7 @@ func TestPruneDoesNotDoubleCountWorktrees(t *testing.T) {
 func TestCtrlRPrunesCompleted(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 	app.wtRoot = t.TempDir() // isolate from real worktrees
 
 	d.Add(&model.Task{ID: "t1", Name: "pending", Status: model.StatusPending, Project: "p", CreatedAt: time.Now()})
@@ -801,7 +801,7 @@ func TestCtrlRPrunesCompleted(t *testing.T) {
 func TestReconcileSkipsOnNilRunning(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	// Simulate daemon mode
 	app.daemonConnected = true
@@ -822,7 +822,7 @@ func TestReconcileSkipsOnNilRunning(t *testing.T) {
 func TestReconcileWorksOnEmptyRunning(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	// Simulate daemon mode
 	app.daemonConnected = true
@@ -840,6 +840,63 @@ func TestReconcileWorksOnEmptyRunning(t *testing.T) {
 	}
 	if !found {
 		t.Error("stale task should have been reconciled to Complete with empty (non-nil) runningIDs")
+	}
+}
+
+func TestReconcileFreshDaemonUsesInReview(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false, true) // daemonFreshStart = true
+
+	app.daemonConnected = true
+
+	d.Add(&model.Task{ID: "t1", Name: "was-running", Status: model.StatusInProgress, Project: "p", CreatedAt: time.Now()})
+	d.Add(&model.Task{ID: "t2", Name: "was-pending", Status: model.StatusPending, Project: "p", CreatedAt: time.Now()})
+
+	// Fresh daemon has no sessions — InProgress tasks should become InReview, not Complete.
+	app.refreshTasksWithIDs([]string{}, []string{})
+
+	for _, task := range app.tasks {
+		switch task.ID {
+		case "t1":
+			if task.Status != model.StatusInReview {
+				t.Errorf("task %q: got status %s, want in_review (fresh daemon start)", task.Name, task.Status)
+			}
+		case "t2":
+			if task.Status != model.StatusPending {
+				t.Errorf("task %q: got status %s, want pending (should not be affected)", task.Name, task.Status)
+			}
+		}
+	}
+
+	// After first reconciliation, daemonFreshStart should be cleared.
+	if app.daemonFreshStart {
+		t.Error("daemonFreshStart should be cleared after first reconciliation")
+	}
+}
+
+func TestReconcileFreshDaemonClearsFlag(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false, true) // daemonFreshStart = true
+
+	app.daemonConnected = true
+
+	d.Add(&model.Task{ID: "t1", Name: "task-a", Status: model.StatusInProgress, Project: "p", CreatedAt: time.Now()})
+
+	// First call: fresh start → InReview
+	app.refreshTasksWithIDs([]string{}, []string{})
+
+	// Add a new InProgress task after daemon is warmed up
+	d.Add(&model.Task{ID: "t2", Name: "task-b", Status: model.StatusInProgress, Project: "p", CreatedAt: time.Now()})
+
+	// Second call: flag cleared → should use Complete
+	app.refreshTasksWithIDs([]string{}, []string{})
+
+	for _, task := range app.tasks {
+		if task.ID == "t2" && task.Status != model.StatusComplete {
+			t.Errorf("task %q: got status %s, want complete (flag should be cleared after first reconciliation)", task.Name, task.Status)
+		}
 	}
 }
 

--- a/internal/tui2/app_test.go
+++ b/internal/tui2/app_test.go
@@ -894,8 +894,17 @@ func TestReconcileFreshDaemonClearsFlag(t *testing.T) {
 	app.refreshTasksWithIDs([]string{}, []string{})
 
 	for _, task := range app.tasks {
-		if task.ID == "t2" && task.Status != model.StatusComplete {
-			t.Errorf("task %q: got status %s, want complete (flag should be cleared after first reconciliation)", task.Name, task.Status)
+		switch task.ID {
+		case "t1":
+			// t1 was reconciled to InReview on the first call and should stay there.
+			if task.Status != model.StatusInReview {
+				t.Errorf("task %q: got status %s, want in_review (should remain from first reconciliation)", task.Name, task.Status)
+			}
+		case "t2":
+			// t2 was added after the flag cleared — should use normal Complete path.
+			if task.Status != model.StatusComplete {
+				t.Errorf("task %q: got status %s, want complete (flag should be cleared after first reconciliation)", task.Name, task.Status)
+			}
 		}
 	}
 }

--- a/internal/tui2/smoke_test.go
+++ b/internal/tui2/smoke_test.go
@@ -224,7 +224,7 @@ func TestLazyScreen_EnableDisableDoesNotPanic(t *testing.T) {
 func TestSmoke_TabSwitching(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	sim, stop := wireApp(t, app)
 	defer stop()
@@ -253,7 +253,7 @@ func TestSmoke_TabSwitching(t *testing.T) {
 func TestSmoke_NewTaskFormPaste(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 	// Ensure there's a project and backend for the form.
 	d.SetProject("test", config.Project{Path: t.TempDir()})
 
@@ -287,7 +287,7 @@ func TestSmoke_NewTaskFormPaste(t *testing.T) {
 func TestSmoke_AgentViewEnterExit(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 
 	task := &model.Task{
 		ID:        "smoke-1",
@@ -322,7 +322,7 @@ func TestSmoke_AgentViewEnterExit(t *testing.T) {
 func TestSmoke_NewTaskFormEscape(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false)
+	app := New(d, runner, false, false)
 	d.SetProject("test", config.Project{Path: t.TempDir()})
 
 	sim, stop := wireApp(t, app)


### PR DESCRIPTION
PruneCompleted now skips todo-linked tasks (AND todo_path = '') so vault file associations survive pruning. Fresh daemon auto-start reconciles InProgress to InReview via client.FreshStart() flag, cleared after first tick with tasks present.

Co-Authored-By: Claude <noreply@anthropic.com>