### PR TITLE
Clear file panel when entering agent view to prevent stale sidebar

### DIFF
--- a/internal/tui2/app.go
+++ b/internal/tui2/app.go
@@ -1823,6 +1823,8 @@ func (a *App) enterPendingAgentView(task *model.Task) {
 	a.agentPane.SetSession(nil)
 	a.agentPane.SetPending(true)
 	a.agentPane.SetFocused(true)
+	a.gitPanel.Clear()
+	a.filePanel.Clear()
 	a.filePanel.SetFocused(false)
 
 	// Hide the tab header in agent view — only the agent header is shown.
@@ -1855,6 +1857,7 @@ func (a *App) onTaskSelect(task *model.Task) {
 	a.worktreeDir = task.Worktree
 	a.lastGitRefresh = time.Time{}
 	a.gitPanel.Clear()
+	a.filePanel.Clear()
 
 	sess := a.runner.Get(task.ID)
 	if sess != nil {

--- a/internal/tui2/fileexplorer.go
+++ b/internal/tui2/fileexplorer.go
@@ -100,6 +100,18 @@ func (fp *FilePanel) SetDirChildren(dir string, children []gitutil.ChangedFile) 
 	fp.ensureVisible()
 }
 
+// Clear resets the file panel to its empty state. Call when switching tasks
+// so stale files from the previous task are not displayed while the async
+// git status fetch runs.
+func (fp *FilePanel) Clear() {
+	fp.files = nil
+	fp.rows = nil
+	fp.expanded = make(map[string]bool)
+	fp.dirChildren = make(map[string][]gitutil.ChangedFile)
+	fp.cursor = 0
+	fp.offset = 0
+}
+
 // SetFocused updates the focus state.
 func (fp *FilePanel) SetFocused(f bool) {
 	fp.focused = f

--- a/internal/tui2/fileexplorer_test.go
+++ b/internal/tui2/fileexplorer_test.go
@@ -760,3 +760,44 @@ func TestFilePanel_CursorUpStaysOnUnfetchedDir(t *testing.T) {
 		t.Errorf("expected cursor on a directory row awaiting fetch, got file %v", f.Path)
 	}
 }
+
+func TestFilePanel_Clear(t *testing.T) {
+	fp := NewFilePanel()
+	fp.Box.SetRect(0, 0, 40, 20)
+	files := []gitutil.ChangedFile{
+		{Status: "M", Path: "src/", IsDir: true},
+		{Status: "A", Path: "a.go"},
+		{Status: "M", Path: "b.go"},
+	}
+	fp.SetFiles(files)
+	fp.SetDirChildren("src/", []gitutil.ChangedFile{
+		{Status: "M", Path: "src/main.go"},
+	})
+	fp.CursorDown()
+
+	// Precondition: panel has data.
+	if fp.FileCount() == 0 {
+		t.Fatal("precondition: expected files before Clear")
+	}
+
+	fp.Clear()
+
+	if fp.FileCount() != 0 {
+		t.Errorf("FileCount after Clear = %d, want 0", fp.FileCount())
+	}
+	if len(fp.rows) != 0 {
+		t.Errorf("rows after Clear = %d, want 0", len(fp.rows))
+	}
+	if len(fp.expanded) != 0 {
+		t.Errorf("expanded after Clear = %d, want 0", len(fp.expanded))
+	}
+	if len(fp.dirChildren) != 0 {
+		t.Errorf("dirChildren after Clear = %d, want 0", len(fp.dirChildren))
+	}
+	if fp.cursor != 0 {
+		t.Errorf("cursor after Clear = %d, want 0", fp.cursor)
+	}
+	if fp.SelectedFile() != nil {
+		t.Error("SelectedFile after Clear should be nil")
+	}
+}

--- a/internal/tui2/fileexplorer_test.go
+++ b/internal/tui2/fileexplorer_test.go
@@ -797,6 +797,9 @@ func TestFilePanel_Clear(t *testing.T) {
 	if fp.cursor != 0 {
 		t.Errorf("cursor after Clear = %d, want 0", fp.cursor)
 	}
+	if fp.offset != 0 {
+		t.Errorf("offset after Clear = %d, want 0", fp.offset)
+	}
 	if fp.SelectedFile() != nil {
 		t.Error("SelectedFile after Clear should be nil")
 	}


### PR DESCRIPTION
File explorer sidebar displayed stale data from the previous task when switching to a new task's agent view. Added FilePanel.Clear() and call it in both onTaskSelect and enterPendingAgentView alongside the existing gitPanel.Clear().

Co-Authored-By: Claude <noreply@anthropic.com>