### PR TITLE
PWA detail view: fixed-flex layout, overflow menu, jump-to-input

### DIFF
--- a/context/knowledge/gotchas/web-remote.md
+++ b/context/knowledge/gotchas/web-remote.md
@@ -30,6 +30,13 @@ Non-obvious invariants for the SPA + REST API + push notifications stack.
 - **Sticky Ctrl is implemented in `term.onData`, not via xterm key events** — xterm's helper textarea fires onData with the un-modified character. The handler intercepts a single ASCII character when `ctrlArmed` is true and applies `code & 0x1f`. Don't try to modify `ev.ctrlKey` on the keyboard event — it's read-only.
 - **Ctrl auto-clears after one keystroke unless locked** — the second tap on the Ctrl button locks (`ctrlLocked = true`); third tap clears. Without this, holding "Ctrl mode" feels stuck.
 
+## Detail-view layout
+
+- **`#detail-view.open` is `position: fixed; height: 100dvh` so only the xterm scrolls** — page-level scroll inside the detail view fights xterm's scrollback for touch and used to make scrolling unusable on iOS. The replacement uses a flex column where `.term-wrap` is `flex: 1`. Don't reintroduce page-flow children that grow the detail view past viewport height; nested scroll comes back the moment you do.
+- **Use `100dvh`, not `100vh`, for the fixed detail view** — Safari's address bar shrinks/grows the visual viewport but `vh` reflects the layout viewport, so `100vh` puts the bottom-anchored vkey-row behind the address bar / soft keyboard. `dvh` resizes with the visible area.
+- **Action buttons live in an overflow menu (`#overflow-menu`)** — only the primary action (Stop / Resume) is inline; Rename/Fork/Archive/PR/Delete are inside a popover toggled via `#btn-overflow`. The IDs (`#btn-rename`, `#btn-archive`, etc.) are preserved on the menu items so existing Playwright selectors still work, but tests must click `#btn-overflow` first to open the menu.
+- **Jump-to-input button visibility is driven by `term.onScroll`, not `term.write`** — the button appears whenever `buffer.active.viewportY < buffer.active.baseY` and hides when xterm auto-scrolls back to the bottom (which fires `onScroll`). Don't try to track scroll state from the SSE message handler — xterm's auto-follow already gets it right and `onScroll` covers manual moves.
+
 ## Web Push / VAPID
 
 - **VAPID keys are persisted in the `config` table** — keys `push.vapid_public` and `push.vapid_private`. Regenerating them invalidates every existing subscription (the push service rejects with 401). Only delete these if you also clear `push_subscriptions`.

--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -11,7 +11,7 @@ Non-obvious invariants and gotchas, split by topic. Read the relevant file when 
 | [gotchas/worktree.md](gotchas/worktree.md) | Worktree creation ordering, transactional CreateAndStart, cleanup, path validation, stale ref pruning | 13 |
 | [gotchas/keybindings.md](gotchas/keybindings.md) | Key routing, ctrl sequences, tcell modifier quirks, agent view navigation | 12 |
 | [gotchas/tasklist-ui.md](gotchas/tasklist-ui.md) | Task list cursor, modals, focus guards, filter, archive, spinner, row rendering | 25 |
-| [gotchas/web-remote.md](gotchas/web-remote.md) | SPA + REST API + service worker, EventSource auth, xterm.js, virtual keys, Web Push, per-device tokens, test harness, HTML escaping | 20 |
+| [gotchas/web-remote.md](gotchas/web-remote.md) | SPA + REST API + service worker, EventSource auth, xterm.js, HTML escaping, virtual keys, detail-view layout, Web Push, per-device tokens, test harness | 26 |
 | [gotchas/misc.md](gotchas/misc.md) | DB patterns, Go idioms, Codex, MCP, todos, PRs, file explorer, vault, quick-add, links | 74 |
 
 ## Other Files

--- a/internal/api/static/index.html
+++ b/internal/api/static/index.html
@@ -140,41 +140,92 @@ button:disabled { opacity: 0.5; cursor: default; }
 .task-chevron { color: var(--text-dim); font-size: 18px; flex-shrink: 0; }
 .empty-state { text-align: center; padding: 48px 24px; color: var(--text-dim); }
 
-/* Task detail */
+/* Task detail — fixed-height flex column so only the terminal scrolls. */
 #detail-view { display: none; }
-.detail-header {
-  padding: 12px; background: var(--surface);
-  border-bottom: 1px solid var(--border);
+#detail-view.open {
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: 100dvh;
+  background: var(--bg);
+  z-index: 50;
 }
-.detail-back { color: var(--accent); font-size: 14px; cursor: pointer; margin-bottom: 8px; display: inline-block; }
-.detail-title { font-size: 18px; font-weight: 600; margin-bottom: 4px; }
+.detail-header {
+  padding: 10px 12px; background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.detail-back { color: var(--accent); font-size: 14px; cursor: pointer; margin-bottom: 6px; display: inline-block; }
+.detail-title { font-size: 17px; font-weight: 600; margin-bottom: 2px; }
 .detail-subtitle { font-size: 13px; color: var(--text-dim); }
-.detail-actions { display: flex; gap: 8px; padding: 12px; flex-wrap: wrap; }
-.detail-actions button { flex: 1; min-width: 80px; }
+.detail-actions {
+  display: flex; gap: 8px; padding: 8px 12px;
+  align-items: center; flex-shrink: 0; position: relative;
+}
+.detail-actions .primary-action { flex: 1; min-height: 44px; }
+.detail-actions .overflow-btn {
+  width: 44px; height: 44px; min-width: 44px;
+  padding: 0; font-size: 22px; flex-shrink: 0;
+  display: flex; align-items: center; justify-content: center;
+}
+.overflow-menu {
+  position: absolute; top: calc(100% - 4px); right: 12px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; padding: 4px; min-width: 180px;
+  z-index: 100; display: none;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.5);
+}
+.overflow-menu.open { display: block; }
+.overflow-menu button {
+  display: block; width: 100%; text-align: left;
+  background: transparent; border: none;
+  padding: 12px; border-radius: 6px;
+  font-size: 15px; min-height: 44px; color: var(--text);
+}
+.overflow-menu button:active { background: var(--border); }
+.overflow-menu button.danger { color: var(--red); }
 .term-wrap {
-  padding: 8px 12px 12px;
+  flex: 1 1 auto; min-height: 0;
+  display: flex; position: relative;
+  padding: 8px 12px;
   background: var(--bg);
 }
 #term {
+  flex: 1 1 auto; min-height: 0;
   background: #000;
   border-radius: 8px;
   padding: 8px;
-  height: 65vh;
-  min-height: 320px;
-  /* xterm renders into its own elements; this wrapper just sizes it. */
+  position: relative;
 }
 #term .xterm { padding: 0; }
 #term .xterm-viewport { background: transparent !important; -webkit-overflow-scrolling: touch; }
+.jump-bottom-btn {
+  position: absolute;
+  right: 24px; bottom: 24px;
+  width: 44px; height: 44px;
+  border-radius: 50%;
+  background: var(--accent); color: #000;
+  border: none; font-size: 22px; font-weight: bold;
+  display: none; align-items: center; justify-content: center;
+  cursor: pointer; z-index: 5;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+  -webkit-tap-highlight-color: transparent;
+}
+.jump-bottom-btn.shown { display: flex; }
+.jump-bottom-btn:active { background: var(--text); }
 .read-only-output {
+  flex: 1 1 auto; min-height: 0;
   background: #000; color: #ccc; font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
-  font-size: 12px; line-height: 1.4; padding: 12px; margin: 8px 12px 12px;
-  border-radius: 8px; min-height: 200px; max-height: 65vh;
+  font-size: 12px; line-height: 1.4; padding: 12px; margin: 8px 12px;
+  border-radius: 8px;
   overflow-y: auto; white-space: pre-wrap; word-break: break-all;
   -webkit-overflow-scrolling: touch;
 }
 .term-status {
   font-size: 11px; color: var(--text-dim); padding: 4px 12px;
   display: flex; gap: 8px; align-items: center;
+  flex-shrink: 0;
 }
 .term-status .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--text-dim); }
 .term-status.live .dot { background: var(--green); }
@@ -182,20 +233,21 @@ button:disabled { opacity: 0.5; cursor: default; }
 .term-status.error .dot { background: var(--red); }
 @keyframes pulse { 50% { opacity: 0.4; } }
 
-/* Virtual key row — floats above keyboard for mobile */
+/* Virtual key row — fills bottom of fixed-flex detail view. */
 .vkey-row {
   display: none;
-  gap: 4px; padding: 6px 8px;
+  gap: 6px; padding: 8px;
   background: var(--surface); border-top: 1px solid var(--border);
   overflow-x: auto; -webkit-overflow-scrolling: touch;
-  position: sticky; bottom: 0;
+  flex-shrink: 0;
+  padding-bottom: max(8px, env(safe-area-inset-bottom));
 }
 .vkey-row.shown { display: flex; }
 .vkey {
-  flex-shrink: 0; min-width: 36px; height: 32px;
-  padding: 0 8px; border-radius: 6px;
+  flex-shrink: 0; min-width: 44px; height: 44px;
+  padding: 0 12px; border-radius: 6px;
   background: var(--bg); border: 1px solid var(--border);
-  color: var(--text); font-size: 13px; font-weight: 500;
+  color: var(--text); font-size: 14px; font-weight: 500;
   cursor: pointer; user-select: none;
   -webkit-tap-highlight-color: transparent;
 }
@@ -325,7 +377,10 @@ button:disabled { opacity: 0.5; cursor: default; }
     <div class="term-status" id="term-status" style="display:none">
       <span class="dot"></span><span id="term-status-text">connecting…</span>
     </div>
-    <div class="term-wrap" id="term-wrap" style="display:none"><div id="term"></div></div>
+    <div class="term-wrap" id="term-wrap" style="display:none">
+      <div id="term"></div>
+      <button class="jump-bottom-btn" id="jump-bottom" aria-label="Scroll to input" type="button">↓</button>
+    </div>
     <div class="vkey-row" id="vkey-row">
       <button class="vkey" data-key="esc">Esc</button>
       <button class="vkey" data-key="tab">Tab</button>
@@ -615,7 +670,7 @@ async function openDetail(id) {
   if (!currentTask) return;
 
   document.getElementById('tasks-view').style.display = 'none';
-  document.getElementById('detail-view').style.display = 'block';
+  document.getElementById('detail-view').classList.add('open');
   document.getElementById('detail-title').textContent = currentTask.name;
   document.getElementById('detail-subtitle').textContent =
     `${currentTask.project} \u00b7 ${statusLabel(currentTask.status)}${currentTask.elapsed ? ' \u00b7 ' + currentTask.elapsed : ''}`;
@@ -630,7 +685,7 @@ function attachTerminal(task) {
 
   if (task.status === 'in_progress') {
     showTermStatus('connecting\u2026', 'reconnecting');
-    document.getElementById('term-wrap').style.display = 'block';
+    document.getElementById('term-wrap').style.display = 'flex';
     document.getElementById('output-box').style.display = 'none';
     document.getElementById('term-status').style.display = 'flex';
     document.getElementById('vkey-row').classList.add('shown');
@@ -679,6 +734,9 @@ function setupTerm() {
     fit();
     term.focus();
   });
+  // Toggle the jump-to-input button when user scrolls up into scrollback.
+  term.onScroll(updateJumpButton);
+  updateJumpButton();
 
   // Forward keystrokes to the agent. xterm gives us already-translated bytes
   // (e.g. arrow keys come as ESC[A). Send them raw.
@@ -778,7 +836,30 @@ function destroyTerm() {
     window.term = null;
     window.fitAddon = null;
   }
+  const btn = document.getElementById('jump-bottom');
+  if (btn) btn.classList.remove('shown');
 }
+
+function termIsAtBottom() {
+  if (!term) return true;
+  try {
+    const buf = term.buffer.active;
+    return buf.viewportY >= buf.baseY;
+  } catch(e) { return true; }
+}
+
+function updateJumpButton() {
+  const btn = document.getElementById('jump-bottom');
+  if (!btn) return;
+  btn.classList.toggle('shown', !!term && !termIsAtBottom());
+}
+
+document.getElementById('jump-bottom').addEventListener('click', () => {
+  if (!term) return;
+  term.scrollToBottom();
+  term.focus();
+  updateJumpButton();
+});
 
 function fit() {
   if (!fitAddon || !term) return;
@@ -862,34 +943,65 @@ async function loadStaticOutput(id) {
 function renderDetailActions() {
   const el = document.getElementById('detail-actions');
   const s = currentTask.status;
-  let html = '';
+  let primary = '';
   if (s === 'in_progress') {
-    html += '<button class="danger" id="btn-stop" onclick="stopTask()">Stop</button>';
-  }
-  if (s === 'pending' || s === 'in_review' || s === 'complete') {
-    html += '<button class="primary" id="btn-resume" onclick="resumeTask()">Resume</button>';
-  }
-  html += '<button id="btn-rename" onclick="renameTask()">Rename</button>';
-  html += '<button id="btn-fork" onclick="forkTask()">Fork</button>';
-  if (currentTask.archived) {
-    html += '<button id="btn-archive" onclick="setArchive(false)">Unarchive</button>';
+    primary = '<button class="primary-action danger" id="btn-stop" onclick="stopTask()">Stop</button>';
+  } else if (s === 'pending' || s === 'in_review' || s === 'complete') {
+    primary = '<button class="primary-action primary" id="btn-resume" onclick="resumeTask()">Resume</button>';
   } else {
-    html += '<button id="btn-archive" onclick="setArchive(true)">Archive</button>';
+    primary = '<div class="primary-action"></div>';
   }
+  el.innerHTML =
+    primary +
+    '<button class="overflow-btn" id="btn-overflow" aria-label="More actions" type="button">⋯</button>' +
+    '<div class="overflow-menu" id="overflow-menu"></div>';
+
+  document.getElementById('btn-overflow').addEventListener('click', e => {
+    e.stopPropagation();
+    document.getElementById('overflow-menu').classList.toggle('open');
+  });
+
+  const menu = document.getElementById('overflow-menu');
+  const items = [
+    { id: 'btn-rename', label: 'Rename', fn: renameTask },
+    { id: 'btn-fork', label: 'Fork', fn: forkTask },
+    currentTask.archived
+      ? { id: 'btn-archive', label: 'Unarchive', fn: () => setArchive(false) }
+      : { id: 'btn-archive', label: 'Archive', fn: () => setArchive(true) },
+  ];
   if (currentTask.pr_url) {
-    html += `<button id="btn-pr" data-url="${esc(currentTask.pr_url)}">View PR</button>`;
-  }
-  html += '<button class="danger" id="btn-delete" onclick="deleteTask()">Delete</button>';
-  el.innerHTML = html;
-  // Bind PR button via JS (not inline onclick) to prevent XSS from crafted URLs.
-  const prBtn = document.getElementById('btn-pr');
-  if (prBtn) {
-    prBtn.addEventListener('click', () => {
-      const url = prBtn.dataset.url;
+    items.push({ id: 'btn-pr', label: 'View PR', fn: () => {
+      const url = currentTask.pr_url;
       if (url && url.startsWith('http')) window.open(url, '_blank');
-    });
+    }});
   }
+  items.push({ id: 'btn-delete', label: 'Delete', fn: deleteTask, danger: true });
+
+  menu.innerHTML = '';
+  items.forEach(it => {
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.id = it.id;
+    b.textContent = it.label;
+    if (it.danger) b.className = 'danger';
+    b.addEventListener('click', () => {
+      closeOverflowMenu();
+      it.fn();
+    });
+    menu.appendChild(b);
+  });
 }
+
+function closeOverflowMenu() {
+  const m = document.getElementById('overflow-menu');
+  if (m) m.classList.remove('open');
+}
+
+document.addEventListener('click', e => {
+  const m = document.getElementById('overflow-menu');
+  if (!m || !m.classList.contains('open')) return;
+  if (!e.target.closest('.detail-actions')) closeOverflowMenu();
+});
 
 function setActionButtons(disabled) {
   actionBusy = disabled;
@@ -1010,8 +1122,9 @@ async function deleteTask() {
 function closeDetail() {
   closeStream();
   destroyTerm();
+  closeOverflowMenu();
   currentTask = null;
-  document.getElementById('detail-view').style.display = 'none';
+  document.getElementById('detail-view').classList.remove('open');
   document.getElementById('tasks-view').style.display = 'block';
 }
 
@@ -1080,7 +1193,8 @@ function switchTab(tab) {
   document.getElementById('tasks-view').style.display = tab === 'tasks' ? 'block' : 'none';
   document.getElementById('create-view').style.display = tab === 'create' ? 'block' : 'none';
   document.getElementById('settings-view').style.display = tab === 'settings' ? 'block' : 'none';
-  document.getElementById('detail-view').style.display = 'none';
+  document.getElementById('detail-view').classList.remove('open');
+  closeOverflowMenu();
   closeStream();
   destroyTerm();
   if (tab === 'tasks') refresh();

--- a/internal/api/static/index.html
+++ b/internal/api/static/index.html
@@ -147,7 +147,8 @@ button:disabled { opacity: 0.5; cursor: default; }
   flex-direction: column;
   position: fixed;
   top: 0; left: 0; right: 0;
-  height: 100dvh;
+  height: 100vh;   /* fallback for Safari < 15.4 */
+  height: 100dvh;  /* shrinks with the visual viewport (address bar / soft keyboard) */
   background: var(--bg);
   z-index: 50;
 }
@@ -170,6 +171,7 @@ button:disabled { opacity: 0.5; cursor: default; }
   display: flex; align-items: center; justify-content: center;
 }
 .overflow-menu {
+  /* -4px overlap so the menu visually merges with the action row. */
   position: absolute; top: calc(100% - 4px); right: 12px;
   background: var(--surface); border: 1px solid var(--border);
   border-radius: 8px; padding: 4px; min-width: 180px;
@@ -323,7 +325,7 @@ button:disabled { opacity: 0.5; cursor: default; }
 .toast {
   position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
   background: var(--red); color: #fff; padding: 10px 20px; border-radius: 8px;
-  font-size: 14px; z-index: 100; max-width: 90vw; text-align: center;
+  font-size: 14px; z-index: 200; max-width: 90vw; text-align: center;
   animation: toast-in 0.2s ease-out;
 }
 @keyframes toast-in { from { opacity: 0; transform: translateX(-50%) translateY(10px); } to { opacity: 1; transform: translateX(-50%) translateY(0); } }
@@ -948,8 +950,6 @@ function renderDetailActions() {
     primary = '<button class="primary-action danger" id="btn-stop" onclick="stopTask()">Stop</button>';
   } else if (s === 'pending' || s === 'in_review' || s === 'complete') {
     primary = '<button class="primary-action primary" id="btn-resume" onclick="resumeTask()">Resume</button>';
-  } else {
-    primary = '<div class="primary-action"></div>';
   }
   el.innerHTML =
     primary +
@@ -972,7 +972,8 @@ function renderDetailActions() {
   if (currentTask.pr_url) {
     items.push({ id: 'btn-pr', label: 'View PR', fn: () => {
       const url = currentTask.pr_url;
-      if (url && url.startsWith('http')) window.open(url, '_blank');
+      // noopener+noreferrer: prevent the opened tab from accessing window.opener.
+      if (url && url.startsWith('http')) window.open(url, '_blank', 'noopener,noreferrer');
     }});
   }
   items.push({ id: 'btn-delete', label: 'Delete', fn: deleteTask, danger: true });
@@ -1005,7 +1006,9 @@ document.addEventListener('click', e => {
 
 function setActionButtons(disabled) {
   actionBusy = disabled;
-  ['btn-stop','btn-resume','btn-delete'].forEach(id => {
+  // btn-overflow gates Rename/Fork/Archive/PR/Delete; disabling it during
+  // an in-flight Stop/Resume/Delete prevents concurrent secondary actions.
+  ['btn-stop','btn-resume','btn-delete','btn-overflow'].forEach(id => {
     const el = document.getElementById(id);
     if (el) el.disabled = disabled;
   });

--- a/web-tests/tests/settings-ui.spec.ts
+++ b/web-tests/tests/settings-ui.spec.ts
@@ -80,4 +80,26 @@ test.describe('detail-view actions', () => {
     await page.locator('#btn-fork').click();
     await expect(page.locator('#detail-title')).toHaveText('forked-via-ui', { timeout: 5000 });
   });
+
+  test('overflow menu closes when navigating Back', async ({ page }) => {
+    await login(page);
+    await page.locator('.task-item').first().click();
+    await page.locator('#btn-overflow').click();
+    await expect(page.locator('#overflow-menu')).toHaveClass(/open/);
+    await page.locator('.detail-back').click();
+    // After back, detail-view is dismissed and overflow-menu is gone from DOM
+    // (innerHTML rebuild on next openDetail), or at minimum no longer .open.
+    await expect(page.locator('#tasks-view')).toBeVisible();
+    await expect(page.locator('#overflow-menu.open')).toHaveCount(0);
+  });
+
+  test('overflow menu closes when switching tabs', async ({ page }) => {
+    await login(page);
+    await page.locator('.task-item').first().click();
+    await page.locator('#btn-overflow').click();
+    await expect(page.locator('#overflow-menu')).toHaveClass(/open/);
+    await page.locator('.tab[data-tab="settings"]').click();
+    await expect(page.locator('#settings-view')).toBeVisible();
+    await expect(page.locator('#overflow-menu.open')).toHaveCount(0);
+  });
 });

--- a/web-tests/tests/settings-ui.spec.ts
+++ b/web-tests/tests/settings-ui.spec.ts
@@ -51,6 +51,7 @@ test.describe('list toolbar', () => {
     // Click the seed task → archive it.
     await page.locator('.task-item').first().click();
     page.on('dialog', d => d.accept());
+    await page.locator('#btn-overflow').click();
     await page.locator('#btn-archive').click();
     await expect(page.locator('#tasks-view')).toBeVisible();
     // Active list is empty.
@@ -66,6 +67,7 @@ test.describe('detail-view actions', () => {
     await login(page);
     await page.locator('.task-item').first().click();
     page.on('dialog', d => d.accept('renamed-via-ui'));
+    await page.locator('#btn-overflow').click();
     await page.locator('#btn-rename').click();
     await expect(page.locator('#detail-title')).toHaveText('renamed-via-ui', { timeout: 3000 });
   });
@@ -74,6 +76,7 @@ test.describe('detail-view actions', () => {
     await login(page);
     await page.locator('.task-item').first().click();
     page.on('dialog', d => d.accept('forked-via-ui'));
+    await page.locator('#btn-overflow').click();
     await page.locator('#btn-fork').click();
     await expect(page.locator('#detail-title')).toHaveText('forked-via-ui', { timeout: 5000 });
   });


### PR DESCRIPTION
The mobile PWA task detail view had two scrolling/touch issues:

1. Page-level scroll fought xterm's internal viewport on iOS — swiping
   inside the terminal (which filled most of the screen at 65vh) went
   to xterm's scrollback, leaving almost no body real estate to reach
   action buttons or the live prompt.
2. Bottom-row buttons (Esc/Tab/Ctrl/arrows/Enter) were 32px tall, well
   below Apple HIG's 44px touch-target floor.

Restructure #detail-view as a fixed-height flex column (height: 100dvh
with a 100vh fallback for Safari < 15.4) so the xterm is the only
scrollable region. Move secondary actions (Rename/Fork/Archive/PR/Delete)
into a "⋯" overflow popover; primary action (Stop/Resume) stays inline.
Bump vkey buttons to 44×44 with safe-area-inset-bottom padding for
home-indicator phones. Add a round jump-to-input button anchored to
.term-wrap that appears via term.onScroll when the user is in xterm
scrollback; tap → scrollToBottom + focus to pop the soft keyboard at
the live prompt.

Preserves existing #btn-rename/#btn-archive/#btn-fork IDs on the menu
items; updates Playwright specs to click #btn-overflow first and adds
assertions that the menu tears down on Back / tab switch.

Co-Authored-By: Claude <noreply@anthropic.com>