### PR TITLE
Fetch remotes before creating worktree for up-to-date branches

### DIFF
--- a/context/knowledge/gotchas/worktree.md
+++ b/context/knowledge/gotchas/worktree.md
@@ -6,5 +6,6 @@
 - **Worktree creation must succeed before task persistence.** Never `db.Add(task)` without a valid worktree. `CreateWorktree` returns `(wtPath, finalName, branchName, err)` — store `branchName` on `task.Branch` so cleanup deletes the correct `argus/*` branch.
 - **`removeWorktree` must validate paths before `os.RemoveAll`.** The `isWorktreeSubdir` guard ensures the path contains `/.argus/worktrees/` or `/.claude/worktrees/` before any removal.
 - **Worktree cleanup must always `os.RemoveAll` after `git worktree remove`.** The git command can exit 0 but leave behind empty dirs. Run `git worktree prune` before `git branch -D` — git refuses to delete branches with stale worktree references.
+- **`CreateWorktree` fetches all remotes before resolving the base branch.** `git fetch --all --prune` runs best-effort before `resolveStartPoint()`. Without this, newly pushed remote branches or updates won't be visible and the worktree starts from stale data.
 - **`git worktree add` requires a valid local ref or remote-tracking ref.** `resolveStartPoint()` checks `git rev-parse --verify` and falls back to `upstream/<branch>` then `origin/<branch>`.
 - **Task names must be sanitized before branch/dir creation.** `sanitizeBranchName()` strips git-invalid characters. Without this, characters like `?` cause exit status 255.

--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -8,7 +8,7 @@ Non-obvious invariants and gotchas, split by topic. Read the relevant file when 
 | [gotchas/pty-terminal.md](gotchas/pty-terminal.md) | PTY sizing, x/vt emulator, ring buffer, replay cache, paint cache, lazyScreen | 31 |
 | [gotchas/ui-threading.md](gotchas/ui-threading.md) | tview thread safety, tick goroutine rules, paste/input batching | 10 |
 | [gotchas/sandbox.md](gotchas/sandbox.md) | macOS sandbox-exec SBPL profiles, symlink resolution, allowed paths | 14 |
-| [gotchas/worktree.md](gotchas/worktree.md) | Worktree creation ordering, cleanup, path validation, stale ref pruning | 8 |
+| [gotchas/worktree.md](gotchas/worktree.md) | Worktree creation ordering, cleanup, path validation, stale ref pruning | 9 |
 | [gotchas/keybindings.md](gotchas/keybindings.md) | Key routing, ctrl sequences, tcell modifier quirks, agent view navigation | 12 |
 | [gotchas/tasklist-ui.md](gotchas/tasklist-ui.md) | Task list cursor, modals, focus guards, filter, archive, spinner, row rendering | 25 |
 | [gotchas/misc.md](gotchas/misc.md) | DB patterns, Go idioms, Codex, MCP, todos, PRs, file explorer, vault, quick-add | 60 |

--- a/internal/agent/worktree.go
+++ b/internal/agent/worktree.go
@@ -86,6 +86,14 @@ func CreateWorktree(projectPath, projectName, taskName, baseBranch string) (wtPa
 		baseBranch = "HEAD"
 	}
 
+	// Fetch all remotes so remote-tracking branches are up to date before
+	// we resolve the start point or create the worktree.
+	fetchCmd := exec.Command("git", "fetch", "--all", "--prune")
+	fetchCmd.Dir = projectPath
+	if out, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
+		uxlog.Log("[worktree] git fetch --all --prune failed (continuing): %v: %s", fetchErr, strings.TrimSpace(string(out)))
+	}
+
 	// Resolve baseBranch to a valid ref. If the local branch doesn't exist,
 	// try remote-tracking branches (origin/<branch>, upstream/<branch>).
 	baseBranch = resolveStartPoint(projectPath, baseBranch)

--- a/internal/agent/worktree.go
+++ b/internal/agent/worktree.go
@@ -1,12 +1,14 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/drn/argus/internal/db"
 	"github.com/drn/argus/internal/uxlog"
@@ -87,11 +89,17 @@ func CreateWorktree(projectPath, projectName, taskName, baseBranch string) (wtPa
 	}
 
 	// Fetch all remotes so remote-tracking branches are up to date before
-	// we resolve the start point or create the worktree.
-	fetchCmd := exec.Command("git", "fetch", "--all", "--prune")
-	fetchCmd.Dir = projectPath
-	if out, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
-		uxlog.Log("[worktree] git fetch --all --prune failed (continuing): %v: %s", fetchErr, strings.TrimSpace(string(out)))
+	// we resolve the start point or create the worktree. Skip for HEAD
+	// (pure-local, no remote needed). Timeout prevents blocking the TUI
+	// on slow or unreachable networks.
+	if baseBranch != "HEAD" {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		fetchCmd := exec.CommandContext(ctx, "git", "fetch", "--all", "--prune")
+		fetchCmd.Dir = projectPath
+		if out, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
+			uxlog.Log("[worktree] git fetch --all --prune failed (continuing): %v: %s", fetchErr, strings.TrimSpace(string(out)))
+		}
 	}
 
 	// Resolve baseBranch to a valid ref. If the local branch doesn't exist,

--- a/internal/agent/worktree_test.go
+++ b/internal/agent/worktree_test.go
@@ -375,6 +375,82 @@ func TestResolveStartPoint(t *testing.T) {
 	}
 }
 
+func TestCreateWorktree_FetchesRemote(t *testing.T) {
+	// Verify that CreateWorktree fetches remotes before resolving the base
+	// branch. We set up a local repo with a remote, push a new branch to
+	// the remote AFTER the clone, and confirm the worktree can be based on
+	// that branch even though the local repo hasn't seen it yet.
+	upstreamDir := t.TempDir()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = upstreamDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s\n%s", args, err, out)
+		}
+	}
+	readme := filepath.Join(upstreamDir, "README.md")
+	if err := os.WriteFile(readme, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"add", "."},
+		{"commit", "-m", "initial"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = upstreamDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s\n%s", args, err, out)
+		}
+	}
+
+	// Clone the upstream.
+	repoDir := t.TempDir()
+	cloneCmd := exec.Command("git", "clone", upstreamDir, repoDir)
+	if out, err := cloneCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git clone: %s\n%s", err, out)
+	}
+
+	// Now create a new branch on the upstream AFTER the clone.
+	for _, args := range [][]string{
+		{"checkout", "-b", "feature-new"},
+		{"commit", "--allow-empty", "-m", "feature commit"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = upstreamDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s\n%s", args, err, out)
+		}
+	}
+
+	// The local repo doesn't know about feature-new yet.
+	checkCmd := exec.Command("git", "rev-parse", "--verify", "--quiet", "origin/feature-new")
+	checkCmd.Dir = repoDir
+	if checkCmd.Run() == nil {
+		t.Fatal("expected origin/feature-new to NOT exist before fetch")
+	}
+
+	origHome := os.Getenv("HOME")
+	tmpHome := t.TempDir()
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	// CreateWorktree should fetch and resolve origin/feature-new.
+	wtPath, finalName, _, err := CreateWorktree(repoDir, "testproj", "fetch-test", "feature-new")
+	if err != nil {
+		t.Fatalf("CreateWorktree with unfetched remote branch failed: %v", err)
+	}
+	if finalName != "fetch-test" {
+		t.Errorf("expected finalName %q, got %q", "fetch-test", finalName)
+	}
+	if _, err := os.Stat(filepath.Join(wtPath, ".git")); err != nil {
+		t.Errorf("expected worktree at %q", wtPath)
+	}
+}
+
 func TestCreateWorktree_ExistingBranch(t *testing.T) {
 	// Test the fallback path where the branch already exists but worktree doesn't.
 	repoDir := t.TempDir()

--- a/internal/agent/worktree_test.go
+++ b/internal/agent/worktree_test.go
@@ -433,10 +433,8 @@ func TestCreateWorktree_FetchesRemote(t *testing.T) {
 		t.Fatal("expected origin/feature-new to NOT exist before fetch")
 	}
 
-	origHome := os.Getenv("HOME")
 	tmpHome := t.TempDir()
-	os.Setenv("HOME", tmpHome)
-	defer os.Setenv("HOME", origHome)
+	t.Setenv("HOME", tmpHome)
 
 	// CreateWorktree should fetch and resolve origin/feature-new.
 	wtPath, finalName, _, err := CreateWorktree(repoDir, "testproj", "fetch-test", "feature-new")
@@ -448,6 +446,24 @@ func TestCreateWorktree_FetchesRemote(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(wtPath, ".git")); err != nil {
 		t.Errorf("expected worktree at %q", wtPath)
+	}
+
+	// Verify the worktree HEAD matches the upstream feature-new commit.
+	wtHead := exec.Command("git", "rev-parse", "HEAD")
+	wtHead.Dir = wtPath
+	wtOut, err := wtHead.Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD in worktree: %v", err)
+	}
+	upstreamHead := exec.Command("git", "rev-parse", "feature-new")
+	upstreamHead.Dir = upstreamDir
+	upOut, err := upstreamHead.Output()
+	if err != nil {
+		t.Fatalf("rev-parse feature-new in upstream: %v", err)
+	}
+	if strings.TrimSpace(string(wtOut)) != strings.TrimSpace(string(upOut)) {
+		t.Errorf("worktree HEAD %q does not match upstream feature-new %q",
+			strings.TrimSpace(string(wtOut)), strings.TrimSpace(string(upOut)))
 	}
 }
 


### PR DESCRIPTION
Add git fetch --all --prune with 15s timeout to CreateWorktree before branch resolution. Skips fetch for HEAD-only (local) tasks. Includes test verifying worktree is based on newly-pushed remote branch.

Co-Authored-By: Claude <noreply@anthropic.com>