### PR TITLE
Display branch name in task list rows

### DIFF
--- a/context/knowledge/gotchas/tasklist-ui.md
+++ b/context/knowledge/gotchas/tasklist-ui.md
@@ -23,6 +23,10 @@
 - **`drawTaskRow` cursor fill must not overwrite elapsed time.** The fill loop extends the highlight to the row edge, but elapsed time is drawn right-aligned first. Compute `elapsedCol` once and use it as the fill boundary — filling past it overwrites the duration indicator.
 - **`moveCursor` must not fire `OnCursorChange` when clamped at boundaries.** When pressing up at the top or down at the bottom, `tl.cursor` is clamped to the same value — firing the callback triggers unnecessary git diff refreshes and preview fetches. Use a deferred guard comparing `tl.cursor != prev`.
 
+## Task Row Rendering
+
+- **`drawTaskRow` gives the task name priority over the branch in width allocation.** The name is sized first (ignoring branch), then the branch fills remaining space. If branch is sized first (reserving space before name), narrow terminals squeeze the name to zero while showing a useless branch fragment.
+
 ## Spinner Animation
 
 - **Spinner frame computation is time-based, not tick-based.** `updateSpinnerFrame()` computes `int(time.Now().UnixMilli() / interval) % frameCount` in `Draw()`. The 1-second tick loop is too slow for 100ms spinner frames. A dedicated `spinnerLoop` (100ms ticker) triggers redraws only when `len(runningIDs) > 0`.

--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -10,7 +10,7 @@ Non-obvious invariants and gotchas, split by topic. Read the relevant file when 
 | [gotchas/sandbox.md](gotchas/sandbox.md) | macOS sandbox-exec SBPL profiles, symlink resolution, allowed paths | 12 |
 | [gotchas/worktree.md](gotchas/worktree.md) | Worktree creation ordering, cleanup, path validation, stale ref pruning | 8 |
 | [gotchas/keybindings.md](gotchas/keybindings.md) | Key routing, ctrl sequences, tcell modifier quirks, agent view navigation | 12 |
-| [gotchas/tasklist-ui.md](gotchas/tasklist-ui.md) | Task list cursor, modals, focus guards, filter, archive, spinner | 24 |
+| [gotchas/tasklist-ui.md](gotchas/tasklist-ui.md) | Task list cursor, modals, focus guards, filter, archive, spinner, row rendering | 25 |
 | [gotchas/misc.md](gotchas/misc.md) | DB patterns, Go idioms, Codex, MCP, todos, PRs, file explorer, vault, quick-add | 60 |
 
 ## Other Files

--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -966,7 +966,7 @@ func (tl *TaskListView) drawTaskRow(screen tcell.Screen, x, y, w int, task *mode
 	// Elapsed time
 	elapsed := task.ElapsedString()
 
-	// Layout: "    ● name                    3m"
+	// Layout: "    ● name  branch              3m"
 	prefix := "    "
 	col := x
 	drawText(screen, col, y, len(prefix), prefix, StyleDefault)
@@ -975,14 +975,9 @@ func (tl *TaskListView) drawTaskRow(screen tcell.Screen, x, y, w int, task *mode
 	screen.SetContent(col, y, statusChar, nil, statusStyle)
 	col += 2 // status char + space
 
-	// Branch label (shown dimmed after name).
-	branch := ""
-	if task.Branch != "" {
-		branch = "  " + task.Branch
-	}
-
+	// Name gets priority; branch fills remaining space after name.
 	nameStr := task.Name
-	maxNameW := w - (col - x) - len(elapsed) - len(branch) - 2
+	maxNameW := w - (col - x) - len(elapsed) - 2 // space for name (ignoring branch)
 	if maxNameW < 0 {
 		maxNameW = 0
 	}
@@ -992,16 +987,20 @@ func (tl *TaskListView) drawTaskRow(screen tcell.Screen, x, y, w int, task *mode
 	drawText(screen, col, y, len(nameStr), nameStr, nameStyle)
 	col += len(nameStr)
 
-	// Draw branch after name.
-	if branch != "" {
+	// Branch label (dimmed, truncated to remaining space).
+	if task.Branch != "" {
+		branch := "  " + task.Branch
 		maxBranchW := w - (col - x) - len(elapsed) - 2
-		branchStr := branch
-		if len(branchStr) > maxBranchW {
-			branchStr = branchStr[:maxBranchW]
-		}
 		if maxBranchW > 0 {
-			drawText(screen, col, y, len(branchStr), branchStr, StyleDimmed)
-			col += len(branchStr)
+			if len(branch) > maxBranchW {
+				branch = branch[:maxBranchW]
+			}
+			branchStyle := StyleDimmed
+			if cursor {
+				branchStyle = StyleDimmed.Background(tcell.ColorDefault)
+			}
+			drawText(screen, col, y, len(branch), branch, branchStyle)
+			col += len(branch)
 		}
 	}
 

--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -975,8 +975,14 @@ func (tl *TaskListView) drawTaskRow(screen tcell.Screen, x, y, w int, task *mode
 	screen.SetContent(col, y, statusChar, nil, statusStyle)
 	col += 2 // status char + space
 
+	// Branch label (shown dimmed after name).
+	branch := ""
+	if task.Branch != "" {
+		branch = "  " + task.Branch
+	}
+
 	nameStr := task.Name
-	maxNameW := w - (col - x) - len(elapsed) - 2
+	maxNameW := w - (col - x) - len(elapsed) - len(branch) - 2
 	if maxNameW < 0 {
 		maxNameW = 0
 	}
@@ -985,6 +991,19 @@ func (tl *TaskListView) drawTaskRow(screen tcell.Screen, x, y, w int, task *mode
 	}
 	drawText(screen, col, y, len(nameStr), nameStr, nameStyle)
 	col += len(nameStr)
+
+	// Draw branch after name.
+	if branch != "" {
+		maxBranchW := w - (col - x) - len(elapsed) - 2
+		branchStr := branch
+		if len(branchStr) > maxBranchW {
+			branchStr = branchStr[:maxBranchW]
+		}
+		if maxBranchW > 0 {
+			drawText(screen, col, y, len(branchStr), branchStr, StyleDimmed)
+			col += len(branchStr)
+		}
+	}
 
 	// Right-align elapsed time. elapsedCol also limits cursor fill below.
 	elapsedCol := -1

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -1398,3 +1398,59 @@ func TestSanitizeTaskName(t *testing.T) {
 		})
 	}
 }
+
+func TestDrawTaskRow_BranchDisplayed(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	screen.SetSize(60, 5)
+
+	tl := NewTaskListView()
+	task := &model.Task{
+		ID:     "1",
+		Name:   "fix-bug",
+		Branch: "argus/fix-bug",
+		Status: model.StatusPending,
+	}
+
+	tl.drawTaskRow(screen, 0, 0, 60, task, false)
+	screen.Show()
+
+	// Read the row content.
+	var line string
+	for col := 0; col < 60; col++ {
+		r, _, _, _ := screen.GetContent(col, 0)
+		line += string(r)
+	}
+
+	testutil.Contains(t, line, "fix-bug")
+	testutil.Contains(t, line, "argus/fix-bug")
+}
+
+func TestDrawTaskRow_NoBranch(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	screen.SetSize(60, 5)
+
+	tl := NewTaskListView()
+	task := &model.Task{
+		ID:     "1",
+		Name:   "fix-bug",
+		Status: model.StatusPending,
+	}
+
+	tl.drawTaskRow(screen, 0, 0, 60, task, false)
+	screen.Show()
+
+	// Read the row content.
+	var line string
+	for col := 0; col < 60; col++ {
+		r, _, _, _ := screen.GetContent(col, 0)
+		line += string(r)
+	}
+
+	testutil.Contains(t, line, "fix-bug")
+}

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -1428,6 +1428,35 @@ func TestDrawTaskRow_BranchDisplayed(t *testing.T) {
 	testutil.Contains(t, line, "argus/fix-bug")
 }
 
+func TestDrawTaskRow_NarrowTerminal(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	screen.SetSize(20, 5)
+
+	tl := NewTaskListView()
+	task := &model.Task{
+		ID:     "1",
+		Name:   "fix-bug",
+		Branch: "argus/very-long-branch-name-that-exceeds-width",
+		Status: model.StatusPending,
+	}
+
+	// Must not panic on narrow terminal.
+	tl.drawTaskRow(screen, 0, 0, 20, task, false)
+	screen.Show()
+
+	var line string
+	for col := 0; col < 20; col++ {
+		r, _, _, _ := screen.GetContent(col, 0)
+		line += string(r)
+	}
+
+	// Name should still appear (possibly truncated).
+	testutil.Contains(t, line, "fix")
+}
+
 func TestDrawTaskRow_NoBranch(t *testing.T) {
 	screen := tcell.NewSimulationScreen("UTF-8")
 	if err := screen.Init(); err != nil {


### PR DESCRIPTION
Show the git branch (dimmed) after the task name in each task list row. Name gets width priority over branch on narrow terminals. Includes panic guard for negative width and narrow-terminal test.

Co-Authored-By: Claude <noreply@anthropic.com>