### PR TITLE
Fix link picker URL splicing from OSC 8 hyperlinks

### DIFF
--- a/context/knowledge/gotchas/misc.md
+++ b/context/knowledge/gotchas/misc.md
@@ -92,3 +92,8 @@
 - **`dirCompletions` is the shared pure function for directory autocomplete.** Both `QuickAddForm` and `ProjectForm` call it — any change to completion logic (hidden dir filter, symlink resolution, case sensitivity) must be made in `dirCompletions`, not in the per-form `update*AC` wrappers.
 - **`maybeLoadBranches` must expand tildes before passing to `OnBranchFocus`.** `acceptPathAC` calls `collapseTilde`, so the path field contains `~/...`. Go's `exec.Command` doesn't shell-expand `~`, so `cmd.Dir = "~/..."` silently fails. Use `pathValue()` which applies `expandTilde` + `TrimSpace`.
 - **Form field truncation must use rune-based slicing, not byte-based.** The cursor character (U+2588) is 3 bytes in UTF-8. Byte-based `val[len(val)-maxW:]` splits it for paths where `pathLen + 3 > maxW > pathLen`, producing garbled symbols. Use `[]rune` conversion. Affects projectform, backendform, and renametask Draw methods.
+
+## Link Extraction
+
+- **`osc8Re` must run BEFORE `ansiRe` in `stripANSI`.** OSC 8 hyperlinks embed URLs in escape sequences (`\x1b]8;;URL\x1b\\`). If `ansiRe` strips them first, the URLs are lost. The two-pass design in `todolinks.go:stripANSI` is intentional.
+- **`tui2/ansiRe` and `sanitize/ansiRe` must both handle ST-terminated OSC (`\x1b\\`).** Claude Code uses ST (not BEL) for OSC 8 hyperlinks. Missing ST support causes URLs to splice with display text.

--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -11,7 +11,7 @@ Non-obvious invariants and gotchas, split by topic. Read the relevant file when 
 | [gotchas/worktree.md](gotchas/worktree.md) | Worktree creation ordering, cleanup, path validation, stale ref pruning | 9 |
 | [gotchas/keybindings.md](gotchas/keybindings.md) | Key routing, ctrl sequences, tcell modifier quirks, agent view navigation | 12 |
 | [gotchas/tasklist-ui.md](gotchas/tasklist-ui.md) | Task list cursor, modals, focus guards, filter, archive, spinner, row rendering | 25 |
-| [gotchas/misc.md](gotchas/misc.md) | DB patterns, Go idioms, Codex, MCP, todos, PRs, file explorer, vault, quick-add | 60 |
+| [gotchas/misc.md](gotchas/misc.md) | DB patterns, Go idioms, Codex, MCP, todos, PRs, file explorer, vault, quick-add, links | 62 |
 
 ## Other Files
 

--- a/internal/tui2/agentpane.go
+++ b/internal/tui2/agentpane.go
@@ -10,7 +10,8 @@ import (
 )
 
 // ansiRe matches ANSI escape sequences (CSI, OSC, simple escapes).
-var ansiRe = regexp.MustCompile(`\x1b(?:\[[0-9;]*[a-zA-Z]|\][^\x07]*\x07|\[[^\x1b]*|[()][0-9A-B]|[78DEHM])`)
+// OSC sequences are terminated by either BEL (\x07) or ST (\x1b\\).
+var ansiRe = regexp.MustCompile(`\x1b(?:\[[0-9;]*[a-zA-Z]|\][^\x07\x1b]*(?:\x07|\x1b\\)|\[[^\x1b]*|[()][0-9A-B]|[78DEHM])`)
 
 // splitLines strips ANSI escape sequences, then splits the result into
 // display lines, wrapping at maxWidth.

--- a/internal/tui2/agentpane.go
+++ b/internal/tui2/agentpane.go
@@ -11,6 +11,8 @@ import (
 
 // ansiRe matches ANSI escape sequences (CSI, OSC, simple escapes).
 // OSC sequences are terminated by either BEL (\x07) or ST (\x1b\\).
+// NOTE: For link extraction, osc8Re in todolinks.go must run BEFORE ansiRe
+// to preserve URLs embedded in OSC 8 hyperlink tags (ansiRe strips them).
 var ansiRe = regexp.MustCompile(`\x1b(?:\[[0-9;]*[a-zA-Z]|\][^\x07\x1b]*(?:\x07|\x1b\\)|\[[^\x1b]*|[()][0-9A-B]|[78DEHM])`)
 
 // splitLines strips ANSI escape sequences, then splits the result into

--- a/internal/tui2/agentpane_test.go
+++ b/internal/tui2/agentpane_test.go
@@ -18,6 +18,8 @@ func TestSplitLines(t *testing.T) {
 		{"cr-lf", []byte("hello\r\nworld"), 80, 2},
 		{"ansi-stripped", []byte("\x1b[32mhello\x1b[0m\nworld"), 80, 2},
 		{"control-chars", []byte("he\x07llo"), 80, 1},
+		{"osc-bel", []byte("\x1b]0;title\x07text"), 80, 1},
+		{"osc-st", []byte("\x1b]0;title\x1b\\text"), 80, 1},
 	}
 
 	// Verify ANSI escapes are actually removed from content

--- a/internal/tui2/todolinks.go
+++ b/internal/tui2/todolinks.go
@@ -22,11 +22,28 @@ type Link struct {
 var mdLinkRe = regexp.MustCompile(`\[([^\]]+)\]\((https?://[^\s)]+)\)`)
 
 // bareLinkRe matches bare URLs not already inside markdown link syntax.
-var bareLinkRe = regexp.MustCompile(`https?://[^\s)\]>]+`)
+// Excludes control characters (\x00-\x1f) to prevent matching through
+// residual escape sequence bytes.
+var bareLinkRe = regexp.MustCompile(`https?://[^\s)\]>\x00-\x1f]+`)
+
+// osc8Re matches OSC 8 hyperlink tags: \x1b]8;params;URL\x07 or \x1b]8;params;URL\x1b\\
+// Captures the URL in group 1. Opening tags have a non-empty URL; closing tags are empty.
+var osc8Re = regexp.MustCompile(`\x1b\]8;[^;]*;([^\x07\x1b]*)(?:\x07|\x1b\\)`)
 
 // stripANSI removes ANSI escape sequences from raw terminal output.
-// Uses the package-level ansiRe defined in agentpane.go.
+// OSC 8 hyperlink tags are replaced with their embedded URL (+ space separator)
+// so the URL is preserved for extraction. Uses the package-level ansiRe from agentpane.go.
 func stripANSI(s string) string {
+	// First pass: extract URLs from OSC 8 hyperlinks before general stripping.
+	// Opening tags become "URL " (preserving the link target); closing tags
+	// (empty URL) become "" so display text stays separated.
+	s = osc8Re.ReplaceAllStringFunc(s, func(match string) string {
+		sub := osc8Re.FindStringSubmatch(match)
+		if len(sub) > 1 && sub[1] != "" {
+			return sub[1] + " "
+		}
+		return ""
+	})
 	return ansiRe.ReplaceAllString(s, "")
 }
 

--- a/internal/tui2/todolinks.go
+++ b/internal/tui2/todolinks.go
@@ -22,8 +22,8 @@ type Link struct {
 var mdLinkRe = regexp.MustCompile(`\[([^\]]+)\]\((https?://[^\s)]+)\)`)
 
 // bareLinkRe matches bare URLs not already inside markdown link syntax.
-// Excludes control characters (\x00-\x1f) to prevent matching through
-// residual escape sequence bytes.
+// Excludes all ASCII control characters (\x00-\x1f, including \x1b ESC) to
+// prevent matching through residual escape sequence bytes.
 var bareLinkRe = regexp.MustCompile(`https?://[^\s)\]>\x00-\x1f]+`)
 
 // osc8Re matches OSC 8 hyperlink tags: \x1b]8;params;URL\x07 or \x1b]8;params;URL\x1b\\
@@ -36,14 +36,8 @@ var osc8Re = regexp.MustCompile(`\x1b\]8;[^;]*;([^\x07\x1b]*)(?:\x07|\x1b\\)`)
 func stripANSI(s string) string {
 	// First pass: extract URLs from OSC 8 hyperlinks before general stripping.
 	// Opening tags become "URL " (preserving the link target); closing tags
-	// (empty URL) become "" so display text stays separated.
-	s = osc8Re.ReplaceAllStringFunc(s, func(match string) string {
-		sub := osc8Re.FindStringSubmatch(match)
-		if len(sub) > 1 && sub[1] != "" {
-			return sub[1] + " "
-		}
-		return ""
-	})
+	// (empty URL) become just a space — harmless for subsequent URL matching.
+	s = osc8Re.ReplaceAllString(s, "$1 ")
 	return ansiRe.ReplaceAllString(s, "")
 }
 

--- a/internal/tui2/todolinks_test.go
+++ b/internal/tui2/todolinks_test.go
@@ -90,6 +90,8 @@ func TestExtractLinks(t *testing.T) {
 			},
 		},
 		{
+			// Display text ("link") is not preserved as label — only the URL
+			// embedded in the OSC 8 tag is extracted. Dedup with the bare URL.
 			name:    "OSC 8 hyperlink with BEL terminator",
 			content: "\x1b]8;;https://example.com\x07link\x1b]8;;\x07 and https://example.com",
 			want:    []Link{{Label: "https://example.com", URL: "https://example.com"}},

--- a/internal/tui2/todolinks_test.go
+++ b/internal/tui2/todolinks_test.go
@@ -90,9 +90,32 @@ func TestExtractLinks(t *testing.T) {
 			},
 		},
 		{
-			name:    "OSC escape sequences stripped",
+			name:    "OSC 8 hyperlink with BEL terminator",
 			content: "\x1b]8;;https://example.com\x07link\x1b]8;;\x07 and https://example.com",
 			want:    []Link{{Label: "https://example.com", URL: "https://example.com"}},
+		},
+		{
+			name:    "OSC 8 hyperlink with ST terminator",
+			content: "\x1b]8;;https://circleci.com/gh/org/repo/123\x1b\\CircleCI\x1b]8;;\x1b\\",
+			want:    []Link{{Label: "https://circleci.com/gh/org/repo/123", URL: "https://circleci.com/gh/org/repo/123"}},
+		},
+		{
+			name:    "OSC 8 hyperlink URL not spliced with display text",
+			content: "\x1b]8;;https://circleci.com/gh/org/repo/456\x1b\\CircleCI Build\x1b]8;;\x1b\\ passed",
+			want:    []Link{{Label: "https://circleci.com/gh/org/repo/456", URL: "https://circleci.com/gh/org/repo/456"}},
+		},
+		{
+			name:    "multiple OSC 8 hyperlinks",
+			content: "\x1b]8;;https://github.com/org/repo/pull/1\x1b\\PR #1\x1b]8;;\x1b\\ and \x1b]8;;https://circleci.com/gh/org/repo/99\x1b\\CI\x1b]8;;\x1b\\",
+			want: []Link{
+				{Label: "https://github.com/org/repo/pull/1", URL: "https://github.com/org/repo/pull/1"},
+				{Label: "https://circleci.com/gh/org/repo/99", URL: "https://circleci.com/gh/org/repo/99"},
+			},
+		},
+		{
+			name:    "OSC 8 hyperlink with params field",
+			content: "\x1b]8;id=link1;https://example.com/page\x1b\\click here\x1b]8;;\x1b\\",
+			want:    []Link{{Label: "https://example.com/page", URL: "https://example.com/page"}},
 		},
 	}
 


### PR DESCRIPTION
OSC 8 hyperlinks (ST-terminated) leaked through ANSI stripping, causing URLs to splice with display text in the link picker. Pre-process OSC 8 tags to extract embedded URLs, update ansiRe to handle ST terminator, exclude control chars from bare URL regex.

Co-Authored-By: Claude <noreply@anthropic.com>