### PR TITLE
Fix MCP config schema key from "transport" to "type"

### DIFF
--- a/context/knowledge/code-quality.md
+++ b/context/knowledge/code-quality.md
@@ -502,7 +502,7 @@ These replaced 4 duplicate instances of the "find last task in project + set cur
 
 **`path/filepath.IsAbs` + `strings.Contains(path, "..")` path validation**: The `kb_ingest` MCP tool validates incoming paths before calling `KBUpsert`. Absolute paths and paths with `..` components are rejected. This prevents agents from injecting arbitrary paths into the FTS5 index.
 
-**Claude Code MCP entries require `"transport": "http"` field**: A bare `{"url": "..."}` entry in `mcpServers` fails to parse. The injected entry must be `{"transport": "http", "url": "..."}`. Idempotency checks must verify both fields to detect and upgrade entries from the old format (pre-2026-04-06).
+**Claude Code MCP entries require `"type": "http"` field**: A bare `{"url": "..."}` entry in `mcpServers` fails to parse. The injected entry must be `{"type": "http", "url": "..."}`. The JSON key is `"type"`, not `"transport"` (which is the CLI flag name). Idempotency checks must verify both fields to detect and upgrade entries from the old format.
 
 **`inject.SetMCPPort` is per-process (atomic variable)**: The daemon calls `SetMCPPort` in `Serve()`, but the TUI is a separate process. `PongResp.MCPPort` carries the port over RPC; the client's `Ping()` calls `inject.SetMCPPort()` locally. `Connect()` calls `Ping()` eagerly so TUI-created worktrees get injection before the first health-check tick. The `InjectWorktreeAll` logs to uxlog on both skip (port == 0) and success for debuggability.
 

--- a/context/knowledge/key-learnings.md
+++ b/context/knowledge/key-learnings.md
@@ -153,7 +153,7 @@ Non-obvious invariants and gotchas. For architecture, see CLAUDE.md. For feature
 - **MCP server echoes client's `protocolVersion`** — Codex workaround.
 - **All config file writes should be atomic** (temp + rename).
 - **KB Indexer started/stopped by daemon.** Start after MCP, stop before MCP shutdown.
-- **Claude Code MCP entries require `"transport": "http"`.** A bare `{"url": "..."}` entry in `mcpServers` fails to parse. Must be `{"transport": "http", "url": "..."}`.
+- **Claude Code MCP entries require `"type": "http"`.** A bare `{"url": "..."}` entry in `mcpServers` fails to parse. Must be `{"type": "http", "url": "..."}`. The JSON key is `"type"`, not `"transport"` (which is the CLI flag name).
 - **`inject.SetMCPPort` is per-process (atomic variable).** The daemon sets it, but the TUI is a separate process. The TUI must fetch the port from the daemon via RPC (piggybacked on `Ping`) and call `SetMCPPort` locally, otherwise `InjectWorktreeAll` is a no-op for TUI-created worktrees.
 
 ### Todo-Task Association

--- a/internal/inject/claude.go
+++ b/internal/inject/claude.go
@@ -53,12 +53,12 @@ func injectClaudeJSON(path string, port int) error {
 
 	// Check if already correct.
 	if existing, ok := mcpServers["argus-kb"].(map[string]interface{}); ok {
-		if existing["url"] == url && existing["transport"] == "http" {
+		if existing["url"] == url && existing["type"] == "http" {
 			return nil // already correct
 		}
 	}
 
-	mcpServers["argus-kb"] = map[string]interface{}{"transport": "http", "url": url}
+	mcpServers["argus-kb"] = map[string]interface{}{"type": "http", "url": url}
 	data["mcpServers"] = mcpServers
 
 	return writeJSON(path, data)
@@ -84,12 +84,12 @@ func injectMCPJSON(path string, port int) error {
 
 	url := fmt.Sprintf("http://localhost:%d/mcp", port)
 	if existing, ok := mcpServers["argus-kb"].(map[string]interface{}); ok {
-		if existing["url"] == url && existing["transport"] == "http" {
+		if existing["url"] == url && existing["type"] == "http" {
 			return nil
 		}
 	}
 
-	mcpServers["argus-kb"] = map[string]interface{}{"transport": "http", "url": url}
+	mcpServers["argus-kb"] = map[string]interface{}{"type": "http", "url": url}
 	data["mcpServers"] = mcpServers
 
 	return writeJSON(path, data)

--- a/internal/inject/claude_test.go
+++ b/internal/inject/claude_test.go
@@ -35,8 +35,8 @@ func TestInjectWorktree_CreatesFile(t *testing.T) {
 	if entry["url"] != "http://localhost:7742/mcp" {
 		t.Errorf("url: got %v", entry["url"])
 	}
-	if entry["transport"] != "http" {
-		t.Errorf("transport: got %v, want http", entry["transport"])
+	if entry["type"] != "http" {
+		t.Errorf("type: got %v, want http", entry["type"])
 	}
 }
 
@@ -110,7 +110,7 @@ func TestInjectWorktree_PreservesOtherEntries(t *testing.T) {
 	}
 }
 
-func TestInjectClaudeJSON_TransportField(t *testing.T) {
+func TestInjectClaudeJSON_TypeField(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".claude.json")
 
@@ -124,8 +124,8 @@ func TestInjectClaudeJSON_TransportField(t *testing.T) {
 
 	mcpServers := config["mcpServers"].(map[string]interface{})
 	entry := mcpServers["argus-kb"].(map[string]interface{})
-	if entry["transport"] != "http" {
-		t.Errorf("transport: got %v, want http", entry["transport"])
+	if entry["type"] != "http" {
+		t.Errorf("type: got %v, want http", entry["type"])
 	}
 	if entry["url"] != "http://localhost:7742/mcp" {
 		t.Errorf("url: got %v", entry["url"])
@@ -155,8 +155,8 @@ func TestInjectClaudeJSON_UpgradesOldFormat(t *testing.T) {
 
 	mcpServers := config["mcpServers"].(map[string]interface{})
 	entry := mcpServers["argus-kb"].(map[string]interface{})
-	if entry["transport"] != "http" {
-		t.Errorf("old format not upgraded: transport=%v, want http", entry["transport"])
+	if entry["type"] != "http" {
+		t.Errorf("old format not upgraded: transport=%v, want http", entry["type"])
 	}
 }
 
@@ -182,8 +182,8 @@ func TestInjectMCPJSON_UpgradesOldFormat(t *testing.T) {
 
 	mcpServers := config["mcpServers"].(map[string]interface{})
 	entry := mcpServers["argus-kb"].(map[string]interface{})
-	if entry["transport"] != "http" {
-		t.Errorf("old format not upgraded: transport=%v, want http", entry["transport"])
+	if entry["type"] != "http" {
+		t.Errorf("old format not upgraded: transport=%v, want http", entry["type"])
 	}
 }
 

--- a/internal/inject/claude_test.go
+++ b/internal/inject/claude_test.go
@@ -156,7 +156,7 @@ func TestInjectClaudeJSON_UpgradesOldFormat(t *testing.T) {
 	mcpServers := config["mcpServers"].(map[string]interface{})
 	entry := mcpServers["argus-kb"].(map[string]interface{})
 	if entry["type"] != "http" {
-		t.Errorf("old format not upgraded: transport=%v, want http", entry["type"])
+		t.Errorf("old format not upgraded: type=%v, want http", entry["type"])
 	}
 }
 
@@ -183,7 +183,7 @@ func TestInjectMCPJSON_UpgradesOldFormat(t *testing.T) {
 	mcpServers := config["mcpServers"].(map[string]interface{})
 	entry := mcpServers["argus-kb"].(map[string]interface{})
 	if entry["type"] != "http" {
-		t.Errorf("old format not upgraded: transport=%v, want http", entry["type"])
+		t.Errorf("old format not upgraded: type=%v, want http", entry["type"])
 	}
 }
 


### PR DESCRIPTION
Claude Code v2.1.92 changed the MCP server JSON schema key. Updates inject code, tests, and knowledge docs.

Co-Authored-By: Claude <noreply@anthropic.com>