### PR TITLE
Slow Progress spinner tick interval from 100ms to 150ms

### DIFF
--- a/internal/spinner/spinner.go
+++ b/internal/spinner/spinner.go
@@ -32,7 +32,7 @@ func (s *Spinner) FrameCount() int {
 
 // All is the ordered list of available spinner styles.
 var All = []Spinner{
-	{StyleProgress, "Progress", []rune{'\uEE06', '\uEE07', '\uEE08', '\uEE09', '\uEE0A', '\uEE0B'}, 100 * time.Millisecond},
+	{StyleProgress, "Progress", []rune{'\uEE06', '\uEE07', '\uEE08', '\uEE09', '\uEE0A', '\uEE0B'}, 150 * time.Millisecond},
 	{StyleDots, "Dots", []rune{'⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'}, 100 * time.Millisecond},
 	{StyleBraille, "Braille", []rune{'⣷', '⣯', '⣟', '⡿', '⢿', '⣻', '⣽', '⣾'}, 100 * time.Millisecond},
 	{StyleClassic, "Classic", []rune{'|', '/', '-', '\\'}, 150 * time.Millisecond},

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -351,8 +351,8 @@ func (a *App) tickLoop() {
 }
 
 // spinnerLoop triggers redraws for smooth spinner animation.
-// Polls at 100ms (the fastest spinner's TickInterval). The actual frame
-// selection is time-based in updateSpinnerFrame, so this just ensures
+// Polls at 100ms (the fastest non-Progress spinner's TickInterval). The actual
+// frame selection is time-based in updateSpinnerFrame, so this just ensures
 // redraws happen often enough. Only fires when tasks are running.
 func (a *App) spinnerLoop() {
 	ticker := time.NewTicker(100 * time.Millisecond)


### PR DESCRIPTION
Reduce the Progress spinner animation speed to 150ms per frame for a calmer visual rhythm. Other spinner styles (Dots, Braille) remain at 100ms.

Co-Authored-By: Claude <noreply@anthropic.com>