### PR TITLE
Fix nil-sentinel panic, SSE timeout, and review findings

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -185,12 +185,15 @@ func (r *Runner) StopAll() {
 }
 
 // Running returns the task IDs of all active sessions.
+// Skips nil-sentinel entries (reserved-but-not-yet-started slots).
 func (r *Runner) Running() []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	ids := make([]string, 0, len(r.sessions))
-	for id := range r.sessions {
-		ids = append(ids, id)
+	for id, sess := range r.sessions {
+		if sess != nil {
+			ids = append(ids, id)
+		}
 	}
 	return ids
 }

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -196,12 +196,13 @@ func (r *Runner) Running() []string {
 }
 
 // Idle returns the task IDs of sessions that are alive but waiting for input.
+// Skips nil-sentinel entries (reserved-but-not-yet-started slots).
 func (r *Runner) Idle() []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	var ids []string
 	for id, sess := range r.sessions {
-		if sess.IsIdle() {
+		if sess != nil && sess.IsIdle() {
 			ids = append(ids, id)
 		}
 	}
@@ -219,23 +220,30 @@ func (r *Runner) WorkDir(taskID string) string {
 
 // Sessions returns a snapshot of all active sessions keyed by task ID.
 // Used by the daemon's ListSessions RPC to avoid per-session Get() calls.
+// Skips nil-sentinel entries (reserved-but-not-yet-started slots).
 func (r *Runner) Sessions() map[string]*Session {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	out := make(map[string]*Session, len(r.sessions))
 	for id, sess := range r.sessions {
-		out[id] = sess
+		if sess != nil {
+			out[id] = sess
+		}
 	}
 	return out
 }
 
 // RunningAndIdle returns the task IDs of all active sessions and of idle
 // sessions in a single pass under one lock acquisition.
+// Skips nil-sentinel entries (reserved-but-not-yet-started slots).
 func (r *Runner) RunningAndIdle() (running, idle []string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	running = make([]string, 0, len(r.sessions))
 	for id, sess := range r.sessions {
+		if sess == nil {
+			continue
+		}
 		running = append(running, id)
 		if sess.IsIdle() {
 			idle = append(idle, id)

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -474,6 +474,53 @@ func TestRunner_StopAll(t *testing.T) {
 	}
 }
 
+func TestRunner_NilSentinelSafety(t *testing.T) {
+	// Verify that observer methods (Idle, RunningAndIdle, Sessions) don't
+	// panic when a nil sentinel is present in the sessions map. The sentinel
+	// is placed by Start() during the window between slot reservation and
+	// actual session creation.
+	r := NewRunner(nil)
+
+	// Directly inject a nil sentinel to simulate the Start() window.
+	r.mu.Lock()
+	r.sessions["sentinel-task"] = nil
+	r.mu.Unlock()
+
+	// These must not panic.
+	idle := r.Idle()
+	if len(idle) != 0 {
+		t.Errorf("Idle() should skip nil sentinel, got %v", idle)
+	}
+
+	running, idleIDs := r.RunningAndIdle()
+	if len(running) != 0 {
+		t.Errorf("RunningAndIdle() should skip nil sentinel in running, got %v", running)
+	}
+	if len(idleIDs) != 0 {
+		t.Errorf("RunningAndIdle() should skip nil sentinel in idle, got %v", idleIDs)
+	}
+
+	sessions := r.Sessions()
+	if len(sessions) != 0 {
+		t.Errorf("Sessions() should skip nil sentinel, got %d entries", len(sessions))
+	}
+
+	// HasSession should still return true for the sentinel (it's a reservation).
+	if !r.HasSession("sentinel-task") {
+		t.Error("HasSession should return true for nil sentinel")
+	}
+
+	// Get should return nil for the sentinel.
+	if r.Get("sentinel-task") != nil {
+		t.Error("Get should return nil for nil sentinel")
+	}
+
+	// Clean up.
+	r.mu.Lock()
+	delete(r.sessions, "sentinel-task")
+	r.mu.Unlock()
+}
+
 func TestRunner_Detach_NoSession(t *testing.T) {
 	r := NewRunner(nil)
 	// Should not panic when detaching a nonexistent session

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -487,6 +487,11 @@ func TestRunner_NilSentinelSafety(t *testing.T) {
 	r.mu.Unlock()
 
 	// These must not panic.
+	runningOnly := r.Running()
+	if len(runningOnly) != 0 {
+		t.Errorf("Running() should skip nil sentinel, got %v", runningOnly)
+	}
+
 	idle := r.Idle()
 	if len(idle) != 0 {
 		t.Errorf("Idle() should skip nil sentinel, got %v", idle)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -429,8 +429,10 @@ func (s *Server) handleListSkills(w http.ResponseWriter, r *http.Request) {
 
 	var extraDirs []string
 	if project != "" {
-		projects, _ := s.db.Projects()
-		if p, ok := projects[project]; ok && p.Path != "" {
+		projects, err := s.db.Projects()
+		if err != nil {
+			log.Printf("[api] handleListSkills: failed to load projects: %v", err)
+		} else if p, ok := projects[project]; ok && p.Path != "" {
 			extraDirs = []string{filepath.Join(p.Path, ".claude", "skills")}
 		}
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -68,8 +68,9 @@ func (s *Server) ListenAndServe(port int) (int, error) {
 	srv := &http.Server{
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
-		WriteTimeout:      60 * time.Second,
 		IdleTimeout:       120 * time.Second,
+		// NOTE: WriteTimeout is intentionally omitted. Setting it would kill
+		// long-lived SSE streams (handleStreamOutput) after the timeout.
 	}
 	s.httpSrv = srv
 	go func() {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -71,6 +71,7 @@ func (s *Server) ListenAndServe(port int) (int, error) {
 		IdleTimeout:       120 * time.Second,
 		// NOTE: WriteTimeout is intentionally omitted. Setting it would kill
 		// long-lived SSE streams (handleStreamOutput) after the timeout.
+		// Non-streaming handlers all complete well within ReadHeaderTimeout.
 	}
 	s.httpSrv = srv
 	go func() {

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"log/slog"
 	"strconv"
 
 	"github.com/drn/argus/internal/config"
@@ -12,11 +13,15 @@ func (d *DB) Config() config.Config {
 	// Load backends (use defaults on error).
 	if backends, err := d.Backends(); err == nil {
 		cfg.Backends = backends
+	} else {
+		slog.Error("db.Config: failed to load backends", "err", err)
 	}
 
 	// Load projects (use defaults on error).
 	if projects, err := d.Projects(); err == nil {
 		cfg.Projects = projects
+	} else {
+		slog.Error("db.Config: failed to load projects", "err", err)
 	}
 
 	// Load scalar config values — hold mutex through iteration

--- a/internal/db/kb.go
+++ b/internal/db/kb.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -58,7 +59,7 @@ func (d *DB) KBUpsert(doc *kb.Document) error {
 }
 
 // ErrKBNotFound is returned when a KB document does not exist.
-var ErrKBNotFound = fmt.Errorf("kb document not found")
+var ErrKBNotFound = errors.New("kb document not found")
 
 // KBDelete removes a document from the knowledge base by its vault-relative path.
 // Returns ErrKBNotFound if the document does not exist.

--- a/internal/db/kb_test.go
+++ b/internal/db/kb_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -119,8 +120,14 @@ func TestKBDelete(t *testing.T) {
 
 	// Deleting a non-existent document should return ErrKBNotFound.
 	err = d.KBDelete("notes/does-not-exist.md")
-	if err == nil {
-		t.Error("expected ErrKBNotFound for non-existent path, got nil")
+	if !errors.Is(err, ErrKBNotFound) {
+		t.Errorf("expected ErrKBNotFound, got %v", err)
+	}
+
+	// Metadata should also be cleaned up.
+	count := d.KBDocumentCount()
+	if count != 0 {
+		t.Errorf("expected 0 documents after delete, got %d", count)
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -515,6 +515,7 @@ func (s *Server) toolKBDelete(id interface{}, args json.RawMessage) *Response {
 	}
 
 	if err := s.db.KBDelete(cleanPath); err != nil {
+		log.Printf("[mcp] kb_delete failed: path=%s err=%v", cleanPath, err)
 		return toolError(id, fmt.Sprintf("Delete failed: %v", err))
 	}
 
@@ -527,6 +528,7 @@ func (s *Server) toolKBDelete(id interface{}, args json.RawMessage) *Response {
 		}
 	}
 
+	log.Printf("[mcp] kb_delete ok: path=%s", cleanPath)
 	return toolResult(id, fmt.Sprintf("Deleted %s", cleanPath))
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/drn/argus/internal/db"
 	"github.com/drn/argus/internal/kb"
 	"github.com/drn/argus/internal/model"
 	"github.com/drn/argus/internal/testutil"
@@ -55,7 +56,7 @@ func (m *mockDB) KBDelete(path string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("kb document not found")
+	return db.ErrKBNotFound
 }
 
 func (m *mockDB) KBDocumentCount() int {
@@ -302,6 +303,28 @@ func TestToolsCall_KBDelete(t *testing.T) {
 		resp := doRequest(t, s, "tools/call", ToolCallParams{
 			Name:      "kb_delete",
 			Arguments: json.RawMessage(`{"path": "../etc/passwd"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "invalid path")
+	})
+
+	t.Run("nested path traversal blocked", func(t *testing.T) {
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "kb_delete",
+			Arguments: json.RawMessage(`{"path": "notes/../../etc/passwd"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "invalid path")
+	})
+
+	t.Run("absolute path blocked", func(t *testing.T) {
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "kb_delete",
+			Arguments: json.RawMessage(`{"path": "/etc/passwd"}`),
 		})
 		testutil.NoError(t, respErr(resp))
 		cr := callResult(t, resp)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -882,6 +882,7 @@ func (a *App) refreshTasksWithIDs(runningIDs, idleIDs []string) {
 	tasks, err := a.db.Tasks()
 	if err != nil {
 		uxlog.Log("[tui] refreshTasksWithIDs: failed to load tasks: %v", err)
+		return
 	}
 	a.tasks = tasks
 	a.runningIDs = runningIDs

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -186,6 +186,7 @@ func (sv *SettingsView) Refresh() {
 	}
 
 	// Projects.
+	// Show empty on error — settings view degrades gracefully to an empty list.
 	projMap, err := sv.database.Projects()
 	if err != nil {
 		uxlog.Log("[settings] failed to load projects: %v", err)
@@ -245,7 +246,7 @@ func (sv *SettingsView) Refresh() {
 	// Review prompt.
 	sv.reviewPrompt = cfg.Defaults.ReviewPrompt
 
-	// Task counts.
+	// Task counts — show empty on error (same graceful degradation as projects).
 	tasks, err := sv.database.Tasks()
 	if err != nil {
 		uxlog.Log("[settings] failed to load tasks: %v", err)

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -186,7 +186,10 @@ func (sv *SettingsView) Refresh() {
 	}
 
 	// Projects.
-	projMap, _ := sv.database.Projects()
+	projMap, err := sv.database.Projects()
+	if err != nil {
+		uxlog.Log("[settings] failed to load projects: %v", err)
+	}
 	sv.projects = nil
 	projNames := make([]string, 0, len(projMap))
 	for name := range projMap {
@@ -243,7 +246,10 @@ func (sv *SettingsView) Refresh() {
 	sv.reviewPrompt = cfg.Defaults.ReviewPrompt
 
 	// Task counts.
-	tasks, _ := sv.database.Tasks()
+	tasks, err := sv.database.Tasks()
+	if err != nil {
+		uxlog.Log("[settings] failed to load tasks: %v", err)
+	}
 	sv.setTasks(tasks)
 
 	sv.rebuildRows()


### PR DESCRIPTION
Address all findings from fresh-eyes re-review of recent refactoring:

- Guard all runner observer methods (Running/Idle/RunningAndIdle/Sessions) for nil-sentinel entries during Start() window
- Remove WriteTimeout that killed SSE streams after 60s
- Log errors instead of discarding in settings, handlers, db.Config
- Return early in refreshTasksWithIDs on db.Tasks() error
- Add kb_delete logging, path traversal tests, ErrKBNotFound fix
- Fix mock to use db.ErrKBNotFound sentinel

Co-Authored-By: Claude <noreply@anthropic.com>