### PR TITLE
Add incremental KB sync for faster daemon startup

### DIFF
--- a/context/knowledge/gotchas/misc.md
+++ b/context/knowledge/gotchas/misc.md
@@ -29,6 +29,8 @@
 - **MCP server echoes client's `protocolVersion`** — Codex workaround.
 - **All config file writes should be atomic** (temp + rename).
 - **KB Indexer started/stopped by daemon.** Start after MCP, stop before MCP shutdown.
+- **Incremental scan compares mtime at unix-second granularity.** Sub-second edits within the same second are missed until the next fsnotify event or daemon restart. The TOCTOU window between `KBMetadataMap()` and fsnotify watcher start means changes during scan are also deferred.
+- **`KBMetadataMap` must check `rows.Err()` after iteration.** A partial result without error check causes `IncrementalScan` to delete documents that weren't returned due to mid-stream DB errors.
 - **Claude Code MCP entries require `"type": "http"`.** A bare `{"url": "..."}` entry in `mcpServers` fails to parse. Must be `{"type": "http", "url": "..."}`. The JSON key is `"type"`, not `"transport"` (which is the CLI flag name).
 - **MCP config is injected globally only (`~/.claude.json`, `~/.codex/config.toml`), not per-worktree.** Per-worktree `.mcp.json`/`.codex/config.toml` injection was removed — it polluted git status in every project and was redundant since global config applies everywhere.
 

--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -11,7 +11,7 @@ Non-obvious invariants and gotchas, split by topic. Read the relevant file when 
 | [gotchas/worktree.md](gotchas/worktree.md) | Worktree creation ordering, cleanup, path validation, stale ref pruning | 8 |
 | [gotchas/keybindings.md](gotchas/keybindings.md) | Key routing, ctrl sequences, tcell modifier quirks, agent view navigation | 11 |
 | [gotchas/tasklist-ui.md](gotchas/tasklist-ui.md) | Task list cursor, modals, focus guards, filter, archive, spinner | 24 |
-| [gotchas/misc.md](gotchas/misc.md) | DB patterns, Go idioms, Codex, MCP, todos, PRs, file explorer, vault, quick-add | 58 |
+| [gotchas/misc.md](gotchas/misc.md) | DB patterns, Go idioms, Codex, MCP, todos, PRs, file explorer, vault, quick-add | 60 |
 
 ## Other Files
 

--- a/internal/db/kb.go
+++ b/internal/db/kb.go
@@ -235,6 +235,9 @@ func (d *DB) KBMetadataMap() (map[string]int64, error) {
 		}
 		m[path] = modAt
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("kb metadata map iteration: %w", err)
+	}
 	return m, nil
 }
 

--- a/internal/db/kb.go
+++ b/internal/db/kb.go
@@ -214,6 +214,30 @@ func (d *DB) KBDocumentCount() int {
 	return count
 }
 
+// KBMetadataMap returns a map of path → modified_at (unix seconds) for all
+// indexed documents. Used by the KB indexer for incremental sync.
+func (d *DB) KBMetadataMap() (map[string]int64, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	rows, err := d.conn.Query(`SELECT path, modified_at FROM kb_metadata`)
+	if err != nil {
+		return nil, fmt.Errorf("kb metadata map: %w", err)
+	}
+	defer rows.Close()
+
+	m := make(map[string]int64)
+	for rows.Next() {
+		var path string
+		var modAt int64
+		if err := rows.Scan(&path, &modAt); err != nil {
+			continue
+		}
+		m[path] = modAt
+	}
+	return m, nil
+}
+
 // KBPendingTask is a task parsed from the Obsidian vault awaiting approval.
 type KBPendingTask struct {
 	ID         int

--- a/internal/kb/indexer.go
+++ b/internal/kb/indexer.go
@@ -16,14 +16,17 @@ import (
 const debounceDelay = 500 * time.Millisecond
 
 // Indexer watches a vault path and keeps kb_documents in sync.
-// It performs an initial full scan on Start() and then watches for changes
-// using fsnotify.
+// It performs an initial scan on Start() (incremental if the DB has data,
+// full otherwise) and then watches for changes using fsnotify.
 type Indexer struct {
 	db        KBStore
 	vaultPath string
 	stopCh    chan struct{}
 	readyCh   chan struct{} // closed when fsnotify watcher is set up
 	wg        sync.WaitGroup
+
+	scanMu   sync.Mutex
+	scanning bool // true while a background full scan is running
 }
 
 // NewIndexer creates a new Indexer for the given vault path.
@@ -36,15 +39,53 @@ func NewIndexer(db KBStore, vaultPath string) *Indexer {
 	}
 }
 
-// Start runs the initial full scan and starts the background fsnotify watcher.
+// Scanning returns true while a background full scan is in progress.
+// Callers can use this to indicate that search results may be incomplete.
+func (idx *Indexer) Scanning() bool {
+	idx.scanMu.Lock()
+	defer idx.scanMu.Unlock()
+	return idx.scanning
+}
+
+// Start runs the initial scan and starts the background fsnotify watcher.
+// If the DB already has indexed documents, it runs an incremental scan
+// (synchronous, fast — only touches changed files). Otherwise it runs a
+// full scan in the background so the daemon starts immediately.
 func (idx *Indexer) Start() error {
 	if idx.vaultPath == "" {
 		close(idx.readyCh)
 		return nil
 	}
-	if err := idx.FullScan(); err != nil {
+
+	meta, err := idx.db.KBMetadataMap()
+	if err != nil {
 		return err
 	}
+
+	if len(meta) > 0 {
+		// Fast path: incremental sync against existing data.
+		if err := idx.IncrementalScan(meta); err != nil {
+			return err
+		}
+	} else {
+		// Cold start: run full scan in background so daemon starts immediately.
+		idx.scanMu.Lock()
+		idx.scanning = true
+		idx.scanMu.Unlock()
+
+		idx.wg.Add(1)
+		go func() {
+			defer idx.wg.Done()
+			if err := idx.FullScan(); err != nil {
+				log.Printf("[kb] background full scan: %v", err)
+			}
+			idx.scanMu.Lock()
+			idx.scanning = false
+			idx.scanMu.Unlock()
+			log.Printf("[kb] background full scan complete")
+		}()
+	}
+
 	idx.wg.Add(1)
 	go func() {
 		defer idx.wg.Done()
@@ -99,6 +140,58 @@ func (idx *Indexer) DeleteFile(absPath string) error {
 		relPath = absPath
 	}
 	return idx.db.KBDelete(relPath)
+}
+
+// IncrementalScan compares disk state against the provided metadata map
+// (path → modified_at unix seconds). It only upserts files whose mtime has
+// changed or that are new, and deletes DB entries for files no longer on disk.
+func (idx *Indexer) IncrementalScan(meta map[string]int64) error {
+	// Track which DB paths we've seen on disk so we can detect deletions.
+	seen := make(map[string]bool, len(meta))
+
+	err := filepath.Walk(idx.vaultPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			if path == idx.vaultPath {
+				return err
+			}
+			return nil
+		}
+		if info.IsDir() {
+			if info.Name() != "." && strings.HasPrefix(info.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(strings.ToLower(info.Name()), ".md") {
+			return nil
+		}
+
+		relPath, relErr := filepath.Rel(idx.vaultPath, path)
+		if relErr != nil {
+			relPath = path
+		}
+		seen[relPath] = true
+
+		diskMtime := info.ModTime().Unix()
+		if storedMtime, exists := meta[relPath]; exists && storedMtime == diskMtime {
+			return nil // unchanged — skip
+		}
+
+		return idx.IngestFile(path)
+	})
+	if err != nil {
+		return err
+	}
+
+	// Delete DB entries for files that no longer exist on disk.
+	for path := range meta {
+		if !seen[path] {
+			if delErr := idx.db.KBDelete(path); delErr != nil {
+				log.Printf("[kb] incremental delete %s: %v", path, delErr)
+			}
+		}
+	}
+	return nil
 }
 
 // FullScan walks all .md files in the vault and upserts them into the KB.

--- a/internal/kb/indexer.go
+++ b/internal/kb/indexer.go
@@ -62,6 +62,9 @@ func (idx *Indexer) Start() error {
 		return err
 	}
 
+	// Note: there is a small TOCTOU window between KBMetadataMap() and the
+	// fsnotify watcher starting below. File changes during the scan are picked
+	// up on the next fsnotify event or daemon restart.
 	if len(meta) > 0 {
 		// Fast path: incremental sync against existing data.
 		if err := idx.IncrementalScan(meta); err != nil {

--- a/internal/kb/indexer_test.go
+++ b/internal/kb/indexer_test.go
@@ -36,6 +36,16 @@ func (m *mockStore) KBDelete(path string) error {
 	return nil
 }
 
+func (m *mockStore) KBMetadataMap() (map[string]int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(map[string]int64, len(m.docs))
+	for path, doc := range m.docs {
+		out[path] = doc.ModifiedAt.Unix()
+	}
+	return out, nil
+}
+
 func (m *mockStore) has(path string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -142,6 +152,155 @@ func TestIsEligibleFile(t *testing.T) {
 	}
 }
 
+func TestIncrementalScan_SkipsUnchanged(t *testing.T) {
+	vault := t.TempDir()
+	store := newMockStore()
+
+	// Write a file and do an initial full scan.
+	absPath := filepath.Join(vault, "stable.md")
+	os.WriteFile(absPath, []byte("# Stable\n\nOriginal."), 0o644) //nolint:errcheck
+
+	idx := NewIndexer(store, vault)
+	testutil.NoError(t, idx.FullScan())
+	testutil.Equal(t, store.count(), 1)
+
+	// Record the ingested doc's body so we can check it doesn't change.
+	store.mu.Lock()
+	origBody := store.docs["stable.md"].Body
+	store.mu.Unlock()
+
+	// Overwrite the doc in the store with a marker body (simulate "already ingested").
+	store.mu.Lock()
+	store.docs["stable.md"].Body = "MARKER"
+	store.mu.Unlock()
+
+	// Run incremental scan — file mtime hasn't changed, so it should be skipped.
+	meta, err := store.KBMetadataMap()
+	testutil.NoError(t, err)
+	testutil.NoError(t, idx.IncrementalScan(meta))
+
+	// Body should still be the marker — IngestFile was NOT called.
+	store.mu.Lock()
+	testutil.Equal(t, store.docs["stable.md"].Body, "MARKER")
+	store.mu.Unlock()
+	_ = origBody
+}
+
+func TestIncrementalScan_IngestsModified(t *testing.T) {
+	vault := t.TempDir()
+	store := newMockStore()
+
+	absPath := filepath.Join(vault, "changing.md")
+	os.WriteFile(absPath, []byte("# V1\n\nOriginal."), 0o644) //nolint:errcheck
+
+	idx := NewIndexer(store, vault)
+	testutil.NoError(t, idx.FullScan())
+
+	// Build metadata with a stale mtime (1 second in the past) to simulate change.
+	meta := map[string]int64{"changing.md": time.Now().Add(-10 * time.Second).Unix()}
+
+	// Update file content.
+	os.WriteFile(absPath, []byte("# V2\n\nUpdated."), 0o644) //nolint:errcheck
+
+	testutil.NoError(t, idx.IncrementalScan(meta))
+
+	store.mu.Lock()
+	testutil.Contains(t, store.docs["changing.md"].Body, "Updated.")
+	store.mu.Unlock()
+}
+
+func TestIncrementalScan_IngestsNew(t *testing.T) {
+	vault := t.TempDir()
+	store := newMockStore()
+	idx := NewIndexer(store, vault)
+
+	// Empty metadata — everything on disk is new.
+	os.WriteFile(filepath.Join(vault, "brand-new.md"), []byte("# New"), 0o644) //nolint:errcheck
+
+	meta := map[string]int64{} // empty but non-nil — simulates "DB has data but this file is new"
+	testutil.NoError(t, idx.IncrementalScan(meta))
+
+	testutil.Equal(t, store.count(), 1)
+	if !store.has("brand-new.md") {
+		t.Error("new file should have been ingested")
+	}
+}
+
+func TestIncrementalScan_DeletesRemoved(t *testing.T) {
+	vault := t.TempDir()
+	store := newMockStore()
+	idx := NewIndexer(store, vault)
+
+	// Simulate a doc in the DB whose file no longer exists on disk.
+	meta := map[string]int64{"gone.md": time.Now().Unix()}
+
+	testutil.NoError(t, idx.IncrementalScan(meta))
+
+	store.mu.Lock()
+	deleted := store.deleted
+	store.mu.Unlock()
+
+	testutil.Equal(t, len(deleted), 1)
+	testutil.Equal(t, deleted[0], "gone.md")
+}
+
+func TestStart_EmptyDB_BackgroundFullScan(t *testing.T) {
+	if testing.Short() {
+		t.Skip("fsnotify test")
+	}
+
+	vault := t.TempDir()
+	store := newMockStore()
+
+	// Pre-create a file.
+	os.WriteFile(filepath.Join(vault, "hello.md"), []byte("# Hello"), 0o644) //nolint:errcheck
+
+	idx := NewIndexer(store, vault)
+	testutil.NoError(t, idx.Start())
+	defer idx.Stop()
+
+	// Scanning should be true initially (background full scan).
+	// Wait for the scan to complete.
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for background scan to complete")
+		default:
+			if !idx.Scanning() && store.has("hello.md") {
+				return // success
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+}
+
+func TestStart_ExistingDB_IncrementalSync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("fsnotify test")
+	}
+
+	vault := t.TempDir()
+	store := newMockStore()
+
+	// Pre-create a file and do a full scan to populate the store.
+	absPath := filepath.Join(vault, "existing.md")
+	os.WriteFile(absPath, []byte("# Existing"), 0o644) //nolint:errcheck
+
+	preIdx := NewIndexer(store, vault)
+	testutil.NoError(t, preIdx.FullScan())
+	testutil.Equal(t, store.count(), 1)
+
+	// Now start a new indexer — should use incremental (not background).
+	idx := NewIndexer(store, vault)
+	testutil.NoError(t, idx.Start())
+	defer idx.Stop()
+
+	// Should NOT be scanning (incremental is synchronous).
+	testutil.Equal(t, idx.Scanning(), false)
+	testutil.Equal(t, store.count(), 1)
+}
+
 func TestWatch_CreateFile(t *testing.T) {
 	if testing.Short() {
 		t.Skip("fsnotify test")
@@ -193,10 +352,20 @@ func TestWatch_DeleteFile(t *testing.T) {
 	defer idx.Stop()
 	<-idx.Ready()
 
-	// Verify it was ingested.
-	if !store.has("doomed.md") {
-		t.Fatal("file should have been ingested on start")
+	// Wait for background scan to complete (cold start uses background FullScan).
+	scanDeadline := time.After(3 * time.Second)
+	for {
+		select {
+		case <-scanDeadline:
+			t.Fatal("timed out waiting for background scan")
+		default:
+			if store.has("doomed.md") {
+				goto ingested
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
 	}
+ingested:
 
 	// Remove the file.
 	os.Remove(absPath) //nolint:errcheck

--- a/internal/kb/types.go
+++ b/internal/kb/types.go
@@ -26,4 +26,7 @@ type SearchResult struct {
 type KBStore interface {
 	KBUpsert(doc *Document) error
 	KBDelete(path string) error
+	// KBMetadataMap returns a map of path → modified_at (unix seconds) for all
+	// indexed documents. Used by IncrementalScan to skip unchanged files.
+	KBMetadataMap() (map[string]int64, error)
 }


### PR DESCRIPTION
On daemon startup, if the DB already has indexed documents, run an incremental scan comparing disk mtime vs stored modified_at — only re-ingesting changed/new files and deleting removed ones. Cold starts (empty DB) run FullScan in a background goroutine so the daemon starts immediately. Includes Scanning() status, rows.Err() safety, and comprehensive test coverage.

Co-Authored-By: Claude <noreply@anthropic.com>