### PR TITLE
Show spinner on project row when any task is actively running

### DIFF
--- a/context/knowledge/gotchas/tasklist-ui.md
+++ b/context/knowledge/gotchas/tasklist-ui.md
@@ -29,5 +29,6 @@
 
 ## Spinner Animation
 
+- **Project status icon priority: actively running > in_review > idle in_progress.** If any task in a project is actively running (`running && !idle`), the project shows the spinner — even if other tasks are in-review. The variable is `hasActivelyRunning`, not the old `allInProgressIdle` inverse.
 - **Spinner frame computation is time-based, not tick-based.** `updateSpinnerFrame()` computes `int(time.Now().UnixMilli() / interval) % frameCount` in `Draw()`. The 1-second tick loop is too slow for 100ms spinner frames. A dedicated `spinnerLoop` (100ms ticker) triggers redraws only when `len(runningIDs) > 0`.
 - **`model.SetActiveSpinner()` is a package-level setter — not thread-safe for concurrent writers.** Currently safe because only the tview main goroutine (settings UI) calls it. If daemon or API ever sets it, add synchronization.

--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -818,7 +818,7 @@ func (tl *TaskListView) drawFilterInput(screen tcell.Screen, x, y, w int) {
 // projectStatusIcon returns the aggregated status icon and style for a project's tasks.
 // Priority: any actively running > any in_review > idle in_progress > all complete > mixed > all pending.
 func (tl *TaskListView) projectStatusIcon(tasks []*model.Task) (rune, tcell.Style) {
-	var hasActivelyRunning, hasInProgress, hasInReview, hasPending, hasComplete bool
+	var hasActivelyRunning, hasIdleInProgress, hasInReview, hasPending, hasComplete bool
 
 	for _, t := range tasks {
 		switch t.Status {
@@ -827,7 +827,7 @@ func (tl *TaskListView) projectStatusIcon(tasks []*model.Task) (rune, tcell.Styl
 				// Idle+unvisited InProgress tasks count as InReview at project level.
 				hasInReview = true
 			} else {
-				hasInProgress = true
+				hasIdleInProgress = true
 				if tl.running[t.ID] && !tl.idle[t.ID] {
 					hasActivelyRunning = true
 				}
@@ -846,7 +846,7 @@ func (tl *TaskListView) projectStatusIcon(tasks []*model.Task) (rune, tcell.Styl
 		return model.SpinnerFrame(tl.animFrame), StyleInProgress
 	case hasInReview:
 		return IconMoonStars, StyleInReview
-	case hasInProgress:
+	case hasIdleInProgress:
 		// All in-progress tasks are idle (waiting for input).
 		return IconMoonOutline, tcell.StyleDefault.Foreground(ColorInReview)
 	case hasComplete && !hasPending:

--- a/internal/tui2/tasklist.go
+++ b/internal/tui2/tasklist.go
@@ -816,10 +816,9 @@ func (tl *TaskListView) drawFilterInput(screen tcell.Screen, x, y, w int) {
 }
 
 // projectStatusIcon returns the aggregated status icon and style for a project's tasks.
-// Priority: any in_review > in_progress alone > all complete > mixed > all pending.
+// Priority: any actively running > any in_review > idle in_progress > all complete > mixed > all pending.
 func (tl *TaskListView) projectStatusIcon(tasks []*model.Task) (rune, tcell.Style) {
-	var hasInProgress, hasInReview, hasPending, hasComplete bool
-	allInProgressIdle := true
+	var hasActivelyRunning, hasInProgress, hasInReview, hasPending, hasComplete bool
 
 	for _, t := range tasks {
 		switch t.Status {
@@ -830,7 +829,7 @@ func (tl *TaskListView) projectStatusIcon(tasks []*model.Task) (rune, tcell.Styl
 			} else {
 				hasInProgress = true
 				if tl.running[t.ID] && !tl.idle[t.ID] {
-					allInProgressIdle = false
+					hasActivelyRunning = true
 				}
 			}
 		case model.StatusInReview:
@@ -843,16 +842,13 @@ func (tl *TaskListView) projectStatusIcon(tasks []*model.Task) (rune, tcell.Styl
 	}
 
 	switch {
-	case hasInProgress:
-		if hasInReview {
-			return IconMoonStars, StyleInReview
-		}
-		if allInProgressIdle {
-			return IconMoonOutline, tcell.StyleDefault.Foreground(ColorInReview)
-		}
+	case hasActivelyRunning:
 		return model.SpinnerFrame(tl.animFrame), StyleInProgress
 	case hasInReview:
 		return IconMoonStars, StyleInReview
+	case hasInProgress:
+		// All in-progress tasks are idle (waiting for input).
+		return IconMoonOutline, tcell.StyleDefault.Foreground(ColorInReview)
 	case hasComplete && !hasPending:
 		return '✓', StyleComplete
 	case hasComplete && hasPending:

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -238,7 +238,7 @@ func TestTaskListView_ProjectStatusIcon(t *testing.T) {
 			name:     "in progress running",
 			tasks:    []*model.Task{{ID: "1", Status: model.StatusInProgress}},
 			running:  map[string]bool{"1": true},
-			wantChar: '\uEE06', // animFrame=0 (spinner frame 1)
+			wantChar: '\uEE06', // animFrame=0, first spinner frame
 		},
 		{
 			name:     "all complete",
@@ -282,7 +282,7 @@ func TestTaskListView_ProjectStatusIcon(t *testing.T) {
 				{ID: "2", Status: model.StatusInReview},
 			},
 			running:  map[string]bool{"1": true},
-			wantChar: '\uEE06', // animFrame=0 (spinner frame 1)
+			wantChar: '\uEE06', // animFrame=0, first spinner frame
 		},
 	}
 

--- a/internal/tui2/tasklist_test.go
+++ b/internal/tui2/tasklist_test.go
@@ -276,13 +276,13 @@ func TestTaskListView_ProjectStatusIcon(t *testing.T) {
 			wantChar: IconMoonStars,
 		},
 		{
-			name: "running in progress plus in review shows review icon",
+			name: "running in progress plus in review shows spinner",
 			tasks: []*model.Task{
 				{ID: "1", Status: model.StatusInProgress},
 				{ID: "2", Status: model.StatusInReview},
 			},
 			running:  map[string]bool{"1": true},
-			wantChar: IconMoonStars,
+			wantChar: '\uEE06', // animFrame=0 (spinner frame 1)
 		},
 	}
 


### PR DESCRIPTION
Project status icon now prioritizes actively running tasks over in-review state, so the spinner is always visible when an agent is working.

Co-Authored-By: Claude <noreply@anthropic.com>