### PR TITLE
Reconcile orphaned in_progress tasks so PWA can reconnect

### DIFF
--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -64,7 +64,6 @@ func runTUI() {
 
 	var runner agent.SessionProvider
 	var daemonConnected bool
-	var daemonFreshStart bool
 	var daemonStale bool
 
 	sockPath := daemon.DefaultSocketPath()
@@ -86,6 +85,14 @@ func runTUI() {
 
 	if err != nil {
 		uxlog.Log("daemon connect failed: %v — falling back to in-process runner", err)
+		// In-process owns the runner exclusively, so any InProgress row in
+		// the DB is from a prior process. The daemon does the same sweep
+		// inside Serve(); this is the no-daemon analogue.
+		if n, rerr := agent.ReconcileStaleSessions(database); rerr != nil {
+			uxlog.Log("reconcile stale sessions failed: %v", rerr)
+		} else if n > 0 {
+			uxlog.Log("reconciled %d stale in_progress task(s) → in_review", n)
+		}
 		runner = agent.NewRunner(func(taskID string, exitErr error, stopped bool, lastOutput []byte) {
 			if appRef != nil {
 				appRef.NotifySessionExit(taskID, exitErr, stopped, lastOutput)
@@ -94,7 +101,6 @@ func runTUI() {
 	} else {
 		uxlog.Log("connected to daemon at %s", sockPath)
 		daemonConnected = true
-		daemonFreshStart = client.FreshStart() // true when daemon was auto-started (no prior sessions)
 		runner = client
 		defer client.Close()
 	}
@@ -110,7 +116,7 @@ func runTUI() {
 		})
 	}
 
-	app := tui.New(database, runner, daemonConnected, daemonFreshStart)
+	app := tui.New(database, runner, daemonConnected)
 	app.SetDaemonStale(daemonStale)
 	appRef = app
 	appRef2 = app

--- a/internal/agent/reconcile.go
+++ b/internal/agent/reconcile.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"log/slog"
+
+	"github.com/drn/argus/internal/db"
+	"github.com/drn/argus/internal/model"
+)
+
+// ReconcileStaleSessions flips DB tasks stuck at InProgress to InReview.
+//
+// Called once at startup (daemon Serve, or in-process TUI fallback) after the
+// runner is created but before any new sessions are started. The runner is
+// empty at that point, so any InProgress row in the DB describes a session
+// that died with the previous process — flip it to InReview so the user (TUI
+// or PWA) can resume or discard it.
+//
+// InReview is the right state because we don't know whether the agent
+// finished or crashed; letting the user decide via Resume is safer than
+// silently marking Complete.
+func ReconcileStaleSessions(database *db.DB) (int, error) {
+	tasks, err := database.Tasks()
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, t := range tasks {
+		if t.Status != model.StatusInProgress {
+			continue
+		}
+		t.SetStatus(model.StatusInReview)
+		if err := database.Update(t); err != nil {
+			slog.Warn("reconcile: update failed", "task", t.ID, "name", t.Name, "err", err)
+			continue
+		}
+		slog.Info("reconcile: stale in_progress → in_review", "task", t.ID, "name", t.Name)
+		count++
+	}
+	return count, nil
+}

--- a/internal/agent/reconcile.go
+++ b/internal/agent/reconcile.go
@@ -29,8 +29,8 @@ func ReconcileStaleSessions(database *db.DB) (int, error) {
 			continue
 		}
 		t.SetStatus(model.StatusInReview)
-		if err := database.Update(t); err != nil {
-			slog.Warn("reconcile: update failed", "task", t.ID, "name", t.Name, "err", err)
+		if uerr := database.Update(t); uerr != nil {
+			slog.Warn("reconcile: update failed", "task", t.ID, "name", t.Name, "err", uerr)
 			continue
 		}
 		slog.Info("reconcile: stale in_progress → in_review", "task", t.ID, "name", t.Name)

--- a/internal/daemon/client/client.go
+++ b/internal/daemon/client/client.go
@@ -33,12 +33,11 @@ var _ agent.SessionProvider = (*Client)(nil)
 
 // Client connects to the daemon and implements agent.SessionProvider.
 type Client struct {
-	rpc        *rpc.Client
-	sockPath   string
-	sessions   map[string]*RemoteSession
-	freshStart bool          // true when the daemon was auto-started (no prior sessions)
-	mu         sync.Mutex
-	closed     chan struct{} // closed by Close(); stops connectStream retries
+	rpc      *rpc.Client
+	sockPath string
+	sessions map[string]*RemoteSession
+	mu       sync.Mutex
+	closed   chan struct{} // closed by Close(); stops connectStream retries
 
 	// leakedCalls tracks goroutines from timed-out RPC calls that are still
 	// blocked in rpc.Call. Logged for observability — drain goroutines
@@ -48,12 +47,6 @@ type Client struct {
 	// onSessionExit is called when a session's stream EOF is detected.
 	// Includes exit info (error, stopped flag, last output) from the daemon.
 	onSessionExit func(taskID string, info daemon.ExitInfo)
-}
-
-// FreshStart returns true when this client connected to a freshly auto-started
-// daemon that has no prior sessions (as opposed to an already-running daemon).
-func (c *Client) FreshStart() bool {
-	return c.freshStart
 }
 
 // Connect dials the daemon socket and returns a Client.
@@ -407,7 +400,6 @@ func AutoStart(sockPath string) (*Client, error) {
 	for time.Now().Before(deadline) {
 		time.Sleep(pollInterval)
 		if client, err := Connect(sockPath); err == nil {
-			client.freshStart = true
 			return client, nil
 		}
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -160,6 +160,17 @@ func (d *Daemon) Serve(sockPath string) error {
 	// Remove stale socket file.
 	os.Remove(sockPath)
 
+	// Sweep DB for tasks stuck at InProgress. The previous daemon's sessions
+	// (if any) are dead; the runner here is empty, so any InProgress row is
+	// orphaned. Flip them to InReview so the TUI/PWA can resume or discard.
+	// Done before the listener accepts connections so first-poll clients see
+	// the reconciled state.
+	if n, err := agent.ReconcileStaleSessions(d.db); err != nil {
+		slog.Warn("reconcile stale sessions failed", "err", err)
+	} else if n > 0 {
+		slog.Info("reconciled stale sessions", "count", n)
+	}
+
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
 		close(d.ready) // unblock Shutdown even on listen failure

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -771,10 +771,11 @@ func (a *App) restartDaemon() {
 
 		a.settings.SetDaemonRestarting(false)
 
-		// The new daemon already swept InProgress → InReview during Serve()
-		// before its socket opened, so by the time we reach this code the DB
-		// is consistent. Just reload locally; an RPC would race with the user
-		// entering tasks while the new daemon is still warming up.
+		// agent.ReconcileStaleSessions ran inside the new daemon's Serve()
+		// before its socket opened, so by the time we reach this code stale
+		// InProgress rows are already InReview. Reload locally; an async RPC
+		// would race with the user entering tasks while the new daemon is
+		// still warming up.
 		a.refreshTasksLocal()
 	})
 }
@@ -1023,8 +1024,8 @@ func (a *App) refreshTasksWithIDs(runningIDs, idleIDs []string) {
 	// for "session exited while we were watching but the OnSessionExit
 	// notification didn't make it through" — the genuine exit path, so
 	// Complete is correct. Stale rows from a daemon crash/restart are flipped
-	// to InReview by ReconcileStaleSessions before we ever see them, so they
-	// won't appear here.
+	// to InReview by ReconcileStaleSessions before the listener opens, so
+	// they shouldn't reach this path in practice.
 	//
 	// Only reconcile when connected to a daemon — the daemon is the source of
 	// truth for running sessions. In-process mode has its own onFinish callback.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -155,7 +155,6 @@ type App struct {
 	// Daemon health
 	daemonFailures    int
 	daemonRestarting  bool
-	daemonFreshStart  bool      // no prior sessions (fresh auto-start or restart); first reconciliation uses InReview
 	lastDaemonRestart time.Time // cooldown: minimum 30s between restart attempts
 	daemonClient      *dclient.Client
 	restartedClient   *dclient.Client // set after daemon restart
@@ -191,10 +190,12 @@ type App struct {
 }
 
 // New creates the tui application shell.
-// daemonFreshStart indicates this daemon instance has no prior sessions (freshly
-// auto-started or restarted), so InProgress tasks should be reconciled to
-// InReview instead of Complete on the first tick.
-func New(database *db.DB, runner agent.SessionProvider, daemonConnected bool, daemonFreshStart bool) *App {
+//
+// Stale-session reconciliation is owned by the runner-holder (daemon Serve, or
+// in-process startup in cmd/argus/main.go) — they sweep InProgress → InReview
+// before the TUI sees the DB, so the TUI's tick reconciler only handles
+// "session exited while we were watching" (always Complete).
+func New(database *db.DB, runner agent.SessionProvider, daemonConnected bool) *App {
 	// Use the terminal's default background instead of tview's hard-coded black.
 	tview.Styles.PrimitiveBackgroundColor = tcell.ColorDefault
 
@@ -203,7 +204,6 @@ func New(database *db.DB, runner agent.SessionProvider, daemonConnected bool, da
 		db:               database,
 		runner:           runner,
 		daemonConnected:  daemonConnected,
-		daemonFreshStart: daemonFreshStart,
 		agentState:       agentview.New(),
 		tickDone:         make(chan struct{}),
 		recentStarts:         make(map[string]time.Time),
@@ -759,15 +759,9 @@ func (a *App) restartDaemon() {
 		a.mu.Lock()
 		a.daemonRestarting = false
 		a.daemonFailures = 0
-		a.daemonFreshStart = true // new daemon has no prior sessions — use InReview for stale tasks
 		a.daemonClient = newClient
 		a.runner = newClient
 		a.restartedClient = newClient
-		// Fresh daemon has no sessions — use InReview (not Complete) for any
-		// stale InProgress tasks that survive past the Pending reset below.
-		// This matches the initial auto-start behavior: the user decides
-		// whether to resume or discard.
-		a.daemonFreshStart = true
 		// Clear stale running/idle IDs from old daemon — the new daemon has
 		// no sessions yet. Using nil (not empty) ensures reconciliation is
 		// skipped until the first tick fetches fresh IDs from the new daemon.
@@ -777,23 +771,10 @@ func (a *App) restartDaemon() {
 
 		a.settings.SetDaemonRestarting(false)
 
-		// Reset in-progress tasks to pending, preserving SessionID for resume.
-		tasks, err := a.db.Tasks()
-		if err != nil {
-			uxlog.Log("[tui] failed to load tasks for reset: %v", err)
-		}
-		for _, t := range tasks {
-			if t.Status == model.StatusInProgress {
-				t.SetStatus(model.StatusPending)
-				a.db.Update(t) //nolint:errcheck
-				uxlog.Log("[tui] reset task %s to pending (daemon restarted)", t.ID)
-			}
-		}
-		// Use refreshTasksLocal (not Async) — the new daemon has no sessions,
-		// and an async RPC would race with the user entering tasks. The async
-		// goroutine captures empty runningIDs, but by the time its callback
-		// runs, startSession may have set a task to InProgress — reconciliation
-		// then sees InProgress + not-in-running-set and marks it Complete.
+		// The new daemon already swept InProgress → InReview during Serve()
+		// before its socket opened, so by the time we reach this code the DB
+		// is consistent. Just reload locally; an RPC would race with the user
+		// entering tasks while the new daemon is still warming up.
 		a.refreshTasksLocal()
 	})
 }
@@ -1038,16 +1019,16 @@ func (a *App) refreshTasksWithIDs(runningIDs, idleIDs []string) {
 	a.idleIDs = idleIDs
 
 	// Reconcile stale in-progress tasks: if a task is InProgress in the DB
-	// but has no running session, mark it Complete. This handles cases where
-	// the exit callback didn't fire (daemon restart, TUI restart, etc.).
+	// but has no running session, mark it Complete. This is the safety net
+	// for "session exited while we were watching but the OnSessionExit
+	// notification didn't make it through" — the genuine exit path, so
+	// Complete is correct. Stale rows from a daemon crash/restart are flipped
+	// to InReview by ReconcileStaleSessions before we ever see them, so they
+	// won't appear here.
+	//
 	// Only reconcile when connected to a daemon — the daemon is the source of
 	// truth for running sessions. In-process mode has its own onFinish callback.
-	// Note: InReview tasks are intentionally non-running (set by handleSessionExitUI
-	// when the user stops an agent) and must NOT be reconciled to Complete.
-	// IMPORTANT: runningIDs is nil when the daemon RPC failed — skip reconciliation
-	// to avoid marking all active tasks as Complete due to a transient error.
-	// Also skip during daemon restart — the new daemon has no sessions yet, so
-	// reconciliation would incorrectly mark all InProgress tasks as Complete.
+	// Skip if runningIDs is nil (transient RPC failure) or during a restart.
 	if a.daemonConnected && runningIDs != nil && !a.daemonRestarting {
 		runningSet := make(map[string]bool, len(runningIDs))
 		for _, id := range runningIDs {
@@ -1063,37 +1044,15 @@ func (a *App) refreshTasksWithIDs(runningIDs, idleIDs []string) {
 					uxlog.Log("[tui] reconciliation grace period for task %s (%s), started %v ago", t.ID, t.Name, now.Sub(startedAt).Round(time.Millisecond))
 					continue
 				}
-				if a.daemonFreshStart {
-					// Daemon was just auto-started — agent sessions were lost
-					// (daemon died or system restarted), not finished normally.
-					// Mark as InReview so the user can decide what to do.
-					t.SetStatus(model.StatusInReview)
-					a.db.Update(t) //nolint:errcheck
-					uxlog.Log("[tui] reconciled stale task %s (%s) → in_review (daemon fresh start, session lost)", t.ID, t.Name)
-				} else {
-					t.SetStatus(model.StatusComplete)
-					a.db.Update(t) //nolint:errcheck
-					uxlog.Log("[tui] reconciled stale task %s (%s) → complete (no running session)", t.ID, t.Name)
-				}
+				t.SetStatus(model.StatusComplete)
+				a.db.Update(t) //nolint:errcheck
+				uxlog.Log("[tui] reconciled stale task %s (%s) → complete (no running session)", t.ID, t.Name)
 				delete(a.recentStarts, t.ID) // consumed; no need to check again
 			}
 		}
-		// Clean up expired grace periods.
+		// Evict expired grace period entries.
 		for id, startedAt := range a.recentStarts {
 			if now.Sub(startedAt) >= recentStartGrace {
-				delete(a.recentStarts, id)
-			}
-		}
-		// Clear fresh-start flag after first reconciliation with tasks present —
-		// subsequent ticks use normal Complete reconciliation for tasks that truly
-		// finished. Only clear when tasks were loaded to avoid a race where a slow
-		// or empty first read clears the flag before InProgress tasks are seen.
-		if len(a.tasks) > 0 {
-			a.daemonFreshStart = false
-		}
-		// Evict expired grace period entries.
-		for id, startTime := range a.recentStarts {
-			if now.Sub(startTime) >= 5*time.Second {
 				delete(a.recentStarts, id)
 			}
 		}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1004,6 +1004,10 @@ func TestReconcileWorksOnEmptyRunning(t *testing.T) {
 	}
 }
 
+// Covers the happy path (InProgress flipped) and idempotency on rows already
+// in a terminal state. The database.Tasks() error path is not exercised
+// directly — propagation is straight pass-through and the helper has no
+// other behavior on top of it.
 func TestReconcileStaleSessionsFlipsInProgress(t *testing.T) {
 	d := testDB(t)
 
@@ -1037,7 +1041,6 @@ func TestReconcileStaleSessionsFlipsInProgress(t *testing.T) {
 		}
 	}
 }
-
 
 // TestReconcileSkipsOnStaleStartGen and TestReconcileWorksWhenStartGenUnchanged
 // replicate the startGen guard logic from onTick's QueueUpdateDraw callback

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -32,7 +32,7 @@ func testDB(t *testing.T) *db.DB {
 func TestNew(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	if app.tapp == nil {
 		t.Error("tview.Application should not be nil")
@@ -57,7 +57,7 @@ func TestNew(t *testing.T) {
 func TestSwitchTab(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	app.switchTab(widget.TabReviews)
 	if app.header.ActiveTab() != widget.TabReviews {
@@ -78,7 +78,7 @@ func TestSwitchTab(t *testing.T) {
 func TestOnTaskSelect(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	task := &model.Task{
 		ID:   "test-1",
@@ -99,7 +99,7 @@ func TestOnTaskSelectAutoStart(t *testing.T) {
 	t.Run("auto-start without session ID", func(t *testing.T) {
 		d := testDB(t)
 		runner := agent.NewRunner(nil)
-		app := New(d, runner, false, false)
+		app := New(d, runner, false)
 
 		task := &model.Task{
 			ID:   "t-no-sid",
@@ -122,7 +122,7 @@ func TestOnTaskSelectAutoStart(t *testing.T) {
 	t.Run("no auto-start for completed task", func(t *testing.T) {
 		d := testDB(t)
 		runner := agent.NewRunner(nil)
-		app := New(d, runner, false, false)
+		app := New(d, runner, false)
 
 		task := &model.Task{
 			ID:        "t-complete",
@@ -144,7 +144,7 @@ func TestOnTaskSelectAutoStart(t *testing.T) {
 	t.Run("auto-start for in-review task with session ID", func(t *testing.T) {
 		d := testDB(t)
 		runner := agent.NewRunner(nil)
-		app := New(d, runner, false, false)
+		app := New(d, runner, false)
 
 		task := &model.Task{
 			ID:        "t-resume",
@@ -168,7 +168,7 @@ func TestOnTaskSelectAutoStart(t *testing.T) {
 	t.Run("no auto-start for archived task", func(t *testing.T) {
 		d := testDB(t)
 		runner := agent.NewRunner(nil)
-		app := New(d, runner, false, false)
+		app := New(d, runner, false)
 
 		task := &model.Task{
 			ID:        "t-archived",
@@ -191,7 +191,7 @@ func TestOnTaskSelectAutoStart(t *testing.T) {
 	t.Run("auto-start for pending task with session ID", func(t *testing.T) {
 		d := testDB(t)
 		runner := agent.NewRunner(nil)
-		app := New(d, runner, false, false)
+		app := New(d, runner, false)
 
 		task := &model.Task{
 			ID:        "t-pending",
@@ -215,7 +215,7 @@ func TestOnTaskSelectAutoStart(t *testing.T) {
 	t.Run("no auto-start when autoStart is false", func(t *testing.T) {
 		d := testDB(t)
 		runner := agent.NewRunner(nil)
-		app := New(d, runner, false, false)
+		app := New(d, runner, false)
 
 		task := &model.Task{
 			ID:        "t-navigate",
@@ -238,7 +238,7 @@ func TestOnTaskSelectAutoStart(t *testing.T) {
 func TestExitAgentView(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	app.mode = modeAgent
 	app.exitAgentView()
@@ -293,7 +293,7 @@ func TestTcellKeyToBytes(t *testing.T) {
 func TestArrowTabNavigation(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	// Start on Tasks tab
 	if app.header.ActiveTab() != widget.TabTasks {
@@ -348,7 +348,7 @@ func TestArrowTabNavigation(t *testing.T) {
 func TestCtrlCForwardsToAgentPTY(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	// Start a real process so we have a live session.
 	task := &model.Task{
@@ -390,7 +390,7 @@ func TestCtrlCForwardsToAgentPTY(t *testing.T) {
 func TestCtrlCNoopInAgentViewDeadSession(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	// Agent mode with no session — ctrl+c should be consumed but not exit
 	app.mode = modeAgent
@@ -409,7 +409,7 @@ func TestCtrlCNoopInAgentViewDeadSession(t *testing.T) {
 func TestCtrlDExitsAgentViewWhenSessionDead(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	app.mode = modeAgent
 	app.agentState.Reset("t1", "test")
@@ -426,7 +426,7 @@ func TestCtrlDExitsAgentViewWhenSessionDead(t *testing.T) {
 func TestEscapeStaysInAgentView(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	app.mode = modeAgent
 	app.agentState.Reset("t1", "test")
@@ -447,7 +447,7 @@ func TestEscapeStaysInAgentView(t *testing.T) {
 func TestCtrlLOpensLinkPicker(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	app.mode = modeAgent
 	app.agentState.Reset("t1", "test")
@@ -461,7 +461,7 @@ func TestCtrlLOpensLinkPicker(t *testing.T) {
 func TestFilePanelKeyRouting(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	// Enter agent mode with file panel focused
 	app.mode = modeAgent
@@ -509,7 +509,7 @@ func TestFilePanelKeyRouting(t *testing.T) {
 func TestDiffModeArrowsNavigateFiles(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	// Enter agent mode
 	app.mode = modeAgent
@@ -560,7 +560,7 @@ func TestDiffModeArrowsNavigateFiles(t *testing.T) {
 func TestFilePanelMouseFocus(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	// Enter agent mode with terminal focused (default)
 	app.mode = modeAgent
@@ -612,7 +612,7 @@ func TestFilePanelMouseFocus(t *testing.T) {
 func TestArrowsIgnoredInAgentMode(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	app.mode = modeAgent
 	app.agentState.Reset("t1", "test")
@@ -630,7 +630,7 @@ func TestArrowsIgnoredInAgentMode(t *testing.T) {
 func TestRefreshTasks(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	// Add a task
 	task := &model.Task{
@@ -718,7 +718,7 @@ func TestConfirmDeleteModal(t *testing.T) {
 func TestOpenConfirmDelete(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	task := &model.Task{
 		ID:        "t1",
@@ -743,7 +743,7 @@ func TestOpenConfirmDelete(t *testing.T) {
 func TestCloseConfirmDelete(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	task := &model.Task{
 		ID:        "t1",
@@ -770,7 +770,7 @@ func TestCloseConfirmDelete(t *testing.T) {
 func TestDeleteTask(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	task := &model.Task{
 		ID:        "t1",
@@ -802,7 +802,7 @@ func TestDeleteTask(t *testing.T) {
 func TestRefreshTasksLocal(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	d.Add(&model.Task{ID: "t1", Name: "task1", Status: model.StatusPending, Project: "p", CreatedAt: time.Now()})
 	d.Add(&model.Task{ID: "t2", Name: "task2", Status: model.StatusPending, Project: "p", CreatedAt: time.Now()})
@@ -827,7 +827,7 @@ func TestRefreshTasksLocal(t *testing.T) {
 func TestCtrlDOpensConfirmDelete(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	task := &model.Task{
 		ID:        "t1",
@@ -854,7 +854,7 @@ func TestCtrlDOpensConfirmDelete(t *testing.T) {
 func TestCtrlDDoesNotDeleteInAgentMode(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	app.mode = modeAgent
 	app.agentState.Reset("t1", "test")
@@ -872,7 +872,7 @@ func TestCtrlDDoesNotDeleteInAgentMode(t *testing.T) {
 func TestPruneCompletedTasks(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 	app.wtRoot = t.TempDir() // isolate from real worktrees
 
 	// Add tasks with various statuses
@@ -903,7 +903,7 @@ func TestPruneCompletedTasks(t *testing.T) {
 func TestPruneDoesNotDoubleCountWorktrees(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 	wtRoot := t.TempDir()
 	app.wtRoot = wtRoot
 
@@ -941,7 +941,7 @@ func TestPruneDoesNotDoubleCountWorktrees(t *testing.T) {
 func TestCtrlRPrunesCompleted(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 	app.wtRoot = t.TempDir() // isolate from real worktrees
 
 	d.Add(&model.Task{ID: "t1", Name: "pending", Status: model.StatusPending, Project: "p", CreatedAt: time.Now()})
@@ -962,7 +962,7 @@ func TestCtrlRPrunesCompleted(t *testing.T) {
 func TestReconcileSkipsOnNilRunning(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	// Simulate daemon mode
 	app.daemonConnected = true
@@ -983,7 +983,7 @@ func TestReconcileSkipsOnNilRunning(t *testing.T) {
 func TestReconcileWorksOnEmptyRunning(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	// Simulate daemon mode
 	app.daemonConnected = true
@@ -1004,71 +1004,40 @@ func TestReconcileWorksOnEmptyRunning(t *testing.T) {
 	}
 }
 
-func TestReconcileFreshDaemonUsesInReview(t *testing.T) {
+func TestReconcileStaleSessionsFlipsInProgress(t *testing.T) {
 	d := testDB(t)
-	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, true) // daemonFreshStart = true
-
-	app.daemonConnected = true
 
 	d.Add(&model.Task{ID: "t1", Name: "was-running", Status: model.StatusInProgress, Project: "p", CreatedAt: time.Now()})
 	d.Add(&model.Task{ID: "t2", Name: "was-pending", Status: model.StatusPending, Project: "p", CreatedAt: time.Now()})
+	d.Add(&model.Task{ID: "t3", Name: "was-review", Status: model.StatusInReview, Project: "p", CreatedAt: time.Now()})
 
-	// Fresh daemon has no sessions — InProgress tasks should become InReview, not Complete.
-	app.refreshTasksWithIDs([]string{}, []string{})
+	n, err := agent.ReconcileStaleSessions(d)
+	if err != nil {
+		t.Fatalf("ReconcileStaleSessions: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("count = %d, want 1", n)
+	}
 
-	for _, task := range app.tasks {
+	tasks, _ := d.Tasks()
+	for _, task := range tasks {
 		switch task.ID {
 		case "t1":
 			if task.Status != model.StatusInReview {
-				t.Errorf("task %q: got status %s, want in_review (fresh daemon start)", task.Name, task.Status)
+				t.Errorf("task %q: got %s, want in_review", task.Name, task.Status)
 			}
 		case "t2":
 			if task.Status != model.StatusPending {
-				t.Errorf("task %q: got status %s, want pending (should not be affected)", task.Name, task.Status)
+				t.Errorf("task %q: got %s, want pending (untouched)", task.Name, task.Status)
 			}
-		}
-	}
-
-	// After first reconciliation, daemonFreshStart should be cleared.
-	if app.daemonFreshStart {
-		t.Error("daemonFreshStart should be cleared after first reconciliation")
-	}
-}
-
-func TestReconcileFreshDaemonClearsFlag(t *testing.T) {
-	d := testDB(t)
-	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, true) // daemonFreshStart = true
-
-	app.daemonConnected = true
-
-	d.Add(&model.Task{ID: "t1", Name: "task-a", Status: model.StatusInProgress, Project: "p", CreatedAt: time.Now()})
-
-	// First call: fresh start → InReview
-	app.refreshTasksWithIDs([]string{}, []string{})
-
-	// Add a new InProgress task after daemon is warmed up
-	d.Add(&model.Task{ID: "t2", Name: "task-b", Status: model.StatusInProgress, Project: "p", CreatedAt: time.Now()})
-
-	// Second call: flag cleared → should use Complete
-	app.refreshTasksWithIDs([]string{}, []string{})
-
-	for _, task := range app.tasks {
-		switch task.ID {
-		case "t1":
-			// t1 was reconciled to InReview on the first call and should stay there.
+		case "t3":
 			if task.Status != model.StatusInReview {
-				t.Errorf("task %q: got status %s, want in_review (should remain from first reconciliation)", task.Name, task.Status)
-			}
-		case "t2":
-			// t2 was added after the flag cleared — should use normal Complete path.
-			if task.Status != model.StatusComplete {
-				t.Errorf("task %q: got status %s, want complete (flag should be cleared after first reconciliation)", task.Name, task.Status)
+				t.Errorf("task %q: got %s, want in_review (untouched)", task.Name, task.Status)
 			}
 		}
 	}
 }
+
 
 // TestReconcileSkipsOnStaleStartGen and TestReconcileWorksWhenStartGenUnchanged
 // replicate the startGen guard logic from onTick's QueueUpdateDraw callback
@@ -1078,7 +1047,7 @@ func TestReconcileFreshDaemonClearsFlag(t *testing.T) {
 func TestReconcileSkipsOnStaleStartGen(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	app.daemonConnected = true
 
@@ -1113,7 +1082,7 @@ func TestReconcileSkipsOnStaleStartGen(t *testing.T) {
 func TestRefreshTasksAsyncStartGenGuard(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	app.daemonConnected = true
 
@@ -1144,7 +1113,7 @@ func TestRefreshTasksAsyncStartGenGuard(t *testing.T) {
 func TestReconcileWorksWhenStartGenUnchanged(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	app.daemonConnected = true
 
@@ -1168,7 +1137,7 @@ func TestReconcileWorksWhenStartGenUnchanged(t *testing.T) {
 func TestReconcileGracePeriodProtectsRecentStarts(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	app.daemonConnected = true
 
@@ -1193,7 +1162,7 @@ func TestReconcileGracePeriodProtectsRecentStarts(t *testing.T) {
 func TestReconcileGracePeriodExpiresAfterTimeout(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	app.daemonConnected = true
 
@@ -1207,26 +1176,6 @@ func TestReconcileGracePeriodExpiresAfterTimeout(t *testing.T) {
 	for _, task := range app.tasks {
 		if task.ID == "t1" {
 			testutil.Equal(t, task.Status, model.StatusComplete)
-		}
-	}
-}
-
-// TestReconcileFreshStartUsesInReview verifies that after a daemon restart,
-// stale InProgress tasks are reconciled to InReview (not Complete).
-func TestReconcileFreshStartUsesInReview(t *testing.T) {
-	d := testDB(t)
-	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, true) // daemonFreshStart=true
-
-	app.daemonConnected = true
-
-	d.Add(&model.Task{ID: "t1", Name: "stale-after-restart", Status: model.StatusInProgress, Project: "p", CreatedAt: time.Now()})
-
-	app.refreshTasksWithIDs([]string{}, []string{})
-
-	for _, task := range app.tasks {
-		if task.ID == "t1" {
-			testutil.Equal(t, task.Status, model.StatusInReview)
 		}
 	}
 }

--- a/internal/tui/clipboard_test.go
+++ b/internal/tui/clipboard_test.go
@@ -58,7 +58,7 @@ func (f *fakeProvider) setPayload(text string, present bool) {
 
 func TestRefreshClipboardCache_NoAccessor(t *testing.T) {
 	d := testDB(t)
-	app := New(d, agent.NewRunner(nil), false, false)
+	app := New(d, agent.NewRunner(nil), false)
 	// Plain runner is NOT a clipboardAccessor — refresh is a no-op.
 	app.refreshClipboardCache("task1")
 	testutil.Equal(t, app.clipboardPending, "")
@@ -69,7 +69,7 @@ func TestRefreshClipboardCache_PresentSetsHint(t *testing.T) {
 	d := testDB(t)
 	fp := newFakeProvider()
 	fp.setPayload("hello", true)
-	app := New(d, fp, false, false)
+	app := New(d, fp, false)
 
 	app.refreshClipboardCache("task1")
 	testutil.Equal(t, app.clipboardPending, "hello")
@@ -81,7 +81,7 @@ func TestRefreshClipboardCache_AbsentClearsHint(t *testing.T) {
 	d := testDB(t)
 	fp := newFakeProvider()
 	fp.setPayload("hi", true)
-	app := New(d, fp, false, false)
+	app := New(d, fp, false)
 
 	app.refreshClipboardCache("task1")
 	testutil.Equal(t, app.agentHeader.ClipboardHint(), true)
@@ -94,7 +94,7 @@ func TestRefreshClipboardCache_AbsentClearsHint(t *testing.T) {
 
 func TestCopyStagedClipboard_NoPayload(t *testing.T) {
 	d := testDB(t)
-	app := New(d, agent.NewRunner(nil), false, false)
+	app := New(d, agent.NewRunner(nil), false)
 
 	if app.copyStagedClipboard() {
 		t.Error("expected false when nothing staged")
@@ -104,7 +104,7 @@ func TestCopyStagedClipboard_NoPayload(t *testing.T) {
 func TestCopyStagedClipboard_ClearsLocalStateAndFiresClearRPC(t *testing.T) {
 	d := testDB(t)
 	fp := newFakeProvider()
-	app := New(d, fp, false, false)
+	app := New(d, fp, false)
 
 	app.clipboardPending = "snippet"
 	app.clipboardPendingTask = "abc123"
@@ -137,7 +137,7 @@ func TestCopyStagedClipboard_ClearError_LoggedNotPanicked(t *testing.T) {
 	d := testDB(t)
 	fp := newFakeProvider()
 	fp.clearErr = errors.New("rpc broken")
-	app := New(d, fp, false, false)
+	app := New(d, fp, false)
 
 	app.clipboardPending = "x"
 	app.clipboardPendingTask = "abc"

--- a/internal/tui/smoke_test.go
+++ b/internal/tui/smoke_test.go
@@ -229,7 +229,7 @@ func TestLazyScreen_EnableDisableDoesNotPanic(t *testing.T) {
 func TestSmoke_RestartDaemonPrompt_OpensAndSkips(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, true, false)
+	app := New(d, runner, true)
 
 	sim, stop := wireApp(t, app)
 	defer stop()
@@ -267,7 +267,7 @@ func TestSmoke_RestartDaemonPrompt_OpensAndSkips(t *testing.T) {
 func TestSetDaemonStale_StoresFlag(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, true, false)
+	app := New(d, runner, true)
 
 	if app.daemonStale {
 		t.Error("daemonStale should default to false")
@@ -294,7 +294,7 @@ func TestSetDaemonStale_StoresFlag(t *testing.T) {
 func TestSmoke_OpenRestartDaemonPromptBeforeRunDoesNotBlock(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, true, false)
+	app := New(d, runner, true)
 
 	tApp, _, ls := simApp(t)
 	app.tapp = tApp
@@ -327,7 +327,7 @@ func TestSmoke_OpenRestartDaemonPromptBeforeRunDoesNotBlock(t *testing.T) {
 func TestSmoke_TabSwitching(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	sim, stop := wireApp(t, app)
 	defer stop()
@@ -355,7 +355,7 @@ func TestSmoke_TabSwitching(t *testing.T) {
 func TestSmoke_NewTaskFormPaste(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 	// Ensure there's a project and backend for the form.
 	d.SetProject("test", config.Project{Path: t.TempDir()})
 
@@ -389,7 +389,7 @@ func TestSmoke_NewTaskFormPaste(t *testing.T) {
 func TestSmoke_AgentViewEnterExit(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	task := &model.Task{
 		ID:        "smoke-1",
@@ -428,7 +428,7 @@ func TestSmoke_AgentViewEnterExit(t *testing.T) {
 func TestSmoke_ExitAgentViewResetsTab(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	task := &model.Task{
 		ID:        "tab-reset-1",
@@ -471,7 +471,7 @@ func TestSmoke_ExitAgentViewResetsTab(t *testing.T) {
 func TestSmoke_LinkPickerFocusRestore(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	_, stop := wireApp(t, app)
 	defer stop()
@@ -508,7 +508,7 @@ func TestSmoke_LinkPickerFocusRestore(t *testing.T) {
 func TestSmoke_FuzzyLinkPickerLifecycle(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	sim, stop := wireApp(t, app)
 	defer stop()
@@ -539,7 +539,7 @@ func TestSmoke_FuzzyLinkPickerLifecycle(t *testing.T) {
 func TestSmoke_NewTaskFormEscape(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 	d.SetProject("test", config.Project{Path: t.TempDir()})
 
 	sim, stop := wireApp(t, app)
@@ -576,7 +576,7 @@ func TestSmoke_ForceRedrawOnTransitions(t *testing.T) {
 
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	task := &model.Task{
 		ID:        "redraw-1",
@@ -633,7 +633,7 @@ func TestSmoke_ForceRedrawOnTransitions(t *testing.T) {
 func TestSmoke_WaitingReviewToggle(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	task := &model.Task{
 		ID:        "wr-1",
@@ -671,7 +671,7 @@ func TestSmoke_WaitingReviewToggle(t *testing.T) {
 func TestSmoke_ClickNonInteractivePanelKeepsFocus(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
-	app := New(d, runner, false, false)
+	app := New(d, runner, false)
 
 	task := &model.Task{
 		ID:        "click-1",


### PR DESCRIPTION
The PWA showed "disconnected" forever for tasks marked `in_progress` in the
DB but with no session in the daemon's runner. The SSE endpoint returned 404
("no active session") and `/resume` rejected with 409 because status was
still `in_progress`. The reconciliation that unstuck these tasks lived only
in the TUI, so PWA-only or daemon-only sessions had no recovery path.

Move the sweep to the runner-holder: a new `agent.ReconcileStaleSessions(db)`
flips InProgress → InReview, called once at `daemon.Serve()` startup and
once at the in-process TUI fallback. By the time the TUI reconnects, the DB
is consistent — so the `daemonFreshStart` flag, the `Client.FreshStart()`
method, and the restart-side InProgress→Pending reset all become dead code
and are removed.

Simplifications:
- `tui.New()` drops its fourth bool arg.
- `dclient.Client` drops the `freshStart` field and accessor.
- `App.daemonFreshStart` field and its conditional reconciliation branch gone.
- `restartDaemon()` no longer manually flips statuses — daemon does it.

Tests:
- New `TestReconcileStaleSessionsFlipsInProgress` exercises the helper directly.
- Removed three obsolete TUI tests that asserted the daemonFreshStart flow.
- Mass-updated `tui.New(...)` callers to drop the dropped arg.

Net -39 lines across 8 files; full suite passes under `-race -count=1`.

Co-Authored-By: Claude <noreply@anthropic.com>