### PR TITLE
Fix file explorer cursor jumping over unfetched directories

### DIFF
--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -1428,6 +1428,7 @@ Replaced 5 separate `notifyCursorChange()` call sites with a single `defer` that
 ### Gotchas
 - `buildChildTree` sorts files alphabetically at each level — test assertions must account for sort order, not insertion order
 - `skipToLastChild` scans the full subtree depth (all indent > 0 rows), not just immediate children — this is intentional for the "enter folder from below" UX
+- `CursorUp`/`CursorDown` must guard `skipToFile` with `awaitingFetch()` — when `autoExpand` returns a fetch request and the cursor is on a dir row, the children haven't arrived yet. Without this, `skipToFile` jumps past all stacked unfetched directories to the nearest file (e.g., pressing up from below 3 closed dirs jumps to the file above all of them instead of pausing on each dir)
 
 ## Configurable Spinner Animation: 2026-03-30
 

--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -202,6 +202,7 @@ Non-obvious invariants and gotchas. For architecture, see CLAUDE.md. For feature
 - **`CursorUp` must track `wasChild` BEFORE decrementing to distinguish entering vs exiting a folder.** `wasChild = fp.rows[fp.cursor].indent > 0` captures whether the cursor is inside a folder pre-move. Without this, `skipToLastChild` traps the cursor inside the folder when navigating up from the first child (it re-enters instead of exiting).
 - **`buildChildTree` groups flat file paths into a trie and emits dirs-before-files at each level.** Sub-directories are always expanded (no interactive collapse). Only top-level directories (indent 0) toggle via `autoExpand`.
 - **`skipToLastChild` scans all nested indent levels, not just immediate children.** It finds the last non-directory row before the next `indent == 0` boundary. For deeply nested trees, this lands on the deepest last file.
+- **`CursorUp`/`CursorDown` must not `skipToFile` when `awaitingFetch` is true.** When `autoExpand` returns a non-empty fetch string and the cursor is on a dir row, the dir's children haven't arrived yet. Calling `skipToFile` skips over all stacked unfetched directories to the nearest file — e.g., pressing up from below 3 closed dirs jumps past all of them. The `awaitingFetch()` helper guards both directions.
 
 ### Fork Context Capture
 

--- a/internal/tui2/fileexplorer.go
+++ b/internal/tui2/fileexplorer.go
@@ -134,7 +134,13 @@ func (fp *FilePanel) CursorUp() string {
 	// When leaving a folder from within (wasChild=true), skip upward past the dir.
 	enteredFolder := !wasChild && fp.skipToLastChild()
 	if !enteredFolder {
-		fp.skipToFile(-1)
+		// If we just expanded a dir that needs children fetched, stay on the dir
+		// row — children will arrive via SetDirChildren. Without this guard,
+		// skipToFile(-1) skips over all stacked directories to the nearest file above.
+		awaitingFetch := fetch != "" && fp.cursor >= 0 && fp.cursor < len(fp.rows) && fp.rows[fp.cursor].IsDir
+		if !awaitingFetch {
+			fp.skipToFile(-1)
+		}
 	}
 	fp.ensureVisible()
 	return fetch
@@ -151,7 +157,13 @@ func (fp *FilePanel) CursorDown() string {
 		}
 	}
 	fetch := fp.autoExpand()
-	fp.skipToFile(1)
+	// If we just expanded a dir that needs children fetched, stay on the dir
+	// row — children will arrive via SetDirChildren. Without this guard,
+	// skipToFile(1) skips over all stacked directories to the nearest file below.
+	awaitingFetch := fetch != "" && fp.cursor >= 0 && fp.cursor < len(fp.rows) && fp.rows[fp.cursor].IsDir
+	if !awaitingFetch {
+		fp.skipToFile(1)
+	}
 	fp.ensureVisible()
 	return fetch
 }

--- a/internal/tui2/fileexplorer.go
+++ b/internal/tui2/fileexplorer.go
@@ -133,14 +133,8 @@ func (fp *FilePanel) CursorUp() string {
 	// When entering a folder from below (wasChild=false), land on the last child.
 	// When leaving a folder from within (wasChild=true), skip upward past the dir.
 	enteredFolder := !wasChild && fp.skipToLastChild()
-	if !enteredFolder {
-		// If we just expanded a dir that needs children fetched, stay on the dir
-		// row — children will arrive via SetDirChildren. Without this guard,
-		// skipToFile(-1) skips over all stacked directories to the nearest file above.
-		awaitingFetch := fetch != "" && fp.cursor >= 0 && fp.cursor < len(fp.rows) && fp.rows[fp.cursor].IsDir
-		if !awaitingFetch {
-			fp.skipToFile(-1)
-		}
+	if !enteredFolder && !fp.awaitingFetch(fetch) {
+		fp.skipToFile(-1)
 	}
 	fp.ensureVisible()
 	return fetch
@@ -157,11 +151,7 @@ func (fp *FilePanel) CursorDown() string {
 		}
 	}
 	fetch := fp.autoExpand()
-	// If we just expanded a dir that needs children fetched, stay on the dir
-	// row — children will arrive via SetDirChildren. Without this guard,
-	// skipToFile(1) skips over all stacked directories to the nearest file below.
-	awaitingFetch := fetch != "" && fp.cursor >= 0 && fp.cursor < len(fp.rows) && fp.rows[fp.cursor].IsDir
-	if !awaitingFetch {
+	if !fp.awaitingFetch(fetch) {
 		fp.skipToFile(1)
 	}
 	fp.ensureVisible()
@@ -197,6 +187,13 @@ func (fp *FilePanel) skipToLastChild() bool {
 
 // skipToFile advances the cursor past directory rows in the given direction.
 // If no file rows exist, the cursor stays on the current row (directory).
+// awaitingFetch reports whether the cursor is on a directory row whose children
+// are being fetched asynchronously. When true, callers should NOT skipToFile —
+// the cursor stays on the dir until SetDirChildren arrives.
+func (fp *FilePanel) awaitingFetch(fetch string) bool {
+	return fetch != "" && fp.cursor >= 0 && fp.cursor < len(fp.rows) && fp.rows[fp.cursor].IsDir
+}
+
 func (fp *FilePanel) skipToFile(dir int) {
 	start := fp.cursor
 	for fp.cursor >= 0 && fp.cursor < len(fp.rows) {

--- a/internal/tui2/fileexplorer_test.go
+++ b/internal/tui2/fileexplorer_test.go
@@ -74,41 +74,100 @@ func TestFilePanel_DirExpansion(t *testing.T) {
 func TestFilePanel_SkipDirDown(t *testing.T) {
 	fp := NewFilePanel()
 	fp.Box.SetRect(0, 0, 40, 20)
-	files := []gitutil.ChangedFile{
-		{Status: "M", Path: "a.go"},
-		{Status: "M", Path: "pkg/", IsDir: true},
-		{Status: "A", Path: "b.go"},
-	}
-	fp.SetFiles(files)
 
-	// Start on a.go, move down — should skip pkg/ dir and land on b.go
-	fp.CursorDown()
-	if f := fp.SelectedFile(); f == nil || f.Path != "b.go" {
-		t.Errorf("should skip dir, got %v", f)
-	}
+	t.Run("unfetched dir pauses on dir", func(t *testing.T) {
+		files := []gitutil.ChangedFile{
+			{Status: "M", Path: "a.go"},
+			{Status: "M", Path: "pkg/", IsDir: true},
+			{Status: "A", Path: "b.go"},
+		}
+		fp.SetFiles(files)
+
+		// Start on a.go, move down — stays on pkg/ while children are fetched
+		fetch := fp.CursorDown()
+		if fetch == "" {
+			t.Error("expected fetch request for unfetched dir")
+		}
+		if f := fp.SelectedFile(); f == nil || f.Path != "pkg/" {
+			t.Errorf("should stay on unfetched dir, got %v", f)
+		}
+	})
+
+	t.Run("cached empty dir skips to next file", func(t *testing.T) {
+		fp2 := NewFilePanel()
+		fp2.Box.SetRect(0, 0, 40, 20)
+		fp2.dirChildren["pkg/"] = []gitutil.ChangedFile{} // cached but empty
+		files := []gitutil.ChangedFile{
+			{Status: "M", Path: "a.go"},
+			{Status: "M", Path: "pkg/", IsDir: true},
+			{Status: "A", Path: "b.go"},
+		}
+		fp2.SetFiles(files)
+
+		// Cached empty dir — skip to b.go
+		fp2.cursor = 0 // a.go
+		fp2.CursorDown()
+		if f := fp2.SelectedFile(); f == nil || f.Path != "b.go" {
+			t.Errorf("should skip cached empty dir, got %v", f)
+		}
+	})
 }
 
 func TestFilePanel_SkipDirUp(t *testing.T) {
 	fp := NewFilePanel()
 	fp.Box.SetRect(0, 0, 40, 20)
-	files := []gitutil.ChangedFile{
-		{Status: "M", Path: "a.go"},
-		{Status: "M", Path: "pkg/", IsDir: true},
-		{Status: "A", Path: "b.go"},
-	}
-	fp.SetFiles(files)
 
-	// Move cursor to b.go first
-	fp.CursorDown()
-	if f := fp.SelectedFile(); f == nil || f.Path != "b.go" {
-		t.Fatalf("setup: expected b.go, got %v", f)
-	}
+	t.Run("cached empty dir skips to prev file", func(t *testing.T) {
+		fp.dirChildren["pkg/"] = []gitutil.ChangedFile{} // cached but empty
+		files := []gitutil.ChangedFile{
+			{Status: "M", Path: "a.go"},
+			{Status: "M", Path: "pkg/", IsDir: true},
+			{Status: "A", Path: "b.go"},
+		}
+		fp.SetFiles(files)
 
-	// Move up — should skip pkg/ dir and land on a.go
-	fp.CursorUp()
-	if f := fp.SelectedFile(); f == nil || f.Path != "a.go" {
-		t.Errorf("should skip dir going up, got %v", f)
-	}
+		// Move cursor to b.go
+		for i, r := range fp.rows {
+			if r.Path == "b.go" {
+				fp.cursor = i
+				break
+			}
+		}
+
+		// Move up — cached empty dir, skip to a.go
+		fp.CursorUp()
+		if f := fp.SelectedFile(); f == nil || f.Path != "a.go" {
+			t.Errorf("should skip cached empty dir going up, got %v", f)
+		}
+	})
+
+	t.Run("unfetched dir pauses on dir", func(t *testing.T) {
+		fp2 := NewFilePanel()
+		fp2.Box.SetRect(0, 0, 40, 20)
+		files := []gitutil.ChangedFile{
+			{Status: "M", Path: "a.go"},
+			{Status: "M", Path: "pkg/", IsDir: true},
+			{Status: "A", Path: "b.go"},
+		}
+		fp2.SetFiles(files)
+
+		// Move cursor to b.go
+		for i, r := range fp2.rows {
+			if r.Path == "b.go" {
+				fp2.cursor = i
+				break
+			}
+		}
+
+		// Move up — unfetched dir, stays on dir
+		fetch := fp2.CursorUp()
+		if fetch == "" {
+			t.Error("expected fetch request for unfetched dir")
+		}
+		if f := fp2.SelectedFile(); f == nil || f.Path != "pkg/" {
+			t.Errorf("should stay on unfetched dir, got %v", f)
+		}
+	})
 }
 
 func TestFilePanel_SetFilesAutoExpandDir(t *testing.T) {
@@ -331,7 +390,7 @@ func TestFilePanel_CursorUpIntoExpandedDir(t *testing.T) {
 		}
 	})
 
-	t.Run("no children fetched yet skips over dir", func(t *testing.T) {
+	t.Run("no children fetched yet stays on dir", func(t *testing.T) {
 		fp := NewFilePanel()
 		fp.Box.SetRect(0, 0, 40, 20)
 		files := []gitutil.ChangedFile{
@@ -341,14 +400,22 @@ func TestFilePanel_CursorUpIntoExpandedDir(t *testing.T) {
 		}
 		fp.SetFiles(files)
 		// Move to b.go
-		fp.CursorDown()
+		for i, r := range fp.rows {
+			if r.Path == "b.go" {
+				fp.cursor = i
+				break
+			}
+		}
 		if f := fp.SelectedFile(); f == nil || f.Path != "b.go" {
 			t.Fatalf("setup: expected b.go, got %v", f)
 		}
-		// Up — no children cached, so should skip dir and land on a.go
-		fp.CursorUp()
-		if f := fp.SelectedFile(); f == nil || f.Path != "a.go" {
-			t.Errorf("expected a.go (no children to enter), got %v", f)
+		// Up — no children cached, stays on dir (fetch in progress)
+		fetch := fp.CursorUp()
+		if fetch == "" {
+			t.Error("expected fetch request for unfetched dir")
+		}
+		if f := fp.SelectedFile(); f == nil || f.Path != "pkg/" {
+			t.Errorf("expected pkg/ (awaiting fetch), got %v", f)
 		}
 	})
 }
@@ -560,5 +627,136 @@ func TestFilePanel_CursorUpIntoNestedFolder(t *testing.T) {
 	fp.CursorUp()
 	if f := fp.SelectedFile(); f == nil || f.Path != "src/main.go" {
 		t.Errorf("expected src/main.go (last child in tree), got %v", f)
+	}
+}
+
+func TestFilePanel_CursorDownStaysOnUnfetchedDir(t *testing.T) {
+	fp := NewFilePanel()
+	fp.Box.SetRect(0, 0, 40, 20)
+	files := []gitutil.ChangedFile{
+		{Status: "M", Path: "a.go"},
+		{Status: "M", Path: "api/", IsDir: true},
+		{Status: "M", Path: "lib/", IsDir: true},
+		{Status: "M", Path: "src/", IsDir: true},
+		{Status: "A", Path: "z.go"},
+	}
+	fp.SetFiles(files)
+
+	// Start on a.go, press down — should land on api/ (unfetched), not jump to z.go
+	fetch := fp.CursorDown()
+	if fetch == "" {
+		t.Error("expected fetch request for unfetched dir")
+	}
+	f := fp.SelectedFile()
+	if f == nil || f.Path == "z.go" {
+		t.Errorf("should NOT jump over unfetched dirs to z.go, got %v", f)
+	}
+	if f == nil || f.Path != "api/" {
+		t.Errorf("expected cursor on api/ (awaiting fetch), got %v", f)
+	}
+}
+
+func TestFilePanel_ConsecutiveUpThroughUnfetchedDirs(t *testing.T) {
+	fp := NewFilePanel()
+	fp.Box.SetRect(0, 0, 40, 20)
+	files := []gitutil.ChangedFile{
+		{Status: "M", Path: "a.go"},
+		{Status: "M", Path: "api/", IsDir: true},
+		{Status: "M", Path: "lib/", IsDir: true},
+		{Status: "A", Path: "z.go"},
+	}
+	fp.SetFiles(files)
+
+	// Start on z.go
+	for i, r := range fp.rows {
+		if r.Path == "z.go" {
+			fp.cursor = i
+			break
+		}
+	}
+
+	// First up: lands on lib/ (unfetched)
+	fp.CursorUp()
+	if f := fp.SelectedFile(); f == nil || f.Path != "lib/" {
+		t.Fatalf("first up: expected lib/, got %v", f)
+	}
+
+	// Second up: lands on api/ (unfetched) — not a.go
+	fp.CursorUp()
+	if f := fp.SelectedFile(); f == nil || f.Path != "api/" {
+		t.Fatalf("second up: expected api/, got %v", f)
+	}
+
+	// Third up: lands on a.go (file)
+	fp.CursorUp()
+	if f := fp.SelectedFile(); f == nil || f.Path != "a.go" {
+		t.Errorf("third up: expected a.go, got %v", f)
+	}
+}
+
+func TestFilePanel_SetDirChildrenAfterPauseOnDir(t *testing.T) {
+	fp := NewFilePanel()
+	fp.Box.SetRect(0, 0, 40, 20)
+	files := []gitutil.ChangedFile{
+		{Status: "M", Path: "a.go"},
+		{Status: "M", Path: "src/", IsDir: true},
+		{Status: "A", Path: "z.go"},
+	}
+	fp.SetFiles(files)
+
+	// Navigate down from a.go — lands on src/ (unfetched, pauses)
+	fetch := fp.CursorDown()
+	if fetch != "src/" {
+		t.Fatalf("setup: expected fetch for src/, got %q", fetch)
+	}
+	if f := fp.SelectedFile(); f == nil || f.Path != "src/" {
+		t.Fatalf("setup: expected cursor on src/, got %v", f)
+	}
+
+	// Children arrive — cursor should move to first child file
+	fp.SetDirChildren("src/", []gitutil.ChangedFile{
+		{Status: "M", Path: "src/main.go"},
+		{Status: "A", Path: "src/util.go"},
+	})
+	if f := fp.SelectedFile(); f == nil || f.Path != "src/main.go" {
+		t.Errorf("after SetDirChildren, expected src/main.go, got %v", f)
+	}
+}
+
+func TestFilePanel_CursorUpStaysOnUnfetchedDir(t *testing.T) {
+	fp := NewFilePanel()
+	fp.Box.SetRect(0, 0, 40, 20)
+	files := []gitutil.ChangedFile{
+		{Status: "M", Path: "docker-compose.e2e.yml"},
+		{Status: "M", Path: "api/", IsDir: true},
+		{Status: "M", Path: "lib/", IsDir: true},
+		{Status: "M", Path: "src/", IsDir: true},
+		{Status: "A", Path: "z.go"},
+	}
+	fp.SetFiles(files)
+
+	// Navigate to z.go
+	for i, r := range fp.rows {
+		if r.Path == "z.go" {
+			fp.cursor = i
+			break
+		}
+	}
+	if f := fp.SelectedFile(); f == nil || f.Path != "z.go" {
+		t.Fatalf("setup: expected z.go, got %v", f)
+	}
+
+	// Press up — should land on the dir above (src/), not jump to docker-compose.
+	// The dir needs fetching (no cached children), so cursor stays on the dir row.
+	fetch := fp.CursorUp()
+	if fetch == "" {
+		t.Error("expected fetch request for the unfetched dir")
+	}
+	f := fp.SelectedFile()
+	if f == nil || f.Path == "docker-compose.e2e.yml" {
+		t.Errorf("should NOT jump over unfetched dirs to docker-compose.e2e.yml, got %v", f)
+	}
+	if f != nil && !f.IsDir {
+		t.Errorf("expected cursor on a directory row awaiting fetch, got file %v", f.Path)
 	}
 }


### PR DESCRIPTION
When pressing up/down past closed directories that haven't been fetched yet, the cursor would skip over all stacked directories to the nearest file. Now the cursor pauses on unfetched directories to await child loading via SetDirChildren.

Co-Authored-By: Claude <noreply@anthropic.com>