### PR TITLE
Auto-expand new folders in file panel

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -1276,7 +1276,9 @@ func (a *App) fetchGitStatus(taskID, dir string) {
 			gitutil.ParseGitDiffNameStatus(msg.BranchFiles),
 			gitutil.ParseGitStatus(msg.Status),
 		)
-		a.filePanel.SetFiles(files)
+		if dir := a.filePanel.SetFiles(files); dir != "" {
+			go a.fetchDirChildren(dir)
+		}
 		uxlog.Log("[tui2] git status refreshed: %d files", len(files))
 	})
 }

--- a/internal/tui2/fileexplorer.go
+++ b/internal/tui2/fileexplorer.go
@@ -43,8 +43,9 @@ func NewFilePanel() *FilePanel {
 	}
 }
 
-// SetFiles updates the file list and rebuilds rows.
-func (fp *FilePanel) SetFiles(files []gitutil.ChangedFile) {
+// SetFiles updates the file list and rebuilds rows. Returns a directory path
+// that needs children fetched (when the cursor lands on an unexpanded dir).
+func (fp *FilePanel) SetFiles(files []gitutil.ChangedFile) string {
 	fp.files = files
 	// Prune stale expansion state
 	dirs := make(map[string]bool)
@@ -61,13 +62,38 @@ func (fp *FilePanel) SetFiles(files []gitutil.ChangedFile) {
 	}
 	fp.buildRows()
 	fp.clampCursor()
+	// Auto-expand directory at cursor and skip to first file — consistent with
+	// CursorUp/CursorDown behavior so new folders don't require manual entry.
+	// Only run when cursor is on a directory row to avoid collapsing expanded
+	// dirs during background git refreshes (autoExpand collapses all non-cursor dirs).
+	var fetch string
+	if len(fp.rows) > 0 && fp.cursor < len(fp.rows) && fp.rows[fp.cursor].IsDir {
+		fetch = fp.autoExpand()
+		fp.skipToFile(1)
+	}
+	return fetch
 }
 
 // SetDirChildren caches directory children and rebuilds.
 func (fp *FilePanel) SetDirChildren(dir string, children []gitutil.ChangedFile) {
+	// Remember cursor path so row insertion doesn't displace it.
+	var cursorPath string
+	if fp.cursor >= 0 && fp.cursor < len(fp.rows) {
+		cursorPath = fp.rows[fp.cursor].Path
+	}
 	fp.dirChildren[dir] = children
 	fp.buildRows()
+	// Restore cursor to the same file by path (row indices shift on child insertion).
+	for i, r := range fp.rows {
+		if r.Path == cursorPath {
+			fp.cursor = i
+			break
+		}
+	}
 	fp.clampCursor()
+	// Skip past the directory row to the first child file.
+	fp.skipToFile(1)
+	fp.ensureVisible()
 }
 
 // SetFocused updates the focus state.

--- a/internal/tui2/fileexplorer_test.go
+++ b/internal/tui2/fileexplorer_test.go
@@ -111,6 +111,135 @@ func TestFilePanel_SkipDirUp(t *testing.T) {
 	}
 }
 
+func TestFilePanel_SetFilesAutoExpandDir(t *testing.T) {
+	fp := NewFilePanel()
+	fp.Box.SetRect(0, 0, 40, 20)
+
+	t.Run("dir at cursor with cached children skips to first file", func(t *testing.T) {
+		// Pre-cache children so autoExpand during SetFiles can skip to the file.
+		fp.dirChildren["src/"] = []gitutil.ChangedFile{
+			{Status: "M", Path: "src/main.go"},
+			{Status: "A", Path: "src/util.go"},
+		}
+		files := []gitutil.ChangedFile{
+			{Status: "M", Path: "src/", IsDir: true},
+			{Status: "A", Path: "b.go"},
+		}
+		fp.SetFiles(files)
+		if f := fp.SelectedFile(); f == nil || f.Path != "src/main.go" {
+			t.Errorf("expected cursor on src/main.go, got %v", f)
+		}
+	})
+
+	t.Run("no dirs returns empty fetch", func(t *testing.T) {
+		fp3 := NewFilePanel()
+		fp3.Box.SetRect(0, 0, 40, 20)
+		files := []gitutil.ChangedFile{
+			{Status: "M", Path: "a.go"},
+			{Status: "A", Path: "b.go"},
+		}
+		fetch := fp3.SetFiles(files)
+		if fetch != "" {
+			t.Errorf("expected empty fetch for no-dir list, got %q", fetch)
+		}
+	})
+
+	t.Run("background refresh preserves expanded dir when cursor on child", func(t *testing.T) {
+		fp4 := NewFilePanel()
+		fp4.Box.SetRect(0, 0, 40, 20)
+		// First call: dir at cursor 0 → auto-expand
+		fp4.dirChildren["src/"] = []gitutil.ChangedFile{
+			{Status: "M", Path: "src/main.go"},
+		}
+		files := []gitutil.ChangedFile{
+			{Status: "M", Path: "src/", IsDir: true},
+			{Status: "A", Path: "b.go"},
+		}
+		fp4.SetFiles(files)
+		// Cursor is now on src/main.go, src/ is expanded
+		if !fp4.expanded["src/"] {
+			t.Fatal("src/ should be expanded after initial SetFiles")
+		}
+		if f := fp4.SelectedFile(); f == nil || f.Path != "src/main.go" {
+			t.Fatalf("setup: expected cursor on src/main.go, got %v", f)
+		}
+		// Simulate background git refresh with same files — cursor on child file,
+		// not a dir row, so autoExpand should NOT fire and expansion is preserved.
+		fp4.SetFiles(files)
+		if !fp4.expanded["src/"] {
+			t.Error("background refresh should not collapse expanded dir when cursor is on child file")
+		}
+		if f := fp4.SelectedFile(); f == nil || f.Path != "src/main.go" {
+			t.Errorf("cursor should stay on src/main.go after refresh, got %v", f)
+		}
+	})
+
+	t.Run("dir at cursor without children returns fetch", func(t *testing.T) {
+		fp2 := NewFilePanel()
+		fp2.Box.SetRect(0, 0, 40, 20)
+		files := []gitutil.ChangedFile{
+			{Status: "M", Path: "pkg/", IsDir: true},
+			{Status: "A", Path: "a.go"},
+		}
+		fetch := fp2.SetFiles(files)
+		if fetch != "pkg/" {
+			t.Errorf("expected fetch = %q, got %q", "pkg/", fetch)
+		}
+		// Cursor should be on a.go (skipped past dir since no children yet)
+		if f := fp2.SelectedFile(); f == nil || f.Path != "a.go" {
+			t.Errorf("expected cursor on a.go, got %v", f)
+		}
+	})
+}
+
+func TestFilePanel_SetDirChildrenSkipsToFile(t *testing.T) {
+	t.Run("cursor on dir row skips to first child", func(t *testing.T) {
+		fp := NewFilePanel()
+		fp.Box.SetRect(0, 0, 40, 20)
+		files := []gitutil.ChangedFile{
+			{Status: "M", Path: "src/", IsDir: true},
+			{Status: "A", Path: "b.go"},
+		}
+		fp.SetFiles(files)
+		// Simulate the dir being expanded (as autoExpand would have done)
+		fp.expanded["src/"] = true
+		// Now move cursor back to the dir row
+		fp.cursor = 0
+
+		// When children arrive, cursor should skip to first child file
+		fp.SetDirChildren("src/", []gitutil.ChangedFile{
+			{Status: "M", Path: "src/main.go"},
+		})
+		if f := fp.SelectedFile(); f == nil || f.Path != "src/main.go" {
+			t.Errorf("expected cursor on src/main.go after SetDirChildren, got %v", f)
+		}
+	})
+
+	t.Run("cursor already on file is not displaced", func(t *testing.T) {
+		fp := NewFilePanel()
+		fp.Box.SetRect(0, 0, 40, 20)
+		files := []gitutil.ChangedFile{
+			{Status: "M", Path: "src/", IsDir: true},
+			{Status: "A", Path: "b.go"},
+			{Status: "M", Path: "c.go"},
+		}
+		fp.SetFiles(files)
+		// Cursor should be on b.go (skipped past dir)
+		if f := fp.SelectedFile(); f == nil || f.Path != "b.go" {
+			t.Fatalf("setup: expected b.go, got %v", f)
+		}
+		// Simulate dir expanded and children arriving while cursor is on b.go
+		fp.expanded["src/"] = true
+		fp.SetDirChildren("src/", []gitutil.ChangedFile{
+			{Status: "M", Path: "src/main.go"},
+		})
+		// Cursor should still be on b.go (not displaced by async children)
+		if f := fp.SelectedFile(); f == nil || f.Path != "b.go" {
+			t.Errorf("cursor should stay on b.go, got %v", f)
+		}
+	})
+}
+
 func TestFilePanel_AllDirsNoSkip(t *testing.T) {
 	fp := NewFilePanel()
 	fp.Box.SetRect(0, 0, 40, 20)


### PR DESCRIPTION
When the files changed panel loads with a directory at the top, auto-expand it and select the first child file — matching the existing CursorUp/CursorDown auto-skip behavior. Guards auto-expand to only fire when cursor is on a dir row, preserving expansion state during background git refreshes. SetDirChildren preserves cursor position by path when child row insertion shifts indices.

Co-Authored-By: Claude <noreply@anthropic.com>