### PR TITLE
Add ZEN ASCII banner to empty To Dos view

### DIFF
--- a/internal/tui2/banner.go
+++ b/internal/tui2/banner.go
@@ -41,7 +41,7 @@ func drawBanner(screen tcell.Screen, x, y, width int) int {
 	row := y
 
 	// Top accent line.
-	drawFadingAccent(screen, x, row, width)
+	drawFadingAccent(screen, x, row, width, bannerTextWidth)
 	row++
 	row++ // blank line
 
@@ -57,7 +57,7 @@ func drawBanner(screen tcell.Screen, x, y, width int) int {
 	}
 
 	// Gradient underline beneath banner.
-	drawGradientUnderline(screen, x, row, width)
+	drawGradientUnderline(screen, x, row, width, bannerTextWidth, bannerGradient[:])
 	row++
 	row++ // blank line
 
@@ -71,15 +71,15 @@ func drawBanner(screen tcell.Screen, x, y, width int) int {
 	row++ // blank line
 
 	// Bottom accent line.
-	drawFadingAccent(screen, x, row, width)
+	drawFadingAccent(screen, x, row, width, bannerTextWidth)
 	row++
 
 	return row - y
 }
 
 // drawFadingAccent draws two fading dash lines from center with a hexagon.
-func drawFadingAccent(screen tcell.Screen, x, y, width int) {
-	sideLen := max((width-bannerTextWidth)/2-2, 3)
+func drawFadingAccent(screen tcell.Screen, x, y, width, textWidth int) {
+	sideLen := max((width-textWidth)/2-2, 3)
 
 	leftPattern := fadeDashes(sideLen, false)
 	rightPattern := fadeDashes(sideLen, true)
@@ -109,20 +109,20 @@ func drawFadingAccent(screen tcell.Screen, x, y, width int) {
 	drawGradientChars(screen, col, y, rightPattern, rgbVal{255, 135, 215}, rgbVal{98, 98, 98})
 }
 
-// drawGradientUnderline draws a centered underline with the banner gradient colors.
-func drawGradientUnderline(screen tcell.Screen, x, y, width int) {
-	lineLen := bannerTextWidth
-	segLen := max(lineLen/len(bannerGradient), 1)
+// drawGradientUnderline draws a centered underline with the given gradient colors.
+func drawGradientUnderline(screen tcell.Screen, x, y, width, textWidth int, gradient []tcell.Color) {
+	lineLen := textWidth
+	segLen := max(lineLen/len(gradient), 1)
 	padLeft := (width - lineLen) / 2
 	if padLeft < 0 {
 		padLeft = 0
 	}
 
 	col := x + padLeft
-	for i, c := range bannerGradient {
+	for i, c := range gradient {
 		n := segLen
-		if i == len(bannerGradient)-1 {
-			n = lineLen - segLen*(len(bannerGradient)-1)
+		if i == len(gradient)-1 {
+			n = lineLen - segLen*(len(gradient)-1)
 		}
 		style := tcell.StyleDefault.Foreground(c)
 		for range n {

--- a/internal/tui2/todos.go
+++ b/internal/tui2/todos.go
@@ -226,12 +226,20 @@ func (v *ToDosView) Draw(screen tcell.Screen) {
 		return
 	}
 
-	// Empty state
+	// Empty state: draw banner centered vertically.
+	bh := todoBannerHeight()
+	hintRow := 1
+	totalH := bh + hintRow
+	topPad := max((height-totalH)/2, 0)
+
+	drawTodoBanner(screen, x, y+topPad, width)
+
+	// Draw hint below the banner.
 	hint := "No to-do notes found"
 	if v.vaultPath != "" {
 		hint += fmt.Sprintf(" in %s", v.vaultPath)
 	}
-	hintY := y + height/2
+	hintY := y + topPad + bh
 	hintPad := max((width-len(hint))/2, 0)
 	drawText(screen, x+hintPad, hintY, width-hintPad, hint, StyleDimmed)
 }

--- a/internal/tui2/todos.go
+++ b/internal/tui2/todos.go
@@ -228,7 +228,7 @@ func (v *ToDosView) Draw(screen tcell.Screen) {
 
 	// Empty state: draw banner centered vertically.
 	bh := todoBannerHeight()
-	hintRow := 1
+	hintRow := 1 // single line for "No to-do notes found" hint
 	totalH := bh + hintRow
 	topPad := max((height-totalH)/2, 0)
 

--- a/internal/tui2/todosbanner.go
+++ b/internal/tui2/todosbanner.go
@@ -21,6 +21,8 @@ var todoBannerGradient = [...]tcell.Color{
 	tcell.Color212, // pink
 }
 
+// todoBannerTextWidth is the rune count of each banner line, used for
+// centering math. Matches the bannerTextWidth convention in banner.go.
 const todoBannerTextWidth = 25
 
 const todoSubtitle = "N O T H I N G   T O   D O"
@@ -31,8 +33,8 @@ func todoBannerHeight() int {
 	return 12
 }
 
-// drawTodoBanner draws the "ZEN" ASCII banner centered at the given y offset.
-// Returns the number of rows consumed.
+// drawTodoBanner draws the To Dos tab empty-state banner centered at the
+// given y offset. Returns the number of rows consumed.
 func drawTodoBanner(screen tcell.Screen, x, y, width int) int {
 	if width <= 0 {
 		return 0

--- a/internal/tui2/todosbanner.go
+++ b/internal/tui2/todosbanner.go
@@ -1,0 +1,78 @@
+package tui2
+
+import (
+	"github.com/gdamore/tcell/v2"
+)
+
+var todoBannerLines = [...]string{
+	`███████  ███████  ██   ██`,
+	`     ██  ██       ███  ██`,
+	`  ███    █████    ██ █ ██`,
+	`██       ██       ██  ███`,
+	`███████  ███████  ██   ██`,
+}
+
+// Per-line gradient colors for the todo banner.
+var todoBannerGradient = [...]tcell.Color{
+	tcell.Color87,  // bright cyan
+	tcell.Color81,  // light blue
+	tcell.Color141, // lavender
+	tcell.Color177, // light purple
+	tcell.Color212, // pink
+}
+
+const todoBannerTextWidth = 25
+
+const todoSubtitle = "N O T H I N G   T O   D O"
+
+// todoBannerHeight returns the total height of the todo banner.
+func todoBannerHeight() int {
+	// accent(1) + blank(1) + 5 logo lines + underline(1) + blank(1) + subtitle(1) + blank(1) + accent(1) = 12
+	return 12
+}
+
+// drawTodoBanner draws the "ZEN" ASCII banner centered at the given y offset.
+// Returns the number of rows consumed.
+func drawTodoBanner(screen tcell.Screen, x, y, width int) int {
+	if width <= 0 {
+		return 0
+	}
+
+	row := y
+
+	// Top accent line.
+	drawFadingAccent(screen, x, row, width, todoBannerTextWidth)
+	row++
+	row++ // blank line
+
+	// Main banner text with per-line gradient.
+	for i, line := range todoBannerLines {
+		padLeft := (width - todoBannerTextWidth) / 2
+		if padLeft < 0 {
+			padLeft = 0
+		}
+		style := tcell.StyleDefault.Foreground(todoBannerGradient[i]).Bold(true)
+		drawText(screen, x+padLeft, row, width-padLeft, line, style)
+		row++
+	}
+
+	// Gradient underline beneath banner.
+	drawGradientUnderline(screen, x, row, width, todoBannerTextWidth, todoBannerGradient[:])
+	row++
+	row++ // blank line
+
+	// Subtitle.
+	subPad := (width - len(todoSubtitle)) / 2
+	if subPad < 0 {
+		subPad = 0
+	}
+	drawText(screen, x+subPad, row, width-subPad, todoSubtitle, tcell.StyleDefault.Foreground(ColorDimmed))
+	row++
+	row++ // blank line
+
+	// Bottom accent line.
+	drawFadingAccent(screen, x, row, width, todoBannerTextWidth)
+	row++
+
+	return row - y
+}

--- a/internal/tui2/todosbanner_test.go
+++ b/internal/tui2/todosbanner_test.go
@@ -51,7 +51,8 @@ func TestDrawTodoBanner_NarrowWidth(t *testing.T) {
 }
 
 func TestTodoBannerLineWidths(t *testing.T) {
-	// All lines must be exactly todoBannerTextWidth.
+	// All lines must have exactly todoBannerTextWidth runes so centering
+	// math in drawTodoBanner produces consistent padding.
 	for i, line := range todoBannerLines {
 		got := len([]rune(line))
 		testutil.Equal(t, got, todoBannerTextWidth)

--- a/internal/tui2/todosbanner_test.go
+++ b/internal/tui2/todosbanner_test.go
@@ -1,0 +1,60 @@
+package tui2
+
+import (
+	"testing"
+
+	"github.com/drn/argus/internal/testutil"
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestTodoBannerHeight(t *testing.T) {
+	h := todoBannerHeight()
+	testutil.Equal(t, h, 12)
+}
+
+func TestDrawTodoBanner_ZeroWidth(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+
+	rows := drawTodoBanner(screen, 0, 0, 0)
+	testutil.Equal(t, rows, 0)
+}
+
+func TestDrawTodoBanner_Normal(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(120, 40)
+
+	rows := drawTodoBanner(screen, 0, 0, 120)
+	testutil.Equal(t, rows, todoBannerHeight())
+}
+
+func TestDrawTodoBanner_NarrowWidth(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(30, 40)
+
+	// Should not panic even with narrow width.
+	rows := drawTodoBanner(screen, 0, 0, 30)
+	if rows == 0 {
+		t.Error("expected non-zero rows for width 30")
+	}
+}
+
+func TestTodoBannerLineWidths(t *testing.T) {
+	// All lines must be exactly todoBannerTextWidth.
+	for i, line := range todoBannerLines {
+		got := len([]rune(line))
+		testutil.Equal(t, got, todoBannerTextWidth)
+		_ = i
+	}
+}


### PR DESCRIPTION
Replace plain "No to-do notes found" text with a gradient ASCII banner matching the ARGUS logo style. Refactors accent/underline helpers to accept textWidth param for reuse across banners.

Co-Authored-By: Claude <noreply@anthropic.com>