### PR TITLE
Add iCloud Obsidian vault discovery with cycle selector in settings

### DIFF
--- a/internal/config/discover.go
+++ b/internal/config/discover.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// DiscoverICloudVaults scans the iCloud Obsidian base directory for vaults.
+// A vault is identified by having a .obsidian/ subdirectory.
+// Returns sorted absolute paths. Returns nil if the base directory does not exist.
+func DiscoverICloudVaults() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return discoverVaultsIn(filepath.Join(home, iCloudObsidianBase))
+}
+
+// discoverVaultsIn scans a base directory for Obsidian vaults. Checks the base
+// itself and its immediate (non-hidden) children for a .obsidian/ subdirectory.
+// Returns sorted absolute paths. Returns nil if base doesn't exist or has no vaults.
+func discoverVaultsIn(base string) []string {
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return nil
+	}
+
+	var vaults []string
+
+	// Check if the base itself is a vault.
+	if isVault(base) {
+		vaults = append(vaults, base)
+	}
+
+	// Check immediate children.
+	for _, e := range entries {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		child := filepath.Join(base, e.Name())
+		if isVault(child) {
+			vaults = append(vaults, child)
+		}
+	}
+
+	if len(vaults) == 0 {
+		return nil
+	}
+	sort.Strings(vaults)
+	return vaults
+}
+
+// isVault returns true if dir contains a .obsidian/ subdirectory.
+func isVault(dir string) bool {
+	info, err := os.Stat(filepath.Join(dir, ".obsidian"))
+	return err == nil && info.IsDir()
+}

--- a/internal/config/discover.go
+++ b/internal/config/discover.go
@@ -29,7 +29,8 @@ func discoverVaultsIn(base string) []string {
 
 	var vaults []string
 
-	// Check if the base itself is a vault.
+	// Check if the base itself is a vault (the Documents root can be a vault
+	// while also containing child vaults as subdirectories).
 	if isVault(base) {
 		vaults = append(vaults, base)
 	}

--- a/internal/config/discover_test.go
+++ b/internal/config/discover_test.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/drn/argus/internal/testutil"
+)
+
+func TestDiscoverVaultsIn(t *testing.T) {
+	t.Run("discovers child vaults with .obsidian subdir", func(t *testing.T) {
+		base := t.TempDir()
+		os.MkdirAll(filepath.Join(base, "MyVault", ".obsidian"), 0o755)
+
+		got := discoverVaultsIn(base)
+		testutil.DeepEqual(t, got, []string{filepath.Join(base, "MyVault")})
+	})
+
+	t.Run("discovers root vault", func(t *testing.T) {
+		base := t.TempDir()
+		os.MkdirAll(filepath.Join(base, ".obsidian"), 0o755)
+
+		got := discoverVaultsIn(base)
+		testutil.DeepEqual(t, got, []string{base})
+	})
+
+	t.Run("discovers root and child vaults", func(t *testing.T) {
+		base := t.TempDir()
+		os.MkdirAll(filepath.Join(base, ".obsidian"), 0o755)
+		os.MkdirAll(filepath.Join(base, "Argus", ".obsidian"), 0o755)
+		os.MkdirAll(filepath.Join(base, "Metis", ".obsidian"), 0o755)
+
+		got := discoverVaultsIn(base)
+		testutil.DeepEqual(t, got, []string{
+			base,
+			filepath.Join(base, "Argus"),
+			filepath.Join(base, "Metis"),
+		})
+	})
+
+	t.Run("skips dirs without .obsidian", func(t *testing.T) {
+		base := t.TempDir()
+		os.MkdirAll(filepath.Join(base, "NotAVault"), 0o755)
+		os.MkdirAll(filepath.Join(base, "IsAVault", ".obsidian"), 0o755)
+
+		got := discoverVaultsIn(base)
+		testutil.DeepEqual(t, got, []string{filepath.Join(base, "IsAVault")})
+	})
+
+	t.Run("skips hidden directories", func(t *testing.T) {
+		base := t.TempDir()
+		os.MkdirAll(filepath.Join(base, ".hidden", ".obsidian"), 0o755)
+		os.MkdirAll(filepath.Join(base, "Visible", ".obsidian"), 0o755)
+
+		got := discoverVaultsIn(base)
+		testutil.DeepEqual(t, got, []string{filepath.Join(base, "Visible")})
+	})
+
+	t.Run("returns nil for nonexistent base", func(t *testing.T) {
+		got := discoverVaultsIn("/nonexistent/path/that/does/not/exist")
+		testutil.Nil(t, got)
+	})
+
+	t.Run("returns sorted results", func(t *testing.T) {
+		base := t.TempDir()
+		os.MkdirAll(filepath.Join(base, "Zebra", ".obsidian"), 0o755)
+		os.MkdirAll(filepath.Join(base, "Alpha", ".obsidian"), 0o755)
+		os.MkdirAll(filepath.Join(base, "Middle", ".obsidian"), 0o755)
+
+		got := discoverVaultsIn(base)
+		testutil.DeepEqual(t, got, []string{
+			filepath.Join(base, "Alpha"),
+			filepath.Join(base, "Middle"),
+			filepath.Join(base, "Zebra"),
+		})
+	})
+
+	t.Run("empty base directory returns nil", func(t *testing.T) {
+		base := t.TempDir()
+
+		got := discoverVaultsIn(base)
+		testutil.Nil(t, got)
+	})
+
+	t.Run("skips files not directories", func(t *testing.T) {
+		base := t.TempDir()
+		os.WriteFile(filepath.Join(base, "file.md"), []byte("hi"), 0o644)
+		os.MkdirAll(filepath.Join(base, "Vault", ".obsidian"), 0o755)
+
+		got := discoverVaultsIn(base)
+		testutil.DeepEqual(t, got, []string{filepath.Join(base, "Vault")})
+	})
+}

--- a/internal/tui2/settings.go
+++ b/internal/tui2/settings.go
@@ -95,8 +95,9 @@ type SettingsView struct {
 	editPromptBuf   string // buffer for in-progress edit
 
 	// Vault path editing.
-	editingVault   string // which vault is being edited: "_metis_vault" or "_argus_vault", or "" if not editing
-	editVaultBuf   string // buffer for in-progress vault path edit
+	editingVault     string   // which vault is being edited: "_metis_vault" or "_argus_vault", or "" if not editing
+	editVaultBuf     string   // buffer for in-progress vault path edit
+	discoveredVaults []string // sorted absolute paths of discovered iCloud Obsidian vaults
 
 	// Logs detail scroll.
 	logScrollOff int
@@ -193,6 +194,8 @@ func (sv *SettingsView) Refresh() {
 		sv.argusVaultAtBoot = cfg.KB.ArgusVaultPath
 		sv.vaultBootRecorded = true
 	}
+	sv.discoveredVaults = config.DiscoverICloudVaults()
+	uxlog.Log("[settings] discovered %d iCloud vaults", len(sv.discoveredVaults))
 	sv.kbTaskSync = cfg.KB.AutoCreateTasks
 	sv.autoStartTodos = cfg.KB.AutoStartTodos
 	sv.autoStartInterval = cfg.KB.AutoStartInterval
@@ -482,6 +485,9 @@ func (sv *SettingsView) HandleKey(ev *tcell.EventKey) bool {
 		case srSpinner:
 			sv.cycleSpinner(-1)
 			return true
+		case srVaultPath:
+			sv.cycleVaultPath(-1)
+			return true
 		}
 		return false
 	case tcell.KeyRight:
@@ -491,6 +497,9 @@ func (sv *SettingsView) HandleKey(ev *tcell.EventKey) bool {
 			return true
 		case srSpinner:
 			sv.cycleSpinner(1)
+			return true
+		case srVaultPath:
+			sv.cycleVaultPath(1)
 			return true
 		}
 		return false
@@ -851,6 +860,57 @@ func (sv *SettingsView) cycleSpinner(dir int) {
 	}
 	model.SetActiveSpinner(sv.spinnerStyle)
 	uxlog.Log("[settings] spinner style set to %q", sv.spinnerStyle)
+	sv.rebuildRows()
+}
+
+// cycleVaultPath cycles the vault path forward or backward through discovered iCloud vaults.
+func (sv *SettingsView) cycleVaultPath(dir int) {
+	if len(sv.discoveredVaults) == 0 {
+		return
+	}
+	row := sv.SelectedRow()
+	if row == nil || row.kind != srVaultPath {
+		return
+	}
+
+	currentPath := sv.argusVaultPath
+	dbKey := "kb.argus_vault_path"
+	if row.key == "_metis_vault" {
+		currentPath = sv.metisVaultPath
+		dbKey = "kb.metis_vault_path"
+	}
+
+	// Find current index in discovered vaults.
+	idx := -1
+	for i, v := range sv.discoveredVaults {
+		if v == currentPath {
+			idx = i
+			break
+		}
+	}
+
+	// Cycle. If current path not in list, start at first (forward) or last (backward).
+	n := len(sv.discoveredVaults)
+	if idx < 0 {
+		if dir > 0 {
+			idx = 0
+		} else {
+			idx = n - 1
+		}
+	} else {
+		idx = (idx + dir + n) % n
+	}
+
+	newPath := sv.discoveredVaults[idx]
+	if row.key == "_metis_vault" {
+		sv.metisVaultPath = newPath
+	} else {
+		sv.argusVaultPath = newPath
+	}
+	if err := sv.database.SetConfigValue(dbKey, newPath); err != nil {
+		uxlog.Log("[settings] failed to persist vault path: %v", err)
+	}
+	uxlog.Log("[settings] %s cycled to %q", dbKey, newPath)
 	sv.rebuildRows()
 }
 
@@ -1234,9 +1294,31 @@ func (sv *SettingsView) renderVaultPathDetail(screen tcell.Screen, x, y, w, h in
 	drawText(screen, x, y+r, w, desc, StyleDimmed)
 	r += 2
 
+	// List discovered vaults (like spinner detail lists available styles).
+	if !editing && len(sv.discoveredVaults) > 0 {
+		drawText(screen, x, y+r, w, "Discovered iCloud vaults:", tcell.StyleDefault.Foreground(ColorTitle))
+		r++
+		for _, v := range sv.discoveredVaults {
+			if r >= h-1 {
+				break
+			}
+			home, _ := os.UserHomeDir()
+			label := "  " + strings.TrimPrefix(v, home)
+			style := StyleDimmed
+			if v == path {
+				style = tcell.StyleDefault.Foreground(ColorSelected).Bold(true)
+			}
+			drawText(screen, x, y+r, w, label, style)
+			r++
+		}
+		r++
+	}
+
 	if r < h {
 		if editing {
 			drawText(screen, x, y+r, w, "[enter] save  [esc] cancel", StyleDimmed)
+		} else if len(sv.discoveredVaults) > 0 {
+			drawText(screen, x, y+r, w, "[enter] edit path  [◀/▶] cycle vaults", StyleDimmed)
 		} else {
 			drawText(screen, x, y+r, w, "[enter] edit path", StyleDimmed)
 		}

--- a/internal/tui2/settings.go
+++ b/internal/tui2/settings.go
@@ -37,6 +37,12 @@ const (
 	srVaultPath
 )
 
+// Vault key constants used in settingsRow.key for vault path rows.
+const (
+	vaultKeyMetis = "_metis_vault"
+	vaultKeyArgus = "_argus_vault"
+)
+
 // settingsRow is a single row in the settings section list.
 type settingsRow struct {
 	kind  settingsRowKind
@@ -95,7 +101,7 @@ type SettingsView struct {
 	editPromptBuf   string // buffer for in-progress edit
 
 	// Vault path editing.
-	editingVault     string   // which vault is being edited: "_metis_vault" or "_argus_vault", or "" if not editing
+	editingVault     string   // which vault is being edited: vaultKeyMetis or vaultKeyArgus, or "" if not editing
 	editVaultBuf     string   // buffer for in-progress vault path edit
 	discoveredVaults []string // sorted absolute paths of discovered iCloud Obsidian vaults
 
@@ -194,8 +200,11 @@ func (sv *SettingsView) Refresh() {
 		sv.argusVaultAtBoot = cfg.KB.ArgusVaultPath
 		sv.vaultBootRecorded = true
 	}
-	sv.discoveredVaults = config.DiscoverICloudVaults()
-	uxlog.Log("[settings] discovered %d iCloud vaults", len(sv.discoveredVaults))
+	// Discover vaults once — filesystem scan is blocking I/O, avoid on every Refresh.
+	if sv.discoveredVaults == nil {
+		sv.discoveredVaults = config.DiscoverICloudVaults()
+		uxlog.Log("[settings] discovered %d iCloud vaults", len(sv.discoveredVaults))
+	}
 	sv.kbTaskSync = cfg.KB.AutoCreateTasks
 	sv.autoStartTodos = cfg.KB.AutoStartTodos
 	sv.autoStartInterval = cfg.KB.AutoStartInterval
@@ -320,7 +329,7 @@ func (sv *SettingsView) rebuildRows() {
 
 	// Vault path rows.
 	metisLabel := "  Metis: " + sv.metisVaultPath
-	if sv.editingVault == "_metis_vault" {
+	if sv.editingVault == vaultKeyMetis {
 		metisLabel = "  Metis: " + sv.editVaultBuf + "▎"
 	} else if sv.metisVaultPath == "" {
 		metisLabel = "  Metis: (not configured)"
@@ -328,10 +337,10 @@ func (sv *SettingsView) rebuildRows() {
 	if sv.vaultBootRecorded && sv.metisVaultPath != sv.metisVaultAtBoot {
 		metisLabel += " (restart required)"
 	}
-	sv.rows = append(sv.rows, settingsRow{kind: srVaultPath, label: metisLabel, key: "_metis_vault"})
+	sv.rows = append(sv.rows, settingsRow{kind: srVaultPath, label: metisLabel, key: vaultKeyMetis})
 
 	argusLabel := "  Argus: " + sv.argusVaultPath
-	if sv.editingVault == "_argus_vault" {
+	if sv.editingVault == vaultKeyArgus {
 		argusLabel = "  Argus: " + sv.editVaultBuf + "▎"
 	} else if sv.argusVaultPath == "" {
 		argusLabel = "  Argus: (not configured)"
@@ -339,7 +348,7 @@ func (sv *SettingsView) rebuildRows() {
 	if sv.vaultBootRecorded && sv.argusVaultPath != sv.argusVaultAtBoot {
 		argusLabel += " (restart required)"
 	}
-	sv.rows = append(sv.rows, settingsRow{kind: srVaultPath, label: argusLabel, key: "_argus_vault"})
+	sv.rows = append(sv.rows, settingsRow{kind: srVaultPath, label: argusLabel, key: vaultKeyArgus})
 
 	// API section.
 	sv.rows = append(sv.rows, settingsRow{kind: srSection, label: "Remote API"})
@@ -651,9 +660,9 @@ func (sv *SettingsView) handleEnter() bool {
 	case srVaultPath:
 		// Start inline editing for the selected vault path.
 		sv.editingVault = row.key
-		if row.key == "_metis_vault" {
+		if row.key == vaultKeyMetis {
 			sv.editVaultBuf = sv.metisVaultPath
-		} else if row.key == "_argus_vault" {
+		} else if row.key == vaultKeyArgus {
 			sv.editVaultBuf = sv.argusVaultPath
 		}
 		sv.rebuildRows()
@@ -786,13 +795,13 @@ func (sv *SettingsView) handleEditVaultKey(ev *tcell.EventKey) bool {
 		path := sv.editVaultBuf
 		key := sv.editingVault
 		sv.editingVault = ""
-		if key == "_metis_vault" {
+		if key == vaultKeyMetis {
 			sv.metisVaultPath = path
 			if err := sv.database.SetConfigValue("kb.metis_vault_path", path); err != nil {
 				uxlog.Log("[settings] failed to persist metis vault path: %v", err)
 			}
 			uxlog.Log("[settings] metis vault path set to %q", path)
-		} else if key == "_argus_vault" {
+		} else if key == vaultKeyArgus {
 			sv.argusVaultPath = path
 			if err := sv.database.SetConfigValue("kb.argus_vault_path", path); err != nil {
 				uxlog.Log("[settings] failed to persist argus vault path: %v", err)
@@ -875,7 +884,7 @@ func (sv *SettingsView) cycleVaultPath(dir int) {
 
 	currentPath := sv.argusVaultPath
 	dbKey := "kb.argus_vault_path"
-	if row.key == "_metis_vault" {
+	if row.key == vaultKeyMetis {
 		currentPath = sv.metisVaultPath
 		dbKey = "kb.metis_vault_path"
 	}
@@ -902,7 +911,7 @@ func (sv *SettingsView) cycleVaultPath(dir int) {
 	}
 
 	newPath := sv.discoveredVaults[idx]
-	if row.key == "_metis_vault" {
+	if row.key == vaultKeyMetis {
 		sv.metisVaultPath = newPath
 	} else {
 		sv.argusVaultPath = newPath
@@ -1268,7 +1277,7 @@ func (sv *SettingsView) renderKBDetail(screen tcell.Screen, x, y, w, h int) {
 }
 
 func (sv *SettingsView) renderVaultPathDetail(screen tcell.Screen, x, y, w, h int, row *settingsRow) {
-	isMetis := row.key == "_metis_vault"
+	isMetis := row.key == vaultKeyMetis
 	title := "Argus Vault"
 	path := sv.argusVaultPath
 	desc := "Obsidian vault for task syncing."
@@ -1298,11 +1307,11 @@ func (sv *SettingsView) renderVaultPathDetail(screen tcell.Screen, x, y, w, h in
 	if !editing && len(sv.discoveredVaults) > 0 {
 		drawText(screen, x, y+r, w, "Discovered iCloud vaults:", tcell.StyleDefault.Foreground(ColorTitle))
 		r++
+		home, _ := os.UserHomeDir()
 		for _, v := range sv.discoveredVaults {
 			if r >= h-1 {
 				break
 			}
-			home, _ := os.UserHomeDir()
 			label := "  " + strings.TrimPrefix(v, home)
 			style := StyleDimmed
 			if v == path {

--- a/internal/tui2/settings_test.go
+++ b/internal/tui2/settings_test.go
@@ -882,10 +882,10 @@ func TestSettingsView_VaultPathEdit(t *testing.T) {
 	metisIdx := -1
 	argusIdx := -1
 	for i, row := range sv.rows {
-		if row.kind == srVaultPath && row.key == "_metis_vault" {
+		if row.kind == srVaultPath && row.key == vaultKeyMetis {
 			metisIdx = i
 		}
-		if row.kind == srVaultPath && row.key == "_argus_vault" {
+		if row.kind == srVaultPath && row.key == vaultKeyArgus {
 			argusIdx = i
 		}
 	}
@@ -899,7 +899,7 @@ func TestSettingsView_VaultPathEdit(t *testing.T) {
 	t.Run("enter starts editing metis", func(t *testing.T) {
 		sv.cursor = metisIdx
 		sv.handleEnter()
-		testutil.Equal(t, sv.editingVault, "_metis_vault")
+		testutil.Equal(t, sv.editingVault, vaultKeyMetis)
 		testutil.Equal(t, sv.editVaultBuf, sv.metisVaultPath)
 		testutil.Equal(t, sv.IsEditing(), true)
 	})
@@ -916,7 +916,7 @@ func TestSettingsView_VaultPathEdit(t *testing.T) {
 	t.Run("typing appends to buffer", func(t *testing.T) {
 		// Re-find row after rebuild.
 		for i, row := range sv.rows {
-			if row.kind == srVaultPath && row.key == "_metis_vault" {
+			if row.kind == srVaultPath && row.key == vaultKeyMetis {
 				sv.cursor = i
 				break
 			}
@@ -945,13 +945,13 @@ func TestSettingsView_VaultPathEdit(t *testing.T) {
 
 	t.Run("enter saves argus and persists", func(t *testing.T) {
 		for i, row := range sv.rows {
-			if row.kind == srVaultPath && row.key == "_argus_vault" {
+			if row.kind == srVaultPath && row.key == vaultKeyArgus {
 				sv.cursor = i
 				break
 			}
 		}
 		sv.handleEnter()
-		testutil.Equal(t, sv.editingVault, "_argus_vault")
+		testutil.Equal(t, sv.editingVault, vaultKeyArgus)
 		sv.editVaultBuf = "/custom/argus/vault"
 		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
 		testutil.Equal(t, sv.argusVaultPath, "/custom/argus/vault")
@@ -962,7 +962,7 @@ func TestSettingsView_VaultPathEdit(t *testing.T) {
 
 	t.Run("vault editing blocks global keys", func(t *testing.T) {
 		for i, row := range sv.rows {
-			if row.kind == srVaultPath && row.key == "_metis_vault" {
+			if row.kind == srVaultPath && row.key == vaultKeyMetis {
 				sv.cursor = i
 				break
 			}
@@ -994,7 +994,7 @@ func TestSettingsView_VaultPathRestartHint(t *testing.T) {
 	}
 
 	t.Run("no hint initially", func(t *testing.T) {
-		label := vaultLabel("_metis_vault")
+		label := vaultLabel(vaultKeyMetis)
 		if strings.Contains(label, "(restart required)") {
 			t.Errorf("should not show restart hint initially, got %q", label)
 		}
@@ -1002,7 +1002,7 @@ func TestSettingsView_VaultPathRestartHint(t *testing.T) {
 
 	t.Run("hint appears after edit", func(t *testing.T) {
 		for i, row := range sv.rows {
-			if row.kind == srVaultPath && row.key == "_metis_vault" {
+			if row.kind == srVaultPath && row.key == vaultKeyMetis {
 				sv.cursor = i
 				break
 			}
@@ -1010,14 +1010,14 @@ func TestSettingsView_VaultPathRestartHint(t *testing.T) {
 		sv.handleEnter()
 		sv.editVaultBuf = "/changed/path"
 		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
-		testutil.Contains(t, vaultLabel("_metis_vault"), "(restart required)")
+		testutil.Contains(t, vaultLabel(vaultKeyMetis), "(restart required)")
 	})
 
 	t.Run("hint clears after daemon restart", func(t *testing.T) {
 		sv.SetDaemonRestarting(false)
 		testutil.Equal(t, sv.vaultBootRecorded, false)
 		sv.Refresh()
-		label := vaultLabel("_metis_vault")
+		label := vaultLabel(vaultKeyMetis)
 		if strings.Contains(label, "(restart required)") {
 			t.Errorf("hint should clear after restart + refresh, got %q", label)
 		}
@@ -1039,10 +1039,10 @@ func TestSettingsView_VaultPathCycle(t *testing.T) {
 	metisIdx := -1
 	argusIdx := -1
 	for i, row := range sv.rows {
-		if row.kind == srVaultPath && row.key == "_metis_vault" {
+		if row.kind == srVaultPath && row.key == vaultKeyMetis {
 			metisIdx = i
 		}
-		if row.kind == srVaultPath && row.key == "_argus_vault" {
+		if row.kind == srVaultPath && row.key == vaultKeyArgus {
 			argusIdx = i
 		}
 	}
@@ -1093,7 +1093,7 @@ func TestSettingsView_VaultPathCycle(t *testing.T) {
 	t.Run("cycle shows restart hint", func(t *testing.T) {
 		// After cycling, vault path differs from boot value → restart hint.
 		for _, row := range sv.rows {
-			if row.kind == srVaultPath && row.key == "_argus_vault" {
+			if row.kind == srVaultPath && row.key == vaultKeyArgus {
 				testutil.Contains(t, row.label, "(restart required)")
 				return
 			}
@@ -1115,7 +1115,7 @@ func TestSettingsView_VaultPathCycleNoVaults(t *testing.T) {
 
 	// Find metis row.
 	for i, row := range sv.rows {
-		if row.kind == srVaultPath && row.key == "_metis_vault" {
+		if row.kind == srVaultPath && row.key == vaultKeyMetis {
 			sv.cursor = i
 			break
 		}

--- a/internal/tui2/settings_test.go
+++ b/internal/tui2/settings_test.go
@@ -1024,6 +1024,111 @@ func TestSettingsView_VaultPathRestartHint(t *testing.T) {
 	})
 }
 
+func TestSettingsView_VaultPathCycle(t *testing.T) {
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sv := NewSettingsView(database)
+	sv.Refresh()
+
+	// Inject discovered vaults (simulating iCloud discovery).
+	sv.discoveredVaults = []string{"/vaults/Alpha", "/vaults/Argus", "/vaults/Metis"}
+
+	// Find vault rows.
+	metisIdx := -1
+	argusIdx := -1
+	for i, row := range sv.rows {
+		if row.kind == srVaultPath && row.key == "_metis_vault" {
+			metisIdx = i
+		}
+		if row.kind == srVaultPath && row.key == "_argus_vault" {
+			argusIdx = i
+		}
+	}
+	if metisIdx < 0 || argusIdx < 0 {
+		t.Fatal("vault path rows not found")
+	}
+
+	t.Run("right arrow cycles metis to first discovered vault", func(t *testing.T) {
+		sv.cursor = metisIdx
+		sv.cycleVaultPath(1)
+		testutil.Equal(t, sv.metisVaultPath, "/vaults/Alpha")
+
+		cfg := database.Config()
+		testutil.Equal(t, cfg.KB.MetisVaultPath, "/vaults/Alpha")
+	})
+
+	t.Run("right arrow cycles metis forward", func(t *testing.T) {
+		sv.cycleVaultPath(1)
+		testutil.Equal(t, sv.metisVaultPath, "/vaults/Argus")
+	})
+
+	t.Run("left arrow cycles metis backward", func(t *testing.T) {
+		sv.cycleVaultPath(-1)
+		testutil.Equal(t, sv.metisVaultPath, "/vaults/Alpha")
+	})
+
+	t.Run("wraps around at end", func(t *testing.T) {
+		sv.metisVaultPath = "/vaults/Metis"
+		sv.cycleVaultPath(1)
+		testutil.Equal(t, sv.metisVaultPath, "/vaults/Alpha")
+	})
+
+	t.Run("wraps around at start", func(t *testing.T) {
+		sv.metisVaultPath = "/vaults/Alpha"
+		sv.cycleVaultPath(-1)
+		testutil.Equal(t, sv.metisVaultPath, "/vaults/Metis")
+	})
+
+	t.Run("right arrow cycles argus independently", func(t *testing.T) {
+		sv.cursor = argusIdx
+		sv.cycleVaultPath(1)
+		testutil.Equal(t, sv.argusVaultPath, "/vaults/Alpha")
+
+		cfg := database.Config()
+		testutil.Equal(t, cfg.KB.ArgusVaultPath, "/vaults/Alpha")
+	})
+
+	t.Run("cycle shows restart hint", func(t *testing.T) {
+		// After cycling, vault path differs from boot value → restart hint.
+		for _, row := range sv.rows {
+			if row.kind == srVaultPath && row.key == "_argus_vault" {
+				testutil.Contains(t, row.label, "(restart required)")
+				return
+			}
+		}
+		t.Fatal("argus vault row not found after cycle")
+	})
+}
+
+func TestSettingsView_VaultPathCycleNoVaults(t *testing.T) {
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sv := NewSettingsView(database)
+	sv.Refresh()
+
+	origMetis := sv.metisVaultPath
+	sv.discoveredVaults = nil
+
+	// Find metis row.
+	for i, row := range sv.rows {
+		if row.kind == srVaultPath && row.key == "_metis_vault" {
+			sv.cursor = i
+			break
+		}
+	}
+
+	// Left/Right should be no-ops.
+	sv.cycleVaultPath(1)
+	testutil.Equal(t, sv.metisVaultPath, origMetis)
+
+	sv.cycleVaultPath(-1)
+	testutil.Equal(t, sv.metisVaultPath, origMetis)
+}
+
 // findProjectEntry locates a project in the settings view by name.
 func findProjectEntry(t *testing.T, sv *SettingsView, name string) *projectEntry {
 	t.Helper()


### PR DESCRIPTION
Scans the iCloud Obsidian base directory for vaults (directories containing .obsidian/) and adds a Left/Right cycle selector on vault path rows in settings. Discovery runs once on first Refresh to avoid blocking I/O. Vault key sentinels extracted into named constants.

Co-Authored-By: Claude <noreply@anthropic.com>