### PR TITLE
Add ctrl+q as alternative to escape for closing modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ argus
 | `R` | Refresh vault |
 | `ctrl+r` | Clean up completed notes |
 
+#### Modals & Forms
+
+| Key | Action |
+|-----|--------|
+| `Esc` / `ctrl+q` | Close / cancel |
+| `Enter` | Confirm / submit |
+| `Tab` / `Shift+Tab` | Navigate fields |
+
 #### Reviews
 
 | Key | Action |

--- a/internal/tui2/app_test.go
+++ b/internal/tui2/app_test.go
@@ -650,7 +650,7 @@ func TestConfirmDeleteModal(t *testing.T) {
 		m := NewConfirmDeleteModal(task)
 
 		handler := m.InputHandler()
-		handler(tcell.NewEventKey(tcell.KeyCtrlQ, 0, 0), func(p tview.Primitive) {})
+		handler(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone), func(p tview.Primitive) {})
 
 		if !m.Canceled() {
 			t.Error("modal should be canceled after Ctrl+Q")

--- a/internal/tui2/app_test.go
+++ b/internal/tui2/app_test.go
@@ -646,6 +646,20 @@ func TestConfirmDeleteModal(t *testing.T) {
 		}
 	})
 
+	t.Run("ctrl+q cancels", func(t *testing.T) {
+		m := NewConfirmDeleteModal(task)
+
+		handler := m.InputHandler()
+		handler(tcell.NewEventKey(tcell.KeyCtrlQ, 0, 0), func(p tview.Primitive) {})
+
+		if !m.Canceled() {
+			t.Error("modal should be canceled after Ctrl+Q")
+		}
+		if m.Confirmed() {
+			t.Error("modal should not be confirmed after Ctrl+Q")
+		}
+	})
+
 	t.Run("confirm", func(t *testing.T) {
 		m := NewConfirmDeleteModal(task)
 

--- a/internal/tui2/backendform.go
+++ b/internal/tui2/backendform.go
@@ -56,7 +56,7 @@ func (bf *BackendForm) Result() (name string, b config.Backend) {
 // HandleKey processes key events for the form.
 func (bf *BackendForm) HandleKey(ev *tcell.EventKey) {
 	switch ev.Key() {
-	case tcell.KeyEscape:
+	case tcell.KeyEscape, tcell.KeyCtrlQ:
 		bf.canceled = true
 		return
 	case tcell.KeyEnter:

--- a/internal/tui2/confirmdelete.go
+++ b/internal/tui2/confirmdelete.go
@@ -34,7 +34,7 @@ func (m *ConfirmDeleteModal) InputHandler() func(event *tcell.EventKey, setFocus
 		switch event.Key() {
 		case tcell.KeyEnter:
 			m.confirmed = true
-		case tcell.KeyEscape:
+		case tcell.KeyEscape, tcell.KeyCtrlQ:
 			m.canceled = true
 		}
 	})

--- a/internal/tui2/forkmodal.go
+++ b/internal/tui2/forkmodal.go
@@ -34,7 +34,7 @@ func (m *ForkTaskModal) InputHandler() func(event *tcell.EventKey, setFocus func
 		switch event.Key() {
 		case tcell.KeyEnter:
 			m.confirmed = true
-		case tcell.KeyEscape:
+		case tcell.KeyEscape, tcell.KeyCtrlQ:
 			m.canceled = true
 		}
 	})

--- a/internal/tui2/forkmodal_test.go
+++ b/internal/tui2/forkmodal_test.go
@@ -36,6 +36,17 @@ func TestForkTaskModal_Escape(t *testing.T) {
 	testutil.Equal(t, m.Canceled(), true)
 }
 
+func TestForkTaskModal_CtrlQ(t *testing.T) {
+	task := &model.Task{Name: "test-task"}
+	m := NewForkTaskModal(task)
+
+	handler := m.InputHandler()
+	handler(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone), func(p tview.Primitive) {})
+
+	testutil.Equal(t, m.Confirmed(), false)
+	testutil.Equal(t, m.Canceled(), true)
+}
+
 func TestForkTaskModal_Draw(t *testing.T) {
 	task := &model.Task{
 		Name:     "my-task",

--- a/internal/tui2/forms_test.go
+++ b/internal/tui2/forms_test.go
@@ -88,6 +88,14 @@ func TestProjectForm_Escape(t *testing.T) {
 	}
 }
 
+func TestProjectForm_CtrlQ(t *testing.T) {
+	pf := NewProjectForm()
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlQ, 0, 0))
+	if !pf.Canceled() {
+		t.Error("should be canceled")
+	}
+}
+
 func TestProjectForm_BranchSelector(t *testing.T) {
 	// syncBranchLoader simulates the async OnBranchFocus pattern used in
 	// production (goroutine + QueueUpdateDraw) by calling SetBranchOptions
@@ -234,6 +242,14 @@ func TestBackendForm_New(t *testing.T) {
 	}
 }
 
+func TestBackendForm_CtrlQ(t *testing.T) {
+	bf := NewBackendForm()
+	bf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlQ, 0, 0))
+	if !bf.Canceled() {
+		t.Error("should be canceled")
+	}
+}
+
 func TestBackendForm_LoadBackend(t *testing.T) {
 	bf := NewBackendForm()
 	bf.LoadBackend("claude", config.Backend{Command: "claude --dangerously-skip-permissions", PromptFlag: "--"})
@@ -339,6 +355,14 @@ func TestRenameTaskForm_TypeAndSubmit(t *testing.T) {
 	}
 	if rf.Name() != "new-name" {
 		t.Errorf("name = %q", rf.Name())
+	}
+}
+
+func TestRenameTaskForm_CtrlQ(t *testing.T) {
+	rf := NewRenameTaskForm("test")
+	rf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlQ, 0, 0))
+	if !rf.Canceled() {
+		t.Error("should be canceled")
 	}
 }
 

--- a/internal/tui2/forms_test.go
+++ b/internal/tui2/forms_test.go
@@ -90,7 +90,7 @@ func TestProjectForm_Escape(t *testing.T) {
 
 func TestProjectForm_CtrlQ(t *testing.T) {
 	pf := NewProjectForm()
-	pf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlQ, 0, 0))
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone))
 	if !pf.Canceled() {
 		t.Error("should be canceled")
 	}
@@ -244,7 +244,7 @@ func TestBackendForm_New(t *testing.T) {
 
 func TestBackendForm_CtrlQ(t *testing.T) {
 	bf := NewBackendForm()
-	bf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlQ, 0, 0))
+	bf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone))
 	if !bf.Canceled() {
 		t.Error("should be canceled")
 	}
@@ -360,7 +360,7 @@ func TestRenameTaskForm_TypeAndSubmit(t *testing.T) {
 
 func TestRenameTaskForm_CtrlQ(t *testing.T) {
 	rf := NewRenameTaskForm("test")
-	rf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlQ, 0, 0))
+	rf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone))
 	if !rf.Canceled() {
 		t.Error("should be canceled")
 	}

--- a/internal/tui2/newtaskform.go
+++ b/internal/tui2/newtaskform.go
@@ -272,7 +272,7 @@ func (f *NewTaskForm) InputHandler() func(event *tcell.EventKey, setFocus func(p
 		// Global form keys
 		switch event.Key() {
 		case tcell.KeyEscape, tcell.KeyCtrlQ:
-			if f.acOpen {
+			if f.acOpen { // two-step: first press closes autocomplete, second cancels form
 				f.acOpen = false
 				return
 			}

--- a/internal/tui2/newtaskform.go
+++ b/internal/tui2/newtaskform.go
@@ -271,7 +271,7 @@ func (f *NewTaskForm) InputHandler() func(event *tcell.EventKey, setFocus func(p
 
 		// Global form keys
 		switch event.Key() {
-		case tcell.KeyEscape:
+		case tcell.KeyEscape, tcell.KeyCtrlQ:
 			if f.acOpen {
 				f.acOpen = false
 				return

--- a/internal/tui2/newtaskform_test.go
+++ b/internal/tui2/newtaskform_test.go
@@ -82,6 +82,22 @@ func TestNewTaskForm_EscapeCancels(t *testing.T) {
 	}
 }
 
+func TestNewTaskForm_CtrlQCancels(t *testing.T) {
+	f := NewNewTaskForm(
+		map[string]config.Project{},
+		"",
+		map[string]config.Backend{},
+		"",
+	)
+
+	handler := f.InputHandler()
+	handler(tcell.NewEventKey(tcell.KeyCtrlQ, 0, 0), func(p tview.Primitive) {})
+
+	if !f.Canceled() {
+		t.Error("ctrl+q should cancel the form")
+	}
+}
+
 func TestNewTaskForm_PromptInput(t *testing.T) {
 	f := NewNewTaskForm(
 		map[string]config.Project{"p": {}},

--- a/internal/tui2/newtaskform_test.go
+++ b/internal/tui2/newtaskform_test.go
@@ -91,10 +91,36 @@ func TestNewTaskForm_CtrlQCancels(t *testing.T) {
 	)
 
 	handler := f.InputHandler()
-	handler(tcell.NewEventKey(tcell.KeyCtrlQ, 0, 0), func(p tview.Primitive) {})
+	handler(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone), func(p tview.Primitive) {})
 
 	if !f.Canceled() {
 		t.Error("ctrl+q should cancel the form")
+	}
+}
+
+func TestNewTaskForm_CtrlQClosesAutocompleteFirst(t *testing.T) {
+	f := NewNewTaskForm(
+		map[string]config.Project{"p": {}},
+		"p",
+		map[string]config.Backend{"b": {}},
+		"b",
+	)
+	f.acOpen = true
+
+	handler := f.InputHandler()
+	// First ctrl+q closes autocomplete
+	handler(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone), func(p tview.Primitive) {})
+	if f.Canceled() {
+		t.Error("first ctrl+q should close autocomplete, not cancel")
+	}
+	if f.acOpen {
+		t.Error("autocomplete should be closed")
+	}
+
+	// Second ctrl+q cancels the form
+	handler(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone), func(p tview.Primitive) {})
+	if !f.Canceled() {
+		t.Error("second ctrl+q should cancel the form")
 	}
 }
 

--- a/internal/tui2/projectform.go
+++ b/internal/tui2/projectform.go
@@ -147,7 +147,7 @@ func (pf *ProjectForm) maybeLoadBranches() {
 // HandleKey processes key events for the form.
 func (pf *ProjectForm) HandleKey(ev *tcell.EventKey) {
 	switch ev.Key() {
-	case tcell.KeyEscape:
+	case tcell.KeyEscape, tcell.KeyCtrlQ:
 		pf.canceled = true
 		return
 	case tcell.KeyEnter:

--- a/internal/tui2/renametask.go
+++ b/internal/tui2/renametask.go
@@ -38,7 +38,7 @@ func (rf *RenameTaskForm) HandleKey(ev *tcell.EventKey) {
 	hasAlt := mod&tcell.ModAlt != 0
 
 	switch ev.Key() {
-	case tcell.KeyEscape:
+	case tcell.KeyEscape, tcell.KeyCtrlQ:
 		rf.canceled = true
 	case tcell.KeyEnter:
 		rf.done = true

--- a/internal/tui2/todocleanup.go
+++ b/internal/tui2/todocleanup.go
@@ -34,7 +34,7 @@ func (m *ConfirmCleanupToDosModal) InputHandler() func(event *tcell.EventKey, se
 		switch event.Key() {
 		case tcell.KeyEnter:
 			m.confirmed = true
-		case tcell.KeyEscape:
+		case tcell.KeyEscape, tcell.KeyCtrlQ:
 			m.canceled = true
 		}
 	})

--- a/internal/tui2/todocleanup_test.go
+++ b/internal/tui2/todocleanup_test.go
@@ -34,6 +34,16 @@ func TestConfirmCleanupToDosModal_Cancel(t *testing.T) {
 	testutil.Equal(t, m.Canceled(), true)
 }
 
+func TestConfirmCleanupToDosModal_CtrlQ(t *testing.T) {
+	m := NewConfirmCleanupToDosModal(5)
+
+	handler := m.InputHandler()
+	handler(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone), func(p tview.Primitive) {})
+
+	testutil.Equal(t, m.Confirmed(), false)
+	testutil.Equal(t, m.Canceled(), true)
+}
+
 func TestToDoCleanup_RemovesFiles(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/tui2/tododeletemodal.go
+++ b/internal/tui2/tododeletemodal.go
@@ -32,7 +32,7 @@ func (m *ConfirmDeleteToDoModal) InputHandler() func(event *tcell.EventKey, setF
 		switch event.Key() {
 		case tcell.KeyEnter:
 			m.confirmed = true
-		case tcell.KeyEscape:
+		case tcell.KeyEscape, tcell.KeyCtrlQ:
 			m.canceled = true
 		}
 	})

--- a/internal/tui2/tododeletemodal_test.go
+++ b/internal/tui2/tododeletemodal_test.go
@@ -36,6 +36,17 @@ func TestConfirmDeleteToDoModal_Cancel(t *testing.T) {
 	testutil.Equal(t, m.Canceled(), true)
 }
 
+func TestConfirmDeleteToDoModal_CtrlQ(t *testing.T) {
+	item := ToDoItem{Name: "my-todo", Path: "/vault/my-todo.md"}
+	m := NewConfirmDeleteToDoModal(item)
+
+	handler := m.InputHandler()
+	handler(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone), func(p tview.Primitive) {})
+
+	testutil.Equal(t, m.Confirmed(), false)
+	testutil.Equal(t, m.Canceled(), true)
+}
+
 func TestToDoDelete_RemovesFile(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/tui2/todolaunch.go
+++ b/internal/tui2/todolaunch.go
@@ -125,7 +125,7 @@ func (m *LaunchToDoModal) InputHandler() func(event *tcell.EventKey, setFocus fu
 
 		// Global keys
 		switch event.Key() {
-		case tcell.KeyEscape:
+		case tcell.KeyEscape, tcell.KeyCtrlQ:
 			m.canceled = true
 			return
 		case tcell.KeyTab:

--- a/internal/tui2/todolaunch_test.go
+++ b/internal/tui2/todolaunch_test.go
@@ -3,6 +3,9 @@ package tui2
 import (
 	"testing"
 
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
 	"github.com/drn/argus/internal/config"
 	"github.com/drn/argus/internal/testutil"
 )
@@ -65,6 +68,17 @@ func TestLaunchToDoModal_FocusStartsOnPrompt(t *testing.T) {
 	item := ToDoItem{Name: "test"}
 	m := NewLaunchToDoModal(item, map[string]config.Project{"p": {}}, "p")
 	testutil.Equal(t, m.focused, ltFieldPrompt)
+}
+
+func TestLaunchToDoModal_CtrlQCancels(t *testing.T) {
+	item := ToDoItem{Name: "test"}
+	m := NewLaunchToDoModal(item, map[string]config.Project{"p": {}}, "p")
+
+	handler := m.InputHandler()
+	handler(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone), func(p tview.Primitive) {})
+
+	testutil.Equal(t, m.Canceled(), true)
+	testutil.Equal(t, m.Done(), false)
 }
 
 func TestBuildToDoPrompt(t *testing.T) {

--- a/internal/tui2/todolinks.go
+++ b/internal/tui2/todolinks.go
@@ -110,7 +110,7 @@ func (m *LinkPickerModal) PasteHandler() func(string, func(tview.Primitive)) {
 func (m *LinkPickerModal) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
 	return m.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
 		switch event.Key() {
-		case tcell.KeyEscape:
+		case tcell.KeyEscape, tcell.KeyCtrlQ:
 			m.canceled = true
 		case tcell.KeyEnter:
 			m.selected = true

--- a/internal/tui2/todolinks_test.go
+++ b/internal/tui2/todolinks_test.go
@@ -152,6 +152,14 @@ func TestLinkPickerModal_Navigation(t *testing.T) {
 		testutil.Equal(t, m.Canceled(), true)
 		testutil.Equal(t, m.Selected(), false)
 	})
+
+	t.Run("ctrl+q cancels", func(t *testing.T) {
+		m := NewLinkPickerModal(links)
+		handler := m.InputHandler()
+		handler(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone), func(p tview.Primitive) {})
+		testutil.Equal(t, m.Canceled(), true)
+		testutil.Equal(t, m.Selected(), false)
+	})
 }
 
 func TestOpenURL_RejectsNonHTTP(t *testing.T) {


### PR DESCRIPTION
All 10 modals and forms now accept ctrl+q in addition to escape for cancel/close. Includes tests for every modal and README keybindings section.

Co-Authored-By: Claude <noreply@anthropic.com>