### PR TITLE
Fix moon icon mapping: stars=unvisited, outline=visited

### DIFF
--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -793,11 +793,11 @@ func (tl *TaskListView) projectStatusIcon(tasks []*model.Task) (rune, tcell.Styl
 	switch {
 	case hasInProgress:
 		if allInProgressIdle {
-			return 0x0F0594, tcell.StyleDefault.Foreground(ColorInReview)
+			return IconMoonOutline, tcell.StyleDefault.Foreground(ColorInReview)
 		}
 		return model.SpinnerFrame(tl.animFrame), StyleInProgress
 	case hasInReview:
-		return 0xF186, StyleInReview
+		return IconMoonStars, StyleInReview
 	case hasComplete && !hasPending:
 		return '✓', StyleComplete
 	case hasComplete && hasPending:
@@ -880,11 +880,11 @@ func (tl *TaskListView) drawTaskRow(screen tcell.Screen, x, y, w int, task *mode
 	case model.StatusInProgress:
 		if tl.idleUnvisited[task.ID] {
 			// Idle and not yet viewed since going idle — moon with stars.
-			statusChar = 0xF186
+			statusChar = IconMoonStars
 			statusStyle = StyleInReview
 		} else if !tl.running[task.ID] || tl.idle[task.ID] {
 			// Session absent or idle (waiting for input) — moon icon.
-			statusChar = 0x0F0594
+			statusChar = IconMoonOutline
 			statusStyle = StyleInReview
 		} else {
 			// Actively running — animated spinner (nerd font progress spinner).
@@ -892,7 +892,7 @@ func (tl *TaskListView) drawTaskRow(screen tcell.Screen, x, y, w int, task *mode
 			statusStyle = StyleInProgress
 		}
 	case model.StatusInReview:
-		statusChar = 0xF186
+		statusChar = IconMoonStars
 		statusStyle = StyleInReview
 	case model.StatusComplete:
 		statusChar = '✓'

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -247,7 +247,7 @@ func TestTaskListView_ProjectStatusIcon(t *testing.T) {
 		{
 			name:     "in review",
 			tasks:    []*model.Task{{ID: "1", Status: model.StatusInReview}},
-			wantChar: 0xF186,
+			wantChar: IconMoonStars,
 		},
 		{
 			name: "mixed complete and pending",
@@ -262,7 +262,7 @@ func TestTaskListView_ProjectStatusIcon(t *testing.T) {
 			tasks:    []*model.Task{{ID: "1", Status: model.StatusInProgress}},
 			running:  map[string]bool{"1": true},
 			idle:     map[string]bool{"1": true},
-			wantChar: 0x0F0594,
+			wantChar: IconMoonOutline,
 		},
 	}
 
@@ -384,8 +384,8 @@ func TestTaskListView_IdleUnvisitedPromotion(t *testing.T) {
 
 	// Project icon should be moon_o when the only InProgress task is idleUnvisited.
 	icon, _ := tl.projectStatusIcon(tasks)
-	if icon != 0xF186 {
-		t.Errorf("projectStatusIcon with idleUnvisited = %c, want moon_o", icon)
+	if icon != IconMoonStars {
+		t.Errorf("projectStatusIcon with idleUnvisited = %c, want moon_stars", icon)
 	}
 }
 

--- a/internal/tui2/theme.go
+++ b/internal/tui2/theme.go
@@ -26,6 +26,12 @@ var (
 	ColorHighlight  = tcell.Color236 // slightly lighter dark gray — cursor/selection highlight
 )
 
+// Icon constants for status indicators (Nerd Font codepoints).
+const (
+	IconMoonStars   = rune(0x0F0594) // 󰖔 nf-md-weather_night — unvisited / needs attention
+	IconMoonOutline = rune(0xF186)   //  nf-fa-moon_o — visited / idle
+)
+
 // Styles for common UI elements.
 var (
 	StyleDefault      = tcell.StyleDefault

--- a/internal/tui2/todos.go
+++ b/internal/tui2/todos.go
@@ -388,7 +388,7 @@ func (p *ToDoListPanel) Draw(screen tcell.Screen) {
 					bullet = '●'
 					bulletStyle = StyleInProgress
 				case model.StatusInReview:
-					bullet = 0xF186
+					bullet = IconMoonStars
 					bulletStyle = StyleInReview
 				case model.StatusComplete:
 					bullet = '✓'


### PR DESCRIPTION
Swap moon-with-stars and moon-outline Nerd Font icons so unvisited/needs-attention states show stars and visited/idle states show the plain moon. Extract named constants (IconMoonStars, IconMoonOutline) in theme.go.

Co-Authored-By: Claude <noreply@anthropic.com>