### PR TITLE
Add directory autocomplete to vault path settings

### DIFF
--- a/internal/tui2/dirac.go
+++ b/internal/tui2/dirac.go
@@ -8,6 +8,7 @@ import (
 // state (matches, selected index, open/closed) and provides key handling and
 // rendering. Consumers call Update after every input change, HandleKey for
 // navigation events, and Draw to render the dropdown.
+// Callers must pass the same maxVisible value to both Len and Draw.
 type dirAC struct {
 	matches []string // full paths of matching dirs
 	idx     int
@@ -31,8 +32,9 @@ func (ac *dirAC) Update(input string) {
 
 // Accept selects the current autocomplete match and returns the accepted path
 // (with trailing slash, tilde-collapsed). Returns "" if the dropdown is closed
-// or the index is out of range. After accepting, the dropdown re-opens if the
-// accepted directory has sub-directories.
+// or the index is out of range. After accepting, Update is called with the
+// tilde-collapsed path to re-open the dropdown if the directory has children.
+// This works because dirCompletions calls expandTilde internally.
 func (ac *dirAC) Accept() string {
 	if !ac.open || ac.idx >= len(ac.matches) {
 		return ""

--- a/internal/tui2/dirac.go
+++ b/internal/tui2/dirac.go
@@ -1,0 +1,155 @@
+package tui2
+
+import (
+	"github.com/gdamore/tcell/v2"
+)
+
+// dirAC is a reusable directory autocomplete widget. It manages the dropdown
+// state (matches, selected index, open/closed) and provides key handling and
+// rendering. Consumers call Update after every input change, HandleKey for
+// navigation events, and Draw to render the dropdown.
+type dirAC struct {
+	matches []string // full paths of matching dirs
+	idx     int
+	open    bool
+}
+
+// Update recomputes directory completions for the given input string.
+// Call this after every keystroke or paste that changes the path buffer.
+func (ac *dirAC) Update(input string) {
+	matches := dirCompletions(input)
+	if matches == nil {
+		ac.Close()
+		return
+	}
+	ac.matches = matches
+	ac.open = true
+	if ac.idx >= len(ac.matches) {
+		ac.idx = 0
+	}
+}
+
+// Accept selects the current autocomplete match and returns the accepted path
+// (with trailing slash, tilde-collapsed). Returns "" if the dropdown is closed
+// or the index is out of range. After accepting, the dropdown re-opens if the
+// accepted directory has sub-directories.
+func (ac *dirAC) Accept() string {
+	if !ac.open || ac.idx >= len(ac.matches) {
+		return ""
+	}
+	path := collapseTilde(ac.matches[ac.idx]) + "/"
+	ac.Close()
+	ac.Update(path)
+	return path
+}
+
+// Close dismisses the autocomplete dropdown.
+func (ac *dirAC) Close() {
+	ac.open = false
+	ac.matches = nil
+	ac.idx = 0
+}
+
+// Open returns whether the autocomplete dropdown is visible.
+func (ac *dirAC) Open() bool {
+	return ac.open
+}
+
+// HandleKey processes navigation keys (Tab, Enter, Up, Down, Escape) when the
+// autocomplete dropdown is relevant. Returns true if the event was consumed.
+// The caller should pass the current input string so Tab can trigger+accept in
+// one step when the dropdown is closed.
+func (ac *dirAC) HandleKey(ev *tcell.EventKey, input string) (consumed bool, accepted string) {
+	switch ev.Key() {
+	case tcell.KeyTab:
+		if ac.open {
+			return true, ac.Accept()
+		}
+		ac.Update(input)
+		if ac.open {
+			return true, ac.Accept()
+		}
+		return false, "" // no completions — let caller handle Tab
+	case tcell.KeyEnter:
+		if ac.open {
+			return true, ac.Accept()
+		}
+		return false, ""
+	case tcell.KeyEscape, tcell.KeyCtrlQ:
+		if ac.open {
+			ac.Close()
+			return true, ""
+		}
+		return false, ""
+	case tcell.KeyDown:
+		if ac.open && len(ac.matches) > 0 {
+			ac.idx = (ac.idx + 1) % len(ac.matches)
+			return true, ""
+		}
+		return false, ""
+	case tcell.KeyUp:
+		if ac.open && len(ac.matches) > 0 {
+			if ac.idx == 0 {
+				ac.idx = len(ac.matches) - 1
+			} else {
+				ac.idx--
+			}
+			return true, ""
+		}
+		return false, ""
+	}
+	return false, ""
+}
+
+// Draw renders the autocomplete dropdown at (x, y) with width w.
+// maxVisible caps the number of rows shown. Returns the number of rows drawn.
+func (ac *dirAC) Draw(screen tcell.Screen, x, y, w, maxVisible int) int {
+	if !ac.open || len(ac.matches) == 0 {
+		return 0
+	}
+
+	visible := len(ac.matches)
+	if visible > maxVisible {
+		visible = maxVisible
+	}
+
+	acScroll := 0
+	if ac.idx >= visible {
+		acScroll = ac.idx - visible + 1
+	}
+
+	selectedStyle := tcell.StyleDefault.Bold(true).Foreground(ColorSelected)
+	for vi := 0; vi < visible; vi++ {
+		idx := acScroll + vi
+		if idx >= len(ac.matches) {
+			break
+		}
+		display := collapseTilde(ac.matches[idx])
+
+		indicator := "  "
+		if idx == ac.idx {
+			indicator = "> "
+		}
+		line := indicator + display
+		st := StyleDimmed
+		if idx == ac.idx {
+			st = selectedStyle
+		}
+		lineRunes := []rune(line)
+		for c := 0; c < w && c < len(lineRunes); c++ {
+			screen.SetContent(x+c, y+vi, lineRunes[c], nil, st)
+		}
+	}
+	return visible
+}
+
+// Len returns the number of visible autocomplete rows (capped at maxVisible).
+func (ac *dirAC) Len(maxVisible int) int {
+	if !ac.open || len(ac.matches) == 0 {
+		return 0
+	}
+	if len(ac.matches) > maxVisible {
+		return maxVisible
+	}
+	return len(ac.matches)
+}

--- a/internal/tui2/dirac_test.go
+++ b/internal/tui2/dirac_test.go
@@ -1,0 +1,198 @@
+package tui2
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/drn/argus/internal/testutil"
+)
+
+// Uses setupACDirs from projectform_test.go (same package).
+
+func TestDirAC_Update(t *testing.T) {
+	root := setupACDirs(t, "alpha", "beta")
+	var ac dirAC
+
+	t.Run("opens on valid input", func(t *testing.T) {
+		ac.Update(root + "/")
+		testutil.Equal(t, ac.Open(), true)
+		testutil.Equal(t, len(ac.matches), 2)
+	})
+
+	t.Run("filters by prefix", func(t *testing.T) {
+		ac.Update(root + "/a")
+		testutil.Equal(t, ac.Open(), true)
+		testutil.Equal(t, len(ac.matches), 1)
+		testutil.Contains(t, ac.matches[0], "alpha")
+	})
+
+	t.Run("closes on no match", func(t *testing.T) {
+		ac.Update(root + "/zzz")
+		testutil.Equal(t, ac.Open(), false)
+	})
+
+	t.Run("closes on empty input", func(t *testing.T) {
+		ac.Update("")
+		testutil.Equal(t, ac.Open(), false)
+	})
+}
+
+func TestDirAC_Accept(t *testing.T) {
+	root := setupACDirs(t, "alpha")
+	var ac dirAC
+	ac.Update(root + "/a")
+
+	testutil.Equal(t, ac.Open(), true)
+
+	path := ac.Accept()
+	testutil.Contains(t, path, "alpha/")
+}
+
+func TestDirAC_AcceptWhenClosed(t *testing.T) {
+	var ac dirAC
+	path := ac.Accept()
+	testutil.Equal(t, path, "")
+}
+
+func TestDirAC_Close(t *testing.T) {
+	root := setupACDirs(t, "alpha", "beta")
+	var ac dirAC
+	ac.Update(root + "/")
+
+	testutil.Equal(t, ac.Open(), true)
+	ac.Close()
+	testutil.Equal(t, ac.Open(), false)
+	testutil.Equal(t, len(ac.matches), 0)
+	testutil.Equal(t, ac.idx, 0)
+}
+
+func TestDirAC_HandleKey_Tab(t *testing.T) {
+	root := setupACDirs(t, "alpha", "beta")
+
+	t.Run("tab triggers and accepts when closed", func(t *testing.T) {
+		var ac dirAC
+		ev := tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone)
+		consumed, accepted := ac.HandleKey(ev, root+"/a")
+		testutil.Equal(t, consumed, true)
+		testutil.Contains(t, accepted, "alpha/")
+	})
+
+	t.Run("tab accepts when open", func(t *testing.T) {
+		var ac dirAC
+		ac.Update(root + "/")
+		ev := tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone)
+		consumed, accepted := ac.HandleKey(ev, root+"/")
+		testutil.Equal(t, consumed, true)
+		testutil.Contains(t, accepted, "alpha/")
+	})
+}
+
+func TestDirAC_HandleKey_Enter(t *testing.T) {
+	root := setupACDirs(t, "alpha")
+
+	t.Run("enter accepts when open", func(t *testing.T) {
+		var ac dirAC
+		ac.Update(root + "/a")
+		ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+		consumed, accepted := ac.HandleKey(ev, root+"/a")
+		testutil.Equal(t, consumed, true)
+		testutil.Contains(t, accepted, "alpha/")
+	})
+
+	t.Run("enter passes through when closed", func(t *testing.T) {
+		var ac dirAC
+		ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+		consumed, _ := ac.HandleKey(ev, "")
+		testutil.Equal(t, consumed, false)
+	})
+}
+
+func TestDirAC_HandleKey_Escape(t *testing.T) {
+	root := setupACDirs(t, "alpha")
+
+	t.Run("escape closes when open", func(t *testing.T) {
+		var ac dirAC
+		ac.Update(root + "/")
+		ev := tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone)
+		consumed, _ := ac.HandleKey(ev, root+"/")
+		testutil.Equal(t, consumed, true)
+		testutil.Equal(t, ac.Open(), false)
+	})
+
+	t.Run("escape passes through when closed", func(t *testing.T) {
+		var ac dirAC
+		ev := tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone)
+		consumed, _ := ac.HandleKey(ev, "")
+		testutil.Equal(t, consumed, false)
+	})
+}
+
+func TestDirAC_HandleKey_CtrlQ(t *testing.T) {
+	root := setupACDirs(t, "alpha")
+
+	t.Run("ctrlq closes when open", func(t *testing.T) {
+		var ac dirAC
+		ac.Update(root + "/")
+		ev := tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone)
+		consumed, _ := ac.HandleKey(ev, root+"/")
+		testutil.Equal(t, consumed, true)
+		testutil.Equal(t, ac.Open(), false)
+	})
+
+	t.Run("ctrlq passes through when closed", func(t *testing.T) {
+		var ac dirAC
+		ev := tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone)
+		consumed, _ := ac.HandleKey(ev, "")
+		testutil.Equal(t, consumed, false)
+	})
+}
+
+func TestDirAC_HandleKey_UpDown(t *testing.T) {
+	root := setupACDirs(t, "aaa", "bbb", "ccc")
+	var ac dirAC
+	ac.Update(root + "/")
+
+	testutil.Equal(t, ac.idx, 0)
+
+	down := tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone)
+	up := tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone)
+
+	consumed, _ := ac.HandleKey(down, root+"/")
+	testutil.Equal(t, consumed, true)
+	testutil.Equal(t, ac.idx, 1)
+
+	ac.HandleKey(down, root+"/")
+	testutil.Equal(t, ac.idx, 2)
+
+	// Wrap around.
+	ac.HandleKey(down, root+"/")
+	testutil.Equal(t, ac.idx, 0)
+
+	// Up wraps to end.
+	consumed, _ = ac.HandleKey(up, root+"/")
+	testutil.Equal(t, consumed, true)
+	testutil.Equal(t, ac.idx, 2)
+}
+
+func TestDirAC_HandleKey_UpDown_WhenClosed(t *testing.T) {
+	var ac dirAC
+	ev := tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone)
+	consumed, _ := ac.HandleKey(ev, "")
+	testutil.Equal(t, consumed, false)
+}
+
+func TestDirAC_Len(t *testing.T) {
+	root := setupACDirs(t, "a", "b", "c", "d", "e")
+	var ac dirAC
+
+	t.Run("zero when closed", func(t *testing.T) {
+		testutil.Equal(t, ac.Len(8), 0)
+	})
+
+	t.Run("capped at maxVisible", func(t *testing.T) {
+		ac.Update(root + "/")
+		testutil.Equal(t, ac.Len(3), 3)
+		testutil.Equal(t, ac.Len(10), 5)
+	})
+}

--- a/internal/tui2/projectform.go
+++ b/internal/tui2/projectform.go
@@ -420,7 +420,6 @@ func (pf *ProjectForm) Draw(screen tcell.Screen) {
 	}
 }
 
-
 // drawSandboxSelector renders the sandbox field as a ◀/▶ selector.
 func (pf *ProjectForm) drawSandboxSelector(screen tcell.Screen, x, y, w int) {
 	name := sandboxOptions[pf.sandboxIdx]

--- a/internal/tui2/projectform.go
+++ b/internal/tui2/projectform.go
@@ -54,10 +54,8 @@ type ProjectForm struct {
 	sandboxDenyRead   []string
 	sandboxExtraWrite []string
 
-	// Path autocomplete state.
-	pathACMatches []string // full paths of matching dirs
-	pathACIdx     int
-	pathACOpen    bool
+	// Path autocomplete.
+	pathAC dirAC
 
 	// OnBranchFocus is called when the branch field gains focus and the
 	// path has changed since the last load. The caller should fetch branches
@@ -261,86 +259,22 @@ func (pf *ProjectForm) HandleKey(ev *tcell.EventKey) {
 // handlePathACKey handles autocomplete-specific keys when the path field is
 // focused. Returns true if the event was consumed.
 func (pf *ProjectForm) handlePathACKey(ev *tcell.EventKey) bool {
-	switch ev.Key() {
-	case tcell.KeyEscape:
-		if pf.pathACOpen {
-			pf.closePathAC()
-			return true
-		}
-		return false
-	case tcell.KeyTab:
-		if pf.pathACOpen {
-			pf.acceptPathAC()
-			return true
-		}
-		// Trigger autocomplete on first Tab press.
-		pf.updatePathAC()
-		if pf.pathACOpen {
-			pf.acceptPathAC()
-			return true
-		}
-		return false
-	case tcell.KeyEnter:
-		if pf.pathACOpen {
-			pf.acceptPathAC()
-			return true
-		}
-		return false
-	case tcell.KeyDown:
-		if pf.pathACOpen && len(pf.pathACMatches) > 0 {
-			pf.pathACIdx = (pf.pathACIdx + 1) % len(pf.pathACMatches)
-			return true
-		}
-		return false // no-op when AC is closed
-	case tcell.KeyUp:
-		if pf.pathACOpen && len(pf.pathACMatches) > 0 {
-			if pf.pathACIdx == 0 {
-				pf.pathACIdx = len(pf.pathACMatches) - 1
-			} else {
-				pf.pathACIdx--
-			}
-			return true
-		}
-		return false // no-op when AC is closed
+	consumed, accepted := pf.pathAC.HandleKey(ev, string(pf.fields[pfFieldPath]))
+	if accepted != "" {
+		pf.fields[pfFieldPath] = []rune(accepted)
+		pf.cursors[pfFieldPath] = len(pf.fields[pfFieldPath])
 	}
-	return false
+	return consumed
 }
 
 // updatePathAC computes directory completions for the current path input.
-// Note: os.ReadDir runs synchronously — acceptable for local filesystems
-// (same pattern as QuickAddForm), but may lag on NFS/iCloud mounts.
 func (pf *ProjectForm) updatePathAC() {
-	raw := string(pf.fields[pfFieldPath])
-	matches := dirCompletions(raw)
-	if matches == nil {
-		pf.closePathAC()
-		return
-	}
-	pf.pathACMatches = matches
-	pf.pathACOpen = true
-	if pf.pathACIdx >= len(pf.pathACMatches) {
-		pf.pathACIdx = 0
-	}
-}
-
-// acceptPathAC replaces the path input with the selected autocomplete match.
-func (pf *ProjectForm) acceptPathAC() {
-	if !pf.pathACOpen || pf.pathACIdx >= len(pf.pathACMatches) {
-		return
-	}
-	path := collapseTilde(pf.pathACMatches[pf.pathACIdx]) + "/"
-	pf.fields[pfFieldPath] = []rune(path)
-	pf.cursors[pfFieldPath] = len(pf.fields[pfFieldPath])
-	pf.closePathAC()
-	// Re-open dropdown if the accepted directory has sub-directories.
-	pf.updatePathAC()
+	pf.pathAC.Update(string(pf.fields[pfFieldPath]))
 }
 
 // closePathAC dismisses the autocomplete dropdown.
 func (pf *ProjectForm) closePathAC() {
-	pf.pathACOpen = false
-	pf.pathACMatches = nil
-	pf.pathACIdx = 0
+	pf.pathAC.Close()
 }
 
 // handleBranchSelector processes keys when the branch field is in selector mode.
@@ -408,13 +342,7 @@ func (pf *ProjectForm) Draw(screen tcell.Screen) {
 	}
 
 	// Compute autocomplete row count for dynamic form height.
-	acRows := 0
-	if pf.pathACOpen && len(pf.pathACMatches) > 0 {
-		acRows = len(pf.pathACMatches)
-		if acRows > pfMaxACVisible {
-			acRows = pfMaxACVisible
-		}
-	}
+	acRows := pf.pathAC.Len(pfMaxACVisible)
 
 	// Center the form.
 	formW := min(60, width-4)
@@ -482,8 +410,8 @@ func (pf *ProjectForm) Draw(screen tcell.Screen) {
 		drawText(screen, formX+12, ly, maxW, val, style)
 
 		// Draw autocomplete dropdown right after the path field.
-		if i == pfFieldPath && pf.pathACOpen && len(pf.pathACMatches) > 0 {
-			extraOffset += pf.drawPathAC(screen, formX+12, ly+1, maxW)
+		if i == pfFieldPath {
+			extraOffset += pf.pathAC.Draw(screen, formX+12, ly+1, maxW, pfMaxACVisible)
 		}
 	}
 
@@ -492,43 +420,6 @@ func (pf *ProjectForm) Draw(screen tcell.Screen) {
 	}
 }
 
-// drawPathAC renders the autocomplete dropdown below the path input.
-// Returns the number of rows drawn.
-func (pf *ProjectForm) drawPathAC(screen tcell.Screen, x, y, w int) int {
-	visible := len(pf.pathACMatches)
-	if visible > pfMaxACVisible {
-		visible = pfMaxACVisible
-	}
-
-	acScroll := 0
-	if pf.pathACIdx >= visible {
-		acScroll = pf.pathACIdx - visible + 1
-	}
-
-	selectedStyle := tcell.StyleDefault.Bold(true).Foreground(ColorSelected)
-	for vi := 0; vi < visible; vi++ {
-		idx := acScroll + vi
-		if idx >= len(pf.pathACMatches) {
-			break
-		}
-		display := collapseTilde(pf.pathACMatches[idx])
-
-		indicator := "  "
-		if idx == pf.pathACIdx {
-			indicator = "> "
-		}
-		line := indicator + display
-		st := StyleDimmed
-		if idx == pf.pathACIdx {
-			st = selectedStyle
-		}
-		lineRunes := []rune(line)
-		for c := 0; c < w && c < len(lineRunes); c++ {
-			screen.SetContent(x+c, y+vi, lineRunes[c], nil, st)
-		}
-	}
-	return visible
-}
 
 // drawSandboxSelector renders the sandbox field as a ◀/▶ selector.
 func (pf *ProjectForm) drawSandboxSelector(screen tcell.Screen, x, y, w int) {

--- a/internal/tui2/projectform_test.go
+++ b/internal/tui2/projectform_test.go
@@ -247,7 +247,7 @@ func TestProjectForm_PathAC_TypingOpensDropdown(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/")
 
-	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, pf.pathAC.Open(), true)
 	testutil.Equal(t, len(pf.pathAC.matches), 3)
 }
 
@@ -258,7 +258,7 @@ func TestProjectForm_PathAC_PrefixFilters(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/a")
 
-	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, pf.pathAC.Open(), true)
 	testutil.Equal(t, len(pf.pathAC.matches), 2) // alpha, arc
 }
 
@@ -269,7 +269,7 @@ func TestProjectForm_PathAC_TabAccepts(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/a")
 
-	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, pf.pathAC.Open(), true)
 	// First match is "alpha".
 	testutil.Contains(t, pf.pathAC.matches[0], "alpha")
 
@@ -312,11 +312,11 @@ func TestProjectForm_PathAC_EscapeClosesDropdown(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/")
 
-	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, pf.pathAC.Open(), true)
 
 	// Escape closes dropdown but does NOT cancel form.
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
-	testutil.Equal(t, pf.pathAC.open, false)
+	testutil.Equal(t, pf.pathAC.Open(), false)
 	testutil.Equal(t, pf.canceled, false)
 }
 
@@ -327,11 +327,11 @@ func TestProjectForm_PathAC_CtrlQClosesDropdown(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/")
 
-	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, pf.pathAC.Open(), true)
 
 	// CtrlQ closes dropdown but does NOT cancel form.
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone))
-	testutil.Equal(t, pf.pathAC.open, false)
+	testutil.Equal(t, pf.pathAC.Open(), false)
 	testutil.Equal(t, pf.canceled, false)
 
 	// Second CtrlQ cancels the form.
@@ -346,7 +346,7 @@ func TestProjectForm_PathAC_BackspaceUpdatesAC(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/al")
 
-	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, pf.pathAC.Open(), true)
 	testutil.Equal(t, len(pf.pathAC.matches), 1) // alpha
 
 	// Backspace → "a" prefix → alpha + arc
@@ -361,7 +361,7 @@ func TestProjectForm_PathAC_HiddenDirsExcluded(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/")
 
-	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, pf.pathAC.Open(), true)
 	// .hidden should not appear in matches.
 	for _, m := range pf.pathAC.matches {
 		if filepath.Base(m) == ".hidden" {
@@ -378,7 +378,7 @@ func TestProjectForm_PathAC_EnterAcceptsWhenOpen(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/a")
 
-	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, pf.pathAC.Open(), true)
 
 	// Enter accepts the autocomplete instead of advancing fields.
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
@@ -393,7 +393,7 @@ func TestProjectForm_PathAC_CaseInsensitive(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/my")
 
-	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, pf.pathAC.Open(), true)
 	testutil.Equal(t, len(pf.pathAC.matches), 2) // both match case-insensitively
 }
 
@@ -429,7 +429,7 @@ func TestProjectForm_PathAC_TabOnClosedTriggersAC(t *testing.T) {
 
 	// Close AC first.
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
-	testutil.Equal(t, pf.pathAC.open, false)
+	testutil.Equal(t, pf.pathAC.Open(), false)
 
 	// Tab triggers + accepts.
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone))
@@ -445,7 +445,7 @@ func TestProjectForm_PathAC_PasteTriggersAC(t *testing.T) {
 	paste := pf.PasteHandler()
 	paste(root+"/", func(p tview.Primitive) {})
 
-	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, pf.pathAC.Open(), true)
 	testutil.Equal(t, len(pf.pathAC.matches), 2)
 }
 
@@ -456,7 +456,7 @@ func TestProjectForm_PathAC_NotOnOtherFields(t *testing.T) {
 	pf.focused = pfFieldName // NOT path
 	typeRunes(pf, root+"/")
 
-	testutil.Equal(t, pf.pathAC.open, false)
+	testutil.Equal(t, pf.pathAC.Open(), false)
 }
 
 func TestProjectForm_MaybeLoadBranches_ExpandsTilde(t *testing.T) {

--- a/internal/tui2/projectform_test.go
+++ b/internal/tui2/projectform_test.go
@@ -247,8 +247,8 @@ func TestProjectForm_PathAC_TypingOpensDropdown(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/")
 
-	testutil.Equal(t, pf.pathACOpen, true)
-	testutil.Equal(t, len(pf.pathACMatches), 3)
+	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, len(pf.pathAC.matches), 3)
 }
 
 func TestProjectForm_PathAC_PrefixFilters(t *testing.T) {
@@ -258,8 +258,8 @@ func TestProjectForm_PathAC_PrefixFilters(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/a")
 
-	testutil.Equal(t, pf.pathACOpen, true)
-	testutil.Equal(t, len(pf.pathACMatches), 2) // alpha, arc
+	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, len(pf.pathAC.matches), 2) // alpha, arc
 }
 
 func TestProjectForm_PathAC_TabAccepts(t *testing.T) {
@@ -269,9 +269,9 @@ func TestProjectForm_PathAC_TabAccepts(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/a")
 
-	testutil.Equal(t, pf.pathACOpen, true)
+	testutil.Equal(t, pf.pathAC.open, true)
 	// First match is "alpha".
-	testutil.Contains(t, pf.pathACMatches[0], "alpha")
+	testutil.Contains(t, pf.pathAC.matches[0], "alpha")
 
 	// Tab accepts.
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone))
@@ -286,23 +286,23 @@ func TestProjectForm_PathAC_DownUpNavigates(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/")
 
-	testutil.Equal(t, pf.pathACIdx, 0)
+	testutil.Equal(t, pf.pathAC.idx, 0)
 
 	// Down → 1
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
-	testutil.Equal(t, pf.pathACIdx, 1)
+	testutil.Equal(t, pf.pathAC.idx, 1)
 
 	// Down → 2
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
-	testutil.Equal(t, pf.pathACIdx, 2)
+	testutil.Equal(t, pf.pathAC.idx, 2)
 
 	// Down → wraps to 0
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
-	testutil.Equal(t, pf.pathACIdx, 0)
+	testutil.Equal(t, pf.pathAC.idx, 0)
 
 	// Up → wraps to 2
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone))
-	testutil.Equal(t, pf.pathACIdx, 2)
+	testutil.Equal(t, pf.pathAC.idx, 2)
 }
 
 func TestProjectForm_PathAC_EscapeClosesDropdown(t *testing.T) {
@@ -312,12 +312,31 @@ func TestProjectForm_PathAC_EscapeClosesDropdown(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/")
 
-	testutil.Equal(t, pf.pathACOpen, true)
+	testutil.Equal(t, pf.pathAC.open, true)
 
 	// Escape closes dropdown but does NOT cancel form.
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
-	testutil.Equal(t, pf.pathACOpen, false)
+	testutil.Equal(t, pf.pathAC.open, false)
 	testutil.Equal(t, pf.canceled, false)
+}
+
+func TestProjectForm_PathAC_CtrlQClosesDropdown(t *testing.T) {
+	root := setupACDirs(t, "alpha", "beta")
+
+	pf := NewProjectForm()
+	pf.focused = pfFieldPath
+	typeRunes(pf, root+"/")
+
+	testutil.Equal(t, pf.pathAC.open, true)
+
+	// CtrlQ closes dropdown but does NOT cancel form.
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone))
+	testutil.Equal(t, pf.pathAC.open, false)
+	testutil.Equal(t, pf.canceled, false)
+
+	// Second CtrlQ cancels the form.
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone))
+	testutil.Equal(t, pf.canceled, true)
 }
 
 func TestProjectForm_PathAC_BackspaceUpdatesAC(t *testing.T) {
@@ -327,12 +346,12 @@ func TestProjectForm_PathAC_BackspaceUpdatesAC(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/al")
 
-	testutil.Equal(t, pf.pathACOpen, true)
-	testutil.Equal(t, len(pf.pathACMatches), 1) // alpha
+	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, len(pf.pathAC.matches), 1) // alpha
 
 	// Backspace → "a" prefix → alpha + arc
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModNone))
-	testutil.Equal(t, len(pf.pathACMatches), 2) // alpha, arc
+	testutil.Equal(t, len(pf.pathAC.matches), 2) // alpha, arc
 }
 
 func TestProjectForm_PathAC_HiddenDirsExcluded(t *testing.T) {
@@ -342,14 +361,14 @@ func TestProjectForm_PathAC_HiddenDirsExcluded(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/")
 
-	testutil.Equal(t, pf.pathACOpen, true)
+	testutil.Equal(t, pf.pathAC.open, true)
 	// .hidden should not appear in matches.
-	for _, m := range pf.pathACMatches {
+	for _, m := range pf.pathAC.matches {
 		if filepath.Base(m) == ".hidden" {
 			t.Errorf("hidden dir should be excluded, got %s", m)
 		}
 	}
-	testutil.Equal(t, len(pf.pathACMatches), 2) // visible, other
+	testutil.Equal(t, len(pf.pathAC.matches), 2) // visible, other
 }
 
 func TestProjectForm_PathAC_EnterAcceptsWhenOpen(t *testing.T) {
@@ -359,7 +378,7 @@ func TestProjectForm_PathAC_EnterAcceptsWhenOpen(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/a")
 
-	testutil.Equal(t, pf.pathACOpen, true)
+	testutil.Equal(t, pf.pathAC.open, true)
 
 	// Enter accepts the autocomplete instead of advancing fields.
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
@@ -374,8 +393,8 @@ func TestProjectForm_PathAC_CaseInsensitive(t *testing.T) {
 	pf.focused = pfFieldPath
 	typeRunes(pf, root+"/my")
 
-	testutil.Equal(t, pf.pathACOpen, true)
-	testutil.Equal(t, len(pf.pathACMatches), 2) // both match case-insensitively
+	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, len(pf.pathAC.matches), 2) // both match case-insensitively
 }
 
 func TestProjectForm_Result_ExpandsTilde(t *testing.T) {
@@ -410,7 +429,7 @@ func TestProjectForm_PathAC_TabOnClosedTriggersAC(t *testing.T) {
 
 	// Close AC first.
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
-	testutil.Equal(t, pf.pathACOpen, false)
+	testutil.Equal(t, pf.pathAC.open, false)
 
 	// Tab triggers + accepts.
 	pf.HandleKey(tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone))
@@ -426,8 +445,8 @@ func TestProjectForm_PathAC_PasteTriggersAC(t *testing.T) {
 	paste := pf.PasteHandler()
 	paste(root+"/", func(p tview.Primitive) {})
 
-	testutil.Equal(t, pf.pathACOpen, true)
-	testutil.Equal(t, len(pf.pathACMatches), 2)
+	testutil.Equal(t, pf.pathAC.open, true)
+	testutil.Equal(t, len(pf.pathAC.matches), 2)
 }
 
 func TestProjectForm_PathAC_NotOnOtherFields(t *testing.T) {
@@ -437,7 +456,7 @@ func TestProjectForm_PathAC_NotOnOtherFields(t *testing.T) {
 	pf.focused = pfFieldName // NOT path
 	typeRunes(pf, root+"/")
 
-	testutil.Equal(t, pf.pathACOpen, false)
+	testutil.Equal(t, pf.pathAC.open, false)
 }
 
 func TestProjectForm_MaybeLoadBranches_ExpandsTilde(t *testing.T) {

--- a/internal/tui2/quickaddform.go
+++ b/internal/tui2/quickaddform.go
@@ -148,6 +148,8 @@ func collapseTilde(path string) string {
 // Expands tilde, filters hidden directories, and suppresses the dropdown when
 // the input already exactly matches the sole result.
 // Used by dirAC for directory autocomplete across all path input fields.
+// Note: os.ReadDir runs synchronously — acceptable for local filesystems
+// but may lag on NFS/iCloud mounts.
 func dirCompletions(raw string) []string {
 	if raw == "" {
 		return nil
@@ -314,6 +316,8 @@ func (f *QuickAddForm) handleDirInputKey(ev *tcell.EventKey) {
 		return
 	}
 
+	// If AC was open, HandleKey already consumed Escape/CtrlQ above.
+	// Reaching here means AC is closed — proceed with normal key handling.
 	switch ev.Key() {
 	case tcell.KeyEscape, tcell.KeyCtrlQ:
 		f.canceled = true

--- a/internal/tui2/quickaddform.go
+++ b/internal/tui2/quickaddform.go
@@ -27,9 +27,7 @@ type QuickAddForm struct {
 	dirCursor int
 
 	// Directory autocomplete.
-	acMatches []string // full paths of matching dirs
-	acIdx     int
-	acOpen    bool
+	ac dirAC
 
 	// Phase 1: repo selection.
 	repos     []repoCandidate
@@ -149,7 +147,7 @@ func collapseTilde(path string) string {
 // Returns nil when there are no matches or the input is empty.
 // Expands tilde, filters hidden directories, and suppresses the dropdown when
 // the input already exactly matches the sole result.
-// Used by both QuickAddForm and ProjectForm — keep in sync.
+// Used by dirAC for directory autocomplete across all path input fields.
 func dirCompletions(raw string) []string {
 	if raw == "" {
 		return nil
@@ -202,31 +200,15 @@ func dirCompletions(raw string) []string {
 
 // updateDirAutocomplete computes directory completions for the current input.
 func (f *QuickAddForm) updateDirAutocomplete() {
-	raw := string(f.dirPath)
-	matches := dirCompletions(raw)
-	if matches == nil {
-		f.acOpen = false
-		f.acMatches = nil
-		return
-	}
-	f.acMatches = matches
-	f.acOpen = true
-	if f.acIdx >= len(f.acMatches) {
-		f.acIdx = 0
-	}
+	f.ac.Update(string(f.dirPath))
 }
 
 // acceptAutocomplete replaces the dir input with the selected autocomplete match.
 func (f *QuickAddForm) acceptAutocomplete() {
-	if !f.acOpen || f.acIdx >= len(f.acMatches) {
-		return
+	if accepted := f.ac.Accept(); accepted != "" {
+		f.dirPath = []rune(accepted)
+		f.dirCursor = len(f.dirPath)
 	}
-	path := collapseTilde(f.acMatches[f.acIdx]) + "/"
-	f.dirPath = []rune(path)
-	f.dirCursor = len(f.dirPath)
-	f.acOpen = false
-	f.acMatches = nil
-	f.updateDirAutocomplete()
 }
 
 // --- Directory scanning ---
@@ -321,31 +303,23 @@ func (f *QuickAddForm) HandleKey(ev *tcell.EventKey) {
 }
 
 func (f *QuickAddForm) handleDirInputKey(ev *tcell.EventKey) {
+	// Delegate navigation keys to the autocomplete widget.
+	consumed, accepted := f.ac.HandleKey(ev, string(f.dirPath))
+	if accepted != "" {
+		f.dirPath = []rune(accepted)
+		f.dirCursor = len(f.dirPath)
+		return
+	}
+	if consumed {
+		return
+	}
+
 	switch ev.Key() {
 	case tcell.KeyEscape, tcell.KeyCtrlQ:
-		if f.acOpen {
-			f.acOpen = false
-			return
-		}
 		f.canceled = true
 		return
 
-	case tcell.KeyTab:
-		if f.acOpen {
-			f.acceptAutocomplete()
-			return
-		}
-		f.updateDirAutocomplete()
-		if f.acOpen {
-			f.acceptAutocomplete()
-		}
-		return
-
 	case tcell.KeyEnter:
-		if f.acOpen {
-			f.acceptAutocomplete()
-			return
-		}
 		if f.scanning {
 			return
 		}
@@ -406,23 +380,6 @@ func (f *QuickAddForm) handleDirInputKey(ev *tcell.EventKey) {
 	case tcell.KeyCtrlK:
 		f.dirPath = f.dirPath[:f.dirCursor]
 		f.updateDirAutocomplete()
-		return
-
-	case tcell.KeyDown:
-		if f.acOpen && len(f.acMatches) > 0 {
-			f.acIdx = (f.acIdx + 1) % len(f.acMatches)
-			// scroll handled in draw
-		}
-		return
-
-	case tcell.KeyUp:
-		if f.acOpen && len(f.acMatches) > 0 {
-			if f.acIdx == 0 {
-				f.acIdx = len(f.acMatches) - 1
-			} else {
-				f.acIdx--
-			}
-		}
 		return
 
 	case tcell.KeyRune:
@@ -544,13 +501,7 @@ func (f *QuickAddForm) drawDirInput(screen tcell.Screen, sx, sy, sw, sh int) {
 	innerW := modalW - 4
 
 	// Compute height: border(2) + title(1) + gap(1) + label(1) + input(1) + ac + gap(1) + help(1) + err
-	acRows := 0
-	if f.acOpen && len(f.acMatches) > 0 {
-		acRows = len(f.acMatches)
-		if acRows > qaMaxVisible {
-			acRows = qaMaxVisible
-		}
-	}
+	acRows := f.ac.Len(qaMaxVisible)
 	modalH := 8 + acRows
 	if f.scanning {
 		modalH++
@@ -646,42 +597,7 @@ func (f *QuickAddForm) drawDirInput(screen tcell.Screen, sx, sy, sw, sh int) {
 	row++
 
 	// Autocomplete dropdown.
-	if f.acOpen && len(f.acMatches) > 0 {
-		visible := len(f.acMatches)
-		if visible > qaMaxVisible {
-			visible = qaMaxVisible
-		}
-		// Ensure selected item is visible.
-		acScroll := 0
-		if f.acIdx >= visible {
-			acScroll = f.acIdx - visible + 1
-		}
-
-		selectedStyle := tcell.StyleDefault.Bold(true).Foreground(ColorSelected)
-		for vi := 0; vi < visible; vi++ {
-			idx := acScroll + vi
-			if idx >= len(f.acMatches) {
-				break
-			}
-			display := collapseTilde(f.acMatches[idx])
-			isSelected := idx == f.acIdx
-
-			indicator := "  "
-			if isSelected {
-				indicator = "> "
-			}
-			line := indicator + display
-			st := StyleDimmed
-			if isSelected {
-				st = selectedStyle
-			}
-			lineRunes := []rune(line)
-			for c := 0; c < innerW && c < len(lineRunes); c++ {
-				screen.SetContent(innerX+c, row+vi, lineRunes[c], nil, st)
-			}
-		}
-		row += visible
-	}
+	row += f.ac.Draw(screen, innerX, row, innerW, qaMaxVisible)
 
 	row++ // gap
 

--- a/internal/tui2/quickaddform_test.go
+++ b/internal/tui2/quickaddform_test.go
@@ -218,7 +218,7 @@ func TestQuickAddForm_DirAutocomplete(t *testing.T) {
 	f.dirCursor = len(f.dirPath)
 
 	f.updateDirAutocomplete()
-	testutil.Equal(t, f.ac.open, true)
+	testutil.Equal(t, f.ac.Open(), true)
 	testutil.Equal(t, len(f.ac.matches), 1)
 	testutil.Equal(t, f.ac.matches[0], filepath.Join(dir, "Development"))
 }
@@ -234,7 +234,7 @@ func TestQuickAddForm_DirAutocompleteListsAll(t *testing.T) {
 	f.dirCursor = len(f.dirPath)
 
 	f.updateDirAutocomplete()
-	testutil.Equal(t, f.ac.open, true)
+	testutil.Equal(t, f.ac.Open(), true)
 	testutil.Equal(t, len(f.ac.matches), 2)
 }
 
@@ -249,7 +249,7 @@ func TestQuickAddForm_DirAutocompleteSkipsHidden(t *testing.T) {
 	f.dirCursor = len(f.dirPath)
 
 	f.updateDirAutocomplete()
-	testutil.Equal(t, f.ac.open, true)
+	testutil.Equal(t, f.ac.Open(), true)
 	testutil.Equal(t, len(f.ac.matches), 1)
 	testutil.Equal(t, f.ac.matches[0], filepath.Join(dir, "visible"))
 }
@@ -263,7 +263,7 @@ func TestQuickAddForm_AcceptAutocomplete(t *testing.T) {
 	f.dirCursor = len(f.dirPath)
 	f.updateDirAutocomplete()
 
-	testutil.Equal(t, f.ac.open, true)
+	testutil.Equal(t, f.ac.Open(), true)
 
 	// Accept via Tab.
 	f.acceptAutocomplete()
@@ -280,11 +280,11 @@ func TestQuickAddForm_EscapeClosesACNotForm(t *testing.T) {
 	f.dirPath = []rune(dir + "/")
 	f.dirCursor = len(f.dirPath)
 	f.updateDirAutocomplete()
-	testutil.Equal(t, f.ac.open, true)
+	testutil.Equal(t, f.ac.Open(), true)
 
 	// Escape should close AC, NOT cancel the form.
 	f.handleDirInputKey(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
-	testutil.Equal(t, f.ac.open, false)
+	testutil.Equal(t, f.ac.Open(), false)
 	testutil.Equal(t, f.canceled, false)
 }
 
@@ -296,11 +296,11 @@ func TestQuickAddForm_CtrlQClosesACNotForm(t *testing.T) {
 	f.dirPath = []rune(dir + "/")
 	f.dirCursor = len(f.dirPath)
 	f.updateDirAutocomplete()
-	testutil.Equal(t, f.ac.open, true)
+	testutil.Equal(t, f.ac.Open(), true)
 
 	// CtrlQ should close AC, NOT cancel the form.
 	f.handleDirInputKey(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone))
-	testutil.Equal(t, f.ac.open, false)
+	testutil.Equal(t, f.ac.Open(), false)
 	testutil.Equal(t, f.canceled, false)
 }
 

--- a/internal/tui2/quickaddform_test.go
+++ b/internal/tui2/quickaddform_test.go
@@ -218,9 +218,9 @@ func TestQuickAddForm_DirAutocomplete(t *testing.T) {
 	f.dirCursor = len(f.dirPath)
 
 	f.updateDirAutocomplete()
-	testutil.Equal(t, f.acOpen, true)
-	testutil.Equal(t, len(f.acMatches), 1)
-	testutil.Equal(t, f.acMatches[0], filepath.Join(dir, "Development"))
+	testutil.Equal(t, f.ac.open, true)
+	testutil.Equal(t, len(f.ac.matches), 1)
+	testutil.Equal(t, f.ac.matches[0], filepath.Join(dir, "Development"))
 }
 
 func TestQuickAddForm_DirAutocompleteListsAll(t *testing.T) {
@@ -234,8 +234,8 @@ func TestQuickAddForm_DirAutocompleteListsAll(t *testing.T) {
 	f.dirCursor = len(f.dirPath)
 
 	f.updateDirAutocomplete()
-	testutil.Equal(t, f.acOpen, true)
-	testutil.Equal(t, len(f.acMatches), 2)
+	testutil.Equal(t, f.ac.open, true)
+	testutil.Equal(t, len(f.ac.matches), 2)
 }
 
 func TestQuickAddForm_DirAutocompleteSkipsHidden(t *testing.T) {
@@ -249,9 +249,9 @@ func TestQuickAddForm_DirAutocompleteSkipsHidden(t *testing.T) {
 	f.dirCursor = len(f.dirPath)
 
 	f.updateDirAutocomplete()
-	testutil.Equal(t, f.acOpen, true)
-	testutil.Equal(t, len(f.acMatches), 1)
-	testutil.Equal(t, f.acMatches[0], filepath.Join(dir, "visible"))
+	testutil.Equal(t, f.ac.open, true)
+	testutil.Equal(t, len(f.ac.matches), 1)
+	testutil.Equal(t, f.ac.matches[0], filepath.Join(dir, "visible"))
 }
 
 func TestQuickAddForm_AcceptAutocomplete(t *testing.T) {
@@ -263,13 +263,45 @@ func TestQuickAddForm_AcceptAutocomplete(t *testing.T) {
 	f.dirCursor = len(f.dirPath)
 	f.updateDirAutocomplete()
 
-	testutil.Equal(t, f.acOpen, true)
+	testutil.Equal(t, f.ac.open, true)
 
 	// Accept via Tab.
 	f.acceptAutocomplete()
 	result := string(f.dirPath)
 	expected := collapseTilde(filepath.Join(dir, "Development")) + "/"
 	testutil.Equal(t, result, expected)
+}
+
+func TestQuickAddForm_EscapeClosesACNotForm(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "alpha"), 0o755)
+
+	f := NewQuickAddForm(nil)
+	f.dirPath = []rune(dir + "/")
+	f.dirCursor = len(f.dirPath)
+	f.updateDirAutocomplete()
+	testutil.Equal(t, f.ac.open, true)
+
+	// Escape should close AC, NOT cancel the form.
+	f.handleDirInputKey(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
+	testutil.Equal(t, f.ac.open, false)
+	testutil.Equal(t, f.canceled, false)
+}
+
+func TestQuickAddForm_CtrlQClosesACNotForm(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "alpha"), 0o755)
+
+	f := NewQuickAddForm(nil)
+	f.dirPath = []rune(dir + "/")
+	f.dirCursor = len(f.dirPath)
+	f.updateDirAutocomplete()
+	testutil.Equal(t, f.ac.open, true)
+
+	// CtrlQ should close AC, NOT cancel the form.
+	f.handleDirInputKey(tcell.NewEventKey(tcell.KeyCtrlQ, 0, tcell.ModNone))
+	testutil.Equal(t, f.ac.open, false)
+	testutil.Equal(t, f.canceled, false)
 }
 
 func TestQuickAddForm_SelectedRepos(t *testing.T) {

--- a/internal/tui2/settings.go
+++ b/internal/tui2/settings.go
@@ -43,6 +43,9 @@ const (
 	vaultKeyArgus = "_argus_vault"
 )
 
+// svMaxACVisible is the maximum number of vault path autocomplete rows shown.
+const svMaxACVisible = 8
+
 // settingsRow is a single row in the settings section list.
 type settingsRow struct {
 	kind  settingsRowKind
@@ -104,6 +107,7 @@ type SettingsView struct {
 	editingVault     string   // which vault is being edited: vaultKeyMetis or vaultKeyArgus, or "" if not editing
 	editVaultBuf     string   // buffer for in-progress vault path edit
 	discoveredVaults []string // sorted absolute paths of discovered iCloud Obsidian vaults
+	vaultAC          dirAC    // directory autocomplete for vault path editing
 
 	// Logs detail scroll.
 	logScrollOff int
@@ -431,6 +435,7 @@ func (sv *SettingsView) PasteHandler() func(pastedText string, setFocus func(p t
 			sv.rebuildRows()
 		} else if sv.editingVault != "" {
 			sv.editVaultBuf += pastedText
+			sv.vaultAC.Update(sv.editVaultBuf)
 			sv.rebuildRows()
 		}
 	})
@@ -660,6 +665,7 @@ func (sv *SettingsView) handleEnter() bool {
 	case srVaultPath:
 		// Start inline editing for the selected vault path.
 		sv.editingVault = row.key
+		sv.vaultAC.Close()
 		if row.key == vaultKeyMetis {
 			sv.editVaultBuf = sv.metisVaultPath
 		} else if row.key == vaultKeyArgus {
@@ -790,11 +796,24 @@ func (sv *SettingsView) handleEditPromptKey(ev *tcell.EventKey) bool {
 
 // handleEditVaultKey handles keystrokes while inline-editing a vault path.
 func (sv *SettingsView) handleEditVaultKey(ev *tcell.EventKey) bool {
+	// Delegate navigation keys to the autocomplete widget.
+	consumed, accepted := sv.vaultAC.HandleKey(ev, sv.editVaultBuf)
+	if accepted != "" {
+		sv.editVaultBuf = accepted
+		sv.rebuildRows()
+		return true
+	}
+	if consumed {
+		sv.rebuildRows()
+		return true
+	}
+
 	switch ev.Key() {
 	case tcell.KeyEnter:
 		path := sv.editVaultBuf
 		key := sv.editingVault
 		sv.editingVault = ""
+		sv.vaultAC.Close()
 		if key == vaultKeyMetis {
 			sv.metisVaultPath = path
 			if err := sv.database.SetConfigValue("kb.metis_vault_path", path); err != nil {
@@ -812,17 +831,22 @@ func (sv *SettingsView) handleEditVaultKey(ev *tcell.EventKey) bool {
 		return true
 	case tcell.KeyEscape:
 		sv.editingVault = ""
+		sv.vaultAC.Close()
 		sv.rebuildRows()
 		return true
+	case tcell.KeyDown, tcell.KeyUp:
+		return true // consume to avoid cursor movement while editing
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
 		if len(sv.editVaultBuf) > 0 {
 			_, size := utf8.DecodeLastRuneInString(sv.editVaultBuf)
 			sv.editVaultBuf = sv.editVaultBuf[:len(sv.editVaultBuf)-size]
+			sv.vaultAC.Update(sv.editVaultBuf)
 			sv.rebuildRows()
 		}
 		return true
 	case tcell.KeyRune:
 		sv.editVaultBuf += string(ev.Rune())
+		sv.vaultAC.Update(sv.editVaultBuf)
 		sv.rebuildRows()
 		return true
 	}
@@ -1298,7 +1322,13 @@ func (sv *SettingsView) renderVaultPathDetail(screen tcell.Screen, x, y, w, h in
 		display = "(not configured)"
 	}
 	drawText(screen, x, y+r, w, display, tcell.StyleDefault.Foreground(ColorComplete))
-	r += 2
+	r++
+
+	// Autocomplete dropdown (only when editing this vault).
+	if editing {
+		r += sv.vaultAC.Draw(screen, x, y+r, w, svMaxACVisible)
+	}
+	r++
 
 	drawText(screen, x, y+r, w, desc, StyleDimmed)
 	r += 2
@@ -1325,7 +1355,7 @@ func (sv *SettingsView) renderVaultPathDetail(screen tcell.Screen, x, y, w, h in
 
 	if r < h {
 		if editing {
-			drawText(screen, x, y+r, w, "[enter] save  [esc] cancel", StyleDimmed)
+			drawText(screen, x, y+r, w, "[enter] save  [tab] complete  [esc] cancel", StyleDimmed)
 		} else if len(sv.discoveredVaults) > 0 {
 			drawText(screen, x, y+r, w, "[enter] edit path  [◀/▶] cycle vaults", StyleDimmed)
 		} else {

--- a/internal/tui2/settings_test.go
+++ b/internal/tui2/settings_test.go
@@ -1129,6 +1129,105 @@ func TestSettingsView_VaultPathCycleNoVaults(t *testing.T) {
 	testutil.Equal(t, sv.metisVaultPath, origMetis)
 }
 
+func TestSettingsView_VaultPathAutocomplete(t *testing.T) {
+	root := setupACDirs(t, "MetisVault", "ArgusVault", "OtherDir")
+
+	database, err := db.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sv := NewSettingsView(database)
+	sv.Refresh()
+
+	// Find metis vault row and start editing.
+	for i, row := range sv.rows {
+		if row.kind == srVaultPath && row.key == vaultKeyMetis {
+			sv.cursor = i
+			break
+		}
+	}
+	sv.handleEnter()
+	testutil.Equal(t, sv.editingVault, vaultKeyMetis)
+
+	t.Run("typing path opens autocomplete", func(t *testing.T) {
+		sv.editVaultBuf = root + "/"
+		sv.vaultAC.Update(sv.editVaultBuf)
+		testutil.Equal(t, sv.vaultAC.Open(), true)
+		testutil.Equal(t, len(sv.vaultAC.matches), 3)
+	})
+
+	t.Run("typing prefix filters", func(t *testing.T) {
+		sv.editVaultBuf = root + "/M"
+		sv.vaultAC.Update(sv.editVaultBuf)
+		testutil.Equal(t, sv.vaultAC.Open(), true)
+		testutil.Equal(t, len(sv.vaultAC.matches), 1)
+		testutil.Contains(t, sv.vaultAC.matches[0], "MetisVault")
+	})
+
+	t.Run("tab accepts autocomplete", func(t *testing.T) {
+		sv.editVaultBuf = root + "/M"
+		sv.vaultAC.Update(sv.editVaultBuf)
+		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone))
+		testutil.Contains(t, sv.editVaultBuf, "MetisVault/")
+	})
+
+	t.Run("tab on closed triggers and accepts", func(t *testing.T) {
+		sv.editVaultBuf = root + "/A"
+		sv.vaultAC.Close()
+		testutil.Equal(t, sv.vaultAC.Open(), false)
+		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone))
+		testutil.Contains(t, sv.editVaultBuf, "ArgusVault/")
+	})
+
+	t.Run("down/up navigates", func(t *testing.T) {
+		sv.editVaultBuf = root + "/"
+		sv.vaultAC.Update(sv.editVaultBuf)
+		testutil.Equal(t, sv.vaultAC.idx, 0)
+
+		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
+		testutil.Equal(t, sv.vaultAC.idx, 1)
+
+		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone))
+		testutil.Equal(t, sv.vaultAC.idx, 0)
+	})
+
+	t.Run("escape closes autocomplete first", func(t *testing.T) {
+		sv.editVaultBuf = root + "/"
+		sv.vaultAC.Update(sv.editVaultBuf)
+		testutil.Equal(t, sv.vaultAC.Open(), true)
+
+		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
+		testutil.Equal(t, sv.vaultAC.Open(), false)
+		testutil.Equal(t, sv.editingVault, vaultKeyMetis) // still editing
+	})
+
+	t.Run("enter accepts autocomplete instead of saving", func(t *testing.T) {
+		sv.editVaultBuf = root + "/O"
+		sv.vaultAC.Update(sv.editVaultBuf)
+		testutil.Equal(t, sv.vaultAC.Open(), true)
+
+		sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+		testutil.Contains(t, sv.editVaultBuf, "OtherDir/")
+		testutil.Equal(t, sv.editingVault, vaultKeyMetis) // still editing, not saved
+	})
+
+	t.Run("paste triggers autocomplete", func(t *testing.T) {
+		sv.editVaultBuf = ""
+		sv.vaultAC.Close()
+
+		paste := sv.PasteHandler()
+		paste(root+"/", func(p tview.Primitive) {})
+
+		testutil.Equal(t, sv.editVaultBuf, root+"/")
+		testutil.Equal(t, sv.vaultAC.Open(), true)
+		testutil.Equal(t, len(sv.vaultAC.matches), 3)
+	})
+
+	// Clean up editing state.
+	sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
+	sv.handleEditVaultKey(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
+}
+
 // findProjectEntry locates a project in the settings view by name.
 func findProjectEntry(t *testing.T, sv *SettingsView, name string) *projectEntry {
 	t.Helper()


### PR DESCRIPTION
Extract reusable dirAC widget from duplicated autocomplete logic in ProjectForm and QuickAddForm, then use it to add tab-complete, paste support, and dropdown navigation to the Obsidian vault path editor in Settings.

Co-Authored-By: Claude <noreply@anthropic.com>