### PR TITLE
Expose all TUI settings through the web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ The dashboard provides:
 - **Task list** — Active and Archived tabs, status badges
 - **Task detail** — Real xterm.js terminal with live SSE byte stream, virtual key row, Stop / Resume / Rename / Fork / Archive / Delete actions. Live writes pause while you scroll into history (preserves iOS momentum-scroll); a green dot on the jump-to-input button shows new output is queued, tapping it flushes and returns to the live tail
 - **Create tasks** — Select a project, enter a prompt, start a new agent. Skill autocomplete (type `/`) suggests per-project and global skills
-- **Settings tab** — Push notifications toggle (VAPID), test push button, API token management (mint/revoke per-device tokens), forget local token
+- **Settings tab** — Full settings parity with the TUI: sandbox (toggle + global deny-read / extra-write), Knowledge Base (vault paths, task sync, auto-start), defaults (backend, todo project, review prompt), Remote API toggle, Projects CRUD (with per-project sandbox overrides), Backends CRUD, push notifications + test push, API token mint/revoke, UX/daemon log viewer, forget local token. Mutating endpoints require the master token; device tokens get read-only access.
 
 The local token persists in `localStorage` until you clear it or tap **Forget token**.
 
@@ -336,7 +336,7 @@ All endpoints require auth — either `Authorization: Bearer <token>` header or 
 |--------|----------|-------------|
 | `GET` | `/api/projects` | List project names |
 | `GET` | `/api/projects/full` | List with path, branch, default_backend |
-| `POST` | `/api/projects` | Create. Body: `{"name", "path", "branch?", "backend?"}` |
+| `POST` | `/api/projects` | Create. Body: `{"name", "path", "branch?", "backend?", "sandbox?"}` where `sandbox` is `{"enabled": true|false|null, "deny_read":[], "extra_write":[]}` (`null` = inherit global) |
 | `PUT` | `/api/projects/{name}` | Update |
 | `DELETE` | `/api/projects/{name}` | Delete |
 | `GET` | `/api/backends` | List with command + prompt_flag |
@@ -366,6 +366,14 @@ The daemon polls running sessions every 5s; when a session transitions to idle, 
 | `DELETE` | `/api/tokens/{id}` | Revoke. **Master token required.** |
 
 Tokens are stored as SHA-256 hashes; plaintext is never persisted on the server.
+
+#### Settings & logs (master only for mutations)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/settings` | Returns sandbox / KB / API / defaults config plus `sandbox.available` (whether `sandbox-exec` is on this host). Device tokens may read. |
+| `PUT` | `/api/settings` | Partial update — every section is optional. Body: `{"sandbox":{...}, "kb":{...}, "api":{...}, "defaults":{...}}`. Setting `kb.auto_start_todos` without `kb.auto_create_tasks` mirrors the TUI invariant: enabling auto-start implies auto-create; disabling it disables both. **Master token required.** |
+| `GET` | `/api/logs/{ux\|daemon}?bytes=N` | Tail the last N bytes of the log (default 64K, max 1M). Missing files return `200` with empty body. |
 
 ### Keep the host awake
 

--- a/context/knowledge/gotchas/web-remote.md
+++ b/context/knowledge/gotchas/web-remote.md
@@ -54,6 +54,15 @@ Non-obvious invariants for the SPA + REST API + push notifications stack.
 - **Master token is the only credential that can mint or revoke device tokens** — auth middleware sets `X-Argus-Auth: master|device` header on the request; mint/revoke handlers check for `master`. If you want to allow device-token-initiated minting, gate it behind a separate explicit capability flag, not just `auth != nil`.
 - **`api_tokens.hash` is SHA-256 of plaintext, NOT bcrypt/argon** — bearer tokens already have ~256 bits of entropy from `crypto/rand`, so a single SHA-256 pass is sufficient. Don't switch to bcrypt thinking it's "more secure"; you'll add latency for no benefit.
 
+## Settings endpoints
+
+- **`PUT /api/settings` is partial — absent keys leave the value unchanged.** The handler dispatches to `buildSettingsUpdates`, which only emits a config write for fields whose pointer is non-nil. Slice fields use a separate sentinel: `nil` slice = leave alone, empty slice (`[]`) = clear. Sending `{"sandbox":{}}` is a no-op, not a reset.
+- **Setting `kb.auto_start_todos` without `kb.auto_create_tasks` mirrors the TUI invariant: enabling auto-start implies auto-create; disabling it disables both.** This avoids the daemon silently falling back to fsnotify watching after a restart. If you let the SPA toggle auto-create independently, send both fields explicitly.
+- **`requireMaster` checks the `X-Argus-Auth` header set by the auth middleware.** Hitting `srv.routes()` directly in tests bypasses that — every mutating settings/projects/backends test must wrap with `authMiddleware(srv.token, db, srv.routes())` or it gets 403.
+- **`projectJSON.Sandbox.Enabled` is `*bool`** so `null` (inherit), `true` (override on), and `false` (override off) all round-trip distinctly. Using a plain `bool` would conflate "inherit" with "off". The SPA project editor renders three radios (Inherit / On / Off) and only sends a `sandbox` block when the user picked anything other than Inherit OR added paths.
+- **`/api/logs/{name}` whitelists `ux` and `daemon`.** Anything else returns 400. Don't broaden by accepting arbitrary paths from the URL — `db.DataDir()` is HOME-rooted and a `..` segment would escape it.
+- **Settings GET is readable by device tokens; PUT requires master.** This matches the existing pattern (devices can stop/start tasks but can't reconfigure the host). Read-only access is fine — every value GET-able from `/api/settings` is also visible in the TUI to anyone who can run argus locally.
+
 ## Test harness
 
 - **`cmd/argus-test-server/` runs an isolated API server with `HOME=$tempdir`** — it MUST set HOME before any path resolution because `WorktreeDir()` and `db.DataDir()` resolve through `$HOME`. Without the override, the harness writes to the real `~/.argus/`.

--- a/context/knowledge/gotchas/web-remote.md
+++ b/context/knowledge/gotchas/web-remote.md
@@ -25,7 +25,7 @@ Non-obvious invariants for the SPA + REST API + push notifications stack.
 
 ## HTML escaping in `index.html`
 
-- **`esc()` only escapes `<`, `>`, `&` — NOT `"` or `'`.** It builds via `textContent` → `innerHTML`, which is safe in element-content position but injectable in attribute position when the attribute value is double-quoted. Patterns like `data-foo="${esc(name)}"` or `<option value="${esc(p)}">` are vulnerable to attribute escape via a `"` in `name`. For untrusted strings going into attributes, prefer index-based lookup against a render-time array (see `renderedProjects` in `renderTaskList`) or a true attribute-aware escape. Project names, task IDs, etc. all flow from user-controlled DB rows.
+- **`esc()` only escapes `<`, `>`, `&` — NOT `"` or `'`.** It builds via `textContent` → `innerHTML`, which is safe in element-content position but injectable in attribute position when the attribute value is double-quoted. Patterns like `data-foo="${esc(name)}"` or `<option value="${esc(p)}">` are vulnerable to attribute escape via a `"` in `name`. For untrusted strings going into attributes, use `escAttr()` (which extends `esc()` by also escaping `"` and `'`), or prefer index-based lookup against a render-time array (see `renderedProjects` in `renderTaskList`). Project names, task IDs, etc. all flow from user-controlled DB rows.
 
 ## Mobile virtual key row
 

--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -2,17 +2,17 @@
 
 Non-obvious invariants and gotchas, split by topic. Read the relevant file when working in that area.
 
-| File                                               | Topic                                                                                                                                                   | Bullets |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| [gotchas/daemon-rpc.md](gotchas/daemon-rpc.md)     | Daemon lifecycle, RPC timeouts, reconciliation races, session resume, binary staleness, self-update                                                     | 31      |
-| [gotchas/pty-terminal.md](gotchas/pty-terminal.md) | PTY sizing, x/vt emulator, ring buffer, replay cache, paint cache, lazyScreen, test concurrency                                                         | 34      |
-| [gotchas/ui-threading.md](gotchas/ui-threading.md) | tview thread safety, tick goroutine rules, lazyScreen fill invariant, paste/input batching                                                              | 16      |
-| [gotchas/sandbox.md](gotchas/sandbox.md)           | macOS sandbox-exec SBPL profiles, symlink resolution, allowed paths                                                                                     | 14      |
-| [gotchas/worktree.md](gotchas/worktree.md)         | Worktree creation ordering, transactional CreateAndStart, cleanup, path validation, stale ref pruning                                                   | 13      |
-| [gotchas/keybindings.md](gotchas/keybindings.md)   | Key routing, ctrl sequences, tcell modifier quirks, agent view navigation                                                                               | 12      |
-| [gotchas/tasklist-ui.md](gotchas/tasklist-ui.md)   | Task list cursor, modals, focus guards, filter, archive, spinner, row rendering                                                                         | 25      |
-| [gotchas/web-remote.md](gotchas/web-remote.md)     | SPA + REST API + service worker, EventSource auth, xterm.js, HTML escaping, virtual keys, detail-view layout, Web Push, per-device tokens, test harness | 31      |
-| [gotchas/misc.md](gotchas/misc.md)                 | DB patterns, Go idioms, Codex, MCP, todos, PRs, file explorer, vault, quick-add, links                                                                  | 74      |
+| File                                               | Topic                                                                                                                                                                          | Bullets |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [gotchas/daemon-rpc.md](gotchas/daemon-rpc.md)     | Daemon lifecycle, RPC timeouts, reconciliation races, session resume, binary staleness, self-update                                                                            | 31      |
+| [gotchas/pty-terminal.md](gotchas/pty-terminal.md) | PTY sizing, x/vt emulator, ring buffer, replay cache, paint cache, lazyScreen, test concurrency                                                                                | 34      |
+| [gotchas/ui-threading.md](gotchas/ui-threading.md) | tview thread safety, tick goroutine rules, lazyScreen fill invariant, paste/input batching                                                                                     | 16      |
+| [gotchas/sandbox.md](gotchas/sandbox.md)           | macOS sandbox-exec SBPL profiles, symlink resolution, allowed paths                                                                                                            | 14      |
+| [gotchas/worktree.md](gotchas/worktree.md)         | Worktree creation ordering, transactional CreateAndStart, cleanup, path validation, stale ref pruning                                                                          | 13      |
+| [gotchas/keybindings.md](gotchas/keybindings.md)   | Key routing, ctrl sequences, tcell modifier quirks, agent view navigation                                                                                                      | 12      |
+| [gotchas/tasklist-ui.md](gotchas/tasklist-ui.md)   | Task list cursor, modals, focus guards, filter, archive, spinner, row rendering                                                                                                | 25      |
+| [gotchas/web-remote.md](gotchas/web-remote.md)     | SPA + REST API + service worker, EventSource auth, xterm.js, HTML escaping, virtual keys, detail-view layout, Web Push, per-device tokens, settings endpoints, test harness    | 37      |
+| [gotchas/misc.md](gotchas/misc.md)                 | DB patterns, Go idioms, Codex, MCP, todos, PRs, file explorer, vault, quick-add, links                                                                                         | 74      |
 
 ## Other Files
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -665,10 +665,46 @@ func (cw *channelWriter) Write(p []byte) (int, error) {
 // --- Projects (full CRUD) ---
 
 type projectJSON struct {
-	Name    string `json:"name"`
-	Path    string `json:"path"`
-	Branch  string `json:"branch,omitempty"`
-	Backend string `json:"backend,omitempty"`
+	Name    string                  `json:"name"`
+	Path    string                  `json:"path"`
+	Branch  string                  `json:"branch,omitempty"`
+	Backend string                  `json:"backend,omitempty"`
+	Sandbox *projectSandboxOverride `json:"sandbox,omitempty"`
+}
+
+// projectSandboxOverride is a JSON-friendly view of config.ProjectSandboxConfig.
+// `enabled` is a *bool because nil means "inherit global"; the JSON encoder
+// emits `null` for that, which the SPA renders as an "Inherit" radio.
+type projectSandboxOverride struct {
+	Enabled    *bool    `json:"enabled"`
+	DenyRead   []string `json:"deny_read"`
+	ExtraWrite []string `json:"extra_write"`
+}
+
+func projectToJSON(name string, p config.Project) projectJSON {
+	out := projectJSON{Name: name, Path: p.Path, Branch: p.Branch, Backend: p.Backend}
+	if p.Sandbox.Enabled != nil || len(p.Sandbox.DenyRead) > 0 || len(p.Sandbox.ExtraWrite) > 0 {
+		out.Sandbox = &projectSandboxOverride{
+			Enabled:    p.Sandbox.Enabled,
+			DenyRead:   stringsOrEmpty(p.Sandbox.DenyRead),
+			ExtraWrite: stringsOrEmpty(p.Sandbox.ExtraWrite),
+		}
+	}
+	return out
+}
+
+func projectFromJSON(req projectJSON) config.Project {
+	out := config.Project{
+		Path:    req.Path,
+		Branch:  req.Branch,
+		Backend: req.Backend,
+	}
+	if req.Sandbox != nil {
+		out.Sandbox.Enabled = req.Sandbox.Enabled
+		out.Sandbox.DenyRead = req.Sandbox.DenyRead
+		out.Sandbox.ExtraWrite = req.Sandbox.ExtraWrite
+	}
+	return out
 }
 
 func (s *Server) handleListProjectsFull(w http.ResponseWriter, r *http.Request) {
@@ -679,7 +715,7 @@ func (s *Server) handleListProjectsFull(w http.ResponseWriter, r *http.Request) 
 	}
 	out := make([]projectJSON, 0, len(projects))
 	for name, p := range projects {
-		out = append(out, projectJSON{Name: name, Path: p.Path, Branch: p.Branch, Backend: p.Backend})
+		out = append(out, projectToJSON(name, p))
 	}
 	// stable order
 	sortByName := func(a, b projectJSON) bool { return a.Name < b.Name }
@@ -709,11 +745,7 @@ func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name and path are required"})
 		return
 	}
-	if err := s.db.SetProject(req.Name, config.Project{
-		Path:    req.Path,
-		Branch:  req.Branch,
-		Backend: req.Backend,
-	}); err != nil {
+	if err := s.db.SetProject(req.Name, projectFromJSON(req)); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
@@ -736,11 +768,7 @@ func (s *Server) handleUpdateProject(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path is required"})
 		return
 	}
-	if err := s.db.SetProject(name, config.Project{
-		Path:    req.Path,
-		Branch:  req.Branch,
-		Backend: req.Backend,
-	}); err != nil {
+	if err := s.db.SetProject(name, projectFromJSON(req)); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -71,6 +71,9 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/source-path", s.handleGetSourcePath)
 	mux.HandleFunc("PUT /api/source-path", s.handleSetSourcePath)
 	mux.HandleFunc("POST /api/update", s.handleUpdateSelf)
+	mux.HandleFunc("GET /api/settings", s.handleGetSettings)
+	mux.HandleFunc("PUT /api/settings", s.handleUpdateSettings)
+	mux.HandleFunc("GET /api/logs/{name}", s.handleGetLog)
 
 	return mux
 }

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -2,8 +2,11 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -254,7 +257,7 @@ func logPath(name string) (string, error) {
 	case "ux":
 		return uxlog.Path(dataDir), nil
 	case "daemon":
-		return dataDir + "/daemon.log", nil
+		return filepath.Join(dataDir, "daemon.log"), nil
 	}
 	return "", &logNameError{name: name}
 }
@@ -278,7 +281,7 @@ func readTail(path string, n int) ([]byte, error) {
 		return nil, err
 	}
 	buf := make([]byte, info.Size()-offset)
-	if _, err := f.Read(buf); err != nil && err.Error() != "EOF" {
+	if _, err := f.Read(buf); err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 	return buf, nil

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -1,0 +1,289 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/drn/argus/internal/agent"
+	"github.com/drn/argus/internal/db"
+	"github.com/drn/argus/internal/uxlog"
+)
+
+// settingsResponse is the JSON shape returned by GET /api/settings.
+// It mirrors the slice of TUI settings that are meaningful to manage from
+// the web (sandbox, KB, defaults, API). TUI-rendering settings (spinner,
+// theme, keybindings) are intentionally omitted.
+type settingsResponse struct {
+	Sandbox  sandboxJSON  `json:"sandbox"`
+	KB       kbJSON       `json:"kb"`
+	API      apiSettings  `json:"api"`
+	Defaults defaultsJSON `json:"defaults"`
+}
+
+type sandboxJSON struct {
+	Enabled    bool     `json:"enabled"`
+	Available  bool     `json:"available"`
+	DenyRead   []string `json:"deny_read"`
+	ExtraWrite []string `json:"extra_write"`
+}
+
+type kbJSON struct {
+	Enabled           bool   `json:"enabled"`
+	MetisVaultPath    string `json:"metis_vault_path"`
+	ArgusVaultPath    string `json:"argus_vault_path"`
+	AutoCreateTasks   bool   `json:"auto_create_tasks"`
+	AutoStartTodos    bool   `json:"auto_start_todos"`
+	AutoStartInterval int    `json:"auto_start_interval"`
+}
+
+type apiSettings struct {
+	Enabled  bool `json:"enabled"`
+	HTTPPort int  `json:"http_port"`
+}
+
+type defaultsJSON struct {
+	Backend      string `json:"backend"`
+	TodoProject  string `json:"todo_project"`
+	ReviewPrompt string `json:"review_prompt"`
+}
+
+func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
+	cfg := s.db.Config()
+	writeJSON(w, http.StatusOK, settingsResponse{
+		Sandbox: sandboxJSON{
+			Enabled:    cfg.Sandbox.Enabled,
+			Available:  isSandboxAvailable(),
+			DenyRead:   stringsOrEmpty(cfg.Sandbox.DenyRead),
+			ExtraWrite: stringsOrEmpty(cfg.Sandbox.ExtraWrite),
+		},
+		KB: kbJSON{
+			Enabled:           cfg.KB.Enabled,
+			MetisVaultPath:    cfg.KB.MetisVaultPath,
+			ArgusVaultPath:    cfg.KB.ArgusVaultPath,
+			AutoCreateTasks:   cfg.KB.AutoCreateTasks,
+			AutoStartTodos:    cfg.KB.AutoStartTodos,
+			AutoStartInterval: cfg.KB.AutoStartInterval,
+		},
+		API: apiSettings{
+			Enabled:  cfg.API.Enabled,
+			HTTPPort: cfg.API.HTTPPort,
+		},
+		Defaults: defaultsJSON{
+			Backend:      cfg.Defaults.Backend,
+			TodoProject:  cfg.Defaults.TodoProject,
+			ReviewPrompt: cfg.Defaults.ReviewPrompt,
+		},
+	})
+}
+
+// updateSettingsReq is the partial-update body for PUT /api/settings.
+// Every section is a pointer so callers can update one section at a time
+// without needing to round-trip the rest.
+type updateSettingsReq struct {
+	Sandbox  *sandboxUpdate  `json:"sandbox,omitempty"`
+	KB       *kbUpdate       `json:"kb,omitempty"`
+	API      *apiUpdate      `json:"api,omitempty"`
+	Defaults *defaultsUpdate `json:"defaults,omitempty"`
+}
+
+// Each *Update mirrors the corresponding response section but with pointer
+// fields so absent keys mean "don't change". Slice fields use a sentinel:
+// nil = leave alone, empty slice ([]) = clear.
+type sandboxUpdate struct {
+	Enabled    *bool     `json:"enabled,omitempty"`
+	DenyRead   *[]string `json:"deny_read,omitempty"`
+	ExtraWrite *[]string `json:"extra_write,omitempty"`
+}
+
+type kbUpdate struct {
+	Enabled           *bool   `json:"enabled,omitempty"`
+	MetisVaultPath    *string `json:"metis_vault_path,omitempty"`
+	ArgusVaultPath    *string `json:"argus_vault_path,omitempty"`
+	AutoCreateTasks   *bool   `json:"auto_create_tasks,omitempty"`
+	AutoStartTodos    *bool   `json:"auto_start_todos,omitempty"`
+	AutoStartInterval *int    `json:"auto_start_interval,omitempty"`
+}
+
+type apiUpdate struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+type defaultsUpdate struct {
+	Backend      *string `json:"backend,omitempty"`
+	TodoProject  *string `json:"todo_project,omitempty"`
+	ReviewPrompt *string `json:"review_prompt,omitempty"`
+}
+
+func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
+	if requireMaster(w, r) {
+		return
+	}
+	var req updateSettingsReq
+	r.Body = http.MaxBytesReader(w, r.Body, 64*1024)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+	updates := buildSettingsUpdates(req)
+	for k, v := range updates {
+		if err := s.db.SetConfigValue(k, v); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		uxlog.Log("[api] settings %s = %q", k, v)
+	}
+	s.handleGetSettings(w, r)
+}
+
+// buildSettingsUpdates flattens the partial update into config (key, value)
+// pairs. Extracted for unit testing — covers the bool/int formatting and
+// CSV joining without needing a server fixture.
+func buildSettingsUpdates(req updateSettingsReq) map[string]string {
+	out := make(map[string]string)
+	if s := req.Sandbox; s != nil {
+		if s.Enabled != nil {
+			out["sandbox.enabled"] = boolStr(*s.Enabled)
+		}
+		if s.DenyRead != nil {
+			out["sandbox.deny_read"] = strings.Join(*s.DenyRead, ",")
+		}
+		if s.ExtraWrite != nil {
+			out["sandbox.extra_write"] = strings.Join(*s.ExtraWrite, ",")
+		}
+	}
+	if k := req.KB; k != nil {
+		if k.Enabled != nil {
+			out["kb.enabled"] = boolStr(*k.Enabled)
+		}
+		if k.MetisVaultPath != nil {
+			out["kb.metis_vault_path"] = *k.MetisVaultPath
+		}
+		if k.ArgusVaultPath != nil {
+			out["kb.argus_vault_path"] = *k.ArgusVaultPath
+		}
+		if k.AutoCreateTasks != nil {
+			out["kb.auto_create_tasks"] = boolStr(*k.AutoCreateTasks)
+		}
+		if k.AutoStartTodos != nil {
+			out["kb.auto_start_todos"] = boolStr(*k.AutoStartTodos)
+			// Match TUI invariant: enabling auto-start implies auto-create.
+			// Disabling auto-start also disables auto-create so we don't
+			// silently fall back to fsnotify watching after a daemon restart.
+			if k.AutoCreateTasks == nil {
+				out["kb.auto_create_tasks"] = boolStr(*k.AutoStartTodos)
+			}
+		}
+		if k.AutoStartInterval != nil && *k.AutoStartInterval > 0 {
+			out["kb.auto_start_interval"] = strconv.Itoa(*k.AutoStartInterval)
+		}
+	}
+	if a := req.API; a != nil {
+		if a.Enabled != nil {
+			out["api.enabled"] = boolStr(*a.Enabled)
+		}
+	}
+	if d := req.Defaults; d != nil {
+		if d.Backend != nil {
+			out["defaults.backend"] = *d.Backend
+		}
+		if d.TodoProject != nil {
+			out["defaults.todo_project"] = *d.TodoProject
+		}
+		if d.ReviewPrompt != nil {
+			out["defaults.review_prompt"] = *d.ReviewPrompt
+		}
+	}
+	return out
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func stringsOrEmpty(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
+// --- Logs ---
+
+func (s *Server) handleGetLog(w http.ResponseWriter, r *http.Request) {
+	// logPath whitelists "ux" and "daemon" — anything else returns an error,
+	// so the path passed to readTail is one of two compile-time-known values
+	// rooted at db.DataDir(). gosec's taint analysis can't see that.
+	path, err := logPath(r.PathValue("name"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	// Default tail = 64KB, max 1MB.
+	tail := 64 * 1024
+	if n, err := strconv.Atoi(r.URL.Query().Get("bytes")); err == nil && n > 0 {
+		tail = min(n, 1<<20)
+	}
+	data, err := readTail(path, tail)
+	if err != nil {
+		// Missing log file is normal (e.g., daemon hasn't logged yet).
+		// Surface as 200 with empty body rather than 404 so the SPA can
+		// render "(empty)" without special-casing.
+		if os.IsNotExist(err) {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	// X-Content-Type-Options: nosniff is set globally in corsMiddleware, so
+	// browsers won't reinterpret log bytes as HTML/JS. Content is server
+	// logs we wrote ourselves, not user input.
+	w.Write(data) //nolint:errcheck,gosec // G705: text/plain log tail, nosniff applied
+}
+
+func logPath(name string) (string, error) {
+	dataDir := db.DataDir()
+	switch name {
+	case "ux":
+		return uxlog.Path(dataDir), nil
+	case "daemon":
+		return dataDir + "/daemon.log", nil
+	}
+	return "", &logNameError{name: name}
+}
+
+type logNameError struct{ name string }
+
+func (e *logNameError) Error() string { return "unknown log: " + e.name }
+
+func readTail(path string, n int) ([]byte, error) {
+	f, err := os.Open(path) //nolint:gosec // G304: path is whitelisted by logPath()
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	offset := max(info.Size()-int64(n), 0)
+	if _, err := f.Seek(offset, 0); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, info.Size()-offset)
+	if _, err := f.Read(buf); err != nil && err.Error() != "EOF" {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// isSandboxAvailable indirects through a function variable so settings tests
+// can stub the result without launching sandbox-exec.
+var isSandboxAvailable = agent.IsSandboxAvailable

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -153,7 +153,7 @@ func TestHandleGetLog(t *testing.T) {
 	testutil.NoError(t, os.MkdirAll(dataDir, 0o700))
 	testutil.NoError(t, os.WriteFile(filepath.Join(dataDir, "ux.log"), []byte("hello\nworld\n"), 0o600))
 
-	srv, _ := testServer(t)
+	srv, d := testServer(t)
 	mux := srv.routes()
 
 	t.Run("ux returns content", func(t *testing.T) {
@@ -176,6 +176,22 @@ func TestHandleGetLog(t *testing.T) {
 		// "(empty)" without special-casing.
 		testutil.Equal(t, w.Code, http.StatusOK)
 		testutil.Equal(t, w.Body.Len(), 0)
+	})
+
+	t.Run("device tokens can read", func(t *testing.T) {
+		// Pin the intent: log-tail is read-only and available to device
+		// tokens (same policy as GET /api/settings). If logs ever need to
+		// be master-only, this test will catch the change.
+		handler := authMiddleware(srv.token, d, srv.routes())
+		plain, _, err := MintToken(d, "phone")
+		testutil.NoError(t, err)
+
+		req := httptest.NewRequest("GET", "/api/logs/ux", nil)
+		req.Header.Set("Authorization", "Bearer "+plain)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		testutil.Equal(t, w.Code, http.StatusOK)
+		testutil.Contains(t, w.Body.String(), "hello")
 	})
 }
 

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -1,0 +1,242 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/testutil"
+)
+
+func TestBuildSettingsUpdates(t *testing.T) {
+	t.Run("empty request produces no updates", func(t *testing.T) {
+		got := buildSettingsUpdates(updateSettingsReq{})
+		testutil.Equal(t, len(got), 0)
+	})
+
+	t.Run("sandbox toggle and paths", func(t *testing.T) {
+		on := true
+		denyRead := []string{"/secrets", "~/.aws"}
+		extraWrite := []string{}
+		got := buildSettingsUpdates(updateSettingsReq{
+			Sandbox: &sandboxUpdate{Enabled: &on, DenyRead: &denyRead, ExtraWrite: &extraWrite},
+		})
+		testutil.Equal(t, got["sandbox.enabled"], "true")
+		testutil.Equal(t, got["sandbox.deny_read"], "/secrets,~/.aws")
+		// Empty slice clears the value (joins to "").
+		testutil.Equal(t, got["sandbox.extra_write"], "")
+	})
+
+	t.Run("auto_start toggle implies auto_create", func(t *testing.T) {
+		on := true
+		got := buildSettingsUpdates(updateSettingsReq{
+			KB: &kbUpdate{AutoStartTodos: &on},
+		})
+		testutil.Equal(t, got["kb.auto_start_todos"], "true")
+		testutil.Equal(t, got["kb.auto_create_tasks"], "true")
+
+		off := false
+		got = buildSettingsUpdates(updateSettingsReq{
+			KB: &kbUpdate{AutoStartTodos: &off},
+		})
+		testutil.Equal(t, got["kb.auto_start_todos"], "false")
+		testutil.Equal(t, got["kb.auto_create_tasks"], "false")
+	})
+
+	t.Run("explicit auto_create overrides implied", func(t *testing.T) {
+		startOn := true
+		createOff := false
+		got := buildSettingsUpdates(updateSettingsReq{
+			KB: &kbUpdate{AutoStartTodos: &startOn, AutoCreateTasks: &createOff},
+		})
+		testutil.Equal(t, got["kb.auto_create_tasks"], "false")
+	})
+
+	t.Run("interval rejects zero/negative", func(t *testing.T) {
+		zero := 0
+		got := buildSettingsUpdates(updateSettingsReq{KB: &kbUpdate{AutoStartInterval: &zero}})
+		_, ok := got["kb.auto_start_interval"]
+		testutil.Equal(t, ok, false)
+	})
+
+	t.Run("defaults flow through", func(t *testing.T) {
+		backend := "claude"
+		todo := "argus"
+		prompt := "/review"
+		got := buildSettingsUpdates(updateSettingsReq{
+			Defaults: &defaultsUpdate{Backend: &backend, TodoProject: &todo, ReviewPrompt: &prompt},
+		})
+		testutil.Equal(t, got["defaults.backend"], "claude")
+		testutil.Equal(t, got["defaults.todo_project"], "argus")
+		testutil.Equal(t, got["defaults.review_prompt"], "/review")
+	})
+}
+
+func TestHandleSettings_GetReturnsCurrentValues(t *testing.T) {
+	srv, d := testServer(t)
+	mux := srv.routes()
+
+	testutil.NoError(t, d.SetConfigValue("sandbox.enabled", "true"))
+	testutil.NoError(t, d.SetConfigValue("sandbox.deny_read", "/secrets,~/.aws"))
+	testutil.NoError(t, d.SetConfigValue("kb.enabled", "true"))
+	testutil.NoError(t, d.SetConfigValue("defaults.review_prompt", "/review-strict"))
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, authedReq("GET", "/api/settings", ""))
+	testutil.Equal(t, w.Code, http.StatusOK)
+
+	var resp settingsResponse
+	testutil.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	testutil.Equal(t, resp.Sandbox.Enabled, true)
+	testutil.DeepEqual(t, resp.Sandbox.DenyRead, []string{"/secrets", "~/.aws"})
+	testutil.Equal(t, resp.KB.Enabled, true)
+	testutil.Equal(t, resp.Defaults.ReviewPrompt, "/review-strict")
+}
+
+func TestHandleSettings_PutPersists(t *testing.T) {
+	srv, d := testServer(t)
+	handler := authMiddleware(srv.token, d, srv.routes())
+
+	body := `{"sandbox": {"enabled": true, "deny_read": ["/etc"]},
+	          "kb": {"enabled": true, "metis_vault_path": "/tmp/m"},
+	          "defaults": {"review_prompt": "/review"}}`
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, authedReq("PUT", "/api/settings", body))
+	testutil.Equal(t, w.Code, http.StatusOK)
+
+	cfg := d.Config()
+	testutil.Equal(t, cfg.Sandbox.Enabled, true)
+	testutil.DeepEqual(t, cfg.Sandbox.DenyRead, []string{"/etc"})
+	testutil.Equal(t, cfg.KB.Enabled, true)
+	testutil.Equal(t, cfg.KB.MetisVaultPath, "/tmp/m")
+	testutil.Equal(t, cfg.Defaults.ReviewPrompt, "/review")
+}
+
+func TestHandleSettings_PutRequiresMaster(t *testing.T) {
+	srv, d := testServer(t)
+	handler := authMiddleware(srv.token, d, srv.routes())
+	plain, _, err := MintToken(d, "phone")
+	testutil.NoError(t, err)
+
+	req := httptest.NewRequest("PUT", "/api/settings", strings.NewReader(`{"sandbox":{"enabled":true}}`))
+	req.Header.Set("Authorization", "Bearer "+plain)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusForbidden)
+}
+
+func TestHandleSettings_GetIsAvailableToDevice(t *testing.T) {
+	srv, d := testServer(t)
+	handler := authMiddleware(srv.token, d, srv.routes())
+	plain, _, err := MintToken(d, "phone")
+	testutil.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/api/settings", nil)
+	req.Header.Set("Authorization", "Bearer "+plain)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusOK)
+}
+
+func TestHandleGetLog(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("ARGUS_DATA_DIR", "")
+	// HOME-rooted ~/.argus/ux.log path.
+	dataDir := filepath.Join(dir, ".argus")
+	testutil.NoError(t, os.MkdirAll(dataDir, 0o700))
+	testutil.NoError(t, os.WriteFile(filepath.Join(dataDir, "ux.log"), []byte("hello\nworld\n"), 0o600))
+
+	srv, _ := testServer(t)
+	mux := srv.routes()
+
+	t.Run("ux returns content", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, authedReq("GET", "/api/logs/ux", ""))
+		testutil.Equal(t, w.Code, http.StatusOK)
+		testutil.Contains(t, w.Body.String(), "hello")
+	})
+
+	t.Run("unknown rejected", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, authedReq("GET", "/api/logs/secret", ""))
+		testutil.Equal(t, w.Code, http.StatusBadRequest)
+	})
+
+	t.Run("daemon missing returns empty", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, authedReq("GET", "/api/logs/daemon", ""))
+		// Missing log returns 200 with empty body so the SPA can render
+		// "(empty)" without special-casing.
+		testutil.Equal(t, w.Code, http.StatusOK)
+		testutil.Equal(t, w.Body.Len(), 0)
+	})
+}
+
+func TestHandleProjects_RoundTripsSandboxOverride(t *testing.T) {
+	srv, d := testServer(t)
+	handler := authMiddleware(srv.token, d, srv.routes())
+
+	body := `{
+	  "name": "alpha",
+	  "path": "/tmp/alpha",
+	  "branch": "main",
+	  "sandbox": {"enabled": false, "deny_read": ["/secrets"], "extra_write": ["~/.npm"]}
+	}`
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, authedReq("POST", "/api/projects", body))
+	testutil.Equal(t, w.Code, http.StatusCreated)
+
+	// Verify it round-trips through the DB and back through GET.
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, authedReq("GET", "/api/projects/full", ""))
+	testutil.Equal(t, w.Code, http.StatusOK)
+	var resp struct {
+		Projects []projectJSON `json:"projects"`
+	}
+	testutil.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	testutil.Equal(t, len(resp.Projects), 1)
+	p := resp.Projects[0]
+	testutil.Equal(t, p.Name, "alpha")
+	testutil.Equal(t, p.Path, "/tmp/alpha")
+	testutil.Equal(t, p.Branch, "main")
+	if p.Sandbox == nil {
+		t.Fatalf("expected sandbox override, got nil")
+	}
+	if p.Sandbox.Enabled == nil || *p.Sandbox.Enabled {
+		t.Fatalf("expected sandbox.enabled false, got %#v", p.Sandbox.Enabled)
+	}
+	testutil.DeepEqual(t, p.Sandbox.DenyRead, []string{"/secrets"})
+	testutil.DeepEqual(t, p.Sandbox.ExtraWrite, []string{"~/.npm"})
+
+	// And the DB stored it via the existing config.Project shape.
+	projects, err := d.Projects()
+	testutil.NoError(t, err)
+	stored, ok := projects["alpha"]
+	testutil.Equal(t, ok, true)
+	if stored.Sandbox.Enabled == nil || *stored.Sandbox.Enabled {
+		t.Fatalf("expected stored Sandbox.Enabled false, got %#v", stored.Sandbox.Enabled)
+	}
+	testutil.DeepEqual(t, stored.Sandbox.DenyRead, []string{"/secrets"})
+}
+
+func TestProjectFromJSON_NilSandboxStaysInherit(t *testing.T) {
+	got := projectFromJSON(projectJSON{Name: "x", Path: "/tmp/x"})
+	if got.Sandbox.Enabled != nil {
+		t.Fatalf("expected inherit (nil), got %#v", got.Sandbox.Enabled)
+	}
+}
+
+// Sanity check that DefaultConfig still returns the expected sandbox shape;
+// guards against a refactor that drops the SandboxConfig type while leaving
+// API code that references it.
+func TestSandboxConfig_IsValueType(t *testing.T) {
+	cfg := config.DefaultConfig()
+	testutil.Equal(t, cfg.Sandbox.Enabled, false)
+}

--- a/internal/api/static/index.html
+++ b/internal/api/static/index.html
@@ -1829,7 +1829,7 @@ function fillSelectOptions(id, names, current, includeBlank) {
   const blank = includeBlank ? '<option value="">(none)</option>' : '';
   el.innerHTML = blank + names.map(n => {
     const sel = n === current ? 'selected' : '';
-    return `<option value="${esc(n)}" ${sel}>${esc(n)}</option>`;
+    return `<option value="${escAttr(n)}" ${sel}>${esc(n)}</option>`;
   }).join('');
   if (!names.includes(current)) el.value = '';
 }
@@ -1843,7 +1843,11 @@ async function patchSettings(body) {
     }
     settingsCache = await r.json();
     renderSettings();
-  } catch(e) { showToast('Save failed: ' + e.message); }
+    return true;
+  } catch(e) {
+    showToast('Save failed: ' + e.message);
+    return false;
+  }
 }
 
 function saveSandboxToggle() {
@@ -1851,17 +1855,16 @@ function saveSandboxToggle() {
   patchSettings({ sandbox: { enabled } });
 }
 
-function saveSandboxPaths() {
+async function saveSandboxPaths() {
   const denyRead = document.getElementById('sandbox-deny-read').value
     .split('\n').map(s => s.trim()).filter(Boolean);
   const extraWrite = document.getElementById('sandbox-extra-write').value
     .split('\n').map(s => s.trim()).filter(Boolean);
-  patchSettings({ sandbox: { deny_read: denyRead, extra_write: extraWrite } })
-    .then(() => {
-      const status = document.getElementById('sandbox-paths-status');
-      status.textContent = 'Saved';
-      setTimeout(() => { status.textContent = ''; }, 2000);
-    });
+  const ok = await patchSettings({ sandbox: { deny_read: denyRead, extra_write: extraWrite } });
+  if (!ok) return; // patchSettings already toasted; don't claim "Saved".
+  const status = document.getElementById('sandbox-paths-status');
+  status.textContent = 'Saved';
+  setTimeout(() => { status.textContent = ''; }, 2000);
 }
 
 function saveKBToggle(field, value) {
@@ -1941,7 +1944,7 @@ function openProjectEditor(p) {
   const beSel = document.getElementById('pm-backend');
   beSel.innerHTML = '<option value="">(default)</option>' + backendsCache.map(b => {
     const sel = p && p.backend === b.name ? 'selected' : '';
-    return `<option value="${esc(b.name)}" ${sel}>${esc(b.name)}</option>`;
+    return `<option value="${escAttr(b.name)}" ${sel}>${esc(b.name)}</option>`;
   }).join('');
   // Sandbox radios.
   let sandboxVal = 'inherit';
@@ -1976,8 +1979,13 @@ async function saveProjectFromModal() {
   const sandboxRadio = document.querySelector('input[name="pm-sandbox"]:checked');
   const denyRead = document.getElementById('pm-deny-read').value.split('\n').map(s => s.trim()).filter(Boolean);
   const extraWrite = document.getElementById('pm-extra-write').value.split('\n').map(s => s.trim()).filter(Boolean);
-  // Only attach sandbox section if user customized any field.
-  if (sandboxRadio && sandboxRadio.value !== 'inherit' || denyRead.length || extraWrite.length) {
+  // Only attach sandbox section if user customized any field. Omitting it
+  // tells the server to clear any prior override (PUT does a full replace
+  // via SetProject).
+  const sandboxOverridden = (sandboxRadio && sandboxRadio.value !== 'inherit')
+    || denyRead.length > 0
+    || extraWrite.length > 0;
+  if (sandboxOverridden) {
     let enabled = null;
     if (sandboxRadio.value === 'true') enabled = true;
     else if (sandboxRadio.value === 'false') enabled = false;
@@ -2021,7 +2029,7 @@ async function refreshProjectsForCreateView() {
     const sel = document.getElementById('create-project');
     if (!sel) return;
     const cur = sel.value;
-    sel.innerHTML = (projects || []).map(p => `<option value="${esc(p)}">${esc(p)}</option>`).join('');
+    sel.innerHTML = (projects || []).map(p => `<option value="${escAttr(p)}">${esc(p)}</option>`).join('');
     if (projects && projects.includes(cur)) sel.value = cur;
   } catch(e) {}
 }
@@ -2284,6 +2292,14 @@ function esc(s) {
   const d = document.createElement('div');
   d.textContent = s;
   return d.innerHTML;
+}
+
+// escAttr escapes for double-quoted attribute context. esc() (which builds
+// via textContent) only handles `<`, `>`, `&` — a `"` inside a project or
+// backend name would close the attribute and let the rest of the value
+// inject markup. Use escAttr for any `attr="${...}"` insertion.
+function escAttr(s) {
+  return esc(s).replaceAll('"', '&quot;').replaceAll("'", '&#39;');
 }
 
 // --- Skill Autocomplete ---

--- a/internal/api/static/index.html
+++ b/internal/api/static/index.html
@@ -317,23 +317,83 @@ button:disabled { opacity: 0.5; cursor: default; }
 .refresh-hint { text-align: center; padding: 8px; color: var(--text-dim); font-size: 12px; display: none; }
 
 /* Settings */
-#settings-view { display: none; padding: 12px; }
+#settings-view { display: none; padding: 12px; padding-bottom: 80px; }
 .settings-section {
   background: var(--surface); border: 1px solid var(--border);
   border-radius: 10px; padding: 12px; margin-bottom: 12px;
 }
 .settings-section h3 { font-size: 14px; margin-bottom: 8px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.5px; }
 .settings-row {
-  display: flex; justify-content: space-between; align-items: center;
+  display: flex; justify-content: space-between; align-items: center; gap: 10px;
   padding: 8px 0; border-bottom: 1px solid var(--border);
 }
 .settings-row:last-child { border-bottom: none; }
 .settings-row .label { font-size: 14px; }
-.settings-row .meta { font-size: 11px; color: var(--text-dim); }
+.settings-row .meta { font-size: 11px; color: var(--text-dim); margin-top: 2px; }
+.settings-row .grow { flex: 1; min-width: 0; }
+.settings-input {
+  width: 100%; padding: 8px 10px; border-radius: 6px;
+  border: 1px solid var(--border); background: var(--bg);
+  color: var(--text); font-size: 13px; font-family: inherit;
+}
+.settings-input.mono { font-family: ui-monospace, Menlo, monospace; font-size: 12px; }
+textarea.settings-input { min-height: 70px; resize: vertical; }
 .token-mint-result {
   background: var(--bg); padding: 10px; border-radius: 6px;
   font-family: monospace; font-size: 12px; word-break: break-all;
   margin-top: 8px; border: 1px solid var(--accent);
+}
+
+/* Switch */
+.switch { position: relative; width: 40px; height: 22px; flex-shrink: 0; cursor: pointer; }
+.switch input { opacity: 0; width: 0; height: 0; }
+.switch .slider {
+  position: absolute; inset: 0; background: var(--border);
+  border-radius: 22px; transition: background 0.15s;
+}
+.switch .slider::before {
+  content: ''; position: absolute; left: 2px; top: 2px;
+  width: 18px; height: 18px; background: #fff; border-radius: 50%;
+  transition: transform 0.15s;
+}
+.switch input:checked + .slider { background: var(--accent); }
+.switch input:checked + .slider::before { transform: translateX(18px); }
+.switch input:disabled + .slider { opacity: 0.5; cursor: not-allowed; }
+
+/* Modal (project/backend editors) */
+.modal-overlay {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.6);
+  z-index: 300; display: none; align-items: flex-start; justify-content: center;
+  overflow-y: auto; padding: 24px 12px;
+}
+.modal-overlay.open { display: flex; }
+.modal {
+  background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
+  width: 100%; max-width: 520px; padding: 16px;
+}
+.modal h3 { font-size: 16px; margin-bottom: 12px; }
+.modal .form-group { padding: 0; margin-bottom: 12px; }
+.modal .form-group label { display: block; font-size: 12px; color: var(--text-dim); margin-bottom: 4px; }
+.modal .form-group input, .modal .form-group textarea, .modal .form-group select {
+  width: 100%; padding: 8px 10px; border-radius: 6px;
+  border: 1px solid var(--border); background: var(--bg);
+  color: var(--text); font-size: 13px; font-family: inherit;
+}
+.modal .form-group textarea { min-height: 60px; resize: vertical; font-family: ui-monospace, Menlo, monospace; }
+.modal .modal-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 16px; }
+.modal .radio-row { display: flex; gap: 12px; font-size: 13px; }
+.modal .radio-row label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+
+/* Logs viewer */
+.logs-pane {
+  background: var(--bg); color: var(--text); font-family: ui-monospace, Menlo, monospace;
+  font-size: 11px; line-height: 1.45; padding: 10px; border-radius: 6px;
+  border: 1px solid var(--border); white-space: pre; overflow: auto;
+  max-height: 280px;
+}
+.restart-required {
+  display: inline-block; margin-left: 6px; font-size: 10px;
+  padding: 1px 6px; border-radius: 4px; background: var(--border); color: var(--accent);
 }
 
 /* Archive toggle */
@@ -430,6 +490,145 @@ button:disabled { opacity: 0.5; cursor: default; }
   <!-- Settings View -->
   <div id="settings-view">
     <div class="settings-section">
+      <h3>Sandbox</h3>
+      <div class="settings-row">
+        <div class="grow">
+          <div class="label">Sandbox agent processes</div>
+          <div class="meta" id="sandbox-meta">macOS sandbox-exec confines agents to the worktree.</div>
+        </div>
+        <label class="switch">
+          <input type="checkbox" id="sandbox-enabled" onchange="saveSandboxToggle()">
+          <span class="slider"></span>
+        </label>
+      </div>
+      <div class="settings-row" style="flex-direction: column; align-items: stretch">
+        <div>
+          <div class="label">Deny read</div>
+          <div class="meta">One path per line. Files agents must not read.</div>
+        </div>
+        <textarea class="settings-input mono" id="sandbox-deny-read" placeholder="/secrets&#10;~/.aws"></textarea>
+      </div>
+      <div class="settings-row" style="flex-direction: column; align-items: stretch">
+        <div>
+          <div class="label">Extra write</div>
+          <div class="meta">One path per line. Paths agents may write outside the worktree.</div>
+        </div>
+        <textarea class="settings-input mono" id="sandbox-extra-write" placeholder="~/.npm&#10;/tmp/build"></textarea>
+      </div>
+      <div class="settings-row">
+        <div class="meta" id="sandbox-paths-status"></div>
+        <button class="primary" onclick="saveSandboxPaths()">Save paths</button>
+      </div>
+    </div>
+
+    <div class="settings-section">
+      <h3>Knowledge Base</h3>
+      <div class="settings-row">
+        <div class="grow">
+          <div class="label">Knowledge base enabled</div>
+          <div class="meta">Index Obsidian vaults for cross-agent recall.</div>
+        </div>
+        <label class="switch">
+          <input type="checkbox" id="kb-enabled" onchange="saveKBToggle('enabled', this.checked)">
+          <span class="slider"></span>
+        </label>
+      </div>
+      <div class="settings-row" style="flex-direction: column; align-items: stretch">
+        <label class="label">Metis vault path</label>
+        <input class="settings-input mono" id="kb-metis-path" onblur="saveKBPath('metis_vault_path', this.value)">
+        <div class="meta" id="kb-metis-meta"></div>
+      </div>
+      <div class="settings-row" style="flex-direction: column; align-items: stretch">
+        <label class="label">Argus vault path</label>
+        <input class="settings-input mono" id="kb-argus-path" onblur="saveKBPath('argus_vault_path', this.value)">
+        <div class="meta" id="kb-argus-meta"></div>
+      </div>
+      <div class="settings-row">
+        <div class="grow">
+          <div class="label">Auto-create tasks</div>
+          <div class="meta">Watch the Argus vault and create tasks from new todo notes.</div>
+        </div>
+        <label class="switch">
+          <input type="checkbox" id="kb-auto-create" onchange="saveKBToggle('auto_create_tasks', this.checked)">
+          <span class="slider"></span>
+        </label>
+      </div>
+      <div class="settings-row">
+        <div class="grow">
+          <div class="label">Auto-start todos</div>
+          <div class="meta">Poll vault and start new todo notes automatically.</div>
+        </div>
+        <label class="switch">
+          <input type="checkbox" id="kb-auto-start" onchange="saveKBAutoStart(this.checked)">
+          <span class="slider"></span>
+        </label>
+      </div>
+      <div class="settings-row">
+        <div class="grow">
+          <div class="label">Auto-start interval (sec)</div>
+          <div class="meta">Default 120. Lower = quicker pickup, more polling.</div>
+        </div>
+        <input class="settings-input" id="kb-interval" type="number" min="10" style="width: 90px"
+               onblur="saveKBInterval(this.value)">
+      </div>
+    </div>
+
+    <div class="settings-section">
+      <h3>Defaults</h3>
+      <div class="settings-row">
+        <div class="grow">
+          <div class="label">Default backend</div>
+          <div class="meta">Used when a project doesn't pin one.</div>
+        </div>
+        <select class="settings-input" id="default-backend" style="width: 160px"
+                onchange="saveDefault('backend', this.value)"></select>
+      </div>
+      <div class="settings-row">
+        <div class="grow">
+          <div class="label">Default todo project</div>
+          <div class="meta">Pre-selected when launching a todo as a task.</div>
+        </div>
+        <select class="settings-input" id="default-todo-project" style="width: 160px"
+                onchange="saveDefault('todo_project', this.value)"></select>
+      </div>
+      <div class="settings-row" style="flex-direction: column; align-items: stretch">
+        <label class="label">Review prompt</label>
+        <input class="settings-input" id="default-review-prompt" onblur="saveDefault('review_prompt', this.value)">
+        <div class="meta">Sent to the agent when starting a PR review (PR URL appended).</div>
+      </div>
+    </div>
+
+    <div class="settings-section">
+      <h3>Projects</h3>
+      <div id="projects-list"></div>
+      <div class="settings-row">
+        <button class="primary" onclick="openProjectEditor()">+ New project</button>
+      </div>
+    </div>
+
+    <div class="settings-section">
+      <h3>Backends</h3>
+      <div id="backends-list"></div>
+      <div class="settings-row">
+        <button class="primary" onclick="openBackendEditor()">+ New backend</button>
+      </div>
+    </div>
+
+    <div class="settings-section">
+      <h3>Remote API<span id="api-restart-flag"></span></h3>
+      <div class="settings-row">
+        <div class="grow">
+          <div class="label">HTTP API enabled</div>
+          <div class="meta" id="api-meta">Port 7743. Disabling will stop this web UI on next daemon restart.</div>
+        </div>
+        <label class="switch">
+          <input type="checkbox" id="api-enabled" onchange="saveAPIToggle(this.checked)">
+          <span class="slider"></span>
+        </label>
+      </div>
+    </div>
+
+    <div class="settings-section">
       <h3>Notifications</h3>
       <div class="settings-row">
         <div>
@@ -443,15 +642,32 @@ button:disabled { opacity: 0.5; cursor: default; }
         <button onclick="sendTestPush()">Send</button>
       </div>
     </div>
+
     <div class="settings-section">
       <h3>API tokens</h3>
       <div id="token-list"></div>
       <div class="settings-row">
-        <input type="text" id="new-token-label" placeholder="Token label (e.g. iPhone)" style="flex:1; padding: 6px 8px; background: var(--bg); border: 1px solid var(--border); color: var(--text); border-radius: 6px;">
+        <input type="text" id="new-token-label" placeholder="Token label (e.g. iPhone)" class="settings-input" style="flex:1">
         <button class="primary" onclick="mintToken()" style="margin-left: 6px;">Create</button>
       </div>
       <div id="token-mint-result" style="display:none"></div>
     </div>
+
+    <div class="settings-section">
+      <h3>Logs</h3>
+      <div class="settings-row" style="flex-direction: column; align-items: stretch">
+        <div class="settings-row" style="border: none; padding: 0">
+          <div class="label">Log file</div>
+          <select class="settings-input" id="log-name" onchange="loadLog()" style="width: 160px">
+            <option value="ux">UX log</option>
+            <option value="daemon">Daemon log</option>
+          </select>
+          <button onclick="loadLog()">Refresh</button>
+        </div>
+        <div class="logs-pane" id="logs-pane">(loading…)</div>
+      </div>
+    </div>
+
     <div class="settings-section">
       <h3>Argus update</h3>
       <div class="settings-row">
@@ -478,6 +694,74 @@ button:disabled { opacity: 0.5; cursor: default; }
       <div class="settings-row">
         <div class="label">Sign out</div>
         <button class="danger" onclick="logout()">Forget token</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Project editor modal -->
+  <div class="modal-overlay" id="project-modal">
+    <div class="modal">
+      <h3 id="project-modal-title">New project</h3>
+      <div class="form-group">
+        <label>Name</label>
+        <input id="pm-name">
+      </div>
+      <div class="form-group">
+        <label>Path</label>
+        <input id="pm-path" class="mono" placeholder="/Users/you/code/myproj">
+      </div>
+      <div class="form-group">
+        <label>Branch (optional, default master)</label>
+        <input id="pm-branch" placeholder="master">
+      </div>
+      <div class="form-group">
+        <label>Backend (blank = default)</label>
+        <select id="pm-backend"></select>
+      </div>
+      <div class="form-group">
+        <label>Sandbox</label>
+        <div class="radio-row">
+          <label><input type="radio" name="pm-sandbox" value="inherit" checked> Inherit</label>
+          <label><input type="radio" name="pm-sandbox" value="true"> On</label>
+          <label><input type="radio" name="pm-sandbox" value="false"> Off</label>
+        </div>
+      </div>
+      <div class="form-group">
+        <label>Sandbox deny read (one per line, appended to global)</label>
+        <textarea id="pm-deny-read"></textarea>
+      </div>
+      <div class="form-group">
+        <label>Sandbox extra write (one per line, appended to global)</label>
+        <textarea id="pm-extra-write"></textarea>
+      </div>
+      <div class="modal-actions">
+        <button class="danger" id="pm-delete" onclick="deleteProjectFromModal()" style="margin-right:auto">Delete</button>
+        <button onclick="closeProjectEditor()">Cancel</button>
+        <button class="primary" onclick="saveProjectFromModal()">Save</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Backend editor modal -->
+  <div class="modal-overlay" id="backend-modal">
+    <div class="modal">
+      <h3 id="backend-modal-title">New backend</h3>
+      <div class="form-group">
+        <label>Name</label>
+        <input id="bm-name">
+      </div>
+      <div class="form-group">
+        <label>Command</label>
+        <textarea id="bm-command" class="mono" placeholder="claude --dangerously-skip-permissions"></textarea>
+      </div>
+      <div class="form-group">
+        <label>Prompt flag (optional)</label>
+        <input id="bm-prompt-flag" placeholder="--prompt or blank for stdin">
+      </div>
+      <div class="modal-actions">
+        <button class="danger" id="bm-delete" onclick="deleteBackendFromModal()" style="margin-right:auto">Delete</button>
+        <button onclick="closeBackendEditor()">Cancel</button>
+        <button class="primary" onclick="saveBackendFromModal()">Save</button>
       </div>
     </div>
   </div>
@@ -1402,9 +1686,24 @@ function switchTab(tab) {
   if (tab === 'settings') loadSettings();
 }
 
-// --- Settings tab: tokens + push ---
+// --- Settings tab: tokens + push + sandbox + KB + projects/backends + logs ---
+let settingsCache = null;
+let settingsBootstrap = null; // sandbox/api enabled state at first load — tracks "restart required" hints
+let projectsCache = [];
+let backendsCache = [];
+let editingProject = null; // null = creating; otherwise the project being edited
+let editingBackend = null;
+
 async function loadSettings() {
-  await Promise.all([loadTokens(), refreshPushState(), loadSourcePath()]);
+  await Promise.all([
+    loadTokens(),
+    refreshPushState(),
+    loadSourcePath(),
+    loadSettingsBlock(),
+    loadProjectsBlock(),
+    loadBackendsBlock(),
+    loadLog(),
+  ]);
 }
 
 async function loadSourcePath() {
@@ -1465,6 +1764,366 @@ async function runUpdate() {
     btn.textContent = 'Update';
     btn.disabled = false;
     out.textContent += '\n\nRequest failed: ' + e.message;
+  }
+}
+
+async function loadSettingsBlock() {
+  try {
+    const r = await api('/api/settings');
+    if (!r.ok) throw new Error('settings fetch failed');
+    const data = await r.json();
+    settingsCache = data;
+    if (!settingsBootstrap) settingsBootstrap = JSON.parse(JSON.stringify(data));
+    renderSettings();
+  } catch(e) { showToast('Failed to load settings: ' + e.message); }
+}
+
+function renderSettings() {
+  const s = settingsCache;
+  if (!s) return;
+  // Sandbox
+  document.getElementById('sandbox-enabled').checked = !!s.sandbox.enabled;
+  document.getElementById('sandbox-meta').textContent =
+    s.sandbox.available
+      ? 'macOS sandbox-exec confines agents to the worktree.'
+      : 'sandbox-exec not available on this host (macOS only).';
+  document.getElementById('sandbox-enabled').disabled = !s.sandbox.available;
+  document.getElementById('sandbox-deny-read').value = (s.sandbox.deny_read || []).join('\n');
+  document.getElementById('sandbox-extra-write').value = (s.sandbox.extra_write || []).join('\n');
+  // KB
+  document.getElementById('kb-enabled').checked = !!s.kb.enabled;
+  document.getElementById('kb-metis-path').value = s.kb.metis_vault_path || '';
+  document.getElementById('kb-argus-path').value = s.kb.argus_vault_path || '';
+  document.getElementById('kb-auto-create').checked = !!s.kb.auto_create_tasks;
+  document.getElementById('kb-auto-start').checked = !!s.kb.auto_start_todos;
+  document.getElementById('kb-interval').value = s.kb.auto_start_interval || 120;
+  setRestartFlag('kb-metis-meta', settingsBootstrap?.kb.metis_vault_path, s.kb.metis_vault_path);
+  setRestartFlag('kb-argus-meta', settingsBootstrap?.kb.argus_vault_path, s.kb.argus_vault_path);
+  // Defaults
+  fillSelectOptions('default-backend', backendsCache.map(b => b.name), s.defaults.backend, true);
+  fillSelectOptions('default-todo-project', projectsCache.map(p => p.name), s.defaults.todo_project, true);
+  document.getElementById('default-review-prompt').value = s.defaults.review_prompt || '';
+  // API
+  document.getElementById('api-enabled').checked = !!s.api.enabled;
+  const apiFlag = document.getElementById('api-restart-flag');
+  if (settingsBootstrap && settingsBootstrap.api.enabled !== s.api.enabled) {
+    apiFlag.innerHTML = ' <span class="restart-required">restart required</span>';
+  } else {
+    apiFlag.innerHTML = '';
+  }
+}
+
+function setRestartFlag(metaId, original, current) {
+  const el = document.getElementById(metaId);
+  if (!el) return;
+  if (original !== undefined && original !== current) {
+    el.innerHTML = '<span class="restart-required">restart required</span>';
+  } else {
+    el.innerHTML = '';
+  }
+}
+
+function fillSelectOptions(id, names, current, includeBlank) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  const blank = includeBlank ? '<option value="">(none)</option>' : '';
+  el.innerHTML = blank + names.map(n => {
+    const sel = n === current ? 'selected' : '';
+    return `<option value="${esc(n)}" ${sel}>${esc(n)}</option>`;
+  }).join('');
+  if (!names.includes(current)) el.value = '';
+}
+
+async function patchSettings(body) {
+  try {
+    const r = await api('/api/settings', { method: 'PUT', body: JSON.stringify(body) });
+    if (!r.ok) {
+      const e = await r.json().catch(() => ({}));
+      throw new Error(e.error || 'save failed');
+    }
+    settingsCache = await r.json();
+    renderSettings();
+  } catch(e) { showToast('Save failed: ' + e.message); }
+}
+
+function saveSandboxToggle() {
+  const enabled = document.getElementById('sandbox-enabled').checked;
+  patchSettings({ sandbox: { enabled } });
+}
+
+function saveSandboxPaths() {
+  const denyRead = document.getElementById('sandbox-deny-read').value
+    .split('\n').map(s => s.trim()).filter(Boolean);
+  const extraWrite = document.getElementById('sandbox-extra-write').value
+    .split('\n').map(s => s.trim()).filter(Boolean);
+  patchSettings({ sandbox: { deny_read: denyRead, extra_write: extraWrite } })
+    .then(() => {
+      const status = document.getElementById('sandbox-paths-status');
+      status.textContent = 'Saved';
+      setTimeout(() => { status.textContent = ''; }, 2000);
+    });
+}
+
+function saveKBToggle(field, value) {
+  patchSettings({ kb: { [field]: value } });
+}
+
+function saveKBPath(field, value) {
+  patchSettings({ kb: { [field]: value } });
+}
+
+function saveKBAutoStart(checked) {
+  // Backend mirrors the TUI invariant: enabling auto-start implies auto-create,
+  // disabling it also disables auto-create. We send only auto_start_todos and
+  // let the server handle the dependent flag.
+  patchSettings({ kb: { auto_start_todos: checked } });
+}
+
+function saveKBInterval(value) {
+  const n = parseInt(value, 10);
+  if (!Number.isFinite(n) || n <= 0) return;
+  patchSettings({ kb: { auto_start_interval: n } });
+}
+
+function saveAPIToggle(checked) {
+  patchSettings({ api: { enabled: checked } });
+}
+
+function saveDefault(field, value) {
+  patchSettings({ defaults: { [field]: value } });
+}
+
+// --- Projects ---
+async function loadProjectsBlock() {
+  try {
+    const r = await api('/api/projects/full');
+    if (!r.ok) throw new Error('projects fetch failed');
+    const { projects } = await r.json();
+    projectsCache = projects || [];
+    renderProjectsBlock();
+    if (settingsCache) renderSettings(); // refresh todo-project select
+  } catch(e) {
+    document.getElementById('projects-list').innerHTML = '<div class="meta">Failed to load projects.</div>';
+  }
+}
+
+function renderProjectsBlock() {
+  const el = document.getElementById('projects-list');
+  if (!projectsCache.length) {
+    el.innerHTML = '<div class="meta" style="padding: 8px 0">No projects configured.</div>';
+    return;
+  }
+  el.innerHTML = projectsCache.map((p, i) => {
+    const sandboxLabel = p.sandbox && p.sandbox.enabled !== null
+      ? (p.sandbox.enabled ? 'sandbox: on' : 'sandbox: off')
+      : 'sandbox: inherit';
+    return `<div class="settings-row">
+      <div class="grow">
+        <div class="label">${esc(p.name)}</div>
+        <div class="meta">${esc(p.path)} · ${esc(p.branch || 'master')} · ${esc(p.backend || 'default')} · ${sandboxLabel}</div>
+      </div>
+      <button data-act="edit-project" data-idx="${i}">Edit</button>
+    </div>`;
+  }).join('');
+  el.querySelectorAll('[data-act="edit-project"]').forEach(b => {
+    b.addEventListener('click', () => openProjectEditor(projectsCache[parseInt(b.dataset.idx, 10)]));
+  });
+}
+
+function openProjectEditor(p) {
+  editingProject = p || null;
+  document.getElementById('project-modal-title').textContent = p ? `Edit ${p.name}` : 'New project';
+  document.getElementById('pm-name').value = p ? p.name : '';
+  document.getElementById('pm-name').disabled = !!p;
+  document.getElementById('pm-path').value = p ? p.path : '';
+  document.getElementById('pm-branch').value = p ? (p.branch || '') : '';
+  // Backend select: default + every backend.
+  const beSel = document.getElementById('pm-backend');
+  beSel.innerHTML = '<option value="">(default)</option>' + backendsCache.map(b => {
+    const sel = p && p.backend === b.name ? 'selected' : '';
+    return `<option value="${esc(b.name)}" ${sel}>${esc(b.name)}</option>`;
+  }).join('');
+  // Sandbox radios.
+  let sandboxVal = 'inherit';
+  if (p && p.sandbox && p.sandbox.enabled === true) sandboxVal = 'true';
+  else if (p && p.sandbox && p.sandbox.enabled === false) sandboxVal = 'false';
+  document.querySelectorAll('input[name="pm-sandbox"]').forEach(r => {
+    r.checked = r.value === sandboxVal;
+  });
+  document.getElementById('pm-deny-read').value =
+    (p && p.sandbox && p.sandbox.deny_read || []).join('\n');
+  document.getElementById('pm-extra-write').value =
+    (p && p.sandbox && p.sandbox.extra_write || []).join('\n');
+  document.getElementById('pm-delete').style.display = p ? 'inline-block' : 'none';
+  document.getElementById('project-modal').classList.add('open');
+}
+
+function closeProjectEditor() {
+  document.getElementById('project-modal').classList.remove('open');
+  editingProject = null;
+}
+
+async function saveProjectFromModal() {
+  const name = document.getElementById('pm-name').value.trim();
+  const path = document.getElementById('pm-path').value.trim();
+  if (!name || !path) { showToast('Name and path are required'); return; }
+  const body = {
+    name,
+    path,
+    branch: document.getElementById('pm-branch').value.trim(),
+    backend: document.getElementById('pm-backend').value,
+  };
+  const sandboxRadio = document.querySelector('input[name="pm-sandbox"]:checked');
+  const denyRead = document.getElementById('pm-deny-read').value.split('\n').map(s => s.trim()).filter(Boolean);
+  const extraWrite = document.getElementById('pm-extra-write').value.split('\n').map(s => s.trim()).filter(Boolean);
+  // Only attach sandbox section if user customized any field.
+  if (sandboxRadio && sandboxRadio.value !== 'inherit' || denyRead.length || extraWrite.length) {
+    let enabled = null;
+    if (sandboxRadio.value === 'true') enabled = true;
+    else if (sandboxRadio.value === 'false') enabled = false;
+    body.sandbox = { enabled, deny_read: denyRead, extra_write: extraWrite };
+  }
+  try {
+    const url = editingProject ? `/api/projects/${encodeURIComponent(editingProject.name)}` : '/api/projects';
+    const method = editingProject ? 'PUT' : 'POST';
+    const r = await api(url, { method, body: JSON.stringify(body) });
+    if (!r.ok) {
+      const e = await r.json().catch(() => ({}));
+      throw new Error(e.error || 'save failed');
+    }
+    closeProjectEditor();
+    loadProjectsBlock();
+    refreshProjectsForCreateView();
+  } catch(e) { showToast('Save failed: ' + e.message); }
+}
+
+async function deleteProjectFromModal() {
+  if (!editingProject) return;
+  if (!confirm(`Delete project "${editingProject.name}"? Existing tasks remain in the database.`)) return;
+  try {
+    const r = await api(`/api/projects/${encodeURIComponent(editingProject.name)}`, { method: 'DELETE' });
+    if (!r.ok) {
+      const e = await r.json().catch(() => ({}));
+      throw new Error(e.error || 'delete failed');
+    }
+    closeProjectEditor();
+    loadProjectsBlock();
+    refreshProjectsForCreateView();
+  } catch(e) { showToast('Delete failed: ' + e.message); }
+}
+
+// Refresh the create-task project dropdown after a project change.
+async function refreshProjectsForCreateView() {
+  try {
+    const r = await api('/api/projects');
+    if (!r.ok) return;
+    const { projects } = await r.json();
+    const sel = document.getElementById('create-project');
+    if (!sel) return;
+    const cur = sel.value;
+    sel.innerHTML = (projects || []).map(p => `<option value="${esc(p)}">${esc(p)}</option>`).join('');
+    if (projects && projects.includes(cur)) sel.value = cur;
+  } catch(e) {}
+}
+
+// --- Backends ---
+async function loadBackendsBlock() {
+  try {
+    const r = await api('/api/backends');
+    if (!r.ok) throw new Error('backends fetch failed');
+    const { backends } = await r.json();
+    backendsCache = backends || [];
+    renderBackendsBlock();
+    if (settingsCache) renderSettings(); // refresh default-backend select
+  } catch(e) {
+    document.getElementById('backends-list').innerHTML = '<div class="meta">Failed to load backends.</div>';
+  }
+}
+
+function renderBackendsBlock() {
+  const el = document.getElementById('backends-list');
+  if (!backendsCache.length) {
+    el.innerHTML = '<div class="meta" style="padding: 8px 0">No backends configured.</div>';
+    return;
+  }
+  const def = settingsCache && settingsCache.defaults && settingsCache.defaults.backend;
+  el.innerHTML = backendsCache.map((b, i) => {
+    const star = b.name === def ? ' ★' : '';
+    return `<div class="settings-row">
+      <div class="grow">
+        <div class="label">${esc(b.name)}${star}</div>
+        <div class="meta">${esc(b.command)}</div>
+      </div>
+      <button data-act="edit-backend" data-idx="${i}">Edit</button>
+    </div>`;
+  }).join('');
+  el.querySelectorAll('[data-act="edit-backend"]').forEach(btn => {
+    btn.addEventListener('click', () => openBackendEditor(backendsCache[parseInt(btn.dataset.idx, 10)]));
+  });
+}
+
+function openBackendEditor(b) {
+  editingBackend = b || null;
+  document.getElementById('backend-modal-title').textContent = b ? `Edit ${b.name}` : 'New backend';
+  document.getElementById('bm-name').value = b ? b.name : '';
+  document.getElementById('bm-name').disabled = !!b;
+  document.getElementById('bm-command').value = b ? b.command : '';
+  document.getElementById('bm-prompt-flag').value = b ? (b.prompt_flag || '') : '';
+  document.getElementById('bm-delete').style.display = b ? 'inline-block' : 'none';
+  document.getElementById('backend-modal').classList.add('open');
+}
+
+function closeBackendEditor() {
+  document.getElementById('backend-modal').classList.remove('open');
+  editingBackend = null;
+}
+
+async function saveBackendFromModal() {
+  const name = document.getElementById('bm-name').value.trim();
+  const command = document.getElementById('bm-command').value.trim();
+  if (!name || !command) { showToast('Name and command are required'); return; }
+  const body = { name, command, prompt_flag: document.getElementById('bm-prompt-flag').value.trim() };
+  try {
+    const url = editingBackend ? `/api/backends/${encodeURIComponent(editingBackend.name)}` : '/api/backends';
+    const method = editingBackend ? 'PUT' : 'POST';
+    const r = await api(url, { method, body: JSON.stringify(body) });
+    if (!r.ok) {
+      const e = await r.json().catch(() => ({}));
+      throw new Error(e.error || 'save failed');
+    }
+    closeBackendEditor();
+    loadBackendsBlock();
+  } catch(e) { showToast('Save failed: ' + e.message); }
+}
+
+async function deleteBackendFromModal() {
+  if (!editingBackend) return;
+  if (!confirm(`Delete backend "${editingBackend.name}"?`)) return;
+  try {
+    const r = await api(`/api/backends/${encodeURIComponent(editingBackend.name)}`, { method: 'DELETE' });
+    if (!r.ok) {
+      const e = await r.json().catch(() => ({}));
+      throw new Error(e.error || 'delete failed');
+    }
+    closeBackendEditor();
+    loadBackendsBlock();
+  } catch(e) { showToast('Delete failed: ' + e.message); }
+}
+
+// --- Logs ---
+async function loadLog() {
+  const name = document.getElementById('log-name').value;
+  const pane = document.getElementById('logs-pane');
+  pane.textContent = '(loading…)';
+  try {
+    const r = await api(`/api/logs/${encodeURIComponent(name)}?bytes=65536`);
+    if (!r.ok) throw new Error('log fetch failed');
+    const text = await r.text();
+    pane.textContent = text || '(empty)';
+    // Auto-scroll to bottom — newest entries are at the end.
+    pane.scrollTop = pane.scrollHeight;
+  } catch(e) {
+    pane.textContent = '(failed: ' + e.message + ')';
   }
 }
 


### PR DESCRIPTION
## Summary
Web Settings tab now mirrors the TUI: sandbox toggle (with global deny-read / extra-write), Knowledge Base config (vault paths, task sync, auto-start), defaults (backend, todo project, review prompt), Remote API toggle, projects/backends CRUD with per-project sandbox overrides, and a UX/daemon log viewer. Mutating endpoints require the master token; device tokens get read-only access.

## Backend
- New `GET/PUT /api/settings` for sandbox, KB, API, defaults; partial updates via pointer fields.
- New `GET /api/logs/{ux|daemon}?bytes=N` tails the last N bytes (default 64K, max 1M); whitelisted names; missing files return 200 with empty body.
- `projectJSON.Sandbox` round-trips per-project overrides as a tri-state (`null` = inherit, `true`/`false` = override).
- Server mirrors the TUI invariant `kb.auto_start_todos ⇒ kb.auto_create_tasks` so the web toggle can't silently leave the daemon falling back to fsnotify after a restart.

## Frontend
- New `escAttr()` helper for `value="..."` attribute context (the existing `esc()` only escapes body context).
- New project editor modal supports the sandbox tri-state via radios + path lists.
- `patchSettings` returns success/failure so "Saved" banners no longer fire on errors.
- "Restart required" hints surface when API/vault path values diverge from boot.

## Test plan
- [x] `make test` (race, in-memory DB)
- [x] `make vet`
- [x] `make lint-pr`
- [x] Sandbox tri-state round-trip through DB (`TestHandleProjects_RoundTripsSandboxOverride`, `TestProjectFromJSON_NilSandboxStaysInherit`)
- [x] Settings PUT requires master, GET readable by device tokens, log tail readable by device tokens
- [x] `kb.auto_start_todos` toggle implies / clears `kb.auto_create_tasks`

Co-Authored-By: Claude <noreply@anthropic.com>