### PR TITLE
Group web task list by project, mirroring TUI

### DIFF
--- a/context/knowledge/gotchas/web-remote.md
+++ b/context/knowledge/gotchas/web-remote.md
@@ -21,6 +21,10 @@ Non-obvious invariants for the SPA + REST API + push notifications stack.
 - **Resize POST is debounced (100ms) on `window.resize`** — but use `setTimeout(200)` for `orientationchange` because iOS Safari fires `orientationchange` before the viewport actually settles.
 - **Empty `[]taskJSON` encodes as `null`, not `[]`** — Go's `encoding/json` will emit `null` for a nil slice. Use `make([]taskJSON, 0)` for any handler whose response slice goes through the wire (`handleListTasks` does this; if you add another, do the same). The SPA does `tasks.find(...)` and crashes on null otherwise.
 
+## HTML escaping in `index.html`
+
+- **`esc()` only escapes `<`, `>`, `&` — NOT `"` or `'`.** It builds via `textContent` → `innerHTML`, which is safe in element-content position but injectable in attribute position when the attribute value is double-quoted. Patterns like `data-foo="${esc(name)}"` or `<option value="${esc(p)}">` are vulnerable to attribute escape via a `"` in `name`. For untrusted strings going into attributes, prefer index-based lookup against a render-time array (see `renderedProjects` in `renderTaskList`) or a true attribute-aware escape. Project names, task IDs, etc. all flow from user-controlled DB rows.
+
 ## Mobile virtual key row
 
 - **Sticky Ctrl is implemented in `term.onData`, not via xterm key events** — xterm's helper textarea fires onData with the un-modified character. The handler intercepts a single ASCII character when `ctrlArmed` is true and applies `code & 0x1f`. Don't try to modify `ev.ctrlKey` on the keyboard event — it's read-only.

--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -11,7 +11,7 @@ Non-obvious invariants and gotchas, split by topic. Read the relevant file when 
 | [gotchas/worktree.md](gotchas/worktree.md) | Worktree creation ordering, transactional CreateAndStart, cleanup, path validation, stale ref pruning | 13 |
 | [gotchas/keybindings.md](gotchas/keybindings.md) | Key routing, ctrl sequences, tcell modifier quirks, agent view navigation | 12 |
 | [gotchas/tasklist-ui.md](gotchas/tasklist-ui.md) | Task list cursor, modals, focus guards, filter, archive, spinner, row rendering | 25 |
-| [gotchas/web-remote.md](gotchas/web-remote.md) | SPA + REST API + service worker, EventSource auth, xterm.js, virtual keys, Web Push, per-device tokens, test harness | 19 |
+| [gotchas/web-remote.md](gotchas/web-remote.md) | SPA + REST API + service worker, EventSource auth, xterm.js, virtual keys, Web Push, per-device tokens, test harness, HTML escaping | 20 |
 | [gotchas/misc.md](gotchas/misc.md) | DB patterns, Go idioms, Codex, MCP, todos, PRs, file explorer, vault, quick-add, links | 74 |
 
 ## Other Files

--- a/internal/api/static/index.html
+++ b/internal/api/static/index.html
@@ -88,13 +88,44 @@ button:disabled { opacity: 0.5; cursor: default; }
 .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
 
 /* Task list */
-.task-list { padding: 8px 0; }
+.task-list { padding: 0; }
 .task-item {
-  display: flex; align-items: center; padding: 12px;
+  display: flex; align-items: center; padding: 12px 12px 12px 28px;
   border-bottom: 1px solid var(--border); cursor: pointer;
   transition: background 0.1s; gap: 10px;
 }
 .task-item:active { background: var(--surface); }
+
+/* Project groups */
+.project-group { border-bottom: 1px solid var(--border); }
+.project-group:last-child { border-bottom: none; }
+.project-header {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 12px; cursor: pointer;
+  background: var(--surface); user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+.project-header:active { background: var(--border); }
+.project-chevron {
+  color: var(--text-dim); font-size: 10px; width: 12px;
+  text-align: center; flex-shrink: 0;
+  transition: transform 0.12s ease-out;
+}
+.project-chevron.expanded { transform: rotate(90deg); }
+.project-dot {
+  width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+  background: var(--text-dim);
+}
+.project-dot.running { background: var(--green); }
+.project-dot.review { background: var(--yellow); }
+.project-dot.complete { background: var(--purple); }
+.project-name {
+  flex: 1; min-width: 0; font-weight: 600; color: var(--accent);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.project-count { font-size: 12px; color: var(--text-dim); flex-shrink: 0; }
+.project-tasks { background: var(--bg); }
+.project-tasks .task-item:last-child { border-bottom: none; }
 .task-badge {
   font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px;
   white-space: nowrap; flex-shrink: 0;
@@ -385,6 +416,8 @@ let actionBusy = false;
 
 let listFilter = 'active'; // 'active' or 'archived'
 let pushSubscribed = false;
+// Currently expanded project per filter view (one project open at a time, like the TUI).
+let expandedProject = { active: null, archived: null };
 
 // Terminal session state.
 let term = null;
@@ -486,19 +519,71 @@ function renderTaskList() {
     el.innerHTML = '<div class="empty-state">No tasks yet.<br>Tap + New to create one.</div>';
     return;
   }
+  // Group tasks by project (alphabetical), like the TUI task list.
+  const groups = {};
+  for (const t of tasks) {
+    const p = t.project || '(no project)';
+    (groups[p] = groups[p] || []).push(t);
+  }
+  const projects = Object.keys(groups).sort((a, b) => a.localeCompare(b));
+  // Auto-expand the first project if none is expanded (or the expanded one
+  // disappeared after a refresh). Mirrors the TUI's "always one open" behavior.
+  if (!expandedProject[listFilter] || !groups[expandedProject[listFilter]]) {
+    expandedProject[listFilter] = projects[0];
+  }
   const order = { in_progress: 0, in_review: 1, pending: 2, complete: 3 };
-  const sorted = [...tasks].sort((a, b) => (order[a.status] ?? 9) - (order[b.status] ?? 9));
-  el.innerHTML = sorted.map(t => `
-    <div class="task-item" onclick="openDetail('${esc(t.id)}')">
-      <span class="task-badge badge-${esc(t.status)}">${statusLabel(t.status)}</span>
-      <div class="task-info">
-        <div class="task-name">${esc(t.name)}</div>
-        <div class="task-meta">${esc(t.project)}${t.elapsed ? ' &middot; ' + t.elapsed : ''}</div>
+  el.innerHTML = projects.map(proj => {
+    const list = groups[proj].sort((a, b) => (order[a.status] ?? 9) - (order[b.status] ?? 9));
+    const isOpen = proj === expandedProject[listFilter];
+    const dot = projectDotClass(list);
+    const tasksHtml = isOpen ? list.map(t => `
+      <div class="task-item" onclick="openDetail('${esc(t.id)}')">
+        <span class="task-badge badge-${esc(t.status)}">${statusLabel(t.status)}</span>
+        <div class="task-info">
+          <div class="task-name">${esc(t.name)}</div>
+          <div class="task-meta">${t.elapsed ? esc(t.elapsed) : ''}</div>
+        </div>
+        <div class="task-chevron">&rsaquo;</div>
       </div>
-      <div class="task-chevron">&rsaquo;</div>
-    </div>
-  `).join('');
+    `).join('') : '';
+    return `<div class="project-group">
+      <div class="project-header" data-project="${esc(proj)}">
+        <span class="project-chevron${isOpen ? ' expanded' : ''}">&#9656;</span>
+        <span class="project-dot ${dot}"></span>
+        <span class="project-name">${esc(proj)}</span>
+        <span class="project-count">${list.length}</span>
+      </div>
+      <div class="project-tasks">${tasksHtml}</div>
+    </div>`;
+  }).join('');
 }
+
+function projectDotClass(list) {
+  let running = false, review = false, pending = false, complete = false;
+  for (const t of list) {
+    if (t.status === 'in_progress') running = true;
+    else if (t.status === 'in_review') review = true;
+    else if (t.status === 'complete') complete = true;
+    else pending = true;
+  }
+  if (running) return 'running';
+  if (review) return 'review';
+  if (complete && !pending) return 'complete';
+  return '';
+}
+
+function toggleProject(proj) {
+  expandedProject[listFilter] = (expandedProject[listFilter] === proj) ? null : proj;
+  renderTaskList();
+}
+
+// Project header click delegation — set up once so toggling never relies on
+// inline onclick (project names may contain quotes).
+document.getElementById('task-list').addEventListener('click', e => {
+  const header = e.target.closest('.project-header');
+  if (!header) return;
+  toggleProject(header.dataset.project);
+});
 
 function statusLabel(s) {
   return { pending: 'Pending', in_progress: 'Running', in_review: 'Review', complete: 'Done' }[s] || s;

--- a/internal/api/static/index.html
+++ b/internal/api/static/index.html
@@ -414,10 +414,19 @@ let currentTask = null;
 let tasks = [];
 let actionBusy = false;
 
-let listFilter = 'active'; // 'active' or 'archived'
+// Filter view keys for the task list.
+const FILTER_ACTIVE = 'active';
+const FILTER_ARCHIVED = 'archived';
+
+let listFilter = FILTER_ACTIVE;
 let pushSubscribed = false;
 // Currently expanded project per filter view (one project open at a time, like the TUI).
-let expandedProject = { active: null, archived: null };
+let expandedProject = { [FILTER_ACTIVE]: null, [FILTER_ARCHIVED]: null };
+// Project names ordered by index, populated each render. The click delegation
+// looks up the clicked project by index instead of round-tripping the name
+// through a data-project attribute, so a project name can never escape its
+// HTML context (esc() does not escape the `"` that closes an attribute).
+let renderedProjects = [];
 
 // Terminal session state.
 let term = null;
@@ -492,7 +501,7 @@ function logout() {
 // --- Refresh ---
 async function refresh() {
   try {
-    const tasksUrl = listFilter === 'archived' ? '/api/tasks?archived=1' : '/api/tasks';
+    const tasksUrl = listFilter === FILTER_ARCHIVED ? '/api/tasks?archived=1' : '/api/tasks';
     const [statusR, tasksR] = await Promise.all([api('/api/status'), api(tasksUrl)]);
     if (!statusR.ok || !tasksR.ok) throw new Error('server error');
     const status = await statusR.json();
@@ -519,7 +528,9 @@ function renderTaskList() {
     el.innerHTML = '<div class="empty-state">No tasks yet.<br>Tap + New to create one.</div>';
     return;
   }
-  // Group tasks by project (alphabetical), like the TUI task list.
+  // Group tasks by project (alphabetical), like the TUI task list. The
+  // "(no project)" fallback string matches groupByProject() in the TUI so the
+  // two clients label unrouted tasks identically.
   const groups = {};
   for (const t of tasks) {
     const p = t.project || '(no project)';
@@ -531,11 +542,15 @@ function renderTaskList() {
   if (!expandedProject[listFilter] || !groups[expandedProject[listFilter]]) {
     expandedProject[listFilter] = projects[0];
   }
+  renderedProjects = projects;
   const order = { in_progress: 0, in_review: 1, pending: 2, complete: 3 };
-  el.innerHTML = projects.map(proj => {
+  // Preserve scroll across the full re-render (5s status poll would otherwise
+  // snap the user back to the top every refresh).
+  const prevScrollY = window.scrollY;
+  el.innerHTML = projects.map((proj, idx) => {
     const list = groups[proj].sort((a, b) => (order[a.status] ?? 9) - (order[b.status] ?? 9));
     const isOpen = proj === expandedProject[listFilter];
-    const dot = projectDotClass(list);
+    const dot = projectDotModifier(list);
     const tasksHtml = isOpen ? list.map(t => `
       <div class="task-item" onclick="openDetail('${esc(t.id)}')">
         <span class="task-badge badge-${esc(t.status)}">${statusLabel(t.status)}</span>
@@ -547,7 +562,7 @@ function renderTaskList() {
       </div>
     `).join('') : '';
     return `<div class="project-group">
-      <div class="project-header" data-project="${esc(proj)}">
+      <div class="project-header" data-idx="${idx}">
         <span class="project-chevron${isOpen ? ' expanded' : ''}">&#9656;</span>
         <span class="project-dot ${dot}"></span>
         <span class="project-name">${esc(proj)}</span>
@@ -556,9 +571,10 @@ function renderTaskList() {
       <div class="project-tasks">${tasksHtml}</div>
     </div>`;
   }).join('');
+  if (prevScrollY > 0) window.scrollTo(0, prevScrollY);
 }
 
-function projectDotClass(list) {
+function projectDotModifier(list) {
   let running = false, review = false, pending = false, complete = false;
   for (const t of list) {
     if (t.status === 'in_progress') running = true;
@@ -572,17 +588,25 @@ function projectDotClass(list) {
   return '';
 }
 
-function toggleProject(proj) {
-  expandedProject[listFilter] = (expandedProject[listFilter] === proj) ? null : proj;
+function expandProject(proj) {
+  // "Always one open" invariant matches the TUI: re-tapping the open header
+  // is a no-op so the user can never end up with everything collapsed.
+  if (expandedProject[listFilter] === proj) return;
+  expandedProject[listFilter] = proj;
   renderTaskList();
 }
 
-// Project header click delegation — set up once so toggling never relies on
-// inline onclick (project names may contain quotes).
+// Project header click delegation. We look up the project by index into
+// renderedProjects rather than reading a data-project attribute, because
+// esc() does not escape the `"` that closes an HTML attribute — embedding
+// untrusted project names in attribute context would be injectable.
 document.getElementById('task-list').addEventListener('click', e => {
   const header = e.target.closest('.project-header');
   if (!header) return;
-  toggleProject(header.dataset.project);
+  const idx = parseInt(header.dataset.idx, 10);
+  if (Number.isInteger(idx) && idx >= 0 && idx < renderedProjects.length) {
+    expandProject(renderedProjects[idx]);
+  }
 });
 
 function statusLabel(s) {


### PR DESCRIPTION
The web PWA task list now groups tasks into collapsible per-project sections (alphabetical), one project expanded at a time per filter view (Active / Archived) — matching the TUI's task list layout. Each header shows a status dot (running / review / complete), project name, and count.

Hardening:
- Click delegation looks up the clicked project by index into a render-time array instead of round-tripping the project name through `data-project`. `esc()` does not escape attribute-closing quotes, so attribute interpolation of user-controlled project names was injectable.
- Re-tapping the open project header is a no-op (matches the TUI "always one open" invariant).
- `window.scrollY` is preserved across the 5s status-poll re-render.

Also adds a gotcha entry in `context/knowledge/gotchas/web-remote.md` documenting the `esc()` attribute-escape limitation so future contributors don't reintroduce the pattern.

Co-Authored-By: Claude <noreply@anthropic.com>