### PR TITLE
Add word and line delete hotkeys to task list filter

### DIFF
--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -612,7 +612,7 @@ func (tl *TaskListView) handleFilterInput(event *tcell.EventKey) bool {
 		}
 		return true
 	case tcell.KeyCtrlU:
-		// Cmd+Delete: clear entire filter text.
+		// Ctrl+U: clear entire filter text (Cmd+Delete on macOS).
 		tl.filter = ""
 		tl.applyFilter()
 		return true

--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -587,6 +587,7 @@ func (tl *TaskListView) applyFilter() {
 // handleFilterInput processes key events while the filter input is active.
 // Returns true if the event was consumed.
 func (tl *TaskListView) handleFilterInput(event *tcell.EventKey) bool {
+	hasAlt := event.Modifiers()&tcell.ModAlt != 0
 	switch event.Key() {
 	case tcell.KeyEscape:
 		tl.ClearFilter()
@@ -596,11 +597,31 @@ func (tl *TaskListView) handleFilterInput(event *tcell.EventKey) bool {
 		tl.filtering = false
 		return true
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
+		if hasAlt {
+			// Option+Delete: delete word left.
+			runes := []rune(tl.filter)
+			runes, _ = deleteWordLeft(runes, len(runes))
+			tl.filter = string(runes)
+			tl.applyFilter()
+			return true
+		}
 		if len(tl.filter) > 0 {
 			_, size := utf8.DecodeLastRuneInString(tl.filter)
 			tl.filter = tl.filter[:len(tl.filter)-size]
 			tl.applyFilter()
 		}
+		return true
+	case tcell.KeyCtrlU:
+		// Cmd+Delete: clear entire filter text.
+		tl.filter = ""
+		tl.applyFilter()
+		return true
+	case tcell.KeyCtrlW:
+		// Ctrl+W: delete word left.
+		runes := []rune(tl.filter)
+		runes, _ = deleteWordLeft(runes, len(runes))
+		tl.filter = string(runes)
+		tl.applyFilter()
 		return true
 	case tcell.KeyUp:
 		tl.CursorUp()

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -1323,6 +1323,56 @@ func TestTaskListView_CopyPromptKey(t *testing.T) {
 	handler(tcell.NewEventKey(tcell.KeyRune, 'c', tcell.ModNone), func(tview.Primitive) {})
 }
 
+func TestTaskListView_FilterOptionDelete(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetTasks(makeTasks())
+
+	handler := tl.InputHandler()
+	handler(tcell.NewEventKey(tcell.KeyRune, '/', tcell.ModNone), func(tview.Primitive) {})
+	for _, ch := range "hello world" {
+		handler(tcell.NewEventKey(tcell.KeyRune, ch, tcell.ModNone), func(tview.Primitive) {})
+	}
+	testutil.Equal(t, tl.Filter(), "hello world")
+
+	// Option+Delete: delete word left ("world")
+	handler(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModAlt), func(tview.Primitive) {})
+	testutil.Equal(t, tl.Filter(), "hello ")
+}
+
+func TestTaskListView_FilterCmdDelete(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetTasks(makeTasks())
+
+	handler := tl.InputHandler()
+	handler(tcell.NewEventKey(tcell.KeyRune, '/', tcell.ModNone), func(tview.Primitive) {})
+	for _, ch := range "hello world" {
+		handler(tcell.NewEventKey(tcell.KeyRune, ch, tcell.ModNone), func(tview.Primitive) {})
+	}
+	testutil.Equal(t, tl.Filter(), "hello world")
+
+	// Cmd+Delete (Ctrl+U): clear entire filter text
+	handler(tcell.NewEventKey(tcell.KeyCtrlU, 0, tcell.ModNone), func(tview.Primitive) {})
+	testutil.Equal(t, tl.Filter(), "")
+	// Should still be in filter mode
+	testutil.Equal(t, tl.Filtering(), true)
+}
+
+func TestTaskListView_FilterCtrlW(t *testing.T) {
+	tl := NewTaskListView()
+	tl.SetTasks(makeTasks())
+
+	handler := tl.InputHandler()
+	handler(tcell.NewEventKey(tcell.KeyRune, '/', tcell.ModNone), func(tview.Primitive) {})
+	for _, ch := range "foo bar" {
+		handler(tcell.NewEventKey(tcell.KeyRune, ch, tcell.ModNone), func(tview.Primitive) {})
+	}
+	testutil.Equal(t, tl.Filter(), "foo bar")
+
+	// Ctrl+W: delete word left
+	handler(tcell.NewEventKey(tcell.KeyCtrlW, 0, tcell.ModNone), func(tview.Primitive) {})
+	testutil.Equal(t, tl.Filter(), "foo ")
+}
+
 func TestSanitizeTaskName(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Support Option+Delete (word left), Ctrl+W (word left), and Ctrl+U (clear line) in the / filter input, matching the hotkeys available in other text inputs.

Co-Authored-By: Claude <noreply@anthropic.com>