### PR TITLE
Add kb_delete MCP tool for knowledge base document removal

### DIFF
--- a/internal/db/kb.go
+++ b/internal/db/kb.go
@@ -57,22 +57,32 @@ func (d *DB) KBUpsert(doc *kb.Document) error {
 	return tx.Commit()
 }
 
+// ErrKBNotFound is returned when a KB document does not exist.
+var ErrKBNotFound = fmt.Errorf("kb document not found")
+
 // KBDelete removes a document from the knowledge base by its vault-relative path.
+// Returns ErrKBNotFound if the document does not exist.
 func (d *DB) KBDelete(path string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	tx, err := d.conn.Begin()
 	if err != nil {
-		return err
+		return fmt.Errorf("kb delete begin tx: %w", err)
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	if _, err := tx.Exec(`DELETE FROM kb_documents WHERE path = ?`, path); err != nil {
-		return err
+	res, err := tx.Exec(`DELETE FROM kb_documents WHERE path = ?`, path)
+	if err != nil {
+		return fmt.Errorf("kb delete documents: %w", err)
 	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrKBNotFound
+	}
+
 	if _, err := tx.Exec(`DELETE FROM kb_metadata WHERE path = ?`, path); err != nil {
-		return err
+		return fmt.Errorf("kb delete metadata: %w", err)
 	}
 	return tx.Commit()
 }

--- a/internal/db/kb_test.go
+++ b/internal/db/kb_test.go
@@ -116,6 +116,12 @@ func TestKBDelete(t *testing.T) {
 	if err == nil {
 		t.Error("expected error after delete, got nil")
 	}
+
+	// Deleting a non-existent document should return ErrKBNotFound.
+	err = d.KBDelete("notes/does-not-exist.md")
+	if err == nil {
+		t.Error("expected ErrKBNotFound for non-existent path, got nil")
+	}
 }
 
 func TestKBDocumentCount(t *testing.T) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -229,7 +229,7 @@ WHAT NOT TO DO:
 - Don't use inline #hashtags — put all tags in YAML frontmatter.
 - Don't nest folders more than 2 levels deep.`
 
-// toolDefs defines the four KB tools exposed via MCP.
+// toolDefs defines the KB tools exposed via MCP.
 var toolDefs = []Tool{
 	{
 		Name: "kb_search",
@@ -506,10 +506,12 @@ func (s *Server) toolKBDelete(id interface{}, args json.RawMessage) *Response {
 	if filepath.IsAbs(cleanPath) || strings.HasPrefix(cleanPath, "..") {
 		return toolError(id, "invalid path: must be vault-relative with no '..' components")
 	}
-
-	// Verify the document exists before deleting.
-	if _, err := s.db.KBGet(cleanPath); err != nil {
-		return toolError(id, fmt.Sprintf("Document not found: %v", err))
+	// After Clean, verify the resolved path stays within the vault.
+	if s.vaultPath != "" {
+		absPath := filepath.Join(s.vaultPath, cleanPath)
+		if !strings.HasPrefix(absPath, s.vaultPath+string(filepath.Separator)) && absPath != s.vaultPath {
+			return toolError(id, "invalid path: escapes vault directory")
+		}
 	}
 
 	if err := s.db.KBDelete(cleanPath); err != nil {
@@ -520,11 +522,12 @@ func (s *Server) toolKBDelete(id interface{}, args json.RawMessage) *Response {
 	if s.vaultPath != "" {
 		absPath := filepath.Join(s.vaultPath, cleanPath)
 		if err := os.Remove(absPath); err != nil && !os.IsNotExist(err) {
-			log.Printf("[mcp] vault delete failed: %v", err)
+			log.Printf("[mcp] vault delete failed for %s: %v", cleanPath, err)
+			return toolResult(id, fmt.Sprintf("Deleted %s from index (warning: vault file removal failed — re-index may restore it)", cleanPath))
 		}
 	}
 
-	return toolResult(id, fmt.Sprintf("Deleted %s", p.Path))
+	return toolResult(id, fmt.Sprintf("Deleted %s", cleanPath))
 }
 
 func (s *Server) toolKBIngest(id interface{}, args json.RawMessage) *Response {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -24,6 +24,7 @@ type KBQuerier interface {
 	KBGet(path string) (*kb.Document, error)
 	KBList(prefix string, limit int) ([]kb.Document, error)
 	KBUpsert(doc *kb.Document) error
+	KBDelete(path string) error
 	KBDocumentCount() int
 }
 
@@ -265,6 +266,17 @@ var toolDefs = []Tool{
 		},
 	},
 	{
+		Name:        "kb_delete",
+		Description: `Delete a document from the knowledge base by vault-relative path. Also removes the file from the Obsidian vault if it exists. Use kb_search or kb_list first to confirm the path.`,
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"path": map[string]interface{}{"type": "string", "description": "Vault-relative path of the document to delete (e.g. 'thanx/hiring.md')"},
+			},
+			"required": []string{"path"},
+		},
+	},
+	{
 		Name: "kb_ingest",
 		// Description intentionally duplicates key rules from kbInstructions —
 		// not all MCP clients surface server instructions at tool-call time.
@@ -376,6 +388,8 @@ func (s *Server) handleToolsCall(req *Request) *Response {
 		return s.toolKBRead(req.ID, params.Arguments)
 	case "kb_list":
 		return s.toolKBList(req.ID, params.Arguments)
+	case "kb_delete":
+		return s.toolKBDelete(req.ID, params.Arguments)
 	case "kb_ingest":
 		return s.toolKBIngest(req.ID, params.Arguments)
 	case "task_create":
@@ -475,6 +489,42 @@ func (s *Server) toolKBList(id interface{}, args json.RawMessage) *Response {
 		fmt.Fprintf(&sb, "- **%s** (%s) [%d words]\n", doc.Path, doc.Tier, doc.WordCount)
 	}
 	return toolResult(id, sb.String())
+}
+
+func (s *Server) toolKBDelete(id interface{}, args json.RawMessage) *Response {
+	var p struct {
+		Path string `json:"path"`
+	}
+	json.Unmarshal(args, &p) //nolint:errcheck
+
+	if p.Path == "" {
+		return toolError(id, "path is required")
+	}
+
+	// Canonicalize and validate the path: must be vault-relative, no escaping.
+	cleanPath := filepath.Clean(p.Path)
+	if filepath.IsAbs(cleanPath) || strings.HasPrefix(cleanPath, "..") {
+		return toolError(id, "invalid path: must be vault-relative with no '..' components")
+	}
+
+	// Verify the document exists before deleting.
+	if _, err := s.db.KBGet(cleanPath); err != nil {
+		return toolError(id, fmt.Sprintf("Document not found: %v", err))
+	}
+
+	if err := s.db.KBDelete(cleanPath); err != nil {
+		return toolError(id, fmt.Sprintf("Delete failed: %v", err))
+	}
+
+	// Remove from Obsidian vault if configured.
+	if s.vaultPath != "" {
+		absPath := filepath.Join(s.vaultPath, cleanPath)
+		if err := os.Remove(absPath); err != nil && !os.IsNotExist(err) {
+			log.Printf("[mcp] vault delete failed: %v", err)
+		}
+	}
+
+	return toolResult(id, fmt.Sprintf("Deleted %s", p.Path))
 }
 
 func (s *Server) toolKBIngest(id interface{}, args json.RawMessage) *Response {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -55,7 +55,7 @@ func (m *mockDB) KBDelete(path string) error {
 			return nil
 		}
 	}
-	return nil
+	return fmt.Errorf("kb document not found")
 }
 
 func (m *mockDB) KBDocumentCount() int {
@@ -284,7 +284,7 @@ func TestToolsCall_KBDelete(t *testing.T) {
 		testutil.NoError(t, respErr(resp))
 		cr := callResult(t, resp)
 		testutil.Equal(t, cr.IsError, true)
-		testutil.Contains(t, cr.Content[0].Text, "Document not found")
+		testutil.Contains(t, cr.Content[0].Text, "Delete failed")
 	})
 
 	t.Run("missing path", func(t *testing.T) {
@@ -321,9 +321,13 @@ func TestToolsCall_KBDelete_VaultRemoval(t *testing.T) {
 
 	// Create the vault file.
 	notesDir := filepath.Join(vaultDir, "notes")
-	os.MkdirAll(notesDir, 0o755)
+	if err := os.MkdirAll(notesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 	vaultFile := filepath.Join(notesDir, "delete-me.md")
-	os.WriteFile(vaultFile, []byte("# Delete Me\n\nbody"), 0o644)
+	if err := os.WriteFile(vaultFile, []byte("# Delete Me\n\nbody"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 
 	resp := doRequest(t, s, "tools/call", ToolCallParams{
 		Name:      "kb_delete",

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -48,6 +48,16 @@ func (m *mockDB) KBUpsert(doc *kb.Document) error {
 	return nil
 }
 
+func (m *mockDB) KBDelete(path string) error {
+	for i, d := range m.docs {
+		if d.Path == path {
+			m.docs = append(m.docs[:i], m.docs[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
 func (m *mockDB) KBDocumentCount() int {
 	return len(m.docs)
 }
@@ -139,15 +149,15 @@ func TestToolsList(t *testing.T) {
 	if err := json.Unmarshal(result, &list); err != nil {
 		t.Fatalf("unmarshal ToolsListResult: %v", err)
 	}
-	if len(list.Tools) != 4 {
-		t.Errorf("tools count: got %d, want 4", len(list.Tools))
+	if len(list.Tools) != 5 {
+		t.Errorf("tools count: got %d, want 5", len(list.Tools))
 	}
 
 	names := make(map[string]bool)
 	for _, tool := range list.Tools {
 		names[tool.Name] = true
 	}
-	for _, want := range []string{"kb_search", "kb_read", "kb_list", "kb_ingest"} {
+	for _, want := range []string{"kb_search", "kb_read", "kb_list", "kb_delete", "kb_ingest"} {
 		if !names[want] {
 			t.Errorf("missing tool: %s", want)
 		}
@@ -247,6 +257,92 @@ func TestToolsCall_KBIngest_NoVaultPath(t *testing.T) {
 	// Document should be in DB.
 	if len(db.docs) == 0 {
 		t.Fatal("document not in DB")
+	}
+}
+
+func TestToolsCall_KBDelete(t *testing.T) {
+	s := testServer()
+
+	t.Run("success", func(t *testing.T) {
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "kb_delete",
+			Arguments: json.RawMessage(`{"path": "notes/test.md"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		testutil.Contains(t, cr.Content[0].Text, "Deleted notes/test.md")
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "kb_delete",
+			Arguments: json.RawMessage(`{"path": "nonexistent.md"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "Document not found")
+	})
+
+	t.Run("missing path", func(t *testing.T) {
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "kb_delete",
+			Arguments: json.RawMessage(`{}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "path is required")
+	})
+
+	t.Run("path traversal blocked", func(t *testing.T) {
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "kb_delete",
+			Arguments: json.RawMessage(`{"path": "../etc/passwd"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "invalid path")
+	})
+}
+
+func TestToolsCall_KBDelete_VaultRemoval(t *testing.T) {
+	vaultDir := t.TempDir()
+	db := &mockDB{
+		docs: []kb.Document{
+			{Path: "notes/delete-me.md", Title: "Delete Me", Body: "body", Tier: "hot"},
+		},
+	}
+	s := New(db, 7742, vaultDir)
+
+	// Create the vault file.
+	notesDir := filepath.Join(vaultDir, "notes")
+	os.MkdirAll(notesDir, 0o755)
+	vaultFile := filepath.Join(notesDir, "delete-me.md")
+	os.WriteFile(vaultFile, []byte("# Delete Me\n\nbody"), 0o644)
+
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name:      "kb_delete",
+		Arguments: json.RawMessage(`{"path": "notes/delete-me.md"}`),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	if cr.IsError {
+		t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+	}
+
+	// Verify file was removed from vault.
+	if _, err := os.Stat(vaultFile); !os.IsNotExist(err) {
+		t.Error("vault file should have been deleted")
+	}
+
+	// Verify document was removed from mock DB.
+	if len(db.docs) != 0 {
+		t.Errorf("db should be empty, got %d docs", len(db.docs))
 	}
 }
 
@@ -370,8 +466,8 @@ func TestToolsList_WithTasks(t *testing.T) {
 	var list ToolsListResult
 	json.Unmarshal(result, &list) //nolint:errcheck
 
-	// 4 KB tools + 4 task tools = 8
-	testutil.Equal(t, len(list.Tools), 8)
+	// 5 KB tools + 4 task tools = 9
+	testutil.Equal(t, len(list.Tools), 9)
 
 	names := make(map[string]bool)
 	for _, tool := range list.Tools {
@@ -393,8 +489,8 @@ func TestToolsList_WithoutTasks(t *testing.T) {
 	var list ToolsListResult
 	json.Unmarshal(result, &list) //nolint:errcheck
 
-	// Only 4 KB tools
-	testutil.Equal(t, len(list.Tools), 4)
+	// Only 5 KB tools
+	testutil.Equal(t, len(list.Tools), 5)
 }
 
 func TestTaskCreate(t *testing.T) {


### PR DESCRIPTION
Wire up db.KBDelete to the MCP tool interface with path validation, vault confinement, vault file removal, ErrKBNotFound sentinel, and partial failure surfacing.

Co-Authored-By: Claude <noreply@anthropic.com>