### PR TITLE
Support multi-term search in task list filter

### DIFF
--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -1074,7 +1074,7 @@ When the daemon crashed, one task was incorrectly marked Complete despite its ag
 
 **Data Model:**
 - `TaskListView.filtering bool` — true while filter input is focused
-- `TaskListView.filter string` — current filter text (case-insensitive substring match against task name or project name)
+- `TaskListView.filter string` — current filter text; split on whitespace into terms, all terms must match at least one of task name or project name (case-insensitive substring). Enables queries like "forge download" to match across project + task name.
 
 **Flow:**
 1. User presses `/` on task list → `filtering = true`, filter input shown at bottom of panel

--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -163,12 +163,23 @@ func (tl *TaskListView) SelectedProject() string {
 }
 
 // matchesFilter returns true if the task matches the current filter.
+// Filter terms are split by whitespace. Each term must match either the
+// project name or task name (case-insensitive substring). This allows
+// queries like "forge download" to match a task "Download-this-video" in
+// the "forge" project.
 func (tl *TaskListView) matchesFilter(t *model.Task) bool {
 	if tl.filter == "" {
 		return true
 	}
-	return strings.Contains(strings.ToLower(t.Name), strings.ToLower(tl.filter)) ||
-		strings.Contains(strings.ToLower(t.Project), strings.ToLower(tl.filter))
+	terms := strings.Fields(strings.ToLower(tl.filter))
+	name := strings.ToLower(t.Name)
+	proj := strings.ToLower(t.Project)
+	for _, term := range terms {
+		if !strings.Contains(name, term) && !strings.Contains(proj, term) {
+			return false
+		}
+	}
+	return true
 }
 
 // buildRows flattens tasks into display rows grouped by project.

--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -163,8 +163,8 @@ func (tl *TaskListView) SelectedProject() string {
 }
 
 // matchesFilter returns true if the task matches the current filter.
-// Filter terms are split by whitespace. Each term must match either the
-// project name or task name (case-insensitive substring). This allows
+// Filter terms are split by whitespace. All terms must match at least one
+// of the project name or task name (case-insensitive substring). This allows
 // queries like "forge download" to match a task "Download-this-video" in
 // the "forge" project.
 func (tl *TaskListView) matchesFilter(t *model.Task) bool {

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -961,6 +961,36 @@ func TestTaskListView_FilterCaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestTaskListView_FilterMultiTerm(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetTasks([]*model.Task{
+		{ID: "1", Name: "Download-this-video", Project: "forge", Status: model.StatusPending},
+		{ID: "2", Name: "Fix-login-bug", Project: "forge", Status: model.StatusInProgress},
+		{ID: "3", Name: "Download-report", Project: "alpha", Status: model.StatusPending},
+	})
+
+	handler := tl.InputHandler()
+	handler(tcell.NewEventKey(tcell.KeyRune, '/', tcell.ModNone), func(tview.Primitive) {})
+
+	// Type "forge download" — should match only task in forge with "download" in name
+	for _, ch := range "forge download" {
+		handler(tcell.NewEventKey(tcell.KeyRune, ch, tcell.ModNone), func(tview.Primitive) {})
+	}
+
+	var matched []string
+	for _, r := range tl.rows {
+		if r.kind == rowTask {
+			matched = append(matched, r.task.Name)
+		}
+	}
+	if len(matched) != 1 {
+		t.Fatalf("expected 1 task, got %d: %v", len(matched), matched)
+	}
+	if matched[0] != "Download-this-video" {
+		t.Errorf("expected Download-this-video, got %s", matched[0])
+	}
+}
+
 func TestTaskListView_FilterEscapeClears(t *testing.T) {
 	tl := NewTaskListView()
 	tl.SetTasks(makeTasks())


### PR DESCRIPTION
Split filter input on whitespace so each term matches independently against project name or task name. Enables queries like 'forge download' to match a task in the forge project with download in the name.

Co-Authored-By: Claude <noreply@anthropic.com>