### PR TITLE
Prioritize moon-stars icon when project has unreviewed tasks

### DIFF
--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -764,7 +764,7 @@ func (tl *TaskListView) drawFilterInput(screen tcell.Screen, x, y, w int) {
 }
 
 // projectStatusIcon returns the aggregated status icon and style for a project's tasks.
-// Priority: in_progress > in_review > all complete > mixed > all pending.
+// Priority: any in_review > in_progress alone > all complete > mixed > all pending.
 func (tl *TaskListView) projectStatusIcon(tasks []*model.Task) (rune, tcell.Style) {
 	var hasInProgress, hasInReview, hasPending, hasComplete bool
 	allInProgressIdle := true
@@ -792,6 +792,9 @@ func (tl *TaskListView) projectStatusIcon(tasks []*model.Task) (rune, tcell.Styl
 
 	switch {
 	case hasInProgress:
+		if hasInReview {
+			return IconMoonStars, StyleInReview
+		}
 		if allInProgressIdle {
 			return IconMoonOutline, tcell.StyleDefault.Foreground(ColorInReview)
 		}

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -264,6 +264,25 @@ func TestTaskListView_ProjectStatusIcon(t *testing.T) {
 			idle:     map[string]bool{"1": true},
 			wantChar: IconMoonOutline,
 		},
+		{
+			name: "idle in progress plus in review shows review icon",
+			tasks: []*model.Task{
+				{ID: "1", Status: model.StatusInProgress},
+				{ID: "2", Status: model.StatusInReview},
+			},
+			running:  map[string]bool{"1": true},
+			idle:     map[string]bool{"1": true},
+			wantChar: IconMoonStars,
+		},
+		{
+			name: "running in progress plus in review shows review icon",
+			tasks: []*model.Task{
+				{ID: "1", Status: model.StatusInProgress},
+				{ID: "2", Status: model.StatusInReview},
+			},
+			running:  map[string]bool{"1": true},
+			wantChar: IconMoonStars,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Show IconMoonStars at the project level when any task is in-review, even if other tasks are actively running. Previously the spinner or idle moon took precedence, hiding the needs-attention state.

Co-Authored-By: Claude <noreply@anthropic.com>