### PR TITLE
Show sandbox status in task detail panel

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -852,10 +852,10 @@ func (a *App) refreshTasksWithIDs(runningIDs, idleIDs []string) {
 		t := a.tasklist.SelectedTask()
 		if t != nil {
 			a.taskPreview.SetTaskID(t.ID)
-			a.taskDetail.SetTask(t, a.isTaskRunning(t.ID))
+			a.taskDetail.SetTask(t, a.isTaskRunning(t.ID), a.isTaskSandboxed(t))
 		} else {
 			a.taskPreview.SetTaskID("")
-			a.taskDetail.SetTask(nil, false)
+			a.taskDetail.SetTask(nil, false, false)
 		}
 	}
 }
@@ -1539,12 +1539,12 @@ func (a *App) switchTab(t Tab) {
 func (a *App) onTaskCursorChange(task *model.Task) {
 	if task == nil {
 		a.taskPreview.SetTaskID("")
-		a.taskDetail.SetTask(nil, false)
+		a.taskDetail.SetTask(nil, false, false)
 		a.taskGitPanel.Clear()
 		return
 	}
 	a.taskPreview.SetTaskID(task.ID)
-	a.taskDetail.SetTask(task, a.isTaskRunning(task.ID))
+	a.taskDetail.SetTask(task, a.isTaskRunning(task.ID), a.isTaskSandboxed(task))
 	// Kick off preview fetch immediately (don't wait for next tick).
 	go func() {
 		a.refreshPreview(task.ID)
@@ -1643,6 +1643,16 @@ func (a *App) isTaskRunning(taskID string) bool {
 		}
 	}
 	return false
+}
+
+// isTaskSandboxed returns whether the given task would run sandboxed.
+func (a *App) isTaskSandboxed(task *model.Task) bool {
+	if task == nil {
+		return false
+	}
+	cfg := a.db.Config()
+	sb := agent.ResolveSandboxConfig(task, cfg)
+	return sb.Enabled && agent.IsSandboxAvailable()
 }
 
 // onTaskSelect handles Enter on a task — enters the agent view.

--- a/internal/tui2/taskdetail.go
+++ b/internal/tui2/taskdetail.go
@@ -14,8 +14,9 @@ import (
 // TaskDetailPanel displays metadata for the selected task in the right panel.
 type TaskDetailPanel struct {
 	*tview.Box
-	task    *model.Task
-	running bool
+	task      *model.Task
+	running   bool
+	sandboxed bool
 }
 
 // NewTaskDetailPanel creates a task detail panel.
@@ -26,9 +27,10 @@ func NewTaskDetailPanel() *TaskDetailPanel {
 }
 
 // SetTask updates the displayed task.
-func (td *TaskDetailPanel) SetTask(t *model.Task, running bool) {
+func (td *TaskDetailPanel) SetTask(t *model.Task, running, sandboxed bool) {
 	td.task = t
 	td.running = running
+	td.sandboxed = sandboxed
 }
 
 // Draw renders the task detail panel.
@@ -85,6 +87,13 @@ func (td *TaskDetailPanel) Draw(screen tcell.Screen) {
 	// Backend
 	if t.Backend != "" {
 		row = td.drawField(screen, inner.X, row, inner.W, "Backend", t.Backend, StyleNormal)
+	}
+
+	// Sandbox
+	if td.sandboxed {
+		row = td.drawField(screen, inner.X, row, inner.W, "Sandbox", "Yes", StyleComplete)
+	} else {
+		row = td.drawField(screen, inner.X, row, inner.W, "Sandbox", "No", StyleDimmed)
 	}
 
 	// PR URL

--- a/internal/tui2/taskdetail_test.go
+++ b/internal/tui2/taskdetail_test.go
@@ -1,12 +1,14 @@
 package tui2
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gdamore/tcell/v2"
 
 	"github.com/drn/argus/internal/model"
+	"github.com/drn/argus/internal/testutil"
 )
 
 func TestTaskDetailPanel_DrawNilTask(t *testing.T) {
@@ -45,7 +47,7 @@ func TestTaskDetailPanel_DrawWithTask(t *testing.T) {
 	}
 	task.SetStatus(model.StatusInProgress)
 
-	td.SetTask(task, true)
+	td.SetTask(task, true, false)
 	td.Draw(screen)
 	// Should render without panic
 }
@@ -60,6 +62,54 @@ func TestTaskDetailPanel_ZeroDimensions(t *testing.T) {
 	td := NewTaskDetailPanel()
 	td.SetRect(0, 0, 0, 0)
 	td.Draw(screen) // must not panic
+}
+
+func TestTaskDetailPanel_SandboxIndicator(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	screen.SetSize(40, 20)
+
+	td := NewTaskDetailPanel()
+	td.SetRect(1, 1, 38, 18)
+
+	task := &model.Task{
+		ID:      "test-sb",
+		Name:    "sandbox-test",
+		Status:  model.StatusPending,
+		Project: "argus",
+		Backend: "claude",
+	}
+
+	readScreen := func() string {
+		var buf strings.Builder
+		w, h := screen.Size()
+		for row := 0; row < h; row++ {
+			for col := 0; col < w; col++ {
+				ch, _, _, _ := screen.GetContent(col, row)
+				buf.WriteRune(ch)
+			}
+			buf.WriteRune('\n')
+		}
+		return buf.String()
+	}
+
+	t.Run("sandboxed", func(t *testing.T) {
+		td.SetTask(task, false, true)
+		td.Draw(screen)
+		content := readScreen()
+		testutil.Contains(t, content, "Sandbox")
+		testutil.Contains(t, content, "Yes")
+	})
+
+	t.Run("not sandboxed", func(t *testing.T) {
+		td.SetTask(task, false, false)
+		td.Draw(screen)
+		content := readScreen()
+		testutil.Contains(t, content, "Sandbox")
+		testutil.Contains(t, content, "No")
+	})
 }
 
 func TestTaskDetailPanel_WrapText(t *testing.T) {


### PR DESCRIPTION
Display whether each task is sandboxed (Yes/No) in the task detail panel, resolved from global and per-project sandbox config.

Co-Authored-By: Claude <noreply@anthropic.com>