### PR TITLE
Fix screen ghosting from lazyScreen.skipClear

### DIFF
--- a/context/knowledge/gotchas/ui-threading.md
+++ b/context/knowledge/gotchas/ui-threading.md
@@ -7,6 +7,12 @@
 - **Never run synchronous git commands on the tick goroutine.** Blocking the tick goroutine prevents `QueueUpdateDraw` from firing, freezing the UI. Use `go` + cooldown (e.g., `lastTaskGitRefresh` with 3s interval). The agent view already follows this pattern — the task list must too.
 - **`onTick` must modify tview widget state only inside `QueueUpdateDraw`.** `TaskListView`, preview panels, agent pane, and reviews have no internal mutex. Direct modification from the tick goroutine races with `Draw()`/`InputHandler()` on the tview goroutine. Symptom: `buildRows()` sets `tl.rows = nil` then rebuilds — a concurrent `Draw()` sees the nil slice and renders an empty task list (project folders disappear).
 
+## lazyScreen & Widget Painting
+
+- **Every widget that uses `DrawBorderedPanel` inherits an interior blank-fill.** `DrawBorderedPanel` calls `FillArea` on the inner rect with `(' ', StyleDefault)` before drawing the border. This keeps `lazyScreen.skipClear` safe: when tview's screen-wide `Clear()` is suppressed for a PTY-forwarded keystroke, widgets whose content shrunk between draws would otherwise leak stale cells (the classic symptom was a stacked ghost statusbar and stray TaskDetail text in the agent view's right column after task switch).
+- **If you add a new widget that does NOT go through `DrawBorderedPanel`, you must fill its full bounding box yourself in `Draw`.** Relying on tview's `Clear()` is unsafe because `lazyScreen.skipClear` can turn it into a no-op. `StatusBar` and `Header` already do this (they fill their row with a background-styled space).
+- **Ghosting that persists across ticks is almost always a widget that only paints occupied rows.** The tick calls `Clear()` within 1s, which consumes `skipClear` and does a real clear next frame — but if the widget's paint only covers part of its bounding box, the newly-cleared cells stay blank while any OLD content written by a DIFFERENT widget in a prior frame is already gone. Ghosting looks permanent because every PTY keystroke keeps setting `skipClear`; fix at the widget level, not the screen level.
+
 ## Paste & Input Batching
 
 - **`tapp.EnablePaste(true)` is required for fast paste.** Without it, tview delivers paste as thousands of individual `EventKey` events, each triggering a full screen redraw. With it, tview buffers all pasted text and delivers it as a single `PasteHandler()` call with one redraw.

--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -6,7 +6,7 @@ Non-obvious invariants and gotchas, split by topic. Read the relevant file when 
 |------|-------|---------|
 | [gotchas/daemon-rpc.md](gotchas/daemon-rpc.md) | Daemon lifecycle, RPC timeouts, reconciliation races, session resume | 26 |
 | [gotchas/pty-terminal.md](gotchas/pty-terminal.md) | PTY sizing, x/vt emulator, ring buffer, replay cache, paint cache, lazyScreen | 31 |
-| [gotchas/ui-threading.md](gotchas/ui-threading.md) | tview thread safety, tick goroutine rules, paste/input batching | 10 |
+| [gotchas/ui-threading.md](gotchas/ui-threading.md) | tview thread safety, tick goroutine rules, lazyScreen fill invariant, paste/input batching | 13 |
 | [gotchas/sandbox.md](gotchas/sandbox.md) | macOS sandbox-exec SBPL profiles, symlink resolution, allowed paths | 14 |
 | [gotchas/worktree.md](gotchas/worktree.md) | Worktree creation ordering, transactional CreateAndStart, cleanup, path validation, stale ref pruning | 13 |
 | [gotchas/keybindings.md](gotchas/keybindings.md) | Key routing, ctrl sequences, tcell modifier quirks, agent view navigation | 12 |

--- a/internal/tui/widget/agentpane.go
+++ b/internal/tui/widget/agentpane.go
@@ -78,16 +78,26 @@ type InnerRect struct {
 }
 
 // DrawBorderedPanel draws a rounded border at (x, y, w, h) with an optional
-// title embedded in the top border, and returns the inner content rect.
-// The interior is filled with blanks on the default style before the border
-// is drawn, so that partial redraws (e.g., when the caller's Draw only paints
+// title embedded in the top border, and returns the inner content rect. All
+// bordered panels should use this to guarantee consistent chrome.
+//
+// The interior is blanked with (' ', tcell.StyleDefault) before the border
+// is drawn so that partial redraws (e.g., when the caller's Draw only paints
 // occupied rows and lazyScreen has suppressed the screen-wide Clear) don't
-// leak stale cells from the previous frame.
-// All bordered panels should use this to guarantee consistent chrome.
+// leak stale cells from the previous frame. The fill style is hardcoded to
+// tcell.StyleDefault because every current caller wants a transparent
+// interior — if a future bordered panel ever lives on top of a tinted layer
+// (e.g., a modal overlay with a coloured background), this helper will need
+// a fillStyle parameter.
+//
+// When w or h is below the 2x2 minimum required for a border, the returned
+// InnerRect is the zero value so callers can short-circuit on
+// `inner.W <= 0 || inner.H <= 0`.
 func DrawBorderedPanel(screen tcell.Screen, x, y, w, h int, title string, style tcell.Style) InnerRect {
-	if w >= 2 && h >= 2 {
-		FillArea(screen, x+1, y+1, w-2, h-2, ' ', tcell.StyleDefault)
+	if w < 2 || h < 2 {
+		return InnerRect{}
 	}
+	FillArea(screen, x+1, y+1, w-2, h-2, ' ', tcell.StyleDefault)
 	DrawBorder(screen, x, y, w, h, style)
 	if title != "" {
 		for i, r := range title {

--- a/internal/tui/widget/agentpane.go
+++ b/internal/tui/widget/agentpane.go
@@ -79,8 +79,15 @@ type InnerRect struct {
 
 // DrawBorderedPanel draws a rounded border at (x, y, w, h) with an optional
 // title embedded in the top border, and returns the inner content rect.
+// The interior is filled with blanks on the default style before the border
+// is drawn, so that partial redraws (e.g., when the caller's Draw only paints
+// occupied rows and lazyScreen has suppressed the screen-wide Clear) don't
+// leak stale cells from the previous frame.
 // All bordered panels should use this to guarantee consistent chrome.
 func DrawBorderedPanel(screen tcell.Screen, x, y, w, h int, title string, style tcell.Style) InnerRect {
+	if w >= 2 && h >= 2 {
+		FillArea(screen, x+1, y+1, w-2, h-2, ' ', tcell.StyleDefault)
+	}
 	DrawBorder(screen, x, y, w, h, style)
 	if title != "" {
 		for i, r := range title {

--- a/internal/tui/widget/draw.go
+++ b/internal/tui/widget/draw.go
@@ -13,3 +13,20 @@ func DrawText(screen tcell.Screen, x, y, maxWidth int, text string, style tcell.
 		col++
 	}
 }
+
+// FillArea fills a rectangle with a rune and style. Use it at the top of a
+// widget's Draw to guarantee every cell in its bounding box is overwritten.
+// That keeps redraws correct even when lazyScreen.skipClear suppresses
+// tview's screen-wide Clear (see internal/tui/lazyscreen.go): widgets that
+// only paint their occupied rows would otherwise leak stale cells from the
+// previous frame's primitive.
+func FillArea(screen tcell.Screen, x, y, w, h int, r rune, style tcell.Style) {
+	if w <= 0 || h <= 0 {
+		return
+	}
+	for row := y; row < y+h; row++ {
+		for col := x; col < x+w; col++ {
+			screen.SetContent(col, row, r, nil, style)
+		}
+	}
+}

--- a/internal/tui/widget/draw_test.go
+++ b/internal/tui/widget/draw_test.go
@@ -1,0 +1,120 @@
+package widget
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// newSimScreen returns a SimulationScreen sized for tests. The screen is
+// pre-seeded with garbage so tests can verify FillArea / DrawBorderedPanel
+// actually overwrite stale cells.
+func newSimScreen(t *testing.T, cols, rows int) tcell.SimulationScreen {
+	t.Helper()
+	s := tcell.NewSimulationScreen("UTF-8")
+	if err := s.Init(); err != nil {
+		t.Fatalf("screen init: %v", err)
+	}
+	s.SetSize(cols, rows)
+	// Seed every cell with a visible glyph so missing writes are detectable.
+	garbageStyle := tcell.StyleDefault.Foreground(tcell.ColorRed)
+	for y := 0; y < rows; y++ {
+		for x := 0; x < cols; x++ {
+			s.SetContent(x, y, 'X', nil, garbageStyle)
+		}
+	}
+	s.Sync()
+	t.Cleanup(s.Fini)
+	return s
+}
+
+func TestFillArea_OverwritesSeededCells(t *testing.T) {
+	s := newSimScreen(t, 20, 10)
+
+	FillArea(s, 2, 3, 5, 4, ' ', tcell.StyleDefault)
+
+	// Cells inside the rect must be blank.
+	for y := 3; y < 7; y++ {
+		for x := 2; x < 7; x++ {
+			r, _, _, _ := s.GetContent(x, y)
+			if r != ' ' {
+				t.Errorf("cell (%d,%d) = %q, want space", x, y, r)
+			}
+		}
+	}
+
+	// Cells outside must still carry the seed.
+	for _, p := range [][2]int{{0, 0}, {1, 3}, {7, 3}, {2, 2}, {2, 7}, {19, 9}} {
+		r, _, _, _ := s.GetContent(p[0], p[1])
+		if r != 'X' {
+			t.Errorf("outside cell (%d,%d) should keep seed, got %q", p[0], p[1], r)
+		}
+	}
+}
+
+func TestFillArea_NoopOnZeroSize(t *testing.T) {
+	s := newSimScreen(t, 10, 5)
+	FillArea(s, 1, 1, 0, 3, ' ', tcell.StyleDefault)
+	FillArea(s, 1, 1, 3, 0, ' ', tcell.StyleDefault)
+	// All cells should still be seeded.
+	for y := 0; y < 5; y++ {
+		for x := 0; x < 10; x++ {
+			r, _, _, _ := s.GetContent(x, y)
+			if r != 'X' {
+				t.Errorf("cell (%d,%d) = %q, want unchanged seed X", x, y, r)
+			}
+		}
+	}
+}
+
+func TestDrawBorderedPanel_ClearsInteriorOfStaleCells(t *testing.T) {
+	s := newSimScreen(t, 20, 10)
+
+	inner := DrawBorderedPanel(s, 2, 1, 10, 6, "Hi", tcell.StyleDefault)
+
+	// Interior cells must be blanked, not left as seeded 'X'.
+	for y := inner.Y; y < inner.Y+inner.H; y++ {
+		for x := inner.X; x < inner.X+inner.W; x++ {
+			r, _, _, _ := s.GetContent(x, y)
+			if r != ' ' {
+				t.Errorf("interior cell (%d,%d) = %q, want blank", x, y, r)
+			}
+		}
+	}
+
+	// Border corners must be drawn.
+	corners := map[[2]int]rune{
+		{2, 1}:  '╭',
+		{11, 1}: '╮',
+		{2, 6}:  '╰',
+		{11, 6}: '╯',
+	}
+	for pos, want := range corners {
+		r, _, _, _ := s.GetContent(pos[0], pos[1])
+		if r != want {
+			t.Errorf("corner (%d,%d) = %q, want %q", pos[0], pos[1], r, want)
+		}
+	}
+
+	// Title must be painted just after the top-left corner.
+	r, _, _, _ := s.GetContent(3, 1)
+	if r != 'H' {
+		t.Errorf("title first rune = %q, want H", r)
+	}
+	r, _, _, _ = s.GetContent(4, 1)
+	if r != 'i' {
+		t.Errorf("title second rune = %q, want i", r)
+	}
+
+	// Returned inner rect must be consistent.
+	if inner.X != 3 || inner.Y != 2 || inner.W != 8 || inner.H != 4 {
+		t.Errorf("inner rect = %+v, want {X:3 Y:2 W:8 H:4}", inner)
+	}
+}
+
+func TestDrawBorderedPanel_TinyPanelDoesNotPanic(t *testing.T) {
+	s := newSimScreen(t, 10, 5)
+	// 1x1 — too small for a border, must no-op safely.
+	inner := DrawBorderedPanel(s, 0, 0, 1, 1, "", tcell.StyleDefault)
+	_ = inner
+}

--- a/internal/tui/widget/draw_test.go
+++ b/internal/tui/widget/draw_test.go
@@ -23,6 +23,10 @@ func newSimScreen(t *testing.T, cols, rows int) tcell.SimulationScreen {
 			s.SetContent(x, y, 'X', nil, garbageStyle)
 		}
 	}
+	// Sync commits the seeded cells so GetContent reads them back. Without
+	// this, GetContent would return the emulator's zero-value initial state
+	// rather than the seed, and the "overwrite" assertions below would pass
+	// trivially even if FillArea silently did nothing.
 	s.Sync()
 	t.Cleanup(s.Fini)
 	return s
@@ -52,10 +56,12 @@ func TestFillArea_OverwritesSeededCells(t *testing.T) {
 	}
 }
 
-func TestFillArea_NoopOnZeroSize(t *testing.T) {
+func TestFillArea_NoopOnZeroOrNegativeSize(t *testing.T) {
 	s := newSimScreen(t, 10, 5)
 	FillArea(s, 1, 1, 0, 3, ' ', tcell.StyleDefault)
 	FillArea(s, 1, 1, 3, 0, ' ', tcell.StyleDefault)
+	FillArea(s, 1, 1, -2, 3, ' ', tcell.StyleDefault)
+	FillArea(s, 1, 1, 3, -2, ' ', tcell.StyleDefault)
 	// All cells should still be seeded.
 	for y := 0; y < 5; y++ {
 		for x := 0; x < 10; x++ {
@@ -112,9 +118,17 @@ func TestDrawBorderedPanel_ClearsInteriorOfStaleCells(t *testing.T) {
 	}
 }
 
-func TestDrawBorderedPanel_TinyPanelDoesNotPanic(t *testing.T) {
+func TestDrawBorderedPanel_TinyPanelReturnsZeroInnerRect(t *testing.T) {
 	s := newSimScreen(t, 10, 5)
-	// 1x1 — too small for a border, must no-op safely.
-	inner := DrawBorderedPanel(s, 0, 0, 1, 1, "", tcell.StyleDefault)
-	_ = inner
+	// 1x1 — too small for a border, must no-op safely and return zero rect
+	// so callers can bail out on `inner.W <= 0 || inner.H <= 0`.
+	got := DrawBorderedPanel(s, 0, 0, 1, 1, "", tcell.StyleDefault)
+	if got != (InnerRect{}) {
+		t.Errorf("tiny panel inner rect = %+v, want zero value", got)
+	}
+	// Seeded cell must be untouched — no border, no fill, no partial writes.
+	r, _, _, _ := s.GetContent(0, 0)
+	if r != 'X' {
+		t.Errorf("tiny panel should not paint; got %q, want X", r)
+	}
 }


### PR DESCRIPTION
## Summary

- Fixes persistent screen-ghosting bug where stale cells leaked through after task switches, page swaps, or layout changes in the agent view (stacked ghost status bars, stray TaskDetail fragments, cyan animation ghosts on Claude Code's thinking line).
- Root cause: `lazyScreen.skipClear` turns tview's screen-wide `Clear()` into a no-op for PTY-forwarded keystrokes; widgets using `DrawBorderedPanel` only painted their border and title, leaving the interior untouched. When widget content shrank between draws, the previous frame's cells leaked.
- Fix: `widget.DrawBorderedPanel` now fills its interior with `(' ', StyleDefault)` before drawing the border. Every bordered widget (FilePanel, TaskDetailPanel, GitPanel, TaskPreviewPanel, ToDoPreviewPanel, TaskListView, ReviewsView, TerminalPane) gets a clean canvas each frame, regardless of `skipClear`.
- Typing-lag optimization is preserved: when a cell's final content matches the previous frame, tcell's `Show()` emits nothing to the terminal.
- Adds `widget.FillArea` helper for future non-bordered widgets that need the same guarantee.
- `DrawBorderedPanel` now returns a zero-value `InnerRect` for panels smaller than 2×2 instead of negative dimensions (all callers already guarded on `W<=0 || H<=0`).

## Test plan

- [x] `make test` (full `-race` suite) passes
- [x] `make build` and `make vet` clean
- [x] New unit tests in `internal/tui/widget/draw_test.go` cover: seeded-cell overwrite, zero/negative size no-op, border corners + title + inner rect, tiny-panel no-paint
- [x] Knowledge base updated: `context/knowledge/gotchas/ui-threading.md` documents the widget-fill invariant so future widgets don't regress

Co-Authored-By: Claude <noreply@anthropic.com>