### PR TITLE
Fix Codex config injection placing top-level key inside TOML section

### DIFF
--- a/context/knowledge/gotchas/misc.md
+++ b/context/knowledge/gotchas/misc.md
@@ -20,6 +20,7 @@
 - **`codex resume --last` is unreliable for multi-session.** Use `codex resume --dangerously-bypass-approvals-and-sandbox <session-id>`.
 - **Session ID captured post-exit from `~/.codex/state_5.sqlite`.** The `_5` suffix is codex's schema version.
 - **`fixupBackends()` migrates old codex flags** (`--yolo`, `--full-auto`) to `--dangerously-bypass-approvals-and-sandbox`.
+- **`ensureTopLevel` must insert before the first `[section]` header, not append.** Appending a top-level TOML key to the end of a file places it inside the last section (e.g. `[notice.model_migrations]`), causing type errors. `ensureTopLevel` also migrates previously misplaced keys.
 
 ## Knowledge Base & MCP
 

--- a/internal/inject/codex/codex.go
+++ b/internal/inject/codex/codex.go
@@ -33,7 +33,8 @@ func injectCodexTOML(path string, port int) error {
 		content = string(raw)
 	}
 
-	// Check if already correct.
+	// Check if MCP section already exists.
+	urlCorrect := false
 	if strings.Contains(content, "[mcp_servers.argus-kb]") {
 		// Find the url line in the section and check its value.
 		idx := strings.Index(content, "[mcp_servers.argus-kb]")
@@ -48,25 +49,30 @@ func injectCodexTOML(path string, port int) error {
 		}
 		wantLine := fmt.Sprintf(`url = "%s"`, url)
 		if strings.Contains(sectionBody, wantLine) {
-			return nil // already correct
+			urlCorrect = true
+		} else {
+			// Port changed — remove old section and re-add below.
+			content = removeSection(content, "[mcp_servers.argus-kb]")
 		}
-		// Port changed — remove old section and re-add below.
-		content = removeSection(content, "[mcp_servers.argus-kb]")
 	}
 
-	// Ensure experimental_use_rmcp_client is present.
-	if !strings.Contains(content, "experimental_use_rmcp_client") {
-		if content != "" && !strings.HasSuffix(content, "\n") {
-			content += "\n"
+	// Ensure experimental_use_rmcp_client = true is at the TOML top level.
+	// Must appear before the first [section] header — appending to the end
+	// places it inside the last section (e.g. [notice.model_migrations]),
+	// causing a type error ("expected a string" for boolean true).
+	updated := ensureTopLevel(content, "experimental_use_rmcp_client", "experimental_use_rmcp_client = true")
+
+	if !urlCorrect {
+		// Append the MCP server section.
+		if updated != "" && !strings.HasSuffix(updated, "\n") {
+			updated += "\n"
 		}
-		content += "experimental_use_rmcp_client = true\n"
+		updated += fmt.Sprintf("\n[mcp_servers.argus-kb]\nurl = %q\n", url)
 	}
 
-	// Append the section.
-	if content != "" && !strings.HasSuffix(content, "\n") {
-		content += "\n"
+	if updated == content {
+		return nil // nothing changed
 	}
-	content += fmt.Sprintf("\n[mcp_servers.argus-kb]\nurl = %q\n", url)
 
 	// Atomic write: write to temp file then rename to avoid partial reads.
 	tmp, err := os.CreateTemp(filepath.Dir(path), ".argus-codex-*.tmp")
@@ -75,7 +81,7 @@ func injectCodexTOML(path string, port int) error {
 	}
 	tmpName := tmp.Name()
 	defer os.Remove(tmpName) //nolint:errcheck — cleanup on failure
-	if _, err := tmp.WriteString(content); err != nil {
+	if _, err := tmp.WriteString(updated); err != nil {
 		tmp.Close()
 		return fmt.Errorf("inject codex: write temp: %w", err)
 	}
@@ -83,6 +89,44 @@ func injectCodexTOML(path string, port int) error {
 		return fmt.Errorf("inject codex: close temp: %w", err)
 	}
 	return os.Rename(tmpName, path)
+}
+
+// ensureTopLevel ensures a key=value line exists at the TOML top level
+// (before the first [section] header). If the key exists only inside a
+// section, it is removed and re-inserted at the top level.
+func ensureTopLevel(content, key, line string) string {
+	// Determine where the top-level (pre-section) area ends.
+	firstSection := strings.Index(content, "\n[")
+	topLevel := content
+	if firstSection != -1 {
+		topLevel = content[:firstSection]
+	}
+	if strings.Contains(topLevel, key) {
+		return content // already at top level
+	}
+	// Remove from wrong section if present.
+	content = removeLine(content, key)
+	// Insert at top level (before first section header).
+	firstSection = strings.Index(content, "\n[")
+	if firstSection == -1 {
+		if content != "" && !strings.HasSuffix(content, "\n") {
+			content += "\n"
+		}
+		return content + line + "\n"
+	}
+	return content[:firstSection+1] + line + "\n" + content[firstSection+1:]
+}
+
+// removeLine removes all lines containing substr from content.
+func removeLine(content, substr string) string {
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if !strings.Contains(l, substr) {
+			out = append(out, l)
+		}
+	}
+	return strings.Join(out, "\n")
 }
 
 // removeSection removes a TOML section header and its key-value lines.

--- a/internal/inject/codex/codex.go
+++ b/internal/inject/codex/codex.go
@@ -24,6 +24,7 @@ func InjectGlobal(port int) error {
 
 // injectCodexTOML inserts or updates the [mcp_servers.argus-kb] section.
 // Uses targeted string manipulation to avoid pulling in a TOML library.
+// Assumes standard Codex-generated TOML — no multi-line values, no inline tables.
 func injectCodexTOML(path string, port int) error {
 	url := fmt.Sprintf("http://localhost:%d/mcp", port)
 
@@ -96,9 +97,13 @@ func injectCodexTOML(path string, port int) error {
 // section, it is removed and re-inserted at the top level.
 func ensureTopLevel(content, key, line string) string {
 	// Determine where the top-level (pre-section) area ends.
+	// Handle files that start directly with a section header (no top-level area).
 	firstSection := strings.Index(content, "\n[")
 	topLevel := content
-	if firstSection != -1 {
+	if strings.HasPrefix(content, "[") {
+		topLevel = ""
+		firstSection = 0 // entire content is sections
+	} else if firstSection != -1 {
 		topLevel = content[:firstSection]
 	}
 	if strings.Contains(topLevel, key) {
@@ -107,6 +112,9 @@ func ensureTopLevel(content, key, line string) string {
 	// Remove from wrong section if present.
 	content = removeLine(content, key)
 	// Insert at top level (before first section header).
+	if strings.HasPrefix(content, "[") {
+		return line + "\n" + content
+	}
 	firstSection = strings.Index(content, "\n[")
 	if firstSection == -1 {
 		if content != "" && !strings.HasSuffix(content, "\n") {
@@ -117,7 +125,7 @@ func ensureTopLevel(content, key, line string) string {
 	return content[:firstSection+1] + line + "\n" + content[firstSection+1:]
 }
 
-// removeLine removes all lines containing substr from content.
+// removeLine removes all lines containing substr (substring match) from content.
 func removeLine(content, substr string) string {
 	lines := strings.Split(content, "\n")
 	out := make([]string, 0, len(lines))

--- a/internal/inject/codex/codex_test.go
+++ b/internal/inject/codex/codex_test.go
@@ -168,9 +168,12 @@ url = "http://localhost:7742/mcp"
 		t.Errorf("expected exactly 1 occurrence, got %d:\n%s",
 			strings.Count(content, "experimental_use_rmcp_client"), content)
 	}
-	// MCP section must still be present and correct.
+	// MCP section must still be present, correct, and not duplicated.
 	if !strings.Contains(content, `url = "http://localhost:7742/mcp"`) {
 		t.Errorf("MCP url missing:\n%s", content)
+	}
+	if strings.Count(content, "[mcp_servers.argus-kb]") != 1 {
+		t.Errorf("MCP section duplicated:\n%s", content)
 	}
 }
 
@@ -178,27 +181,26 @@ func TestEnsureTopLevel(t *testing.T) {
 	tests := []struct {
 		name    string
 		content string
-		wantAt  string // "top" or "absent->top"
 	}{
 		{
 			name:    "empty file",
 			content: "",
-			wantAt:  "absent->top",
 		},
 		{
 			name:    "already at top level",
 			content: "experimental_use_rmcp_client = true\n\n[section]\nkey = val\n",
-			wantAt:  "top",
 		},
 		{
 			name:    "inside section",
 			content: "model = \"gpt-5\"\n\n[section]\nexperimental_use_rmcp_client = true\n",
-			wantAt:  "absent->top",
 		},
 		{
 			name:    "no sections",
 			content: "model = \"gpt-5\"\n",
-			wantAt:  "absent->top",
+		},
+		{
+			name:    "file starts with section header",
+			content: "[section]\nkey = val\n",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/inject/codex/codex_test.go
+++ b/internal/inject/codex/codex_test.go
@@ -97,6 +97,128 @@ func TestInjectCodexTOML_PreservesExistingContent(t *testing.T) {
 	}
 }
 
+func TestInjectCodexTOML_TopLevelKeyNotInSection(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	// Simulate existing config where a section is the last thing in the file.
+	// The old code would append experimental_use_rmcp_client AFTER the section,
+	// placing it inside [notice.model_migrations] instead of at the top level.
+	existing := `model = "gpt-5.4"
+
+[notice.model_migrations]
+"gpt-5.3-codex" = "gpt-5.4"
+`
+	os.WriteFile(path, []byte(existing), 0644) //nolint:errcheck
+
+	if err := injectCodexTOML(path, 7742); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+
+	// experimental_use_rmcp_client must be before the first section header.
+	idx := strings.Index(content, "experimental_use_rmcp_client")
+	firstSection := strings.Index(content, "\n[")
+	if idx == -1 {
+		t.Fatal("missing experimental_use_rmcp_client")
+	}
+	if firstSection != -1 && idx > firstSection {
+		t.Errorf("experimental_use_rmcp_client is inside a section (pos %d > first section at %d):\n%s",
+			idx, firstSection, content)
+	}
+}
+
+func TestInjectCodexTOML_MigratesMisplacedKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	// Reproduce the exact broken state: experimental_use_rmcp_client inside
+	// [notice.model_migrations] with a correct MCP section already present.
+	broken := `model = "gpt-5.4"
+
+[notice.model_migrations]
+"gpt-5.3-codex" = "gpt-5.4"
+experimental_use_rmcp_client = true
+
+[mcp_servers.argus-kb]
+url = "http://localhost:7742/mcp"
+`
+	os.WriteFile(path, []byte(broken), 0644) //nolint:errcheck
+
+	if err := injectCodexTOML(path, 7742); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+
+	// Key must now be at the top level.
+	idx := strings.Index(content, "experimental_use_rmcp_client")
+	firstSection := strings.Index(content, "\n[")
+	if idx == -1 {
+		t.Fatal("missing experimental_use_rmcp_client")
+	}
+	if firstSection != -1 && idx > firstSection {
+		t.Errorf("experimental_use_rmcp_client still inside a section:\n%s", content)
+	}
+	// Must not appear twice.
+	if strings.Count(content, "experimental_use_rmcp_client") != 1 {
+		t.Errorf("expected exactly 1 occurrence, got %d:\n%s",
+			strings.Count(content, "experimental_use_rmcp_client"), content)
+	}
+	// MCP section must still be present and correct.
+	if !strings.Contains(content, `url = "http://localhost:7742/mcp"`) {
+		t.Errorf("MCP url missing:\n%s", content)
+	}
+}
+
+func TestEnsureTopLevel(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantAt  string // "top" or "absent->top"
+	}{
+		{
+			name:    "empty file",
+			content: "",
+			wantAt:  "absent->top",
+		},
+		{
+			name:    "already at top level",
+			content: "experimental_use_rmcp_client = true\n\n[section]\nkey = val\n",
+			wantAt:  "top",
+		},
+		{
+			name:    "inside section",
+			content: "model = \"gpt-5\"\n\n[section]\nexperimental_use_rmcp_client = true\n",
+			wantAt:  "absent->top",
+		},
+		{
+			name:    "no sections",
+			content: "model = \"gpt-5\"\n",
+			wantAt:  "absent->top",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ensureTopLevel(tt.content, "experimental_use_rmcp_client", "experimental_use_rmcp_client = true")
+			idx := strings.Index(result, "experimental_use_rmcp_client")
+			if idx == -1 {
+				t.Fatal("key missing from result")
+			}
+			firstSection := strings.Index(result, "\n[")
+			if firstSection != -1 && idx > firstSection {
+				t.Errorf("key is inside a section:\n%s", result)
+			}
+			if strings.Count(result, "experimental_use_rmcp_client") != 1 {
+				t.Errorf("duplicate keys:\n%s", result)
+			}
+		})
+	}
+}
+
 func TestRemoveSection(t *testing.T) {
 	content := "a = 1\n\n[mcp_servers.argus-kb]\nurl = \"http://localhost:7742/mcp\"\n\n[other]\nkey = val\n"
 	result := removeSection(content, "[mcp_servers.argus-kb]")


### PR DESCRIPTION
injectCodexTOML appended experimental_use_rmcp_client = true to the end of file content, placing it inside the last TOML section (e.g. [notice.model_migrations]). Codex expected string values in that section, causing 'expected a string' errors on launch.

ensureTopLevel now inserts before the first [section] header and migrates previously misplaced keys. Also handles edge case where file starts with a section header at byte 0.

Co-Authored-By: Claude <noreply@anthropic.com>