### PR TITLE
Add MCP server instructions and rich KB tool descriptions

### DIFF
--- a/context/knowledge/gotchas/misc.md
+++ b/context/knowledge/gotchas/misc.md
@@ -33,6 +33,8 @@
 - **`KBMetadataMap` must check `rows.Err()` after iteration.** A partial result without error check causes `IncrementalScan` to delete documents that weren't returned due to mid-stream DB errors.
 - **Claude Code MCP entries require `"type": "http"`.** A bare `{"url": "..."}` entry in `mcpServers` fails to parse. Must be `{"type": "http", "url": "..."}`. The JSON key is `"type"`, not `"transport"` (which is the CLI flag name).
 - **MCP config is injected globally only (`~/.claude.json`, `~/.codex/config.toml`), not per-worktree.** Per-worktree `.mcp.json`/`.codex/config.toml` injection was removed — it polluted git status in every project and was redundant since global config applies everywhere.
+- **MCP `instructions` field in `InitializeResult` is truncated at ~2KB by Claude Code.** Put the most critical rules first. The `kb_ingest` tool description intentionally duplicates key rules from `kbInstructions` because not all MCP clients surface server instructions at tool-call time.
+- **`toolDefs` slice must be copied before append in `handleToolsList`.** The package-level `var` could be corrupted if `append` reuses its backing array when adding task tools.
 
 ## Todo-Task Association
 

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -36,6 +36,7 @@ type InitializeResult struct {
 	ProtocolVersion string       `json:"protocolVersion"`
 	ServerInfo      ServerInfo   `json:"serverInfo"`
 	Capabilities    Capabilities `json:"capabilities"`
+	Instructions    string       `json:"instructions,omitempty"`
 }
 
 // ClientInfo describes the connecting MCP client.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -61,6 +61,9 @@ type Server struct {
 
 // New creates a new MCP server.
 func New(db KBQuerier, port int, vaultPath string) *Server {
+	if vaultPath != "" {
+		vaultPath = filepath.Clean(vaultPath)
+	}
 	return &Server{db: db, port: port, vaultPath: vaultPath}
 }
 
@@ -191,7 +194,7 @@ func (s *Server) handleInitialize(req *Request) *Response {
 
 // kbInstructions is sent to MCP clients during initialization to guide how
 // agents interact with the knowledge base. Claude Code truncates this at ~2KB,
-// so the most critical rules come first.
+// so the most critical rules come first. Current size: ~1.8KB (~160 bytes headroom).
 const kbInstructions = `Argus KB is an Obsidian-backed knowledge base indexed with FTS5. Documents are markdown files with YAML frontmatter, organized by topic in a flat folder hierarchy.
 
 BEFORE WRITING: Always kb_search first to check if an entry already exists. Update existing documents rather than creating duplicates.
@@ -262,6 +265,8 @@ var toolDefs = []Tool{
 	},
 	{
 		Name: "kb_ingest",
+		// Description intentionally duplicates key rules from kbInstructions —
+		// not all MCP clients surface server instructions at tool-call time.
 		Description: `Add or update a document in the knowledge base. The document is indexed for search and written back to the Obsidian vault.
 
 IMPORTANT: Always kb_search first to avoid duplicates. If a document exists on the topic, kb_read it and update rather than creating a new one.
@@ -344,7 +349,9 @@ func (s *Server) taskMgmtEnabled() bool {
 }
 
 func (s *Server) handleToolsList(req *Request) *Response {
-	tools := toolDefs
+	// Copy to avoid mutating the package-level toolDefs slice via append.
+	tools := make([]Tool, len(toolDefs))
+	copy(tools, toolDefs)
 	if s.taskMgmtEnabled() {
 		tools = append(tools, taskToolDefs...)
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -184,54 +184,104 @@ func (s *Server) handleInitialize(req *Request) *Response {
 			Capabilities: Capabilities{
 				Tools: &ToolsCapability{},
 			},
+			Instructions: kbInstructions,
 		},
 	}
 }
 
+// kbInstructions is sent to MCP clients during initialization to guide how
+// agents interact with the knowledge base. Claude Code truncates this at ~2KB,
+// so the most critical rules come first.
+const kbInstructions = `Argus KB is an Obsidian-backed knowledge base indexed with FTS5. Documents are markdown files with YAML frontmatter, organized by topic in a flat folder hierarchy.
+
+BEFORE WRITING: Always kb_search first to check if an entry already exists. Update existing documents rather than creating duplicates.
+
+DOCUMENT SCHEMA — every document MUST have YAML frontmatter:
+---
+title: "Short Descriptive Title"
+tags: [lowercase, kebab-case, terms]
+---
+
+The title and tags fields are required. Title should be concise (under 60 chars). Tags are a flat YAML array of lowercase kebab-case identifiers — use them for thematic clustering, not hierarchy. Hierarchy belongs in the folder path.
+
+PATH CONVENTIONS:
+- Vault-relative paths with topic folders: "thanx/data-investigation.md", "patterns/agent-frameworks.md"
+- Kebab-case filenames, 2-3 words: "vendor-evaluations.md" not "list-of-all-vendor-and-tool-evaluations.md"
+- File name = the topic noun, not a sentence: "hiring.md" not "how-we-hire.md"
+- Group by domain (thanx/, tools/, patterns/, knowledge/) — match existing folders
+
+CONTENT STRUCTURE:
+- One topic per document. If covering multiple unrelated things, split into separate files.
+- Lead with the key insight, rule, or summary — not background or preamble.
+- Use ## H2 sections for subtopics. Each H2 should be independently useful.
+- Bullet lists with **bold keys** for structured data (specs, criteria, evaluations).
+- Keep entries focused: 50-500 words is the sweet spot for retrieval quality.
+- Source and date claims when possible: "— Source: website Apr 2026"
+
+WHAT NOT TO DO:
+- Don't create near-empty stubs — every entry should be immediately useful.
+- Don't duplicate content across files. Cross-reference instead.
+- Don't use inline #hashtags — put all tags in YAML frontmatter.
+- Don't nest folders more than 2 levels deep.`
+
 // toolDefs defines the four KB tools exposed via MCP.
 var toolDefs = []Tool{
 	{
-		Name:        "kb_search",
-		Description: "Search the Argus knowledge base using full-text search. Returns ranked results with snippets.",
+		Name: "kb_search",
+		Description: `Search the knowledge base using full-text search (BM25 ranking). Returns results with highlighted snippets. Use this BEFORE kb_ingest to check if a document already exists on the topic — update rather than duplicate.`,
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
-				"query": map[string]interface{}{"type": "string", "description": "Search query"},
-				"limit": map[string]interface{}{"type": "number", "description": "Maximum results (default 10)"},
+				"query": map[string]interface{}{"type": "string", "description": "Natural language search query. Supports stemming (e.g. 'running' matches 'run')."},
+				"limit": map[string]interface{}{"type": "number", "description": "Maximum results to return (default 10, max 100)"},
 			},
 			"required": []string{"query"},
 		},
 	},
 	{
-		Name:        "kb_read",
-		Description: "Read the full content of a knowledge base document by its vault-relative path.",
+		Name: "kb_read",
+		Description: `Read the full content of a knowledge base document by vault-relative path. Use after kb_search or kb_list to get the complete document including frontmatter, body, tags, and metadata.`,
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
-				"path": map[string]interface{}{"type": "string", "description": "Vault-relative path, e.g. 'projects/thanx.md'"},
+				"path": map[string]interface{}{"type": "string", "description": "Vault-relative path (e.g. 'thanx/hiring.md', 'patterns/agent-frameworks.md')"},
 			},
 			"required": []string{"path"},
 		},
 	},
 	{
-		Name:        "kb_list",
-		Description: "List documents in the knowledge base, optionally filtered by path prefix.",
+		Name: "kb_list",
+		Description: `List documents in the knowledge base, optionally filtered by path prefix. Use to discover what exists in a topic area before creating new entries.`,
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
-				"prefix": map[string]interface{}{"type": "string", "description": "Path prefix filter (optional)"},
-				"limit":  map[string]interface{}{"type": "number", "description": "Maximum documents (default 100)"},
+				"prefix": map[string]interface{}{"type": "string", "description": "Path prefix to filter by (e.g. 'thanx/' for all Thanx docs, 'patterns/' for patterns)"},
+				"limit":  map[string]interface{}{"type": "number", "description": "Maximum documents to return (default 100)"},
 			},
 		},
 	},
 	{
-		Name:        "kb_ingest",
-		Description: "Add or update a document in the knowledge base.",
+		Name: "kb_ingest",
+		Description: `Add or update a document in the knowledge base. The document is indexed for search and written back to the Obsidian vault.
+
+IMPORTANT: Always kb_search first to avoid duplicates. If a document exists on the topic, kb_read it and update rather than creating a new one.
+
+REQUIRED FORMAT: Full markdown with YAML frontmatter. Every document must have:
+---
+title: "Descriptive Title"
+tags: [lowercase-tag, another-tag]
+---
+
+Content body here with ## sections.
+
+PATH RULES: Use kebab-case filenames in topic folders (e.g. 'thanx/hiring.md', 'tools/vendor-evaluations.md'). Match existing folder structure — use kb_list to see current organization.
+
+CONTENT RULES: One topic per document. Lead with the key insight. Use ## H2 for subtopics. Bold key terms in bullet lists. Keep entries 50-500 words.`,
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
-				"path":    map[string]interface{}{"type": "string", "description": "Vault-relative path for the document"},
-				"content": map[string]interface{}{"type": "string", "description": "Full markdown content to index"},
+				"path":    map[string]interface{}{"type": "string", "description": "Vault-relative path (e.g. 'thanx/data-investigation.md'). Kebab-case, 2-3 word filenames, organized in topic folders."},
+				"content": map[string]interface{}{"type": "string", "description": "Full markdown with YAML frontmatter (title and tags required). See tool description for format."},
 			},
 			"required": []string{"path", "content"},
 		},

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -115,9 +115,7 @@ func TestInitialize(t *testing.T) {
 		t.Fatalf("result is not a map: %T", resp.Result)
 	}
 	// Should echo client's protocol version (Codex workaround).
-	if result["protocolVersion"] != "2025-06-18" {
-		t.Errorf("protocolVersion: got %v, want 2025-06-18", result["protocolVersion"])
-	}
+	testutil.Equal(t, result["protocolVersion"], "2025-06-18")
 
 	// Should include KB instructions.
 	instructions, ok := result["instructions"].(string)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -118,6 +118,14 @@ func TestInitialize(t *testing.T) {
 	if result["protocolVersion"] != "2025-06-18" {
 		t.Errorf("protocolVersion: got %v, want 2025-06-18", result["protocolVersion"])
 	}
+
+	// Should include KB instructions.
+	instructions, ok := result["instructions"].(string)
+	if !ok || instructions == "" {
+		t.Error("initialize response missing instructions field")
+	}
+	testutil.Contains(t, instructions, "YAML frontmatter")
+	testutil.Contains(t, instructions, "kb_search")
 }
 
 func TestToolsList(t *testing.T) {


### PR DESCRIPTION
Guide agents on KB document structure via MCP instructions field and enriched tool descriptions. Includes frontmatter schema, path conventions, content structure rules, and search-before-write workflow.

Co-Authored-By: Claude <noreply@anthropic.com>