### PR TITLE
Skip directory rows in FilePanel cursor navigation

### DIFF
--- a/internal/tui2/fileexplorer.go
+++ b/internal/tui2/fileexplorer.go
@@ -88,7 +88,7 @@ func (fp *FilePanel) FileCount() int {
 	return len(fp.files)
 }
 
-// CursorUp moves cursor up, auto-expands directories. Returns dir needing fetch.
+// CursorUp moves cursor up, skipping directories. Returns dir needing fetch.
 func (fp *FilePanel) CursorUp() string {
 	if fp.cursor > 0 {
 		fp.cursor--
@@ -96,10 +96,13 @@ func (fp *FilePanel) CursorUp() string {
 			fp.offset = fp.cursor
 		}
 	}
-	return fp.autoExpand()
+	fetch := fp.autoExpand()
+	fp.skipToFile(-1)
+	fp.ensureVisible()
+	return fetch
 }
 
-// CursorDown moves cursor down, auto-expands directories. Returns dir needing fetch.
+// CursorDown moves cursor down, skipping directories. Returns dir needing fetch.
 func (fp *FilePanel) CursorDown() string {
 	_, _, _, h := fp.GetInnerRect()
 	visible := max(h-3, 1) // reserve for border + header
@@ -109,7 +112,43 @@ func (fp *FilePanel) CursorDown() string {
 			fp.offset = fp.cursor - visible + 1
 		}
 	}
-	return fp.autoExpand()
+	fetch := fp.autoExpand()
+	fp.skipToFile(1)
+	fp.ensureVisible()
+	return fetch
+}
+
+// skipToFile advances the cursor past directory rows in the given direction.
+// If no file rows exist, the cursor stays on the current row (directory).
+func (fp *FilePanel) skipToFile(dir int) {
+	start := fp.cursor
+	for fp.cursor >= 0 && fp.cursor < len(fp.rows) {
+		if !fp.rows[fp.cursor].IsDir {
+			return
+		}
+		fp.cursor += dir
+	}
+	// Went past bounds — search the other direction.
+	fp.cursor = max(0, min(fp.cursor, len(fp.rows)-1))
+	for fp.cursor >= 0 && fp.cursor < len(fp.rows) {
+		if !fp.rows[fp.cursor].IsDir {
+			return
+		}
+		fp.cursor -= dir
+	}
+	// No file rows at all — stay put.
+	fp.cursor = start
+}
+
+// ensureVisible adjusts offset so cursor is within the viewport.
+func (fp *FilePanel) ensureVisible() {
+	_, _, _, h := fp.GetInnerRect()
+	visible := max(h-3, 1)
+	if fp.cursor < fp.offset {
+		fp.offset = fp.cursor
+	} else if fp.cursor >= fp.offset+visible {
+		fp.offset = fp.cursor - visible + 1
+	}
 }
 
 // CursorIndex returns the current cursor index.

--- a/internal/tui2/fileexplorer.go
+++ b/internal/tui2/fileexplorer.go
@@ -128,7 +128,8 @@ func (fp *FilePanel) skipToFile(dir int) {
 		}
 		fp.cursor += dir
 	}
-	// Went past bounds — search the other direction.
+	// Went past bounds — scan the opposite direction to find the nearest file
+	// (e.g., navigating down past the last file, look upward instead).
 	fp.cursor = max(0, min(fp.cursor, len(fp.rows)-1))
 	for fp.cursor >= 0 && fp.cursor < len(fp.rows) {
 		if !fp.rows[fp.cursor].IsDir {

--- a/internal/tui2/fileexplorer_test.go
+++ b/internal/tui2/fileexplorer_test.go
@@ -48,23 +48,82 @@ func TestFilePanel_DirExpansion(t *testing.T) {
 	fp := NewFilePanel()
 	fp.Box.SetRect(0, 0, 40, 20)
 	files := []gitutil.ChangedFile{
+		{Status: "M", Path: "a.go"},
 		{Status: "M", Path: "src/", IsDir: true},
 		{Status: "A", Path: "b.go"},
 	}
 	fp.SetFiles(files)
 
-	// Moving to dir auto-expands it and returns dir path for fetch
-	dir := fp.CursorDown()
-	// First cursor should be on src/ (already expanded or needs fetch)
-	_ = dir
-
+	// Pre-populate children so skip-to-file can land on a child
 	fp.SetDirChildren("src/", []gitutil.ChangedFile{
 		{Status: "M", Path: "src/main.go"},
 	})
 
-	// Now there should be rows for: src/, src/main.go, b.go
-	if len(fp.rows) < 2 {
-		t.Errorf("expected at least 2 rows after expansion, got %d", len(fp.rows))
+	// From a.go, CursorDown hits src/ dir → autoExpand expands it → skipToFile lands on first child
+	fp.CursorDown()
+
+	// Rows: a.go, src/, src/main.go, b.go — cursor should skip src/ dir and land on src/main.go
+	if len(fp.rows) != 4 {
+		t.Errorf("expected 4 rows after expansion, got %d", len(fp.rows))
+	}
+	if f := fp.SelectedFile(); f == nil || f.Path != "src/main.go" {
+		t.Errorf("cursor should skip dir and land on src/main.go, got %v", f)
+	}
+}
+
+func TestFilePanel_SkipDirDown(t *testing.T) {
+	fp := NewFilePanel()
+	fp.Box.SetRect(0, 0, 40, 20)
+	files := []gitutil.ChangedFile{
+		{Status: "M", Path: "a.go"},
+		{Status: "M", Path: "pkg/", IsDir: true},
+		{Status: "A", Path: "b.go"},
+	}
+	fp.SetFiles(files)
+
+	// Start on a.go, move down — should skip pkg/ dir and land on b.go
+	fp.CursorDown()
+	if f := fp.SelectedFile(); f == nil || f.Path != "b.go" {
+		t.Errorf("should skip dir, got %v", f)
+	}
+}
+
+func TestFilePanel_SkipDirUp(t *testing.T) {
+	fp := NewFilePanel()
+	fp.Box.SetRect(0, 0, 40, 20)
+	files := []gitutil.ChangedFile{
+		{Status: "M", Path: "a.go"},
+		{Status: "M", Path: "pkg/", IsDir: true},
+		{Status: "A", Path: "b.go"},
+	}
+	fp.SetFiles(files)
+
+	// Move cursor to b.go first
+	fp.CursorDown()
+	if f := fp.SelectedFile(); f == nil || f.Path != "b.go" {
+		t.Fatalf("setup: expected b.go, got %v", f)
+	}
+
+	// Move up — should skip pkg/ dir and land on a.go
+	fp.CursorUp()
+	if f := fp.SelectedFile(); f == nil || f.Path != "a.go" {
+		t.Errorf("should skip dir going up, got %v", f)
+	}
+}
+
+func TestFilePanel_AllDirsNoSkip(t *testing.T) {
+	fp := NewFilePanel()
+	fp.Box.SetRect(0, 0, 40, 20)
+	files := []gitutil.ChangedFile{
+		{Status: "M", Path: "src/", IsDir: true},
+		{Status: "M", Path: "pkg/", IsDir: true},
+	}
+	fp.SetFiles(files)
+
+	// With only dirs, cursor should stay put (not crash or go out of bounds)
+	fp.CursorDown()
+	if fp.cursor < 0 || fp.cursor >= len(fp.rows) {
+		t.Errorf("cursor out of bounds: %d (rows: %d)", fp.cursor, len(fp.rows))
 	}
 }
 

--- a/internal/tui2/fileexplorer_test.go
+++ b/internal/tui2/fileexplorer_test.go
@@ -120,7 +120,7 @@ func TestFilePanel_AllDirsNoSkip(t *testing.T) {
 	}
 	fp.SetFiles(files)
 
-	// With only dirs, cursor should stay put (not crash or go out of bounds)
+	// With only dirs, cursor moves normally (skipToFile preserves position) and stays in bounds
 	fp.CursorDown()
 	if fp.cursor < 0 || fp.cursor >= len(fp.rows) {
 		t.Errorf("cursor out of bounds: %d (rows: %d)", fp.cursor, len(fp.rows))


### PR DESCRIPTION
Up/Down keys in the files changed pane now skip directory rows and land on file rows, matching the task list's header-skipping UX. Adds skipToFile() and ensureVisible() helpers with edge case handling for all-directory lists.

Co-Authored-By: Claude <noreply@anthropic.com>