### PR TITLE
Fix skill autocomplete not reloading on project change

### DIFF
--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -1624,7 +1624,7 @@ Extended the fork task modal (`ForkTaskModal`) with a project typeahead selector
 
 **Key entities**: `ntFieldBranch`, `handleBranchKey`, `onProjectChanged`, `SetBranchOptions`, `updateBranchAC`, `drawBranchField`, `drawBranchAC`.
 
-**Gotchas**: (1) Field indices shifted — `ntFieldBranch=1`, `ntFieldBackend=2`, `ntFieldPrompt=3`. Tab cycling uses `ntFieldCount=4`. (2) `projACAccept()` must call `onProjectChanged()` to reset the branch field when a project is selected from the autocomplete dropdown. (3) `onProjectChanged()` clears `branchACAll` and resets `branchPath` to force a fresh branch load. (4) Initial branch load is triggered in `onNewTask()` via `maybeLoadBranches()` after wiring `OnBranchFocus`. (5) Modal height increased by 1 base row (branch field) plus dynamic `branchACRows`.
+**Gotchas**: (1) Field indices shifted — `ntFieldBranch=1`, `ntFieldBackend=2`, `ntFieldPrompt=3`. Tab cycling uses `ntFieldCount=4`. (2) `projACAccept()` must call `onProjectChanged()` to reset the branch field when a project is selected from the autocomplete dropdown. (3) `onProjectChanged()` clears `branchACAll` and resets `branchPath` to force a fresh branch load. It also calls `loadSkills()` to reload project-specific skill autocomplete — all project-change paths (Enter, Down, AC accept) go through `onProjectChanged`. (4) Initial branch load is triggered in `onNewTask()` via `maybeLoadBranches()` after wiring `OnBranchFocus`. (5) Modal height increased by 1 base row (branch field) plus dynamic `branchACRows`.
 
 ## Settings: Delete Project — 2026-04-06
 

--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -214,6 +214,7 @@ Non-obvious invariants and gotchas. For architecture, see CLAUDE.md. For feature
 - **PTY session logs contain `\u00a0` (non-breaking space) that must be normalized.** Claude Code uses NBSP in tool result formatting. Without normalization, `\s+` patterns may not match as expected.
 - **Long terminal lines (>120 bytes) need inline noise stripping, not just per-line filtering.** VT cell rendering concatenates the content area, status bar, separators, and prompt onto a single line with whitespace padding. `cleanLongLine` removes these inline patterns before per-line `isNoiseLine` runs.
 - **Modal typeahead AC must NOT be initialized at construction when input is pre-filled.** Calling `updateProjectAC()` in the constructor opens the dropdown immediately (the pre-filled name matches itself). Then Enter is consumed by `projACAccept` instead of confirming the modal, and Escape closes the AC instead of canceling. AC should only open in response to user typing — same pattern as `NewTaskForm`.
+- **`onProjectChanged()` must call `loadSkills()`.** Skill autocomplete depends on the selected project's `.claude/skills/` directory. Without reloading in `onProjectChanged`, the Enter and Down-arrow non-AC paths leave stale skills cached from the previous project. `projACAccept` delegates to `onProjectChanged` — don't duplicate the call.
 
 ### MCP Task Tools
 

--- a/internal/tui2/newtaskform.go
+++ b/internal/tui2/newtaskform.go
@@ -279,13 +279,13 @@ func (f *NewTaskForm) projACAccept() {
 	f.projInput = []rune(name)
 	f.projCursorPos = len(f.projInput)
 	f.projACOpen = false
-	f.loadSkills()
 	f.onProjectChanged()
 }
 
 // onProjectChanged resets the branch field to the new project's default
 // branch and triggers async branch loading.
 func (f *NewTaskForm) onProjectChanged() {
+	f.loadSkills()
 	proj := f.resolveProject()
 	defaultBranch := ""
 	if proj != "" {

--- a/internal/tui2/newtaskform_test.go
+++ b/internal/tui2/newtaskform_test.go
@@ -1,6 +1,8 @@
 package tui2
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/drn/argus/internal/config"
@@ -986,6 +988,85 @@ func TestNewTaskForm_ProjectTypeahead(t *testing.T) {
 		}
 		if f.Canceled() {
 			t.Error("should not cancel form when AC was open")
+		}
+	})
+}
+
+func TestNewTaskForm_ProjectChangeReloadsSkills(t *testing.T) {
+	// Create two projects with different skill directories.
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+
+	// Project A has skill "deploy"
+	skillDirA := filepath.Join(dirA, ".claude", "skills", "deploy")
+	os.MkdirAll(skillDirA, 0o755)
+	os.WriteFile(filepath.Join(skillDirA, "SKILL.md"), []byte("---\ndescription: Deploy app\n---\n"), 0o644)
+
+	// Project B has skill "file-scenes"
+	skillDirB := filepath.Join(dirB, ".claude", "skills", "file-scenes")
+	os.MkdirAll(skillDirB, 0o755)
+	os.WriteFile(filepath.Join(skillDirB, "SKILL.md"), []byte("---\ndescription: Manage file scenes\n---\n"), 0o644)
+
+	projects := map[string]config.Project{
+		"alpha": {Path: dirA},
+		"bravo": {Path: dirB},
+	}
+	backends := map[string]config.Backend{"b": {Command: "claude"}}
+
+	t.Run("enter without AC reloads skills", func(t *testing.T) {
+		f := NewNewTaskForm(projects, "alpha", backends, "b")
+
+		// Verify initial skills loaded from project alpha.
+		hasSkill := func(name string) bool {
+			for _, s := range f.skills {
+				if s.Name == name {
+					return true
+				}
+			}
+			return false
+		}
+		if !hasSkill("deploy") {
+			t.Error("initial skills should include deploy from alpha")
+		}
+		if hasSkill("file-scenes") {
+			t.Error("initial skills should not include file-scenes")
+		}
+
+		// Switch to project bravo by typing the name and pressing Enter
+		// (without using AC selection).
+		f.focused = ntFieldProject
+		f.projInput = []rune("bravo")
+		f.projCursorPos = 5
+		f.projACOpen = false
+
+		handler := f.InputHandler()
+		handler(tcell.NewEventKey(tcell.KeyEnter, 0, 0), func(p tview.Primitive) {})
+
+		if !hasSkill("file-scenes") {
+			t.Error("skills should include file-scenes after switching to bravo")
+		}
+	})
+
+	t.Run("down arrow without AC reloads skills", func(t *testing.T) {
+		f := NewNewTaskForm(projects, "alpha", backends, "b")
+
+		f.focused = ntFieldProject
+		f.projInput = []rune("bravo")
+		f.projCursorPos = 5
+		f.projACOpen = false
+
+		handler := f.InputHandler()
+		handler(tcell.NewEventKey(tcell.KeyDown, 0, 0), func(p tview.Primitive) {})
+
+		hasFileScenes := false
+		for _, s := range f.skills {
+			if s.Name == "file-scenes" {
+				hasFileScenes = true
+				break
+			}
+		}
+		if !hasFileScenes {
+			t.Error("skills should include file-scenes after down-arrow project change")
 		}
 	})
 }

--- a/internal/tui2/newtaskform_test.go
+++ b/internal/tui2/newtaskform_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/drn/argus/internal/config"
 	"github.com/drn/argus/internal/model"
 	"github.com/drn/argus/internal/skills"
+	"github.com/drn/argus/internal/testutil"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -997,15 +998,15 @@ func TestNewTaskForm_ProjectChangeReloadsSkills(t *testing.T) {
 	dirA := t.TempDir()
 	dirB := t.TempDir()
 
-	// Project A has skill "deploy"
-	skillDirA := filepath.Join(dirA, ".claude", "skills", "deploy")
-	os.MkdirAll(skillDirA, 0o755)
-	os.WriteFile(filepath.Join(skillDirA, "SKILL.md"), []byte("---\ndescription: Deploy app\n---\n"), 0o644)
+	// Project A has skill "test-skill-alpha"
+	skillDirA := filepath.Join(dirA, ".claude", "skills", "test-skill-alpha")
+	testutil.NoError(t, os.MkdirAll(skillDirA, 0o755))
+	testutil.NoError(t, os.WriteFile(filepath.Join(skillDirA, "SKILL.md"), []byte("---\ndescription: Alpha skill\n---\n"), 0o644))
 
-	// Project B has skill "file-scenes"
-	skillDirB := filepath.Join(dirB, ".claude", "skills", "file-scenes")
-	os.MkdirAll(skillDirB, 0o755)
-	os.WriteFile(filepath.Join(skillDirB, "SKILL.md"), []byte("---\ndescription: Manage file scenes\n---\n"), 0o644)
+	// Project B has skill "test-skill-bravo"
+	skillDirB := filepath.Join(dirB, ".claude", "skills", "test-skill-bravo")
+	testutil.NoError(t, os.MkdirAll(skillDirB, 0o755))
+	testutil.NoError(t, os.WriteFile(filepath.Join(skillDirB, "SKILL.md"), []byte("---\ndescription: Bravo skill\n---\n"), 0o644))
 
 	projects := map[string]config.Project{
 		"alpha": {Path: dirA},
@@ -1013,23 +1014,24 @@ func TestNewTaskForm_ProjectChangeReloadsSkills(t *testing.T) {
 	}
 	backends := map[string]config.Backend{"b": {Command: "claude"}}
 
+	hasSkill := func(f *NewTaskForm, name string) bool {
+		for _, s := range f.skills {
+			if s.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
 	t.Run("enter without AC reloads skills", func(t *testing.T) {
 		f := NewNewTaskForm(projects, "alpha", backends, "b")
 
 		// Verify initial skills loaded from project alpha.
-		hasSkill := func(name string) bool {
-			for _, s := range f.skills {
-				if s.Name == name {
-					return true
-				}
-			}
-			return false
+		if !hasSkill(f, "test-skill-alpha") {
+			t.Error("initial skills should include test-skill-alpha")
 		}
-		if !hasSkill("deploy") {
-			t.Error("initial skills should include deploy from alpha")
-		}
-		if hasSkill("file-scenes") {
-			t.Error("initial skills should not include file-scenes")
+		if hasSkill(f, "test-skill-bravo") {
+			t.Error("initial skills should not include test-skill-bravo")
 		}
 
 		// Switch to project bravo by typing the name and pressing Enter
@@ -1042,8 +1044,11 @@ func TestNewTaskForm_ProjectChangeReloadsSkills(t *testing.T) {
 		handler := f.InputHandler()
 		handler(tcell.NewEventKey(tcell.KeyEnter, 0, 0), func(p tview.Primitive) {})
 
-		if !hasSkill("file-scenes") {
-			t.Error("skills should include file-scenes after switching to bravo")
+		if !hasSkill(f, "test-skill-bravo") {
+			t.Error("skills should include test-skill-bravo after switching")
+		}
+		if hasSkill(f, "test-skill-alpha") {
+			t.Error("test-skill-alpha from old project should be gone")
 		}
 	})
 
@@ -1058,15 +1063,11 @@ func TestNewTaskForm_ProjectChangeReloadsSkills(t *testing.T) {
 		handler := f.InputHandler()
 		handler(tcell.NewEventKey(tcell.KeyDown, 0, 0), func(p tview.Primitive) {})
 
-		hasFileScenes := false
-		for _, s := range f.skills {
-			if s.Name == "file-scenes" {
-				hasFileScenes = true
-				break
-			}
+		if !hasSkill(f, "test-skill-bravo") {
+			t.Error("skills should include test-skill-bravo after down-arrow project change")
 		}
-		if !hasFileScenes {
-			t.Error("skills should include file-scenes after down-arrow project change")
+		if hasSkill(f, "test-skill-alpha") {
+			t.Error("test-skill-alpha from old project should be gone")
 		}
 	})
 }


### PR DESCRIPTION
Move loadSkills() into onProjectChanged() so all project-change paths (Enter, Down arrow, AC selection) reload project-specific skills consistently. Fixes skill autocomplete being stale when switching projects in the new task form.

Co-Authored-By: Claude <noreply@anthropic.com>