### PR TITLE
Strip ANSI from session logs before link extraction

### DIFF
--- a/internal/tui2/todolinks.go
+++ b/internal/tui2/todolinks.go
@@ -32,8 +32,8 @@ func stripANSI(s string) string {
 
 // cleanURL strips trailing punctuation that is not part of the URL.
 func cleanURL(u string) string {
-	// Strip trailing characters that are common sentence punctuation but
-	// rarely valid URL endings. Repeated in case of e.g. ")."
+	// Strip trailing ASCII punctuation that commonly follows URLs in prose.
+	// Byte indexing is safe here — all stripped chars are single-byte ASCII.
 	for len(u) > 0 {
 		last := u[len(u)-1]
 		if last == '.' || last == ',' || last == ';' || last == ':' || last == '\'' || last == '"' {

--- a/internal/tui2/todolinks.go
+++ b/internal/tui2/todolinks.go
@@ -24,17 +24,42 @@ var mdLinkRe = regexp.MustCompile(`\[([^\]]+)\]\((https?://[^\s)]+)\)`)
 // bareLinkRe matches bare URLs not already inside markdown link syntax.
 var bareLinkRe = regexp.MustCompile(`https?://[^\s)\]>]+`)
 
-// ExtractLinks extracts unique URLs from markdown content.
-// Markdown-style links [text](url) are preferred; bare URLs not already
-// captured by a markdown link are added with the URL as the label.
+// stripANSI removes ANSI escape sequences from raw terminal output.
+// Uses the package-level ansiRe defined in agentpane.go.
+func stripANSI(s string) string {
+	return ansiRe.ReplaceAllString(s, "")
+}
+
+// cleanURL strips trailing punctuation that is not part of the URL.
+func cleanURL(u string) string {
+	// Strip trailing characters that are common sentence punctuation but
+	// rarely valid URL endings. Repeated in case of e.g. ")."
+	for len(u) > 0 {
+		last := u[len(u)-1]
+		if last == '.' || last == ',' || last == ';' || last == ':' || last == '\'' || last == '"' {
+			u = u[:len(u)-1]
+		} else {
+			break
+		}
+	}
+	return u
+}
+
+// ExtractLinks extracts unique URLs from content that may contain ANSI escape
+// sequences (e.g. raw PTY session logs). Markdown-style links [text](url) are
+// preferred; bare URLs not already captured by a markdown link are added with
+// the URL as the label.
 func ExtractLinks(content string) []Link {
+	// Strip ANSI escape sequences so terminal formatting doesn't pollute URLs.
+	content = stripANSI(content)
+
 	seen := make(map[string]bool)
 	var links []Link
 
 	// First pass: markdown links
 	for _, m := range mdLinkRe.FindAllStringSubmatch(content, -1) {
-		url := m[2]
-		if seen[url] {
+		url := cleanURL(m[2])
+		if url == "" || seen[url] {
 			continue
 		}
 		seen[url] = true
@@ -42,8 +67,9 @@ func ExtractLinks(content string) []Link {
 	}
 
 	// Second pass: bare URLs not already captured
-	for _, url := range bareLinkRe.FindAllString(content, -1) {
-		if seen[url] {
+	for _, raw := range bareLinkRe.FindAllString(content, -1) {
+		url := cleanURL(raw)
+		if url == "" || seen[url] {
 			continue
 		}
 		seen[url] = true

--- a/internal/tui2/todolinks_test.go
+++ b/internal/tui2/todolinks_test.go
@@ -66,6 +66,34 @@ func TestExtractLinks(t *testing.T) {
 			content: "PR: https://github.com/org/repo/pull/123",
 			want:    []Link{{Label: "https://github.com/org/repo/pull/123", URL: "https://github.com/org/repo/pull/123"}},
 		},
+		{
+			name:    "URL with ANSI escape sequences",
+			content: "see \x1b[34mhttps://example.com/page\x1b[0m for info",
+			want:    []Link{{Label: "https://example.com/page", URL: "https://example.com/page"}},
+		},
+		{
+			name:    "ANSI mid-URL stripped before matching",
+			content: "visit https://example.com/\x1b[1mpath\x1b[0m done",
+			want:    []Link{{Label: "https://example.com/path", URL: "https://example.com/path"}},
+		},
+		{
+			name:    "duplicate URLs after ANSI stripping",
+			content: "\x1b[34mhttps://example.com\x1b[0m and https://example.com",
+			want:    []Link{{Label: "https://example.com", URL: "https://example.com"}},
+		},
+		{
+			name:    "trailing punctuation stripped",
+			content: "see https://example.com/page. Also https://other.com,",
+			want: []Link{
+				{Label: "https://example.com/page", URL: "https://example.com/page"},
+				{Label: "https://other.com", URL: "https://other.com"},
+			},
+		},
+		{
+			name:    "OSC escape sequences stripped",
+			content: "\x1b]8;;https://example.com\x07link\x1b]8;;\x07 and https://example.com",
+			want:    []Link{{Label: "https://example.com", URL: "https://example.com"}},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fix link picker showing non-link text by stripping ANSI escape sequences from raw PTY session logs before URL extraction. Also cleans trailing punctuation and ensures URL uniqueness after cleaning.

Co-Authored-By: Claude <noreply@anthropic.com>