### PR TITLE
Add border-colored brackets around filter query in task list header

### DIFF
--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -709,12 +709,19 @@ func (tl *TaskListView) Draw(screen tcell.Screen) {
 	if tl.filter != "" || tl.filtering {
 		filterStr := "/" + tl.filter
 		col := x + 1 + ansi.StringWidth(title) // after the title text
+		if col < x+width-1 {
+			screen.SetContent(col, y, '[', nil, StyleBorder)
+			col++
+		}
 		for _, r := range filterStr {
 			if col >= x+width-1 {
 				break
 			}
 			screen.SetContent(col, y, r, nil, StyleFilter)
 			col++
+		}
+		if col < x+width-1 {
+			screen.SetContent(col, y, ']', nil, StyleBorder)
 		}
 	}
 	if inner.W <= 0 || inner.H <= 0 {


### PR DESCRIPTION
Wrap the magenta filter text with [] drawn in StyleBorder so the filter indicator matches the panel title bar style.

Co-Authored-By: Claude <noreply@anthropic.com>