### PR TITLE
Replace status icons with Nerd Font moon variants (blue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A terminal-native LLM code orchestrator. Manage multiple Claude Code / Codex ses
 
 - **To Dos tab** — Browse an Obsidian vault as a task inbox. Three-panel view: note list, markdown preview, and metadata
 - **Auto-launch from vault** — Select a note, pick a project, optionally add a prompt, and launch it as a new agent task. The note content becomes the agent's instructions
-- **Task-note linking** — Each launched task tracks its source vault file. Status badges (○ pending, ● running, ◎ review, ✓ done) show progress inline
+- **Task-note linking** — Each launched task tracks its source vault file. Status badges (○ pending, ● running,  review, ✓ done) show progress inline
 - **Vault auto-create** — When enabled, the daemon watches the vault directory for new `.md` files and automatically creates and starts agent tasks. Share a note to Obsidian from your phone, and the agent starts working
 - **Cleanup** — `ctrl+r` on the To Dos tab deletes vault files for completed tasks, keeping the inbox clean
 - **Knowledge base** — A separate FTS5-powered full-text search store indexes another Obsidian vault and exposes it as an MCP server (port 7742), auto-injected into every agent worktree

--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -640,7 +640,7 @@ The tui2 migration (Phase 11) ported individual task status icons but dropped:
 ### Data Model & Flow
 - `TaskListView.tickEven bool` — toggles each tick for status icon animation (Nerd Font \uF10C circle-o ↔ \uF192 dot-circle-o)
 - `TaskListView.Tick()` — called from `refreshTasksWithIDs` on every refresh cycle
-- `projectStatusIcon(tasks) (rune, tcell.Style)` — computes aggregated icon with priority: in_progress > in_review > all_complete > mixed(✓ dimmed) > all_pending. Idle detection: when all in-progress tasks are idle, shows moon (☾).
+- `projectStatusIcon(tasks) (rune, tcell.Style)` — computes aggregated icon with priority: in_progress > in_review > all_complete > mixed(✓ dimmed) > all_pending. Idle detection: when all in-progress tasks are idle, shows moon (󰖔 nf-md-moon_first_quarter, blue).
 - `drawProjectRow` now renders: 2-char indent + status icon + chevron (▸/▾) + project name + count `(N)`
 - `refreshTasksWithIDs(runningIDs, idleIDs []string)` — signature expanded to accept idle IDs. All three call sites updated: `onTick`, `handleSessionExitUI` goroutine, `refreshTasks`.
 - `handleSessionExitUI` now calls `exitAgentView()` when viewing a completed task's agent pane (not stopped — stopped tasks stay on agent view with cleared session).
@@ -652,7 +652,7 @@ The tui2 migration (Phase 11) ported individual task status icons but dropped:
 - **Stopped agent → InReview**: `handleSessionExitUI` now sets `StatusInReview` (not Pending) when `stopped == true`. Matches the Bubble Tea `determinePostExitStatus` behavior where explicit stop = "needs human review".
 - **Idle+unvisited visual promotion**: `App` struct gains `idleUnvisited` and `viewedWhileAgent` maps. `refreshTasksWithIDs` diffs newly-idle tasks against `TaskListView.IdleSet()` to populate `idleUnvisited`. Entering agent view clears the flag via `onTaskSelect`. `drawTaskRow` renders idleUnvisited InProgress tasks with InReview icon (◎, cyan). `projectStatusIcon` counts them as InReview at project level.
 - **Manual status cycling**: `s`/`S` keys in task list call `Status.Next()`/`Prev()` via `OnStatusChange` callback → `db.Update` + `refreshTasks`.
-- **Task row animation**: `drawTaskRow` now checks `tickEven` for running InProgress tasks, alternating Nerd Font \uF10C (circle-o) and \uF192 (dot-circle-o). Idle (visited) tasks show moon (☾). Idle+unvisited show ◎.
+- **Task row animation**: `drawTaskRow` now checks `tickEven` for running InProgress tasks, alternating Nerd Font \uF10C (circle-o) and \uF192 (dot-circle-o). Idle (visited) tasks show moon (󰖔, blue). Idle+unvisited show ◎.
 
 **New fields on `TaskListView`**: `idleUnvisited map[string]bool`, `OnStatusChange func(task)`.
 **New methods**: `SetIdleUnvisited(ids)`, `IdleSet() map[string]bool`.

--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -650,9 +650,9 @@ The tui2 migration (Phase 11) ported individual task status icons but dropped:
 **Restored pre-tcell behavior for task status transitions and visual feedback:**
 
 - **Stopped agent → InReview**: `handleSessionExitUI` now sets `StatusInReview` (not Pending) when `stopped == true`. Matches the Bubble Tea `determinePostExitStatus` behavior where explicit stop = "needs human review".
-- **Idle+unvisited visual promotion**: `App` struct gains `idleUnvisited` and `viewedWhileAgent` maps. `refreshTasksWithIDs` diffs newly-idle tasks against `TaskListView.IdleSet()` to populate `idleUnvisited`. Entering agent view clears the flag via `onTaskSelect`. `drawTaskRow` renders idleUnvisited InProgress tasks with InReview icon (◎, cyan). `projectStatusIcon` counts them as InReview at project level.
+- **Idle+unvisited visual promotion**: `App` struct gains `idleUnvisited` and `viewedWhileAgent` maps. `refreshTasksWithIDs` diffs newly-idle tasks against `TaskListView.IdleSet()` to populate `idleUnvisited`. Entering agent view clears the flag via `onTaskSelect`. `drawTaskRow` renders idleUnvisited InProgress tasks with moon_o icon (nf-fa-moon_o 0xF186, blue). `projectStatusIcon` counts them as InReview at project level.
 - **Manual status cycling**: `s`/`S` keys in task list call `Status.Next()`/`Prev()` via `OnStatusChange` callback → `db.Update` + `refreshTasks`.
-- **Task row animation**: `drawTaskRow` now checks `tickEven` for running InProgress tasks, alternating Nerd Font \uF10C (circle-o) and \uF192 (dot-circle-o). Idle (visited) tasks show moon (󰖔, blue). Idle+unvisited show ◎.
+- **Task row animation**: `drawTaskRow` now checks `tickEven` for running InProgress tasks, alternating Nerd Font \uF10C (circle-o) and \uF192 (dot-circle-o). Idle (visited) tasks show moon (󰖔, blue). Idle+unvisited show moon_o (nf-fa-moon_o, blue).
 
 **New fields on `TaskListView`**: `idleUnvisited map[string]bool`, `OnStatusChange func(task)`.
 **New methods**: `SetIdleUnvisited(ids)`, `IdleSet() map[string]bool`.
@@ -1033,7 +1033,7 @@ When the daemon crashed, one task was incorrectly marked Complete despite its ag
 1. User presses Enter on a todo → `LaunchToDoModal` shows with project selector + prompt field
 2. On confirm: `task.TodoPath = item.Path`, prompt = `buildToDoPrompt(userPrompt, noteContent)`, worktree created, task persisted
 3. `refreshTasksWithIDs` calls `a.db.TasksByTodoPath()` on every tick → `ToDosView.SyncTasks()` propagates to list panel
-4. `ToDoListPanel.Draw` renders status-aware bullets: `○` pending, `●` in progress, `◎` in review, `✓` complete
+4. `ToDoListPanel.Draw` renders status-aware bullets: `○` pending, `●` in progress, `` in review (nf-fa-moon_o), `✓` complete
 5. Ctrl+R on ToDos tab → `cleanupCompletedToDos()` → confirmation modal → `executeToDoCleanup()` removes vault `.md` files, refreshes async
 
 6. `s`/`S` keys on ToDos tab toggle linked task status via `OnStatusChange` callback → `db.Update` + `refreshTasksAsync`. No-op if todo has no linked task.

--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -793,11 +793,11 @@ func (tl *TaskListView) projectStatusIcon(tasks []*model.Task) (rune, tcell.Styl
 	switch {
 	case hasInProgress:
 		if allInProgressIdle {
-			return '☾', tcell.StyleDefault.Foreground(ColorInProgress)
+			return 0x0F0594, tcell.StyleDefault.Foreground(ColorInReview)
 		}
 		return model.SpinnerFrame(tl.animFrame), StyleInProgress
 	case hasInReview:
-		return '◎', StyleInReview
+		return 0xF186, StyleInReview
 	case hasComplete && !hasPending:
 		return '✓', StyleComplete
 	case hasComplete && hasPending:
@@ -879,20 +879,20 @@ func (tl *TaskListView) drawTaskRow(screen tcell.Screen, x, y, w int, task *mode
 		statusStyle = StylePending
 	case model.StatusInProgress:
 		if tl.idleUnvisited[task.ID] {
-			// Idle and not yet viewed since going idle — show as in-review.
-			statusChar = '◎'
+			// Idle and not yet viewed since going idle — moon with stars.
+			statusChar = 0xF186
 			statusStyle = StyleInReview
 		} else if !tl.running[task.ID] || tl.idle[task.ID] {
 			// Session absent or idle (waiting for input) — moon icon.
-			statusChar = '☾'
-			statusStyle = StyleInProgress
+			statusChar = 0x0F0594
+			statusStyle = StyleInReview
 		} else {
 			// Actively running — animated spinner (nerd font progress spinner).
 			statusChar = model.SpinnerFrame(tl.animFrame)
 			statusStyle = StyleInProgress
 		}
 	case model.StatusInReview:
-		statusChar = '◎'
+		statusChar = 0xF186
 		statusStyle = StyleInReview
 	case model.StatusComplete:
 		statusChar = '✓'

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -247,7 +247,7 @@ func TestTaskListView_ProjectStatusIcon(t *testing.T) {
 		{
 			name:     "in review",
 			tasks:    []*model.Task{{ID: "1", Status: model.StatusInReview}},
-			wantChar: '◎',
+			wantChar: 0xF186,
 		},
 		{
 			name: "mixed complete and pending",
@@ -262,7 +262,7 @@ func TestTaskListView_ProjectStatusIcon(t *testing.T) {
 			tasks:    []*model.Task{{ID: "1", Status: model.StatusInProgress}},
 			running:  map[string]bool{"1": true},
 			idle:     map[string]bool{"1": true},
-			wantChar: '☾',
+			wantChar: 0x0F0594,
 		},
 	}
 
@@ -382,10 +382,10 @@ func TestTaskListView_IdleUnvisitedPromotion(t *testing.T) {
 	tl.idle = map[string]bool{"1": true}
 	tl.animFrame = 0
 
-	// Project icon should be InReview (◎) when the only InProgress task is idleUnvisited.
+	// Project icon should be moon_o when the only InProgress task is idleUnvisited.
 	icon, _ := tl.projectStatusIcon(tasks)
-	if icon != '◎' {
-		t.Errorf("projectStatusIcon with idleUnvisited = %c, want ◎", icon)
+	if icon != 0xF186 {
+		t.Errorf("projectStatusIcon with idleUnvisited = %c, want moon_o", icon)
 	}
 }
 

--- a/internal/tui2/todos.go
+++ b/internal/tui2/todos.go
@@ -388,7 +388,7 @@ func (p *ToDoListPanel) Draw(screen tcell.Screen) {
 					bullet = '●'
 					bulletStyle = StyleInProgress
 				case model.StatusInReview:
-					bullet = '◎'
+					bullet = 0xF186
 					bulletStyle = StyleInReview
 				case model.StatusComplete:
 					bullet = '✓'


### PR DESCRIPTION
Swap dot-circle and unicode moon icons for Nerd Font alternatives:
- Idle+visited: nf-md-moon_first_quarter (0x0F0594), blue
- Idle+unvisited / in-review: nf-fa-moon_o (0xF186), blue
- Updated across task list, project icons, todos panel, and docs

Co-Authored-By: Claude <noreply@anthropic.com>