### PR TITLE
Add task_archive MCP tool and rename server to argus

### DIFF
--- a/.claude/skills/archive/SKILL.md
+++ b/.claude/skills/archive/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: archive
+description: Archive the current Argus task so it moves to the Archive section of the task list. Use at the end of a session when the work is done.
+allowed-tools: mcp__argus__task_archive
+---
+
+# Archive Current Task
+
+Mark the Argus task owning the current worktree as archived. Archiving moves the task into the Archive section of the task list and clears its waiting-for-review flag.
+
+## Context
+
+- Current directory: !`pwd`
+
+## Your task
+
+Call the `mcp__argus__task_archive` MCP tool with the working directory from the Context block above as the `cwd` argument, and `archived: true`:
+
+```
+mcp__argus__task_archive(cwd: "<pwd from context>", archived: true)
+```
+
+Argus resolves the task from `cwd` by matching it against task worktree paths — the agent process does not know its own task ID, so `cwd` is the required hand-off.
+
+Do **not** pass `id` — the agent has no reliable way to know it.
+
+After the call, report the tool's response verbatim in one line. If the tool errors (e.g. "no task matches cwd"), show the error and stop; do not retry with guessed arguments.
+
+### Unarchiving
+
+If `$ARGUMENTS` is the literal word `undo`, call with `archived: false` instead. Otherwise always pass `archived: true` — toggling from an unknown prior state is surprising.

--- a/README.md
+++ b/README.md
@@ -255,8 +255,9 @@ The MCP server exposes the following tools to connected agents:
 | `task_list` | List tasks, filtered by `status` and/or `project` |
 | `task_get` | Get task details by `id` |
 | `task_stop` | Stop a running agent (moves task to "in review") |
+| `task_archive` | Archive or unarchive a task. Pass `cwd` (from the agent's `pwd`) to resolve the task by worktree, or `id`. Omit `archived` to toggle. |
 
-Task management tools enable an external agent (e.g. Claude Code running in another terminal) to programmatically launch and monitor Argus tasks via MCP.
+Task management tools enable an external agent (e.g. Claude Code running in another terminal) to programmatically launch and monitor Argus tasks via MCP. A sample `/archive` skill lives at `.claude/skills/archive/SKILL.md` — it calls `task_archive` with the current working directory so an agent can mark its own task done at the end of a session.
 
 ## Remote Control
 

--- a/context/knowledge/gotchas/misc.md
+++ b/context/knowledge/gotchas/misc.md
@@ -74,6 +74,8 @@
 - **MCP task tools use the same `TaskCreator` injection pattern as API/vault.** `SetTaskManager()` wires in the creator, querier, and stopper after construction — the same circular-import-avoidance pattern. Task tools only appear in `tools/list` when `taskMgmtEnabled()` confirms all three deps are non-nil.
 - **MCP `task_create` is rate-limited to 5 concurrent calls.** `maxConcurrentCreates` prevents unbounded process spawning from a misbehaving MCP client. Each HeadlessCreateTask creates a worktree + PTY process.
 - **MCP `task_stop` must NOT pre-check DB status before calling `Stop()`.** TOCTOU race: the process can exit between the status read and the Stop() call, causing confusing errors. Let the stopper determine whether the session is alive.
+- **MCP `task_archive` cwd resolution must compare against `worktree + separator`, not raw prefix.** Otherwise a task with worktree `…/add-tests` would match a cwd inside `…/add-tests-extra`. `resolveTask` uses `strings.HasPrefix(cwd, wt+string(filepath.Separator))` plus an exact-equals check. Longest-match wins across siblings.
+- **MCP `task_archive` mirrors the TUI 'a' keybinding — archiving clears `WaitingReview`, status is untouched.** The archive flag is independent of `Status`; `/archive` does not set `StatusComplete`.
 
 ## Vault Watcher & Remote API
 

--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -11,7 +11,7 @@ Non-obvious invariants and gotchas, split by topic. Read the relevant file when 
 | [gotchas/worktree.md](gotchas/worktree.md) | Worktree creation ordering, transactional CreateAndStart, cleanup, path validation, stale ref pruning | 13 |
 | [gotchas/keybindings.md](gotchas/keybindings.md) | Key routing, ctrl sequences, tcell modifier quirks, agent view navigation | 12 |
 | [gotchas/tasklist-ui.md](gotchas/tasklist-ui.md) | Task list cursor, modals, focus guards, filter, archive, spinner, row rendering | 25 |
-| [gotchas/misc.md](gotchas/misc.md) | DB patterns, Go idioms, Codex, MCP, todos, PRs, file explorer, vault, quick-add, links | 62 |
+| [gotchas/misc.md](gotchas/misc.md) | DB patterns, Go idioms, Codex, MCP, todos, PRs, file explorer, vault, quick-add, links | 64 |
 
 ## Other Files
 

--- a/internal/inject/claude.go
+++ b/internal/inject/claude.go
@@ -69,6 +69,8 @@ func injectClaudeJSON(path string, port int) error {
 }
 
 // writeJSON marshals data as indented JSON and writes it to path atomically.
+// Uses os.CreateTemp for a unique tempfile name so concurrent writers do not
+// clobber each other before the rename.
 func writeJSON(path string, data map[string]interface{}) error {
 	out, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
@@ -76,13 +78,23 @@ func writeJSON(path string, data map[string]interface{}) error {
 	}
 	out = append(out, '\n')
 
-	// Atomic write via temp file.
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, out, 0644); err != nil {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".argus-inject-*.tmp")
+	if err != nil {
+		return fmt.Errorf("inject: create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(out); err != nil {
+		tmp.Close() //nolint:errcheck
+		os.Remove(tmpName) //nolint:errcheck
 		return fmt.Errorf("inject: write temp: %w", err)
 	}
-	if err := os.Rename(tmp, path); err != nil {
-		os.Remove(tmp) //nolint:errcheck
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName) //nolint:errcheck
+		return fmt.Errorf("inject: close temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName) //nolint:errcheck
 		return fmt.Errorf("inject: rename: %w", err)
 	}
 	return nil

--- a/internal/inject/claude.go
+++ b/internal/inject/claude.go
@@ -8,9 +8,17 @@ import (
 	"path/filepath"
 )
 
-// InjectGlobal reads ~/.claude.json, adds/updates the argus-kb MCP server entry,
+// mcpServerName is the key used for Argus in Claude Code's mcpServers map.
+// Previously "argus-kb"; renamed to "argus" now that the server exposes both
+// KB and task tools. The legacy key is cleaned up on inject.
+const mcpServerName = "argus"
+
+// legacyMcpServerName is the old pre-rename key, removed on the next inject.
+const legacyMcpServerName = "argus-kb"
+
+// InjectGlobal reads ~/.claude.json, adds/updates the argus MCP server entry,
 // and writes the file back. Idempotent — only writes if the entry is absent or
-// the port has changed.
+// the port has changed. Also removes the legacy "argus-kb" entry if present.
 func InjectGlobal(port int) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -20,8 +28,9 @@ func InjectGlobal(port int) error {
 	return injectClaudeJSON(path, port)
 }
 
-// injectClaudeJSON mutates only the mcpServers.argus-kb key in the given JSON file.
-// All other keys are preserved verbatim.
+// injectClaudeJSON mutates only the mcpServers.argus key in the given JSON
+// file, and removes the legacy mcpServers.argus-kb key if present. All other
+// keys are preserved verbatim.
 func injectClaudeJSON(path string, port int) error {
 	var data map[string]interface{}
 
@@ -43,14 +52,17 @@ func injectClaudeJSON(path string, port int) error {
 
 	url := fmt.Sprintf("http://localhost:%d/mcp", port)
 
-	// Check if already correct.
-	if existing, ok := mcpServers["argus-kb"].(map[string]interface{}); ok {
+	_, hasLegacy := mcpServers[legacyMcpServerName]
+
+	// Check if already correct (and no legacy cleanup pending).
+	if existing, ok := mcpServers[mcpServerName].(map[string]interface{}); ok && !hasLegacy {
 		if existing["url"] == url && existing["type"] == "http" {
 			return nil // already correct
 		}
 	}
 
-	mcpServers["argus-kb"] = map[string]interface{}{"type": "http", "url": url}
+	mcpServers[mcpServerName] = map[string]interface{}{"type": "http", "url": url}
+	delete(mcpServers, legacyMcpServerName)
 	data["mcpServers"] = mcpServers
 
 	return writeJSON(path, data)

--- a/internal/inject/claude_test.go
+++ b/internal/inject/claude_test.go
@@ -20,7 +20,7 @@ func TestInjectClaudeJSON_TypeField(t *testing.T) {
 	json.Unmarshal(data, &config) //nolint:errcheck
 
 	mcpServers := config["mcpServers"].(map[string]interface{})
-	entry := mcpServers["argus-kb"].(map[string]interface{})
+	entry := mcpServers["argus"].(map[string]interface{})
 	if entry["type"] != "http" {
 		t.Errorf("type: got %v, want http", entry["type"])
 	}
@@ -36,7 +36,7 @@ func TestInjectClaudeJSON_UpgradesOldFormat(t *testing.T) {
 
 	old := map[string]interface{}{
 		"mcpServers": map[string]interface{}{
-			"argus-kb": map[string]interface{}{"url": "http://localhost:7742/mcp"},
+			"argus": map[string]interface{}{"url": "http://localhost:7742/mcp"},
 		},
 	}
 	raw, _ := json.Marshal(old)
@@ -51,9 +51,45 @@ func TestInjectClaudeJSON_UpgradesOldFormat(t *testing.T) {
 	json.Unmarshal(data, &config) //nolint:errcheck
 
 	mcpServers := config["mcpServers"].(map[string]interface{})
-	entry := mcpServers["argus-kb"].(map[string]interface{})
+	entry := mcpServers["argus"].(map[string]interface{})
 	if entry["type"] != "http" {
 		t.Errorf("old format not upgraded: type=%v, want http", entry["type"])
+	}
+}
+
+// TestInjectClaudeJSON_MigratesLegacyKey verifies the pre-rename "argus-kb"
+// key is removed when the new "argus" entry is written. Simulates an upgrade
+// from an older Argus build where the MCP server was named argus-kb.
+func TestInjectClaudeJSON_MigratesLegacyKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude.json")
+
+	old := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"argus-kb": map[string]interface{}{"type": "http", "url": "http://localhost:7742/mcp"},
+			"other":    map[string]interface{}{"type": "http", "url": "http://localhost:9000/mcp"},
+		},
+	}
+	raw, _ := json.Marshal(old)
+	os.WriteFile(path, raw, 0644) //nolint:errcheck
+
+	if err := injectClaudeJSON(path, 7742); err != nil {
+		t.Fatalf("injectClaudeJSON: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	var config map[string]interface{}
+	json.Unmarshal(data, &config) //nolint:errcheck
+
+	mcpServers := config["mcpServers"].(map[string]interface{})
+	if _, still := mcpServers["argus-kb"]; still {
+		t.Error("legacy argus-kb key was not removed")
+	}
+	if _, have := mcpServers["argus"]; !have {
+		t.Error("new argus key was not added")
+	}
+	if _, preserved := mcpServers["other"]; !preserved {
+		t.Error("unrelated MCP entries were clobbered during migration")
 	}
 }
 

--- a/internal/inject/codex/codex.go
+++ b/internal/inject/codex/codex.go
@@ -8,8 +8,18 @@ import (
 	"strings"
 )
 
-// InjectGlobal reads ~/.codex/config.toml and adds/updates the argus-kb MCP
+// mcpSection is the TOML header for the Argus MCP entry in Codex config.
+// Previously "[mcp_servers.argus-kb]"; renamed to "[mcp_servers.argus]" now
+// that the server exposes task tools alongside KB. The legacy section is
+// cleaned up on inject.
+const mcpSection = "[mcp_servers.argus]"
+
+// legacyMcpSection is the old pre-rename header, removed on the next inject.
+const legacyMcpSection = "[mcp_servers.argus-kb]"
+
+// InjectGlobal reads ~/.codex/config.toml and adds/updates the argus MCP
 // server entry. Idempotent — only writes if the entry is absent or changed.
+// Also removes the legacy [mcp_servers.argus-kb] section if present.
 func InjectGlobal(port int) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -22,9 +32,10 @@ func InjectGlobal(port int) error {
 	return injectCodexTOML(path, port)
 }
 
-// injectCodexTOML inserts or updates the [mcp_servers.argus-kb] section.
-// Uses targeted string manipulation to avoid pulling in a TOML library.
-// Assumes standard Codex-generated TOML — no multi-line values, no inline tables.
+// injectCodexTOML inserts or updates the [mcp_servers.argus] section and
+// removes any pre-existing [mcp_servers.argus-kb] section. Uses targeted
+// string manipulation to avoid pulling in a TOML library. Assumes standard
+// Codex-generated TOML — no multi-line values, no inline tables.
 func injectCodexTOML(path string, port int) error {
 	url := fmt.Sprintf("http://localhost:%d/mcp", port)
 
@@ -34,11 +45,16 @@ func injectCodexTOML(path string, port int) error {
 		content = string(raw)
 	}
 
+	// Migrate: drop the legacy section unconditionally.
+	if strings.Contains(content, legacyMcpSection) {
+		content = removeSection(content, legacyMcpSection)
+	}
+
 	// Check if MCP section already exists.
 	urlCorrect := false
-	if strings.Contains(content, "[mcp_servers.argus-kb]") {
+	if strings.Contains(content, mcpSection) {
 		// Find the url line in the section and check its value.
-		idx := strings.Index(content, "[mcp_servers.argus-kb]")
+		idx := strings.Index(content, mcpSection)
 		section := content[idx:]
 		// Find the end of this section (next [ or EOF).
 		end := strings.Index(section[1:], "\n[")
@@ -53,7 +69,7 @@ func injectCodexTOML(path string, port int) error {
 			urlCorrect = true
 		} else {
 			// Port changed — remove old section and re-add below.
-			content = removeSection(content, "[mcp_servers.argus-kb]")
+			content = removeSection(content, mcpSection)
 		}
 	}
 
@@ -68,7 +84,7 @@ func injectCodexTOML(path string, port int) error {
 		if updated != "" && !strings.HasSuffix(updated, "\n") {
 			updated += "\n"
 		}
-		updated += fmt.Sprintf("\n[mcp_servers.argus-kb]\nurl = %q\n", url)
+		updated += fmt.Sprintf("\n%s\nurl = %q\n", mcpSection, url)
 	}
 
 	if updated == content {
@@ -138,7 +154,7 @@ func removeLine(content, substr string) string {
 }
 
 // removeSection removes a TOML section header and its key-value lines.
-// section is the header line, e.g. "[mcp_servers.argus-kb]".
+// section is the header line, e.g. "[mcp_servers.argus]".
 func removeSection(content, section string) string {
 	idx := strings.Index(content, section)
 	if idx == -1 {

--- a/internal/inject/codex/codex_test.go
+++ b/internal/inject/codex/codex_test.go
@@ -21,8 +21,8 @@ func TestInjectCodexTOML_CreatesFile(t *testing.T) {
 	}
 	content := string(data)
 
-	if !strings.Contains(content, "[mcp_servers.argus-kb]") {
-		t.Error("missing [mcp_servers.argus-kb] section")
+	if !strings.Contains(content, "[mcp_servers.argus]") {
+		t.Error("missing [mcp_servers.argus] section")
 	}
 	if !strings.Contains(content, `url = "http://localhost:7742/mcp"`) {
 		t.Error("missing url entry")
@@ -92,8 +92,8 @@ func TestInjectCodexTOML_PreservesExistingContent(t *testing.T) {
 	if !strings.Contains(content, "[other_servers.foo]") {
 		t.Error("other section was removed")
 	}
-	if !strings.Contains(content, "[mcp_servers.argus-kb]") {
-		t.Error("argus-kb section not added")
+	if !strings.Contains(content, "[mcp_servers.argus]") {
+		t.Error("argus section not added")
 	}
 }
 
@@ -142,7 +142,7 @@ func TestInjectCodexTOML_MigratesMisplacedKey(t *testing.T) {
 "gpt-5.3-codex" = "gpt-5.4"
 experimental_use_rmcp_client = true
 
-[mcp_servers.argus-kb]
+[mcp_servers.argus]
 url = "http://localhost:7742/mcp"
 `
 	os.WriteFile(path, []byte(broken), 0644) //nolint:errcheck
@@ -172,8 +172,43 @@ url = "http://localhost:7742/mcp"
 	if !strings.Contains(content, `url = "http://localhost:7742/mcp"`) {
 		t.Errorf("MCP url missing:\n%s", content)
 	}
-	if strings.Count(content, "[mcp_servers.argus-kb]") != 1 {
+	if strings.Count(content, "[mcp_servers.argus]") != 1 {
 		t.Errorf("MCP section duplicated:\n%s", content)
+	}
+}
+
+// TestInjectCodexTOML_MigratesLegacySection verifies the pre-rename
+// [mcp_servers.argus-kb] section is removed when the new [mcp_servers.argus]
+// section is written. Simulates an upgrade from an older Argus build.
+func TestInjectCodexTOML_MigratesLegacySection(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	legacy := `model = "gpt-5.4"
+
+[mcp_servers.argus-kb]
+url = "http://localhost:7742/mcp"
+
+[other]
+key = "val"
+`
+	os.WriteFile(path, []byte(legacy), 0644) //nolint:errcheck
+
+	if err := injectCodexTOML(path, 7742); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+
+	if strings.Contains(content, "[mcp_servers.argus-kb]") {
+		t.Errorf("legacy section not removed:\n%s", content)
+	}
+	if !strings.Contains(content, "[mcp_servers.argus]") {
+		t.Errorf("new section not added:\n%s", content)
+	}
+	if !strings.Contains(content, "[other]") {
+		t.Errorf("unrelated section was clobbered:\n%s", content)
 	}
 }
 
@@ -222,10 +257,10 @@ func TestEnsureTopLevel(t *testing.T) {
 }
 
 func TestRemoveSection(t *testing.T) {
-	content := "a = 1\n\n[mcp_servers.argus-kb]\nurl = \"http://localhost:7742/mcp\"\n\n[other]\nkey = val\n"
-	result := removeSection(content, "[mcp_servers.argus-kb]")
+	content := "a = 1\n\n[mcp_servers.argus]\nurl = \"http://localhost:7742/mcp\"\n\n[other]\nkey = val\n"
+	result := removeSection(content, "[mcp_servers.argus]")
 
-	if strings.Contains(result, "[mcp_servers.argus-kb]") {
+	if strings.Contains(result, "[mcp_servers.argus]") {
 		t.Error("section not removed")
 	}
 	if !strings.Contains(result, "[other]") {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -32,10 +32,11 @@ type KBQuerier interface {
 // Same signature as daemon.HeadlessCreateTask (injected to avoid import cycle).
 type TaskCreator func(name, prompt, project, todoPath string) (*model.Task, error)
 
-// TaskQuerier provides read access to tasks.
-type TaskQuerier interface {
+// TaskStore provides read and write access to tasks.
+type TaskStore interface {
 	Tasks() ([]*model.Task, error)
 	Get(id string) (*model.Task, error)
+	Update(t *model.Task) error
 }
 
 // TaskStopper can stop a running agent session.
@@ -54,7 +55,7 @@ type Server struct {
 	vaultPath   string // Metis vault path for write-back to Obsidian
 	httpSrv     *http.Server
 	createTask  TaskCreator
-	taskDB      TaskQuerier
+	taskDB      TaskStore
 	taskStopper TaskStopper
 	createMu    sync.Mutex
 	creating    int // number of in-flight task_create calls
@@ -69,8 +70,9 @@ func New(db KBQuerier, port int, vaultPath string) *Server {
 }
 
 // SetTaskManager wires in task management capabilities.
-// When set, the server exposes task_create, task_list, task_get, and task_stop tools.
-func (s *Server) SetTaskManager(creator TaskCreator, taskDB TaskQuerier, stopper TaskStopper) {
+// When set, the server exposes task_create, task_list, task_get, task_stop,
+// and task_archive tools.
+func (s *Server) SetTaskManager(creator TaskCreator, taskDB TaskStore, stopper TaskStopper) {
 	s.createTask = creator
 	s.taskDB = taskDB
 	s.taskStopper = stopper
@@ -354,6 +356,20 @@ var taskToolDefs = []Tool{
 			"required": []string{"id"},
 		},
 	},
+	{
+		Name: "task_archive",
+		Description: `Archive or unarchive an Argus task. Archived tasks move to the Archive section of the task list.
+
+The agent process does not know its own task ID, so the task is resolved from the working directory: pass ` + "`cwd`" + ` and Argus finds the task whose worktree matches. If ` + "`archived`" + ` is omitted, the current archive state is toggled.`,
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"id":       map[string]interface{}{"type": "string", "description": "Task ID. If omitted, cwd is used to resolve the task."},
+				"cwd":      map[string]interface{}{"type": "string", "description": "Working directory inside the task's worktree. Used when id is omitted."},
+				"archived": map[string]interface{}{"type": "boolean", "description": "Explicit archived state. If omitted, the current value is toggled."},
+			},
+		},
+	},
 }
 
 // taskMgmtEnabled returns true when all task management dependencies are wired.
@@ -400,6 +416,8 @@ func (s *Server) handleToolsCall(req *Request) *Response {
 		return s.toolTaskGet(req.ID, params.Arguments)
 	case "task_stop":
 		return s.toolTaskStop(req.ID, params.Arguments)
+	case "task_archive":
+		return s.toolTaskArchive(req.ID, params.Arguments)
 	default:
 		return errorResp(req.ID, -32601, "unknown tool: "+params.Name)
 	}
@@ -756,6 +774,95 @@ func (s *Server) toolTaskStop(id interface{}, args json.RawMessage) *Response {
 	}
 
 	return toolResult(id, fmt.Sprintf("Stop signal sent for task %s. It will transition to in_review when the agent exits.", p.ID))
+}
+
+func (s *Server) toolTaskArchive(id interface{}, args json.RawMessage) *Response {
+	if !s.taskMgmtEnabled() {
+		return toolError(id, "task management not configured")
+	}
+
+	var p struct {
+		ID       string `json:"id"`
+		Cwd      string `json:"cwd"`
+		Archived *bool  `json:"archived"`
+	}
+	json.Unmarshal(args, &p) //nolint:errcheck
+
+	task, err := s.resolveTask(p.ID, p.Cwd)
+	if err != nil {
+		return toolError(id, err.Error())
+	}
+
+	newArchived := !task.Archived
+	if p.Archived != nil {
+		newArchived = *p.Archived
+	}
+
+	// No-op: report current state without a DB write.
+	if newArchived == task.Archived {
+		state := "unarchived"
+		if task.Archived {
+			state = "archived"
+		}
+		return toolResult(id, fmt.Sprintf("Task %s (%s) already %s.", task.ID, task.Name, state))
+	}
+
+	task.Archived = newArchived
+	// Mirror the TUI 'a' keybinding: archiving clears waiting-review.
+	if task.Archived {
+		task.WaitingReview = false
+	}
+	if err := s.taskDB.Update(task); err != nil {
+		log.Printf("[mcp] task_archive failed: id=%s err=%v", task.ID, err)
+		return toolError(id, fmt.Sprintf("Failed to archive task: %v", err))
+	}
+
+	action := "Archived"
+	if !task.Archived {
+		action = "Unarchived"
+	}
+	log.Printf("[mcp] task_archive ok: id=%s archived=%v", task.ID, task.Archived)
+	return toolResult(id, fmt.Sprintf("%s task %s (%s).", action, task.ID, task.Name))
+}
+
+// resolveTask finds a task by explicit ID, or by matching cwd against
+// task worktree paths (longest prefix wins). Returns an error if neither
+// input is provided or no match is found.
+func (s *Server) resolveTask(taskID, cwd string) (*model.Task, error) {
+	if taskID != "" {
+		t, err := s.taskDB.Get(taskID)
+		if err != nil || t == nil {
+			return nil, fmt.Errorf("task not found: %s", taskID)
+		}
+		return t, nil
+	}
+	if cwd == "" {
+		return nil, fmt.Errorf("provide id or cwd")
+	}
+	cleanCwd := filepath.Clean(cwd)
+	tasks, err := s.taskDB.Tasks()
+	if err != nil {
+		return nil, fmt.Errorf("list tasks: %w", err)
+	}
+	var best *model.Task
+	var bestLen int
+	for _, t := range tasks {
+		if t.Worktree == "" {
+			continue
+		}
+		wt := filepath.Clean(t.Worktree)
+		if cleanCwd != wt && !strings.HasPrefix(cleanCwd, wt+string(filepath.Separator)) {
+			continue
+		}
+		if len(wt) > bestLen {
+			best = t
+			bestLen = len(wt)
+		}
+	}
+	if best == nil {
+		return nil, fmt.Errorf("no task matches cwd: %s", cwd)
+	}
+	return best, nil
 }
 
 // truncatePromptToName generates a task name from a prompt (first 40 runes).

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -793,6 +793,10 @@ func (s *Server) toolTaskArchive(id interface{}, args json.RawMessage) *Response
 		return toolError(id, err.Error())
 	}
 
+	// Read-then-write is not atomic — a concurrent /archive call or a
+	// TUI 'a' keypress racing this handler can blindly re-flip the toggle.
+	// Acceptable for a single-user local daemon; callers wanting determinism
+	// should pass an explicit `archived` bool instead of relying on toggle.
 	newArchived := !task.Archived
 	if p.Archived != nil {
 		newArchived = *p.Archived
@@ -818,16 +822,21 @@ func (s *Server) toolTaskArchive(id interface{}, args json.RawMessage) *Response
 	}
 
 	action := "Archived"
-	if !task.Archived {
+	if !newArchived {
 		action = "Unarchived"
 	}
-	log.Printf("[mcp] task_archive ok: id=%s archived=%v", task.ID, task.Archived)
+	log.Printf("[mcp] task_archive ok: id=%s archived=%v", task.ID, newArchived)
 	return toolResult(id, fmt.Sprintf("%s task %s (%s).", action, task.ID, task.Name))
 }
 
 // resolveTask finds a task by explicit ID, or by matching cwd against
-// task worktree paths (longest prefix wins). Returns an error if neither
+// task worktree paths (longest prefix wins, separator-guarded so siblings
+// don't collide). Archived tasks are included in the lookup so unarchive
+// from inside an archived worktree works. Returns an error if neither
 // input is provided or no match is found.
+//
+// Callers must guarantee s.taskMgmtEnabled() — this method dereferences
+// s.taskDB without a nil check.
 func (s *Server) resolveTask(taskID, cwd string) (*model.Task, error) {
 	if taskID != "" {
 		t, err := s.taskDB.Get(taskID)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -844,8 +844,13 @@ func TestTaskArchive(t *testing.T) {
 
 	t.Run("archiving clears waiting_review", func(t *testing.T) {
 		s, taskDB, _ := testServerWithTasks()
-		task, _ := taskDB.Get("abc123")
-		task.WaitingReview = true
+		// Set WaitingReview via Update so the test does not depend on
+		// mockTaskDB.Get returning the slice's pointer.
+		seed, _ := taskDB.Get("abc123")
+		seed.WaitingReview = true
+		if err := taskDB.Update(seed); err != nil {
+			t.Fatalf("seed Update: %v", err)
+		}
 		resp := doRequest(t, s, "tools/call", ToolCallParams{
 			Name:      "task_archive",
 			Arguments: json.RawMessage(`{"id": "abc123", "archived": true}`),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -423,6 +423,16 @@ func (m *mockTaskDB) Get(id string) (*model.Task, error) {
 	return nil, fmt.Errorf("not found")
 }
 
+func (m *mockTaskDB) Update(t *model.Task) error {
+	for i, existing := range m.tasks {
+		if existing.ID == t.ID {
+			m.tasks[i] = t
+			return nil
+		}
+	}
+	return fmt.Errorf("not found")
+}
+
 type mockStopper struct {
 	stopped []string
 }
@@ -437,20 +447,22 @@ func testServerWithTasks() (*Server, *mockTaskDB, *mockStopper) {
 	taskDB := &mockTaskDB{
 		tasks: []*model.Task{
 			{
-				ID:      "abc123",
-				Name:    "fix-login",
-				Status:  model.StatusInProgress,
-				Project: "myapp",
-				Branch:  "argus/fix-login",
-				Backend: "claude",
-				Prompt:  "Fix the login bug",
+				ID:       "abc123",
+				Name:     "fix-login",
+				Status:   model.StatusInProgress,
+				Project:  "myapp",
+				Branch:   "argus/fix-login",
+				Backend:  "claude",
+				Prompt:   "Fix the login bug",
+				Worktree: "/tmp/worktrees/myapp/fix-login",
 			},
 			{
-				ID:      "def456",
-				Name:    "add-tests",
-				Status:  model.StatusComplete,
-				Project: "myapp",
-				Branch:  "argus/add-tests",
+				ID:       "def456",
+				Name:     "add-tests",
+				Status:   model.StatusComplete,
+				Project:  "myapp",
+				Branch:   "argus/add-tests",
+				Worktree: "/tmp/worktrees/myapp/add-tests",
 			},
 			{
 				ID:       "ghi789",
@@ -493,14 +505,14 @@ func TestToolsList_WithTasks(t *testing.T) {
 	var list ToolsListResult
 	json.Unmarshal(result, &list) //nolint:errcheck
 
-	// 5 KB tools + 4 task tools = 9
-	testutil.Equal(t, len(list.Tools), 9)
+	// 5 KB tools + 5 task tools = 10
+	testutil.Equal(t, len(list.Tools), 10)
 
 	names := make(map[string]bool)
 	for _, tool := range list.Tools {
 		names[tool.Name] = true
 	}
-	for _, want := range []string{"task_create", "task_list", "task_get", "task_stop"} {
+	for _, want := range []string{"task_create", "task_list", "task_get", "task_stop", "task_archive"} {
 		if !names[want] {
 			t.Errorf("missing tool: %s", want)
 		}
@@ -730,7 +742,7 @@ func TestTaskCreate_RateLimit(t *testing.T) {
 func TestTaskTools_NotConfigured(t *testing.T) {
 	s := testServer() // no SetTaskManager
 
-	for _, tool := range []string{"task_create", "task_list", "task_get", "task_stop"} {
+	for _, tool := range []string{"task_create", "task_list", "task_get", "task_stop", "task_archive"} {
 		t.Run(tool, func(t *testing.T) {
 			resp := doRequest(t, s, "tools/call", ToolCallParams{
 				Name:      tool,
@@ -742,6 +754,163 @@ func TestTaskTools_NotConfigured(t *testing.T) {
 			testutil.Contains(t, cr.Content[0].Text, "not configured")
 		})
 	}
+}
+
+func TestTaskArchive(t *testing.T) {
+	t.Run("by id toggle archive", func(t *testing.T) {
+		s, taskDB, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_archive",
+			Arguments: json.RawMessage(`{"id": "abc123"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		testutil.Contains(t, cr.Content[0].Text, "Archived")
+		got, _ := taskDB.Get("abc123")
+		testutil.Equal(t, got.Archived, true)
+	})
+
+	t.Run("by id explicit unarchive", func(t *testing.T) {
+		s, taskDB, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_archive",
+			Arguments: json.RawMessage(`{"id": "ghi789", "archived": false}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		testutil.Contains(t, cr.Content[0].Text, "Unarchived")
+		got, _ := taskDB.Get("ghi789")
+		testutil.Equal(t, got.Archived, false)
+	})
+
+	t.Run("by cwd exact worktree match", func(t *testing.T) {
+		s, taskDB, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_archive",
+			Arguments: json.RawMessage(`{"cwd": "/tmp/worktrees/myapp/fix-login"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		got, _ := taskDB.Get("abc123")
+		testutil.Equal(t, got.Archived, true)
+	})
+
+	t.Run("by cwd nested subdirectory", func(t *testing.T) {
+		s, taskDB, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_archive",
+			Arguments: json.RawMessage(`{"cwd": "/tmp/worktrees/myapp/fix-login/internal/foo"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		got, _ := taskDB.Get("abc123")
+		testutil.Equal(t, got.Archived, true)
+	})
+
+	t.Run("cwd does not match sibling worktree with shared prefix", func(t *testing.T) {
+		s, taskDB, _ := testServerWithTasks()
+		// "/tmp/worktrees/myapp/add-tests" must not match a cwd under
+		// "/tmp/worktrees/myapp/add-tests-extra".
+		taskDB.tasks = append(taskDB.tasks, &model.Task{
+			ID: "zzz", Name: "sibling", Worktree: "/tmp/worktrees/myapp/add-tests-extra",
+		})
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_archive",
+			Arguments: json.RawMessage(`{"cwd": "/tmp/worktrees/myapp/add-tests-extra/x"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		// add-tests should still be unarchived — only the sibling flipped.
+		addTests, _ := taskDB.Get("def456")
+		testutil.Equal(t, addTests.Archived, false)
+		sibling, _ := taskDB.Get("zzz")
+		testutil.Equal(t, sibling.Archived, true)
+	})
+
+	t.Run("archiving clears waiting_review", func(t *testing.T) {
+		s, taskDB, _ := testServerWithTasks()
+		task, _ := taskDB.Get("abc123")
+		task.WaitingReview = true
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_archive",
+			Arguments: json.RawMessage(`{"id": "abc123", "archived": true}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		got, _ := taskDB.Get("abc123")
+		testutil.Equal(t, got.Archived, true)
+		testutil.Equal(t, got.WaitingReview, false)
+	})
+
+	t.Run("no-op when already in desired state", func(t *testing.T) {
+		s, taskDB, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_archive",
+			Arguments: json.RawMessage(`{"id": "ghi789", "archived": true}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		testutil.Contains(t, cr.Content[0].Text, "already")
+		got, _ := taskDB.Get("ghi789")
+		testutil.Equal(t, got.Archived, true)
+	})
+
+	t.Run("missing id and cwd", func(t *testing.T) {
+		s, _, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_archive",
+			Arguments: json.RawMessage(`{}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "provide id or cwd")
+	})
+
+	t.Run("unknown id", func(t *testing.T) {
+		s, _, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_archive",
+			Arguments: json.RawMessage(`{"id": "nope"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "not found")
+	})
+
+	t.Run("cwd with no matching worktree", func(t *testing.T) {
+		s, _, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_archive",
+			Arguments: json.RawMessage(`{"cwd": "/nowhere/special"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "no task matches cwd")
+	})
 }
 
 // --- test helpers ---


### PR DESCRIPTION
Adds a `task_archive` MCP tool that lets an agent mark its own Argus task
as archived at session end. The agent process does not know its own task
ID, so the tool resolves the task by matching `cwd` against task worktree
paths (longest-prefix match, separator-guarded against sibling collisions).
Mirrors the TUI 'a' keybinding: archiving clears `WaitingReview`, status
is untouched. Toggle is the default; pass an explicit `archived` bool for
deterministic behavior under concurrent calls.

Renames the MCP server key in injected client configs from `argus-kb` to
`argus`. The server now exposes both KB and task tools, so the kb suffix
was misleading. Both inject paths (`~/.claude.json` and
`~/.codex/config.toml`) remove the legacy entry on the next daemon boot.
Migration tests cover both. `writeJSON` in the Claude injector now uses
`os.CreateTemp` instead of a predictable `path+".tmp"` name, matching the
codex injector and avoiding clobbers under concurrent writes.

Ships a sample `/archive` skill at `.claude/skills/archive/SKILL.md` that
hands `pwd` to the tool and reports the result. README and gotchas
updated accordingly.

Co-Authored-By: Claude <noreply@anthropic.com>