### PR TITLE
Change link picker hotkey from ctrl+/ to ctrl+l

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ argus
 | `Cmd+←` / `Cmd+→` | Switch panels |
 | `Cmd+↑` / `Cmd+↓` | Navigate between tasks |
 | `ctrl+p` | Open PR in browser |
-| `ctrl+/` | Open link picker (fuzzy search all session URLs) |
+| `ctrl+l` | Open link picker (fuzzy search all session URLs) |
 | `o` | Open PR in browser (when session is finished) |
 | `Shift+↑` / `Shift+↓` | Scroll terminal (with acceleration) |
 

--- a/context/knowledge/gotchas/keybindings.md
+++ b/context/knowledge/gotchas/keybindings.md
@@ -4,7 +4,7 @@
 - **`ctrl+q` in diff mode must exit diff AND refocus terminal.** Otherwise user needs a second keypress.
 - **`ctrl+d` exits agent view when session is dead.** Without this, Ctrl+D after agent exit is silently dropped.
 - **`ctrl+p` opens PR URL (works while agent runs).** `o` also works when session is finished.
-- **`ctrl+l` opens fuzzy link picker (works while agent runs).** Uses `tcell.KeyCtrlL` — reliable across all terminals (unlike `ctrl+/` which has inconsistent encodings). Reads session log in a background goroutine; the `QueueUpdateDraw` callback must guard `a.mode == modeAgent` because the user may leave agent view during I/O.
+- **`ctrl+l` opens fuzzy link picker (works while agent runs).** Uses `tcell.KeyCtrlL` — reliable across all terminals (unlike `ctrl+/` which has inconsistent encodings). Overrides the typical "clear screen" behavior; the agent PTY never sees it. Reads session log in a background goroutine; the `QueueUpdateDraw` callback must guard `a.mode == modeAgent` because the user may leave agent view during I/O.
 - **Escape in agent view:** Refocuses terminal from diff/files but does NOT exit agent view. Always returns `nil` to consume the event.
 - **Mouse clicks must update `agentFocus`, not just tview focus.** Custom `MouseHandler` overrides needed.
 - **In diff mode: Up/Down switch files, j/k scroll diff.**

--- a/context/knowledge/gotchas/keybindings.md
+++ b/context/knowledge/gotchas/keybindings.md
@@ -4,7 +4,7 @@
 - **`ctrl+q` in diff mode must exit diff AND refocus terminal.** Otherwise user needs a second keypress.
 - **`ctrl+d` exits agent view when session is dead.** Without this, Ctrl+D after agent exit is silently dropped.
 - **`ctrl+p` opens PR URL (works while agent runs).** `o` also works when session is finished.
-- **`ctrl+/` opens fuzzy link picker (works while agent runs).** Must handle TWO encodings: legacy terminals send 0x1F (`tcell.KeyCtrlUnderscore`), but kitty/CSI-u terminals send `KeyRune` `'/'` with `ModCtrl`. Both must be matched in `handleAgentKey`. Reads session log in a background goroutine; the `QueueUpdateDraw` callback must guard `a.mode == modeAgent` because the user may leave agent view during I/O.
+- **`ctrl+l` opens fuzzy link picker (works while agent runs).** Uses `tcell.KeyCtrlL` — reliable across all terminals (unlike `ctrl+/` which has inconsistent encodings). Reads session log in a background goroutine; the `QueueUpdateDraw` callback must guard `a.mode == modeAgent` because the user may leave agent view during I/O.
 - **Escape in agent view:** Refocuses terminal from diff/files but does NOT exit agent view. Always returns `nil` to consume the event.
 - **Mouse clicks must update `agentFocus`, not just tview focus.** Custom `MouseHandler` overrides needed.
 - **In diff mode: Up/Down switch files, j/k scroll diff.**

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -1245,7 +1245,7 @@ func (a *App) handleAgentKey(event *tcell.EventKey) *tcell.EventKey {
 	case tcell.KeyCtrlP:
 		a.agentPane.OpenPR()
 		return nil
-	case tcell.KeyCtrlL:
+	case tcell.KeyCtrlL: // Overrides typical "clear screen" — intercepted before PTY
 		a.openAgentLinks()
 		return nil
 	case tcell.KeyLeft:

--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -1245,15 +1245,9 @@ func (a *App) handleAgentKey(event *tcell.EventKey) *tcell.EventKey {
 	case tcell.KeyCtrlP:
 		a.agentPane.OpenPR()
 		return nil
-	case tcell.KeyCtrlUnderscore: // Ctrl+/ (legacy terminals send 0x1F)
+	case tcell.KeyCtrlL:
 		a.openAgentLinks()
 		return nil
-	case tcell.KeyRune:
-		// Kitty/CSI-u terminals send Ctrl+/ as KeyRune '/' with ModCtrl
-		if event.Rune() == '/' && event.Modifiers()&tcell.ModCtrl != 0 {
-			a.openAgentLinks()
-			return nil
-		}
 	case tcell.KeyLeft:
 		if event.Modifiers()&(tcell.ModCtrl|tcell.ModAlt) != 0 {
 			if a.agentFocus > focusTerminal {

--- a/internal/tui2/app_test.go
+++ b/internal/tui2/app_test.go
@@ -428,7 +428,7 @@ func TestEscapeStaysInAgentView(t *testing.T) {
 	}
 }
 
-func TestCtrlSlashOpensLinkPicker(t *testing.T) {
+func TestCtrlLOpensLinkPicker(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
 	app := New(d, runner, false, false)
@@ -436,27 +436,9 @@ func TestCtrlSlashOpensLinkPicker(t *testing.T) {
 	app.mode = modeAgent
 	app.agentState.Reset("t1", "test")
 
-	tests := []struct {
-		name  string
-		event *tcell.EventKey
-	}{
-		{
-			name:  "legacy 0x1F",
-			event: tcell.NewEventKey(tcell.KeyCtrlUnderscore, 0, tcell.ModNone),
-		},
-		{
-			name:  "CSI-u Ctrl+/",
-			event: tcell.NewEventKey(tcell.KeyRune, '/', tcell.ModCtrl),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			app.mode = modeAgent
-			result := app.handleAgentKey(tt.event)
-			if result != nil {
-				t.Error("Ctrl+/ should return nil (consumed)")
-			}
-		})
+	result := app.handleAgentKey(tcell.NewEventKey(tcell.KeyCtrlL, 0, tcell.ModNone))
+	if result != nil {
+		t.Error("Ctrl+L should return nil (consumed)")
 	}
 }
 


### PR DESCRIPTION
ctrl+/ had inconsistent terminal encodings across legacy and CSI-u terminals. Replace with ctrl+l which sends a reliable standard byte (0x0c). Adds a comment noting the intentional clear-screen override.

Co-Authored-By: Claude <noreply@anthropic.com>