### PR TITLE
Render filter query in magenta in task list header

### DIFF
--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -705,11 +705,18 @@ func (tl *TaskListView) Draw(screen tcell.Screen) {
 
 	// Show filter text in panel title when active.
 	title := " Tasks "
-	if tl.filter != "" || tl.filtering {
-		title = " Tasks [/" + tl.filter + "] "
-	}
-
 	inner := drawBorderedPanel(screen, x, y, width, height, title, StyleBorder)
+	if tl.filter != "" || tl.filtering {
+		filterStr := "/" + tl.filter
+		col := x + 1 + ansi.StringWidth(title) // after the title text
+		for _, r := range filterStr {
+			if col >= x+width-1 {
+				break
+			}
+			screen.SetContent(col, y, r, nil, StyleFilter)
+			col++
+		}
+	}
 	if inner.W <= 0 || inner.H <= 0 {
 		return
 	}

--- a/internal/tui2/theme.go
+++ b/internal/tui2/theme.go
@@ -24,6 +24,7 @@ var (
 	ColorKeyHint    = tcell.Color87  // cyan — keybinding hints
 	ColorKeyLabel   = tcell.Color240 // dim — keybinding labels
 	ColorHighlight  = tcell.Color236 // slightly lighter dark gray — cursor/selection highlight
+	ColorFilter     = tcell.Color201 // magenta — active filter query
 )
 
 // Icon constants for status indicators (Nerd Font codepoints).
@@ -48,4 +49,5 @@ var (
 	StyleBorder       = tcell.StyleDefault.Foreground(ColorBorder)
 	StyleFocusedBorder = tcell.StyleDefault.Foreground(ColorTitle)
 	StyleError        = tcell.StyleDefault.Foreground(ColorError)
+	StyleFilter       = tcell.StyleDefault.Foreground(ColorFilter).Bold(true)
 )


### PR DESCRIPTION
Use a dedicated StyleFilter (ColorFilter/Color201 magenta) for the filter query in the Tasks panel title bar. Fixes column positioning to use ansi.StringWidth and a column counter for correct multi-byte character handling.

Co-Authored-By: Claude <noreply@anthropic.com>