### PR TITLE
Broaden sandbox write access to ~/.dots for merge skill

### DIFF
--- a/internal/agent/sandbox.go
+++ b/internal/agent/sandbox.go
@@ -60,8 +60,8 @@ const sandboxProfileBase = `(version 1)
 (allow file-write* (subpath (string-append (param "HOME") "/.cargo")))
 (allow file-write* (subpath (string-append (param "HOME") "/.local")))
 (allow file-write* (subpath (string-append (param "HOME") "/.cache")))
-; Skill usage tracking
-(allow file-write* (subpath (string-append (param "HOME") "/.dots/sys/skill-usage")))
+; Dotfiles — allow full write for master branch syncing (merge skill)
+(allow file-write* (subpath (string-append (param "HOME") "/.dots")))
 `
 
 // IsSandboxAvailable checks whether sandbox-exec is available on this system.

--- a/internal/agent/sandbox.go
+++ b/internal/agent/sandbox.go
@@ -60,7 +60,8 @@ const sandboxProfileBase = `(version 1)
 (allow file-write* (subpath (string-append (param "HOME") "/.cargo")))
 (allow file-write* (subpath (string-append (param "HOME") "/.local")))
 (allow file-write* (subpath (string-append (param "HOME") "/.cache")))
-; Dotfiles — allow full write for master branch syncing (merge skill)
+; Dotfiles — full write required for merge skill (git reset --hard origin/master).
+; Expands from ~/.dots/sys/skill-usage; acceptable since sole-user threat model.
 (allow file-write* (subpath (string-append (param "HOME") "/.dots")))
 `
 


### PR DESCRIPTION
The merge skill runs git reset --hard origin/master in ~/.dots to sync dotfiles after merging. The previous narrow subpath only allowed skill-usage tracking writes, blocking the full working tree reset.

Co-Authored-By: Claude <noreply@anthropic.com>