### PR TITLE
Allow deletion of todo-triggered tasks

### DIFF
--- a/context/knowledge/gotchas/misc.md
+++ b/context/knowledge/gotchas/misc.md
@@ -39,8 +39,8 @@
 ## Todo-Task Association
 
 - **`TodoPath` links a task to its source vault `.md` file.** Set only during `handleLaunchToDoKey`. `TasksByTodoPath()` returns most-recent task per path (ORDER BY created_at ASC, last wins).
-- **`PruneCompleted` must skip tasks with `todo_path` set.** Without the `AND todo_path = ''` filter, pruning deletes todo-linked completed tasks. The vault files survive but the association is lost — todo bullets revert to "not started" on next scan. Todo-linked tasks should only be cleaned up via the ToDo cleanup flow (Ctrl+R on ToDos tab), which removes vault files and tasks together.
-- **Ctrl+R cleanup on ToDos tab deletes vault files, not tasks.** Only `.md` files for todos with completed linked tasks are removed. Tasks remain in Argus history.
+- **Deleting or pruning a todo-linked task auto-deletes the vault `.md` file.** `deleteTask` and `pruneCompletedTasks` both call `removeTodoVaultFile`, which canonicalizes paths with `filepath.Clean` before the vault-boundary prefix check. The vault refresh (`RefreshAsync`) fires once after the loop in prune, not per-task.
+- **`removeTodoVaultFile` must canonicalize paths before the prefix guard.** A `TodoPath` like `/vault/../../../etc/passwd` would bypass a raw `strings.HasPrefix` check. Always `filepath.Clean` both the todo path and vault path before comparing.
 - **`taskColumns`/`scanTask`/`Add`/`Update` lockstep includes `todo_path`.** Column position is after `pr_url`, before `archived`. Missing any site causes runtime panics.
 
 ## PR & Reviews

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1417,7 +1417,7 @@ func TestDB_PruneCompleted_AllStatuses(t *testing.T) {
 	}
 }
 
-func TestDB_PruneCompleted_PreservesToDoLinked(t *testing.T) {
+func TestDB_PruneCompleted_IncludesToDoLinked(t *testing.T) {
 	d := testDB(t)
 
 	_ = d.Add(&model.Task{Name: "regular-done", Status: model.StatusComplete})
@@ -1428,22 +1428,16 @@ func TestDB_PruneCompleted_PreservesToDoLinked(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(pruned) != 1 {
-		t.Errorf("expected 1 pruned (regular only), got %d", len(pruned))
-	}
-	if len(pruned) > 0 && pruned[0].Name != "regular-done" {
-		t.Errorf("pruned wrong task: %q", pruned[0].Name)
+	if len(pruned) != 2 {
+		t.Errorf("expected 2 pruned (both completed), got %d", len(pruned))
 	}
 
 	remaining := d.Tasks()
-	if len(remaining) != 2 {
-		t.Errorf("expected 2 remaining (todo-done + pending), got %d", len(remaining))
+	if len(remaining) != 1 {
+		t.Errorf("expected 1 remaining (pending only), got %d", len(remaining))
 	}
-
-	// The todo-linked task should still be retrievable via TasksByTodoPath.
-	todoMap := d.TasksByTodoPath()
-	if _, ok := todoMap["/vault/task.md"]; !ok {
-		t.Error("todo-linked completed task should be preserved after prune")
+	if len(remaining) > 0 && remaining[0].Name != "pending" {
+		t.Errorf("remaining task should be pending, got %q", remaining[0].Name)
 	}
 }
 

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -146,10 +146,7 @@ func (d *DB) PruneCompleted() ([]*model.Task, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	// Fetch completed tasks first. Skip tasks with a todo_path — those are
-	// linked to vault files and should only be cleaned up via the ToDo
-	// cleanup flow (which removes the vault file + association together).
-	rows, err := d.conn.Query(`SELECT ` + taskColumns + ` FROM tasks WHERE status='complete' AND todo_path = ''`)
+	rows, err := d.conn.Query(`SELECT ` + taskColumns + ` FROM tasks WHERE status='complete'`)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +163,7 @@ func (d *DB) PruneCompleted() ([]*model.Task, error) {
 		return nil, nil
 	}
 
-	_, err = d.conn.Exec(`DELETE FROM tasks WHERE status='complete' AND todo_path = ''`)
+	_, err = d.conn.Exec(`DELETE FROM tasks WHERE status='complete'`)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -2392,6 +2392,21 @@ func (a *App) executeDeleteToDo() {
 	a.todos.RefreshAsync(a.tapp)
 }
 
+// deleteTodoFile removes a todo vault file if it falls within the configured vault directory.
+func (a *App) deleteTodoFile(todoPath string) {
+	vaultPath := a.todos.VaultPath()
+	if vaultPath == "" || !strings.HasPrefix(todoPath, vaultPath+string(os.PathSeparator)) {
+		uxlog.Log("[todos] auto-delete: skipping %s (not in vault %s)", todoPath, vaultPath)
+		return
+	}
+	if err := os.Remove(todoPath); err != nil {
+		uxlog.Log("[todos] auto-delete: failed to remove %s: %v", todoPath, err)
+	} else {
+		uxlog.Log("[todos] auto-delete: removed %s", todoPath)
+	}
+	a.todos.RefreshAsync(a.tapp)
+}
+
 // closeDeleteToDoModal closes the delete to-do confirmation modal.
 func (a *App) closeDeleteToDoModal() {
 	a.mode = modeTaskList
@@ -2992,6 +3007,11 @@ func (a *App) deleteTask(t *model.Task) {
 	// Remove session log file.
 	os.Remove(agent.SessionLogPath(t.ID)) //nolint:errcheck
 
+	// Delete the linked todo vault file if present.
+	if t.TodoPath != "" {
+		a.deleteTodoFile(t.TodoPath)
+	}
+
 	// Delete from database first so the UI updates immediately.
 	if err := a.db.Delete(t.ID); err != nil {
 		uxlog.Log("[tui2] failed to delete task %s: %v", t.ID, err)
@@ -3037,9 +3057,12 @@ func (a *App) pruneCompletedTasks() {
 		}
 	}
 
-	// Remove session logs for all pruned tasks.
+	// Remove session logs and linked todo vault files for all pruned tasks.
 	for _, t := range pruned {
 		os.Remove(agent.SessionLogPath(t.ID)) //nolint:errcheck
+		if t.TodoPath != "" {
+			a.deleteTodoFile(t.TodoPath)
+		}
 	}
 
 	cfg := a.db.Config()

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -2392,19 +2392,22 @@ func (a *App) executeDeleteToDo() {
 	a.todos.RefreshAsync(a.tapp)
 }
 
-// deleteTodoFile removes a todo vault file if it falls within the configured vault directory.
-func (a *App) deleteTodoFile(todoPath string) {
+// removeTodoVaultFile removes a todo vault file if it falls within the configured vault directory.
+// No-op if the vault path is unconfigured or todoPath falls outside it.
+// Does NOT trigger a vault refresh — callers must call a.todos.RefreshAsync when done.
+func (a *App) removeTodoVaultFile(todoPath string) {
 	vaultPath := a.todos.VaultPath()
-	if vaultPath == "" || !strings.HasPrefix(todoPath, vaultPath+string(os.PathSeparator)) {
+	cleanPath := filepath.Clean(todoPath)
+	cleanVault := filepath.Clean(vaultPath)
+	if cleanVault == "" || !strings.HasPrefix(cleanPath, cleanVault+string(os.PathSeparator)) {
 		uxlog.Log("[todos] auto-delete: skipping %s (not in vault %s)", todoPath, vaultPath)
 		return
 	}
-	if err := os.Remove(todoPath); err != nil {
-		uxlog.Log("[todos] auto-delete: failed to remove %s: %v", todoPath, err)
+	if err := os.Remove(cleanPath); err != nil {
+		uxlog.Log("[todos] auto-delete: failed to remove %s: %v", cleanPath, err)
 	} else {
-		uxlog.Log("[todos] auto-delete: removed %s", todoPath)
+		uxlog.Log("[todos] auto-delete: removed %s", cleanPath)
 	}
-	a.todos.RefreshAsync(a.tapp)
 }
 
 // closeDeleteToDoModal closes the delete to-do confirmation modal.
@@ -3009,7 +3012,8 @@ func (a *App) deleteTask(t *model.Task) {
 
 	// Delete the linked todo vault file if present.
 	if t.TodoPath != "" {
-		a.deleteTodoFile(t.TodoPath)
+		a.removeTodoVaultFile(t.TodoPath)
+		a.todos.RefreshAsync(a.tapp)
 	}
 
 	// Delete from database first so the UI updates immediately.
@@ -3058,11 +3062,16 @@ func (a *App) pruneCompletedTasks() {
 	}
 
 	// Remove session logs and linked todo vault files for all pruned tasks.
+	hasTodo := false
 	for _, t := range pruned {
 		os.Remove(agent.SessionLogPath(t.ID)) //nolint:errcheck
 		if t.TodoPath != "" {
-			a.deleteTodoFile(t.TodoPath)
+			a.removeTodoVaultFile(t.TodoPath)
+			hasTodo = true
 		}
+	}
+	if hasTodo {
+		a.todos.RefreshAsync(a.tapp)
 	}
 
 	cfg := a.db.Config()

--- a/internal/tui2/app_test.go
+++ b/internal/tui2/app_test.go
@@ -801,6 +801,87 @@ func TestDeleteTask(t *testing.T) {
 	}
 }
 
+func TestDeleteTask_AutoDeletesTodoFile(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false, false)
+
+	// Create a vault directory with a todo file.
+	vaultDir := t.TempDir()
+	todoFile := filepath.Join(vaultDir, "my-todo.md")
+	os.WriteFile(todoFile, []byte("# My Todo"), 0644)
+
+	// Set the vault path on the todos view (no scan needed — just path).
+	app.todos.SetVaultPath(vaultDir)
+
+	task := &model.Task{
+		ID:        "t1",
+		Name:      "todo-triggered",
+		Status:    model.StatusPending,
+		Project:   "proj",
+		TodoPath:  todoFile,
+		CreatedAt: time.Now(),
+	}
+	d.Add(task)
+	app.refreshTasks()
+
+	app.deleteTask(task)
+
+	// Task should be deleted from DB.
+	if len(d.Tasks()) != 0 {
+		t.Errorf("expected 0 tasks in DB, got %d", len(d.Tasks()))
+	}
+
+	// Todo vault file should be auto-deleted.
+	if _, err := os.Stat(todoFile); !os.IsNotExist(err) {
+		t.Error("todo vault file should be deleted when its task is deleted")
+	}
+}
+
+func TestDeleteTask_NoTodoPath_NoFileRemoval(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false, false)
+
+	task := &model.Task{
+		ID:        "t1",
+		Name:      "regular task",
+		Status:    model.StatusPending,
+		Project:   "proj",
+		CreatedAt: time.Now(),
+	}
+	d.Add(task)
+	app.refreshTasks()
+
+	// Should not panic or error when TodoPath is empty.
+	app.deleteTask(task)
+
+	if len(d.Tasks()) != 0 {
+		t.Errorf("expected 0 tasks in DB, got %d", len(d.Tasks()))
+	}
+}
+
+func TestDeleteTodoFile_OutsideVault(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false, false)
+
+	vaultDir := t.TempDir()
+	app.todos.SetVaultPath(vaultDir)
+
+	// Create a file outside the vault.
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "sneaky.md")
+	os.WriteFile(outsideFile, []byte("# Sneaky"), 0644)
+
+	app.deleteTodoFile(outsideFile)
+
+	// File should NOT be deleted — it's outside the vault.
+	if _, err := os.Stat(outsideFile); os.IsNotExist(err) {
+		t.Error("file outside vault should not be deleted")
+	}
+}
+
 func TestRefreshTasksLocal(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)

--- a/internal/tui2/app_test.go
+++ b/internal/tui2/app_test.go
@@ -861,7 +861,7 @@ func TestDeleteTask_NoTodoPath_NoFileRemoval(t *testing.T) {
 	}
 }
 
-func TestDeleteTodoFile_OutsideVault(t *testing.T) {
+func TestRemoveTodoVaultFile_OutsideVault(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
 	app := New(d, runner, false, false)
@@ -874,7 +874,7 @@ func TestDeleteTodoFile_OutsideVault(t *testing.T) {
 	outsideFile := filepath.Join(outsideDir, "sneaky.md")
 	os.WriteFile(outsideFile, []byte("# Sneaky"), 0644)
 
-	app.deleteTodoFile(outsideFile)
+	app.removeTodoVaultFile(outsideFile)
 
 	// File should NOT be deleted — it's outside the vault.
 	if _, err := os.Stat(outsideFile); os.IsNotExist(err) {


### PR DESCRIPTION
PruneCompleted no longer skips tasks with a todo_path, so Ctrl+R cleans them up like any other completed task. When a task with a linked todo is deleted (manual or prune), the vault .md file is automatically removed — guarded with filepath.Clean to prevent path traversal and batched RefreshAsync to avoid redundant vault scans during prune.

Co-Authored-By: Claude <noreply@anthropic.com>