### PR TITLE
Sort task list projects alphabetically

### DIFF
--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -2,6 +2,7 @@ package tui2
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"unicode/utf8"
 
@@ -219,22 +220,21 @@ func (tl *TaskListView) buildRows() {
 	}
 }
 
-// groupByProject groups tasks by project name, preserving insertion order.
+// groupByProject groups tasks by project name, sorted alphabetically.
 func groupByProject(tasks []*model.Task) ([]string, map[string][]*model.Task) {
-	order := []string{}
 	groups := map[string][]*model.Task{}
-	seen := map[string]bool{}
 	for _, t := range tasks {
 		proj := t.Project
 		if proj == "" {
 			proj = "(no project)"
 		}
-		if !seen[proj] {
-			seen[proj] = true
-			order = append(order, proj)
-		}
 		groups[proj] = append(groups[proj], t)
 	}
+	order := make([]string, 0, len(groups))
+	for proj := range groups {
+		order = append(order, proj)
+	}
+	sort.Strings(order)
 	return order, groups
 }
 

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -121,8 +121,15 @@ func TestGroupByProject(t *testing.T) {
 	if len(order) != 3 {
 		t.Errorf("len(order) = %d, want 3", len(order))
 	}
-	if order[0] != "alpha" {
-		t.Errorf("first project = %q, want alpha", order[0])
+	// Alphabetical: "(no project)" < "alpha" < "beta"
+	if order[0] != "(no project)" {
+		t.Errorf("first project = %q, want (no project)", order[0])
+	}
+	if order[1] != "alpha" {
+		t.Errorf("second project = %q, want alpha", order[1])
+	}
+	if order[2] != "beta" {
+		t.Errorf("third project = %q, want beta", order[2])
 	}
 	if len(groups["alpha"]) != 2 {
 		t.Errorf("alpha tasks = %d, want 2", len(groups["alpha"]))


### PR DESCRIPTION
groupByProject now sorts project names with sort.Strings instead of preserving insertion order, making the task list consistent with the new-task modal.

Co-Authored-By: Claude <noreply@anthropic.com>