### PR TITLE
Allow configuration of Argus and Metis vault paths in settings

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -1151,7 +1151,7 @@ func (a *App) handleGlobalKey(event *tcell.EventKey) *tcell.EventKey {
 		if a.mode == modeTaskList && a.tasklist.Filtering() {
 			break
 		}
-		if a.mode == modeTaskList && a.settings.IsEditingPrompt() {
+		if a.mode == modeTaskList && a.settings.IsEditing() {
 			break
 		}
 		switch event.Rune() {

--- a/internal/tui2/settings.go
+++ b/internal/tui2/settings.go
@@ -69,6 +69,9 @@ type SettingsView struct {
 	kbEnabled          bool
 	metisVaultPath     string
 	argusVaultPath     string
+	metisVaultAtBoot   string // value when daemon started; used to show "restart required"
+	argusVaultAtBoot   string
+	vaultBootRecorded  bool   // true after first Refresh captures boot values
 	kbTaskSync         bool
 	autoStartTodos     bool
 	autoStartInterval  int
@@ -185,6 +188,11 @@ func (sv *SettingsView) Refresh() {
 	sv.kbEnabled = cfg.KB.Enabled
 	sv.metisVaultPath = cfg.KB.MetisVaultPath
 	sv.argusVaultPath = cfg.KB.ArgusVaultPath
+	if !sv.vaultBootRecorded {
+		sv.metisVaultAtBoot = cfg.KB.MetisVaultPath
+		sv.argusVaultAtBoot = cfg.KB.ArgusVaultPath
+		sv.vaultBootRecorded = true
+	}
 	sv.kbTaskSync = cfg.KB.AutoCreateTasks
 	sv.autoStartTodos = cfg.KB.AutoStartTodos
 	sv.autoStartInterval = cfg.KB.AutoStartInterval
@@ -314,6 +322,9 @@ func (sv *SettingsView) rebuildRows() {
 	} else if sv.metisVaultPath == "" {
 		metisLabel = "  Metis: (not configured)"
 	}
+	if sv.vaultBootRecorded && sv.metisVaultPath != sv.metisVaultAtBoot {
+		metisLabel += " (restart required)"
+	}
 	sv.rows = append(sv.rows, settingsRow{kind: srVaultPath, label: metisLabel, key: "_metis_vault"})
 
 	argusLabel := "  Argus: " + sv.argusVaultPath
@@ -321,6 +332,9 @@ func (sv *SettingsView) rebuildRows() {
 		argusLabel = "  Argus: " + sv.editVaultBuf + "▎"
 	} else if sv.argusVaultPath == "" {
 		argusLabel = "  Argus: (not configured)"
+	}
+	if sv.vaultBootRecorded && sv.argusVaultPath != sv.argusVaultAtBoot {
+		argusLabel += " (restart required)"
 	}
 	sv.rows = append(sv.rows, settingsRow{kind: srVaultPath, label: argusLabel, key: "_argus_vault"})
 
@@ -415,10 +429,6 @@ func (sv *SettingsView) IsEditing() bool {
 	return sv.editingPrompt || sv.editingVault != ""
 }
 
-// IsEditingPrompt returns true when the user is inline-editing the review prompt.
-func (sv *SettingsView) IsEditingPrompt() bool {
-	return sv.editingPrompt
-}
 
 // SelectedProject returns the project at the cursor, or nil.
 func (sv *SettingsView) SelectedProject() *projectEntry {
@@ -634,7 +644,7 @@ func (sv *SettingsView) handleEnter() bool {
 		sv.editingVault = row.key
 		if row.key == "_metis_vault" {
 			sv.editVaultBuf = sv.metisVaultPath
-		} else {
+		} else if row.key == "_argus_vault" {
 			sv.editVaultBuf = sv.argusVaultPath
 		}
 		sv.rebuildRows()
@@ -773,7 +783,7 @@ func (sv *SettingsView) handleEditVaultKey(ev *tcell.EventKey) bool {
 				uxlog.Log("[settings] failed to persist metis vault path: %v", err)
 			}
 			uxlog.Log("[settings] metis vault path set to %q", path)
-		} else {
+		} else if key == "_argus_vault" {
 			sv.argusVaultPath = path
 			if err := sv.database.SetConfigValue("kb.argus_vault_path", path); err != nil {
 				uxlog.Log("[settings] failed to persist argus vault path: %v", err)
@@ -1338,6 +1348,7 @@ func (sv *SettingsView) SetDaemonRestarting(restarting bool) {
 	if !restarting {
 		// Daemon just came back — re-capture boot state on next Refresh.
 		sv.apiBootRecorded = false
+		sv.vaultBootRecorded = false
 	}
 	sv.rebuildRows()
 }

--- a/internal/tui2/settings.go
+++ b/internal/tui2/settings.go
@@ -34,6 +34,7 @@ const (
 	srAPI
 	srDaemon
 	srSpinner
+	srVaultPath
 )
 
 // settingsRow is a single row in the settings section list.
@@ -89,6 +90,10 @@ type SettingsView struct {
 	reviewPrompt    string // current review prompt template
 	editingPrompt   bool   // true when inline-editing the review prompt
 	editPromptBuf   string // buffer for in-progress edit
+
+	// Vault path editing.
+	editingVault   string // which vault is being edited: "_metis_vault" or "_argus_vault", or "" if not editing
+	editVaultBuf   string // buffer for in-progress vault path edit
 
 	// Logs detail scroll.
 	logScrollOff int
@@ -302,6 +307,23 @@ func (sv *SettingsView) rebuildRows() {
 	}
 	sv.rows = append(sv.rows, settingsRow{kind: srKB, label: kbLabel, key: "_kb"})
 
+	// Vault path rows.
+	metisLabel := "  Metis: " + sv.metisVaultPath
+	if sv.editingVault == "_metis_vault" {
+		metisLabel = "  Metis: " + sv.editVaultBuf + "▎"
+	} else if sv.metisVaultPath == "" {
+		metisLabel = "  Metis: (not configured)"
+	}
+	sv.rows = append(sv.rows, settingsRow{kind: srVaultPath, label: metisLabel, key: "_metis_vault"})
+
+	argusLabel := "  Argus: " + sv.argusVaultPath
+	if sv.editingVault == "_argus_vault" {
+		argusLabel = "  Argus: " + sv.editVaultBuf + "▎"
+	} else if sv.argusVaultPath == "" {
+		argusLabel = "  Argus: (not configured)"
+	}
+	sv.rows = append(sv.rows, settingsRow{kind: srVaultPath, label: argusLabel, key: "_argus_vault"})
+
 	// API section.
 	sv.rows = append(sv.rows, settingsRow{kind: srSection, label: "Remote API"})
 	apiLabel := "  Disabled"
@@ -372,15 +394,25 @@ func (sv *SettingsView) SelectedRow() *settingsRow {
 	return nil
 }
 
-// PasteHandler implements tview's paste interface for the inline prompt editor.
+// PasteHandler implements tview's paste interface for inline editors.
 func (sv *SettingsView) PasteHandler() func(pastedText string, setFocus func(p tview.Primitive)) {
 	return sv.WrapPasteHandler(func(pastedText string, setFocus func(p tview.Primitive)) {
-		if !sv.editingPrompt || pastedText == "" {
+		if pastedText == "" {
 			return
 		}
-		sv.editPromptBuf += pastedText
-		sv.rebuildRows()
+		if sv.editingPrompt {
+			sv.editPromptBuf += pastedText
+			sv.rebuildRows()
+		} else if sv.editingVault != "" {
+			sv.editVaultBuf += pastedText
+			sv.rebuildRows()
+		}
 	})
+}
+
+// IsEditing returns true when the user is inline-editing any field.
+func (sv *SettingsView) IsEditing() bool {
+	return sv.editingPrompt || sv.editingVault != ""
 }
 
 // IsEditingPrompt returns true when the user is inline-editing the review prompt.
@@ -421,6 +453,9 @@ func (sv *SettingsView) SelectedBackend() *backendEntry {
 func (sv *SettingsView) HandleKey(ev *tcell.EventKey) bool {
 	if sv.editingPrompt {
 		return sv.handleEditPromptKey(ev)
+	}
+	if sv.editingVault != "" {
+		return sv.handleEditVaultKey(ev)
 	}
 	switch ev.Key() {
 	case tcell.KeyUp:
@@ -594,6 +629,16 @@ func (sv *SettingsView) handleEnter() bool {
 	case srSpinner:
 		sv.cycleSpinner(1)
 		return true
+	case srVaultPath:
+		// Start inline editing for the selected vault path.
+		sv.editingVault = row.key
+		if row.key == "_metis_vault" {
+			sv.editVaultBuf = sv.metisVaultPath
+		} else {
+			sv.editVaultBuf = sv.argusVaultPath
+		}
+		sv.rebuildRows()
+		return true
 	case srReviewPrompt:
 		sv.editingPrompt = true
 		sv.editPromptBuf = sv.reviewPrompt
@@ -709,6 +754,47 @@ func (sv *SettingsView) handleEditPromptKey(ev *tcell.EventKey) bool {
 		return true
 	case tcell.KeyRune:
 		sv.editPromptBuf += string(ev.Rune())
+		sv.rebuildRows()
+		return true
+	}
+	return false
+}
+
+// handleEditVaultKey handles keystrokes while inline-editing a vault path.
+func (sv *SettingsView) handleEditVaultKey(ev *tcell.EventKey) bool {
+	switch ev.Key() {
+	case tcell.KeyEnter:
+		path := sv.editVaultBuf
+		key := sv.editingVault
+		sv.editingVault = ""
+		if key == "_metis_vault" {
+			sv.metisVaultPath = path
+			if err := sv.database.SetConfigValue("kb.metis_vault_path", path); err != nil {
+				uxlog.Log("[settings] failed to persist metis vault path: %v", err)
+			}
+			uxlog.Log("[settings] metis vault path set to %q", path)
+		} else {
+			sv.argusVaultPath = path
+			if err := sv.database.SetConfigValue("kb.argus_vault_path", path); err != nil {
+				uxlog.Log("[settings] failed to persist argus vault path: %v", err)
+			}
+			uxlog.Log("[settings] argus vault path set to %q", path)
+		}
+		sv.rebuildRows()
+		return true
+	case tcell.KeyEscape:
+		sv.editingVault = ""
+		sv.rebuildRows()
+		return true
+	case tcell.KeyBackspace, tcell.KeyBackspace2:
+		if len(sv.editVaultBuf) > 0 {
+			_, size := utf8.DecodeLastRuneInString(sv.editVaultBuf)
+			sv.editVaultBuf = sv.editVaultBuf[:len(sv.editVaultBuf)-size]
+			sv.rebuildRows()
+		}
+		return true
+	case tcell.KeyRune:
+		sv.editVaultBuf += string(ev.Rune())
 		sv.rebuildRows()
 		return true
 	}
@@ -856,6 +942,8 @@ func (sv *SettingsView) renderDetail(screen tcell.Screen, x, y, w, h int) {
 		sv.renderBackendDetail(screen, innerX, innerY, innerW, innerH, row)
 	case srKB:
 		sv.renderKBDetail(screen, innerX, innerY, innerW, innerH)
+	case srVaultPath:
+		sv.renderVaultPathDetail(screen, innerX, innerY, innerW, innerH, row)
 	case srToDoProject:
 		sv.renderToDoProjectDetail(screen, innerX, innerY, innerW, innerH)
 	case srSpinner:
@@ -1106,6 +1194,42 @@ func (sv *SettingsView) renderKBDetail(screen tcell.Screen, x, y, w, h int) {
 
 	if r < h {
 		drawText(screen, x, y+r, w, "[enter] toggle KB  [a] toggle auto-start", StyleDimmed)
+	}
+}
+
+func (sv *SettingsView) renderVaultPathDetail(screen tcell.Screen, x, y, w, h int, row *settingsRow) {
+	isMetis := row.key == "_metis_vault"
+	title := "Argus Vault"
+	path := sv.argusVaultPath
+	desc := "Obsidian vault for task syncing."
+	if isMetis {
+		title = "Metis Vault"
+		path = sv.metisVaultPath
+		desc = "Obsidian vault for KB indexing."
+	}
+
+	drawText(screen, x, y, w, title, StyleTitle)
+	r := 2
+
+	display := path
+	editing := sv.editingVault == row.key
+	if editing {
+		display = sv.editVaultBuf + "▎"
+	} else if display == "" {
+		display = "(not configured)"
+	}
+	drawText(screen, x, y+r, w, display, tcell.StyleDefault.Foreground(ColorComplete))
+	r += 2
+
+	drawText(screen, x, y+r, w, desc, StyleDimmed)
+	r += 2
+
+	if r < h {
+		if editing {
+			drawText(screen, x, y+r, w, "[enter] save  [esc] cancel", StyleDimmed)
+		} else {
+			drawText(screen, x, y+r, w, "[enter] edit path", StyleDimmed)
+		}
 	}
 }
 

--- a/internal/tui2/settings_test.go
+++ b/internal/tui2/settings_test.go
@@ -871,8 +871,12 @@ func TestSettingsView_VaultPathEdit(t *testing.T) {
 	sv.Refresh()
 
 	// Verify default paths are populated from DB seed.
-	testutil.Contains(t, sv.metisVaultPath, "Metis")
-	testutil.Contains(t, sv.argusVaultPath, "Argus")
+	if sv.metisVaultPath == "" {
+		t.Fatal("metisVaultPath should be populated from DB seed")
+	}
+	if sv.argusVaultPath == "" {
+		t.Fatal("argusVaultPath should be populated from DB seed")
+	}
 
 	// Verify vault path rows exist.
 	metisIdx := -1
@@ -972,6 +976,51 @@ func TestSettingsView_VaultPathEdit(t *testing.T) {
 		testutil.Contains(t, sv.editVaultBuf, "q")
 
 		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
+	})
+}
+
+func TestSettingsView_VaultPathRestartHint(t *testing.T) {
+	database, _ := db.OpenInMemory()
+	sv := NewSettingsView(database)
+	sv.Refresh()
+
+	vaultLabel := func(key string) string {
+		for _, row := range sv.rows {
+			if row.kind == srVaultPath && row.key == key {
+				return row.label
+			}
+		}
+		return ""
+	}
+
+	t.Run("no hint initially", func(t *testing.T) {
+		label := vaultLabel("_metis_vault")
+		if strings.Contains(label, "(restart required)") {
+			t.Errorf("should not show restart hint initially, got %q", label)
+		}
+	})
+
+	t.Run("hint appears after edit", func(t *testing.T) {
+		for i, row := range sv.rows {
+			if row.kind == srVaultPath && row.key == "_metis_vault" {
+				sv.cursor = i
+				break
+			}
+		}
+		sv.handleEnter()
+		sv.editVaultBuf = "/changed/path"
+		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+		testutil.Contains(t, vaultLabel("_metis_vault"), "(restart required)")
+	})
+
+	t.Run("hint clears after daemon restart", func(t *testing.T) {
+		sv.SetDaemonRestarting(false)
+		testutil.Equal(t, sv.vaultBootRecorded, false)
+		sv.Refresh()
+		label := vaultLabel("_metis_vault")
+		if strings.Contains(label, "(restart required)") {
+			t.Errorf("hint should clear after restart + refresh, got %q", label)
+		}
 	})
 }
 

--- a/internal/tui2/settings_test.go
+++ b/internal/tui2/settings_test.go
@@ -862,6 +862,119 @@ func TestSettingsView_AutoStartToggle(t *testing.T) {
 	})
 }
 
+func TestSettingsView_VaultPathEdit(t *testing.T) {
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sv := NewSettingsView(database)
+	sv.Refresh()
+
+	// Verify default paths are populated from DB seed.
+	testutil.Contains(t, sv.metisVaultPath, "Metis")
+	testutil.Contains(t, sv.argusVaultPath, "Argus")
+
+	// Verify vault path rows exist.
+	metisIdx := -1
+	argusIdx := -1
+	for i, row := range sv.rows {
+		if row.kind == srVaultPath && row.key == "_metis_vault" {
+			metisIdx = i
+		}
+		if row.kind == srVaultPath && row.key == "_argus_vault" {
+			argusIdx = i
+		}
+	}
+	if metisIdx < 0 {
+		t.Fatal("no metis vault path row found")
+	}
+	if argusIdx < 0 {
+		t.Fatal("no argus vault path row found")
+	}
+
+	t.Run("enter starts editing metis", func(t *testing.T) {
+		sv.cursor = metisIdx
+		sv.handleEnter()
+		testutil.Equal(t, sv.editingVault, "_metis_vault")
+		testutil.Equal(t, sv.editVaultBuf, sv.metisVaultPath)
+		testutil.Equal(t, sv.IsEditing(), true)
+	})
+
+	t.Run("escape cancels without saving", func(t *testing.T) {
+		origPath := sv.metisVaultPath
+		sv.editVaultBuf = "/some/other/path"
+		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
+		testutil.Equal(t, sv.editingVault, "")
+		testutil.Equal(t, sv.metisVaultPath, origPath) // unchanged
+		testutil.Equal(t, sv.IsEditing(), false)
+	})
+
+	t.Run("typing appends to buffer", func(t *testing.T) {
+		// Re-find row after rebuild.
+		for i, row := range sv.rows {
+			if row.kind == srVaultPath && row.key == "_metis_vault" {
+				sv.cursor = i
+				break
+			}
+		}
+		sv.handleEnter()
+		sv.editVaultBuf = "/new"
+		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyRune, '/', tcell.ModNone))
+		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyRune, 'p', tcell.ModNone))
+		testutil.Equal(t, sv.editVaultBuf, "/new/p")
+	})
+
+	t.Run("backspace removes last rune", func(t *testing.T) {
+		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModNone))
+		testutil.Equal(t, sv.editVaultBuf, "/new/")
+	})
+
+	t.Run("enter saves metis and persists", func(t *testing.T) {
+		sv.editVaultBuf = "/custom/metis/vault"
+		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+		testutil.Equal(t, sv.editingVault, "")
+		testutil.Equal(t, sv.metisVaultPath, "/custom/metis/vault")
+
+		cfg := database.Config()
+		testutil.Equal(t, cfg.KB.MetisVaultPath, "/custom/metis/vault")
+	})
+
+	t.Run("enter saves argus and persists", func(t *testing.T) {
+		for i, row := range sv.rows {
+			if row.kind == srVaultPath && row.key == "_argus_vault" {
+				sv.cursor = i
+				break
+			}
+		}
+		sv.handleEnter()
+		testutil.Equal(t, sv.editingVault, "_argus_vault")
+		sv.editVaultBuf = "/custom/argus/vault"
+		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+		testutil.Equal(t, sv.argusVaultPath, "/custom/argus/vault")
+
+		cfg := database.Config()
+		testutil.Equal(t, cfg.KB.ArgusVaultPath, "/custom/argus/vault")
+	})
+
+	t.Run("vault editing blocks global keys", func(t *testing.T) {
+		for i, row := range sv.rows {
+			if row.kind == srVaultPath && row.key == "_metis_vault" {
+				sv.cursor = i
+				break
+			}
+		}
+		sv.handleEnter()
+		testutil.Equal(t, sv.IsEditing(), true)
+
+		// 'q' should be captured as a rune, not trigger quit.
+		handled := sv.HandleKey(tcell.NewEventKey(tcell.KeyRune, 'q', tcell.ModNone))
+		testutil.Equal(t, handled, true)
+		testutil.Contains(t, sv.editVaultBuf, "q")
+
+		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
+	})
+}
+
 // findProjectEntry locates a project in the settings view by name.
 func findProjectEntry(t *testing.T, sv *SettingsView, name string) *projectEntry {
 	t.Helper()


### PR DESCRIPTION
Add inline editing for vault directory paths in the KB settings section. Paths show a (restart required) hint when changed from daemon boot values, following the existing API toggle pattern.

Co-Authored-By: Claude <noreply@anthropic.com>