### PR TITLE
Remove stop-all button from web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Argus includes a built-in HTTP API and mobile web dashboard for controlling agen
 Open `http://<your-machine>:7743/` in your phone browser. Enter the API token from `~/.argus/api-token` to authenticate. Tap **Add to Home Screen** in Safari to install as a PWA.
 
 The dashboard provides:
-- **Task list** — Active and Archived tabs, status badges, Stop-all action
+- **Task list** — Active and Archived tabs, status badges
 - **Task detail** — Real xterm.js terminal with live SSE byte stream, virtual key row, Stop / Resume / Rename / Fork / Archive / Delete actions
 - **Create tasks** — Select a project, enter a prompt, start a new agent. Skill autocomplete (type `/`) suggests per-project and global skills
 - **Settings tab** — Push notifications toggle (VAPID), test push button, API token management (mint/revoke per-device tokens), forget local token

--- a/internal/api/static/index.html
+++ b/internal/api/static/index.html
@@ -266,8 +266,6 @@ button:disabled { opacity: 0.5; cursor: default; }
   padding: 4px 10px; border-radius: 6px; cursor: pointer; color: var(--text-dim);
 }
 .list-toolbar .seg.active { background: var(--surface); color: var(--accent); }
-.list-toolbar button { font-size: 12px; padding: 4px 8px; }
-.list-toolbar .spacer { flex: 1; }
 
 /* Toast notifications */
 .toast {
@@ -311,7 +309,6 @@ button:disabled { opacity: 0.5; cursor: default; }
     <div class="list-toolbar">
       <span class="seg active" data-filter="active" onclick="setListFilter('active')">Active</span>
       <span class="seg" data-filter="archived" onclick="setListFilter('archived')">Archived</span>
-      <span class="spacer"></span>
     </div>
     <div class="refresh-hint" id="refresh-hint">Pull to refresh</div>
     <div class="task-list" id="task-list"></div>

--- a/internal/api/static/index.html
+++ b/internal/api/static/index.html
@@ -312,7 +312,6 @@ button:disabled { opacity: 0.5; cursor: default; }
       <span class="seg active" data-filter="active" onclick="setListFilter('active')">Active</span>
       <span class="seg" data-filter="archived" onclick="setListFilter('archived')">Archived</span>
       <span class="spacer"></span>
-      <button class="danger" onclick="stopAll()">Stop all</button>
     </div>
     <div class="refresh-hint" id="refresh-hint">Pull to refresh</div>
     <div class="task-list" id="task-list"></div>
@@ -984,17 +983,6 @@ async function setArchive(archived) {
     if (!r.ok) throw new Error('archive failed');
     currentTask.archived = archived;
     closeDetail();
-    refresh();
-  } catch(e) { showToast(e.message); }
-}
-
-async function stopAll() {
-  if (!confirm('Stop all running agents?')) return;
-  try {
-    const r = await api('/api/sessions/stop-all', { method: 'POST' });
-    if (!r.ok) throw new Error('stop-all failed');
-    const j = await r.json();
-    showToast(`Stopped ${j.stopped} agents`);
     refresh();
   } catch(e) { showToast(e.message); }
 }


### PR DESCRIPTION
Remove the Stop-all toolbar button and its JS handler from the mobile
web dashboard, plus the README dashboard-features bullet. Following the
removal, drop the now-dead `.list-toolbar button` CSS rule and the
purposeless `<span class="spacer">` (with its flex:1 rule) — there is
no longer any sibling for the spacer to push apart.

The `POST /api/sessions/stop-all` HTTP endpoint, its Go handler, and
its Playwright API test are intentionally retained for programmatic
clients.

Co-Authored-By: Claude <noreply@anthropic.com>