### PR TITLE
Use magenta text for selected settings row

### DIFF
--- a/internal/tui2/settings.go
+++ b/internal/tui2/settings.go
@@ -625,7 +625,7 @@ func (sv *SettingsView) renderList(screen tcell.Screen, x, y, w, h int) {
 			style = tcell.StyleDefault.Foreground(ColorInProgress)
 		}
 		if row.kind != srSection && rowIdx == sv.cursor {
-			style = style.Background(ColorHighlight)
+			style = style.Foreground(ColorSelected).Bold(true)
 		}
 
 		label := row.label


### PR DESCRIPTION
Replace gray background highlight with magenta text color for the currently selected setting, matching the selection style used elsewhere in the app.

Co-Authored-By: Claude <noreply@anthropic.com>