### PR TITLE
Remove hint line from empty To Dos view and fix flaky tests

### DIFF
--- a/internal/daemon/client/client_test.go
+++ b/internal/daemon/client/client_test.go
@@ -63,7 +63,7 @@ func TestClient_StartAndGetOutput(t *testing.T) {
 	// Use a backend that sleeps before echoing — the stream connection is
 	// async (goroutine in getOrCreateSession), so "echo" alone exits before
 	// the stream subscribes, causing "session not found" on the daemon.
-	database.SetBackend("slow-test", config.Backend{Command: "sh -c 'sleep 0.3 && echo hello-from-daemon'"}) //nolint:errcheck
+	database.SetBackend("slow-test", config.Backend{Command: "sh -c 'sleep 1 && echo hello-from-daemon'"}) //nolint:errcheck
 
 	c, err := Connect(sockPath)
 	if err != nil {
@@ -81,7 +81,7 @@ func TestClient_StartAndGetOutput(t *testing.T) {
 	}
 
 	// Poll until output arrives (process must exit AND stream must deliver).
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	var output string
 	for time.Now().Before(deadline) {
 		output = string(sess.RecentOutput())

--- a/internal/tui2/todos.go
+++ b/internal/tui2/todos.go
@@ -228,20 +228,9 @@ func (v *ToDosView) Draw(screen tcell.Screen) {
 
 	// Empty state: draw banner centered vertically.
 	bh := todoBannerHeight()
-	hintRow := 1 // single line for "No to-do notes found" hint
-	totalH := bh + hintRow
-	topPad := max((height-totalH)/2, 0)
+	topPad := max((height-bh)/2, 0)
 
 	drawTodoBanner(screen, x, y+topPad, width)
-
-	// Draw hint below the banner.
-	hint := "No to-do notes found"
-	if v.vaultPath != "" {
-		hint += fmt.Sprintf(" in %s", v.vaultPath)
-	}
-	hintY := y + topPad + bh
-	hintPad := max((width-len(hint))/2, 0)
-	drawText(screen, x+hintPad, hintY, width-hintPad, hint, StyleDimmed)
 }
 
 // Focus delegates to the inner flex.


### PR DESCRIPTION
Remove the 'No to-do notes found in ...' hint below the ZEN banner in the empty To Dos view. Fix stale TestDrawTaskRow_BranchDisplayed test and increase timing tolerance in flaky daemon client test for CI.

Co-Authored-By: Claude <noreply@anthropic.com>