### PR TITLE
Exclude truncated URLs with ellipsis from open link list

### DIFF
--- a/internal/tui2/todolinks.go
+++ b/internal/tui2/todolinks.go
@@ -73,10 +73,11 @@ func cleanURL(u string) string {
 	return u
 }
 
-// isTruncatedURL returns true if the URL contains an ellipsis ("…" or "...")
-// indicating it was truncated and is not a valid link target.
-func isTruncatedURL(url string) bool {
-	return strings.Contains(url, "\u2026") || strings.Contains(url, "...")
+// isTruncatedURL returns true if the URL contains a truncation marker.
+// Unicode ellipsis (…) can appear anywhere; ASCII "..." is only checked as a
+// suffix to avoid false-positives on legitimate URLs (e.g. GitHub compare ranges).
+func isTruncatedURL(raw string) bool {
+	return strings.Contains(raw, "\u2026") || strings.HasSuffix(raw, "...")
 }
 
 // ExtractLinks extracts unique URLs from content that may contain ANSI escape

--- a/internal/tui2/todolinks.go
+++ b/internal/tui2/todolinks.go
@@ -73,6 +73,12 @@ func cleanURL(u string) string {
 	return u
 }
 
+// isTruncatedURL returns true if the URL contains an ellipsis ("…" or "...")
+// indicating it was truncated and is not a valid link target.
+func isTruncatedURL(url string) bool {
+	return strings.Contains(url, "\u2026") || strings.Contains(url, "...")
+}
+
 // ExtractLinks extracts unique URLs from content that may contain ANSI escape
 // sequences (e.g. raw PTY session logs). Markdown-style links [text](url) are
 // preferred; bare URLs not already captured by a markdown link are added with
@@ -86,7 +92,11 @@ func ExtractLinks(content string) []Link {
 
 	// First pass: markdown links
 	for _, m := range mdLinkRe.FindAllStringSubmatch(content, -1) {
-		url := cleanURL(m[2])
+		raw := m[2]
+		if isTruncatedURL(raw) {
+			continue
+		}
+		url := cleanURL(raw)
 		if url == "" || seen[url] {
 			continue
 		}
@@ -96,6 +106,9 @@ func ExtractLinks(content string) []Link {
 
 	// Second pass: bare URLs not already captured
 	for _, raw := range bareLinkRe.FindAllString(content, -1) {
+		if isTruncatedURL(raw) {
+			continue
+		}
 		url := cleanURL(raw)
 		if url == "" || seen[url] {
 			continue

--- a/internal/tui2/todolinks_test.go
+++ b/internal/tui2/todolinks_test.go
@@ -159,6 +159,26 @@ func TestExtractLinks(t *testing.T) {
 			content: "https://example.com/articles/16\x1b[39m\x1b[2C\x1b[1Bextra",
 			want:    []Link{{Label: "https://example.com/articles/16", URL: "https://example.com/articles/16"}},
 		},
+		{
+			name:    "bare URL with unicode ellipsis excluded",
+			content: "see https://example.com/very/long/path/that/gets\u2026 for info",
+			want:    nil,
+		},
+		{
+			name:    "bare URL with three-dot ellipsis excluded",
+			content: "see https://example.com/very/long/path/that/gets... for info",
+			want:    nil,
+		},
+		{
+			name:    "markdown link with ellipsis in URL excluded",
+			content: "[Truncated](https://example.com/path\u2026)",
+			want:    nil,
+		},
+		{
+			name:    "ellipsis URL excluded but valid URL kept",
+			content: "https://example.com/truncated\u2026 and https://example.com/valid",
+			want:    []Link{{Label: "https://example.com/valid", URL: "https://example.com/valid"}},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/tui2/todolinks_test.go
+++ b/internal/tui2/todolinks_test.go
@@ -179,6 +179,11 @@ func TestExtractLinks(t *testing.T) {
 			content: "https://example.com/truncated\u2026 and https://example.com/valid",
 			want:    []Link{{Label: "https://example.com/valid", URL: "https://example.com/valid"}},
 		},
+		{
+			name:    "github compare range with triple dots not excluded",
+			content: "https://github.com/org/repo/compare/v1.0...v1.1",
+			want:    []Link{{Label: "https://github.com/org/repo/compare/v1.0...v1.1", URL: "https://github.com/org/repo/compare/v1.0...v1.1"}},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Filter out URLs containing ellipsis characters (Unicode … and trailing ASCII ...) from the link picker, since they represent truncated URLs that are not valid link targets. Uses HasSuffix for ASCII dots to avoid false-positives on legitimate URLs like GitHub compare ranges.

Co-Authored-By: Claude <noreply@anthropic.com>