### PR TITLE
Fix MCP config injection for KB tools

### DIFF
--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -502,6 +502,10 @@ These replaced 4 duplicate instances of the "find last task in project + set cur
 
 **`path/filepath.IsAbs` + `strings.Contains(path, "..")` path validation**: The `kb_ingest` MCP tool validates incoming paths before calling `KBUpsert`. Absolute paths and paths with `..` components are rejected. This prevents agents from injecting arbitrary paths into the FTS5 index.
 
+**Claude Code MCP entries require `"transport": "http"` field**: A bare `{"url": "..."}` entry in `mcpServers` fails to parse. The injected entry must be `{"transport": "http", "url": "..."}`. Idempotency checks must verify both fields to detect and upgrade entries from the old format (pre-2026-04-06).
+
+**`inject.SetMCPPort` is per-process (atomic variable)**: The daemon calls `SetMCPPort` in `Serve()`, but the TUI is a separate process. `PongResp.MCPPort` carries the port over RPC; the client's `Ping()` calls `inject.SetMCPPort()` locally. `Connect()` calls `Ping()` eagerly so TUI-created worktrees get injection before the first health-check tick. The `InjectWorktreeAll` logs to uxlog on both skip (port == 0) and success for debuggability.
+
 ### Config Keys
 - `kb.enabled` — `"true"` / `""` (default `""` = off)
 - `kb.http_port` — integer string (default `"7742"`)

--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -151,6 +151,8 @@ Non-obvious invariants and gotchas. For architecture, see CLAUDE.md. For feature
 - **MCP server echoes client's `protocolVersion`** — Codex workaround.
 - **All config file writes should be atomic** (temp + rename).
 - **KB Indexer started/stopped by daemon.** Start after MCP, stop before MCP shutdown.
+- **Claude Code MCP entries require `"transport": "http"`.** A bare `{"url": "..."}` entry in `mcpServers` fails to parse. Must be `{"transport": "http", "url": "..."}`.
+- **`inject.SetMCPPort` is per-process (atomic variable).** The daemon sets it, but the TUI is a separate process. The TUI must fetch the port from the daemon via RPC (piggybacked on `Ping`) and call `SetMCPPort` locally, otherwise `InjectWorktreeAll` is a no-op for TUI-created worktrees.
 
 ### Todo-Task Association
 

--- a/internal/daemon/client/client.go
+++ b/internal/daemon/client/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/drn/argus/internal/config"
 	"github.com/drn/argus/internal/daemon"
 	"github.com/drn/argus/internal/db"
+	"github.com/drn/argus/internal/inject"
 	"github.com/drn/argus/internal/model"
 	"github.com/drn/argus/internal/uxlog"
 )
@@ -69,12 +70,18 @@ func Connect(sockPath string) (*Client, error) {
 		return nil, err
 	}
 
-	return &Client{
+	c := &Client{
 		rpc:      jsonrpc.NewClient(conn),
 		sockPath: sockPath,
 		sessions: make(map[string]*RemoteSession),
 		closed:   make(chan struct{}),
-	}, nil
+	}
+
+	// Fetch the MCP port eagerly so TUI-created worktrees get .mcp.json
+	// injection even before the first health-check tick fires.
+	c.Ping() //nolint:errcheck — best-effort; health check will retry
+
+	return c, nil
 }
 
 // OnSessionExit registers a callback invoked when a session's stream reports EOF.
@@ -365,9 +372,17 @@ func WaitForShutdown(sockPath string, timeout time.Duration) {
 }
 
 // Ping verifies the daemon is responsive. Returns nil on success.
+// Also propagates the daemon's MCP port to the in-process inject package
+// so that TUI-created worktrees receive .mcp.json injection.
 func (c *Client) Ping() error {
 	var resp daemon.PongResp
-	return c.call("Daemon.Ping", &daemon.Empty{}, &resp)
+	if err := c.call("Daemon.Ping", &daemon.Empty{}, &resp); err != nil {
+		return err
+	}
+	if resp.MCPPort > 0 {
+		inject.SetMCPPort(resp.MCPPort)
+	}
+	return nil
 }
 
 // removeSessionStreamLost cleans up a session from the client's map and fires

--- a/internal/daemon/rpc.go
+++ b/internal/daemon/rpc.go
@@ -16,6 +16,9 @@ type RPCService struct {
 // Ping verifies the daemon is responsive.
 func (s *RPCService) Ping(_ *Empty, resp *PongResp) error {
 	resp.OK = true
+	s.daemon.mu.Lock()
+	resp.MCPPort = s.daemon.mcpPort
+	s.daemon.mu.Unlock()
 	return nil
 }
 

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -68,7 +68,8 @@ type ListResp struct {
 
 // PongResp is the RPC response for a Ping request.
 type PongResp struct {
-	OK bool
+	OK      bool
+	MCPPort int // MCP HTTP server port; 0 if KB is disabled
 }
 
 // Empty is a placeholder for RPC methods that take no arguments.

--- a/internal/inject/claude.go
+++ b/internal/inject/claude.go
@@ -53,12 +53,12 @@ func injectClaudeJSON(path string, port int) error {
 
 	// Check if already correct.
 	if existing, ok := mcpServers["argus-kb"].(map[string]interface{}); ok {
-		if existing["url"] == url {
+		if existing["url"] == url && existing["transport"] == "http" {
 			return nil // already correct
 		}
 	}
 
-	mcpServers["argus-kb"] = map[string]interface{}{"url": url}
+	mcpServers["argus-kb"] = map[string]interface{}{"transport": "http", "url": url}
 	data["mcpServers"] = mcpServers
 
 	return writeJSON(path, data)
@@ -84,12 +84,12 @@ func injectMCPJSON(path string, port int) error {
 
 	url := fmt.Sprintf("http://localhost:%d/mcp", port)
 	if existing, ok := mcpServers["argus-kb"].(map[string]interface{}); ok {
-		if existing["url"] == url {
+		if existing["url"] == url && existing["transport"] == "http" {
 			return nil
 		}
 	}
 
-	mcpServers["argus-kb"] = map[string]interface{}{"url": url}
+	mcpServers["argus-kb"] = map[string]interface{}{"transport": "http", "url": url}
 	data["mcpServers"] = mcpServers
 
 	return writeJSON(path, data)

--- a/internal/inject/claude_test.go
+++ b/internal/inject/claude_test.go
@@ -35,6 +35,9 @@ func TestInjectWorktree_CreatesFile(t *testing.T) {
 	if entry["url"] != "http://localhost:7742/mcp" {
 		t.Errorf("url: got %v", entry["url"])
 	}
+	if entry["transport"] != "http" {
+		t.Errorf("transport: got %v, want http", entry["transport"])
+	}
 }
 
 func TestInjectWorktree_Idempotent(t *testing.T) {
@@ -104,6 +107,83 @@ func TestInjectWorktree_PreservesOtherEntries(t *testing.T) {
 	}
 	if _, ok := mcpServers["argus-kb"]; !ok {
 		t.Error("argus-kb entry was not added")
+	}
+}
+
+func TestInjectClaudeJSON_TransportField(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude.json")
+
+	if err := injectClaudeJSON(path, 7742); err != nil {
+		t.Fatalf("injectClaudeJSON: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	var config map[string]interface{}
+	json.Unmarshal(data, &config) //nolint:errcheck
+
+	mcpServers := config["mcpServers"].(map[string]interface{})
+	entry := mcpServers["argus-kb"].(map[string]interface{})
+	if entry["transport"] != "http" {
+		t.Errorf("transport: got %v, want http", entry["transport"])
+	}
+	if entry["url"] != "http://localhost:7742/mcp" {
+		t.Errorf("url: got %v", entry["url"])
+	}
+}
+
+func TestInjectClaudeJSON_UpgradesOldFormat(t *testing.T) {
+	// Simulate the old format (no transport field) and verify it gets upgraded.
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude.json")
+
+	old := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"argus-kb": map[string]interface{}{"url": "http://localhost:7742/mcp"},
+		},
+	}
+	raw, _ := json.Marshal(old)
+	os.WriteFile(path, raw, 0644) //nolint:errcheck
+
+	if err := injectClaudeJSON(path, 7742); err != nil {
+		t.Fatalf("injectClaudeJSON: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	var config map[string]interface{}
+	json.Unmarshal(data, &config) //nolint:errcheck
+
+	mcpServers := config["mcpServers"].(map[string]interface{})
+	entry := mcpServers["argus-kb"].(map[string]interface{})
+	if entry["transport"] != "http" {
+		t.Errorf("old format not upgraded: transport=%v, want http", entry["transport"])
+	}
+}
+
+func TestInjectMCPJSON_UpgradesOldFormat(t *testing.T) {
+	dir := t.TempDir()
+	mcpPath := filepath.Join(dir, ".mcp.json")
+
+	old := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"argus-kb": map[string]interface{}{"url": "http://localhost:7742/mcp"},
+		},
+	}
+	raw, _ := json.Marshal(old)
+	os.WriteFile(mcpPath, raw, 0644) //nolint:errcheck
+
+	if err := InjectWorktree(dir, 7742); err != nil {
+		t.Fatalf("InjectWorktree: %v", err)
+	}
+
+	data, _ := os.ReadFile(mcpPath)
+	var config map[string]interface{}
+	json.Unmarshal(data, &config) //nolint:errcheck
+
+	mcpServers := config["mcpServers"].(map[string]interface{})
+	entry := mcpServers["argus-kb"].(map[string]interface{})
+	if entry["transport"] != "http" {
+		t.Errorf("old format not upgraded: transport=%v, want http", entry["transport"])
 	}
 }
 

--- a/internal/inject/worktree.go
+++ b/internal/inject/worktree.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 
 	injectcodex "github.com/drn/argus/internal/inject/codex"
+	"github.com/drn/argus/internal/uxlog"
 )
 
 // mcpPort holds the actual MCP server port for worktree injection.
@@ -27,6 +28,7 @@ func MCPPort() int {
 func InjectWorktreeAll(worktreePath string) {
 	port := MCPPort()
 	if port == 0 {
+		uxlog.Log("[inject] skipping worktree injection: MCP port not set")
 		return
 	}
 	if err := InjectWorktree(worktreePath, port); err != nil {
@@ -35,4 +37,5 @@ func InjectWorktreeAll(worktreePath string) {
 	if err := injectcodex.InjectWorktree(worktreePath, port); err != nil {
 		log.Printf("inject worktree codex: %v", err)
 	}
+	uxlog.Log("[inject] worktree injection complete: path=%s port=%d", worktreePath, port)
 }


### PR DESCRIPTION
Two bugs prevented KB MCP tools from working in Claude Code:

1. Injected mcpServers entries were missing the required transport: http field, causing Claude Code to fail parsing the config.

2. inject.SetMCPPort() is per-process (atomic variable), so TUI-created worktrees never received .mcp.json injection. Fixed by piggybacking the MCP port on PongResp so the TUI receives it via Ping RPC.

Also added uxlog to InjectWorktreeAll for debuggability.

Co-Authored-By: Claude <noreply@anthropic.com>