### PR TITLE
Skill autocomplete: Tab/Backtab accept, mid-prompt trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A terminal-native LLM code orchestrator. Manage multiple Claude Code / Codex ses
 - **Persistent daemon** — Agent sessions survive TUI restarts via a background daemon that keeps PTY fds alive. Auto-starts on launch, graceful shutdown on exit. Similar to tmux, but purpose-built for agent workflows
 - **Session resume** — `--resume` for Claude Code, `codex resume <session-id>` for Codex — conversations survive daemon restarts
 - **Configurable backends** — Define command templates for any LLM CLI tool. Per-backend flags, prompt interpolation, and plan mode defaults
-- **Skill autocomplete** — `/` in the prompt field triggers autocomplete from `~/.claude/skills/` and per-project skill directories
+- **Skill autocomplete** — `/` anywhere in the prompt field triggers autocomplete from `~/.claude/skills/` and per-project skill directories (`$` for Codex backends). Select with Enter or Tab
 - **Agent forking** — Duplicate a running or finished task with full context (source info, recent output, git diff) injected into the new agent's worktree
 
 ### Task Workflow

--- a/internal/tui/newtaskform.go
+++ b/internal/tui/newtaskform.go
@@ -389,20 +389,34 @@ func (f *NewTaskForm) loadSkills() {
 	f.skills = skills.LoadSkills(extraDirs)
 }
 
-// updateAutocomplete recomputes the autocomplete matches based on the current
-// prompt value. Autocomplete is active when the value starts with the trigger
-// character ("/" for claude, "$" for codex) and contains no spaces.
+// promptTokenBounds returns the [start, end) rune indices of the
+// space-delimited token containing the cursor position.
+func (f *NewTaskForm) promptTokenBounds() (int, int) {
+	start := f.cursorPos
+	for start > 0 && f.prompt[start-1] != ' ' {
+		start--
+	}
+	end := f.cursorPos
+	for end < len(f.prompt) && f.prompt[end] != ' ' {
+		end++
+	}
+	return start, end
+}
+
+// updateAutocomplete recomputes the autocomplete matches based on the token
+// at the cursor position. Autocomplete is active when the current
+// space-delimited token starts with the trigger character ("/" for claude,
+// "$" for codex). Triggering works anywhere in the prompt, not just at the
+// start.
 func (f *NewTaskForm) updateAutocomplete() {
-	val := string(f.prompt)
 	trigger := f.acTrigger()
-	if !strings.HasPrefix(val, trigger) || (len(val) > 1 && strings.ContainsRune(val[1:], ' ')) {
+	start, end := f.promptTokenBounds()
+	token := string(f.prompt[start:end])
+	if !strings.HasPrefix(token, trigger) {
 		f.acOpen = false
 		return
 	}
-	filter := ""
-	if len(val) > 1 {
-		filter = val[1:]
-	}
+	filter := token[len(trigger):]
 	f.acMatches = skills.FilterSkills(f.skills, filter)
 	if len(f.acMatches) == 0 {
 		f.acOpen = false
@@ -413,6 +427,23 @@ func (f *NewTaskForm) updateAutocomplete() {
 		f.acIdx = 0
 		f.acScroll = 0
 	}
+}
+
+// acAccept replaces the token at the cursor with the selected skill and
+// appends a trailing space. Closes the autocomplete dropdown.
+func (f *NewTaskForm) acAccept() {
+	if !f.acOpen || len(f.acMatches) == 0 {
+		return
+	}
+	start, end := f.promptTokenBounds()
+	replacement := []rune(f.acTrigger() + f.acMatches[f.acIdx].Name + " ")
+	newPrompt := make([]rune, 0, len(f.prompt)-(end-start)+len(replacement))
+	newPrompt = append(newPrompt, f.prompt[:start]...)
+	newPrompt = append(newPrompt, replacement...)
+	newPrompt = append(newPrompt, f.prompt[end:]...)
+	f.prompt = newPrompt
+	f.cursorPos = start + len(replacement)
+	f.acOpen = false
 }
 
 // acMoveDown moves the autocomplete cursor down one item (wraps around).
@@ -503,6 +534,13 @@ func (f *NewTaskForm) InputHandler() func(event *tcell.EventKey, setFocus func(p
 			f.canceled = true
 			return
 		case tcell.KeyTab:
+			// In the prompt field, tab accepts an open skill autocomplete
+			// without advancing focus — lets the user keep typing after the
+			// skill is inserted.
+			if f.focused == ntFieldPrompt && f.acOpen && len(f.acMatches) > 0 {
+				f.acAccept()
+				return
+			}
 			// Accept any open autocomplete before advancing field
 			if f.projACOpen && len(f.projACMatches) > 0 {
 				f.projACAccept()
@@ -798,10 +836,7 @@ func (f *NewTaskForm) handlePromptKey(event *tcell.EventKey) {
 	case tcell.KeyEnter:
 		// Select autocomplete suggestion if open
 		if f.acOpen && len(f.acMatches) > 0 {
-			text := f.acTrigger() + f.acMatches[f.acIdx].Name + " "
-			f.prompt = []rune(text)
-			f.cursorPos = len(f.prompt)
-			f.acOpen = false
+			f.acAccept()
 			return
 		}
 		if f.resolveProject() == "" {

--- a/internal/tui/newtaskform.go
+++ b/internal/tui/newtaskform.go
@@ -78,6 +78,8 @@ type NewTaskForm struct {
 	acMatches []skills.SkillItem
 	acIdx     int
 	acScroll  int
+	acStart   int // [start, end) bounds of the token being autocompleted,
+	acEnd     int // captured when acOpen transitions to true
 }
 
 // NewNewTaskForm creates a new task form with sorted project and backend lists.
@@ -413,29 +415,39 @@ func (f *NewTaskForm) updateAutocomplete() {
 	start, end := f.promptTokenBounds()
 	token := string(f.prompt[start:end])
 	if !strings.HasPrefix(token, trigger) {
-		f.acOpen = false
+		f.closeAC()
 		return
 	}
 	filter := token[len(trigger):]
 	f.acMatches = skills.FilterSkills(f.skills, filter)
 	if len(f.acMatches) == 0 {
-		f.acOpen = false
+		f.closeAC()
 		return
 	}
 	f.acOpen = true
+	f.acStart = start
+	f.acEnd = end
 	if f.acIdx >= len(f.acMatches) {
 		f.acIdx = 0
 		f.acScroll = 0
 	}
 }
 
-// acAccept replaces the token at the cursor with the selected skill and
-// appends a trailing space. Closes the autocomplete dropdown.
+// closeAC closes the autocomplete dropdown and resets its navigation state.
+// Having a single closer means acIdx/acScroll don't leak across open cycles.
+func (f *NewTaskForm) closeAC() {
+	f.acOpen = false
+	f.acIdx = 0
+	f.acScroll = 0
+}
+
+// acAccept replaces the token captured when the dropdown opened with the
+// selected skill and appends a trailing space. Closes the dropdown.
 func (f *NewTaskForm) acAccept() {
 	if !f.acOpen || len(f.acMatches) == 0 {
 		return
 	}
-	start, end := f.promptTokenBounds()
+	start, end := f.acStart, f.acEnd
 	replacement := []rune(f.acTrigger() + f.acMatches[f.acIdx].Name + " ")
 	newPrompt := make([]rune, 0, len(f.prompt)-(end-start)+len(replacement))
 	newPrompt = append(newPrompt, f.prompt[:start]...)
@@ -443,7 +455,7 @@ func (f *NewTaskForm) acAccept() {
 	newPrompt = append(newPrompt, f.prompt[end:]...)
 	f.prompt = newPrompt
 	f.cursorPos = start + len(replacement)
-	f.acOpen = false
+	f.closeAC()
 }
 
 // acMoveDown moves the autocomplete cursor down one item (wraps around).
@@ -526,7 +538,7 @@ func (f *NewTaskForm) InputHandler() func(event *tcell.EventKey, setFocus func(p
 		switch event.Key() {
 		case tcell.KeyEscape, tcell.KeyCtrlQ:
 			if f.acOpen || f.projACOpen || f.branchACOpen { // two-step: first press closes autocomplete, second cancels form
-				f.acOpen = false
+				f.closeAC()
 				f.projACOpen = false
 				f.branchACOpen = false
 				return
@@ -535,8 +547,7 @@ func (f *NewTaskForm) InputHandler() func(event *tcell.EventKey, setFocus func(p
 			return
 		case tcell.KeyTab:
 			// In the prompt field, tab accepts an open skill autocomplete
-			// without advancing focus — lets the user keep typing after the
-			// skill is inserted.
+			// without advancing focus — so the user can keep typing.
 			if f.focused == ntFieldPrompt && f.acOpen && len(f.acMatches) > 0 {
 				f.acAccept()
 				return
@@ -548,7 +559,7 @@ func (f *NewTaskForm) InputHandler() func(event *tcell.EventKey, setFocus func(p
 			if f.branchACOpen && len(f.branchACMatches) > 0 {
 				f.branchACAccept()
 			}
-			f.acOpen = false
+			f.closeAC()
 			f.projACOpen = false
 			f.branchACOpen = false
 			prev := f.focused
@@ -558,6 +569,12 @@ func (f *NewTaskForm) InputHandler() func(event *tcell.EventKey, setFocus func(p
 			}
 			return
 		case tcell.KeyBacktab:
+			// In the prompt field, shift-tab accepts an open skill autocomplete
+			// without changing focus — mirrors Tab's behavior for consistency.
+			if f.focused == ntFieldPrompt && f.acOpen && len(f.acMatches) > 0 {
+				f.acAccept()
+				return
+			}
 			// Accept any open autocomplete before retreating field
 			if f.projACOpen && len(f.projACMatches) > 0 {
 				f.projACAccept()
@@ -565,7 +582,7 @@ func (f *NewTaskForm) InputHandler() func(event *tcell.EventKey, setFocus func(p
 			if f.branchACOpen && len(f.branchACMatches) > 0 {
 				f.branchACAccept()
 			}
-			f.acOpen = false
+			f.closeAC()
 			f.projACOpen = false
 			f.branchACOpen = false
 			f.focused = (f.focused + ntFieldCount - 1) % ntFieldCount

--- a/internal/tui/newtaskform_test.go
+++ b/internal/tui/newtaskform_test.go
@@ -609,6 +609,77 @@ func TestNewTaskForm_Autocomplete(t *testing.T) {
 	}
 }
 
+func TestNewTaskForm_ACTabAccepts(t *testing.T) {
+	f := NewNewTaskForm(
+		map[string]config.Project{"p": {}}, "p",
+		map[string]config.Backend{"b": {Command: "claude"}}, "b",
+	)
+	f.skills = []skills.SkillItem{
+		{Name: "commit", Description: "Create a commit"},
+	}
+	handler := f.InputHandler()
+
+	// Focus prompt (default focused is ntFieldProject after NewNewTaskForm).
+	// The form starts focused on prompt by default actually — verify by typing.
+	for _, r := range "/co" {
+		handler(tcell.NewEventKey(tcell.KeyRune, r, 0), func(p tview.Primitive) {})
+	}
+	if !f.acOpen {
+		t.Fatal("autocomplete should be open after /co")
+	}
+
+	// Tab should accept the skill and NOT advance focus
+	prevFocus := f.focused
+	handler(tcell.NewEventKey(tcell.KeyTab, 0, 0), func(p tview.Primitive) {})
+	if f.acOpen {
+		t.Error("tab should close autocomplete")
+	}
+	if got := string(f.prompt); got != "/commit " {
+		t.Errorf("prompt = %q, want %q", got, "/commit ")
+	}
+	if f.focused != prevFocus {
+		t.Errorf("tab should not change focus when accepting AC: focused = %d, want %d", f.focused, prevFocus)
+	}
+	if f.Done() {
+		t.Error("tab accept should not submit form")
+	}
+}
+
+func TestNewTaskForm_ACMidPromptTrigger(t *testing.T) {
+	f := NewNewTaskForm(
+		map[string]config.Project{"p": {}}, "p",
+		map[string]config.Backend{"b": {Command: "claude"}}, "b",
+	)
+	f.skills = []skills.SkillItem{
+		{Name: "commit", Description: "Create a commit"},
+		{Name: "review", Description: "Review PR"},
+	}
+	handler := f.InputHandler()
+
+	// Type some text, a space, then trigger a skill
+	for _, r := range "fix bug /co" {
+		handler(tcell.NewEventKey(tcell.KeyRune, r, 0), func(p tview.Primitive) {})
+	}
+	if !f.acOpen {
+		t.Fatal("autocomplete should open when trigger follows non-initial text")
+	}
+	if len(f.acMatches) != 1 || f.acMatches[0].Name != "commit" {
+		t.Errorf("matches = %+v, want [commit]", f.acMatches)
+	}
+
+	// Enter accepts: replaces only the /co token, preserving preceding text
+	handler(tcell.NewEventKey(tcell.KeyEnter, 0, 0), func(p tview.Primitive) {})
+	if got := string(f.prompt); got != "fix bug /commit " {
+		t.Errorf("prompt = %q, want %q", got, "fix bug /commit ")
+	}
+	if f.acOpen {
+		t.Error("AC should close after accept")
+	}
+	if f.Done() {
+		t.Error("accept should not submit form")
+	}
+}
+
 func TestNewTaskForm_ACEscCloses(t *testing.T) {
 	f := NewNewTaskForm(
 		map[string]config.Project{"p": {}}, "p",

--- a/internal/tui/newtaskform_test.go
+++ b/internal/tui/newtaskform_test.go
@@ -617,10 +617,11 @@ func TestNewTaskForm_ACTabAccepts(t *testing.T) {
 	f.skills = []skills.SkillItem{
 		{Name: "commit", Description: "Create a commit"},
 	}
+	// Pin focus to prompt so the test is robust to changes in the default
+	// focused field of NewNewTaskForm.
+	f.focused = ntFieldPrompt
 	handler := f.InputHandler()
 
-	// Focus prompt (default focused is ntFieldProject after NewNewTaskForm).
-	// The form starts focused on prompt by default actually — verify by typing.
 	for _, r := range "/co" {
 		handler(tcell.NewEventKey(tcell.KeyRune, r, 0), func(p tview.Primitive) {})
 	}
@@ -629,7 +630,6 @@ func TestNewTaskForm_ACTabAccepts(t *testing.T) {
 	}
 
 	// Tab should accept the skill and NOT advance focus
-	prevFocus := f.focused
 	handler(tcell.NewEventKey(tcell.KeyTab, 0, 0), func(p tview.Primitive) {})
 	if f.acOpen {
 		t.Error("tab should close autocomplete")
@@ -637,11 +637,42 @@ func TestNewTaskForm_ACTabAccepts(t *testing.T) {
 	if got := string(f.prompt); got != "/commit " {
 		t.Errorf("prompt = %q, want %q", got, "/commit ")
 	}
-	if f.focused != prevFocus {
-		t.Errorf("tab should not change focus when accepting AC: focused = %d, want %d", f.focused, prevFocus)
+	if f.focused != ntFieldPrompt {
+		t.Errorf("tab should not change focus when accepting AC: focused = %d, want %d", f.focused, ntFieldPrompt)
 	}
 	if f.Done() {
 		t.Error("tab accept should not submit form")
+	}
+}
+
+func TestNewTaskForm_ACBacktabAccepts(t *testing.T) {
+	f := NewNewTaskForm(
+		map[string]config.Project{"p": {}}, "p",
+		map[string]config.Backend{"b": {Command: "claude"}}, "b",
+	)
+	f.skills = []skills.SkillItem{
+		{Name: "commit", Description: "Create a commit"},
+	}
+	f.focused = ntFieldPrompt
+	handler := f.InputHandler()
+
+	for _, r := range "/co" {
+		handler(tcell.NewEventKey(tcell.KeyRune, r, 0), func(p tview.Primitive) {})
+	}
+	if !f.acOpen {
+		t.Fatal("autocomplete should be open after /co")
+	}
+
+	// Shift-Tab should accept the skill and NOT change focus (mirrors Tab).
+	handler(tcell.NewEventKey(tcell.KeyBacktab, 0, 0), func(p tview.Primitive) {})
+	if f.acOpen {
+		t.Error("backtab should close autocomplete")
+	}
+	if got := string(f.prompt); got != "/commit " {
+		t.Errorf("prompt = %q, want %q", got, "/commit ")
+	}
+	if f.focused != ntFieldPrompt {
+		t.Errorf("backtab should not change focus when accepting AC: focused = %d, want %d", f.focused, ntFieldPrompt)
 	}
 }
 


### PR DESCRIPTION
Improve the new-task modal's skill autocomplete:

- Tab and Shift-Tab now accept an open skill suggestion in the prompt
  field without changing focus, in addition to Enter.
- The `/` (or `$` for Codex) trigger now activates autocomplete on any
  space-delimited token at the cursor — not only at the start of the
  prompt. Acceptance replaces just that token, preserving surrounding
  text.

Internals: token bounds are captured when the dropdown opens and
reused on accept (no re-computation from cursor); a `closeAC()` helper
keeps `acIdx`/`acScroll` reset alongside `acOpen`.

Co-Authored-By: Claude <noreply@anthropic.com>