### PR TITLE
Add task_complete MCP tool + /argus-complete skill

### DIFF
--- a/.claude/skills/argus-complete/SKILL.md
+++ b/.claude/skills/argus-complete/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: argus-complete
+description: Mark the current Argus task as complete. Use when the work for the current worktree is done and the user wants the task to transition to the "complete" status.
+allowed-tools: mcp__argus__task_complete
+---
+
+# Mark Current Task Complete
+
+Mark the Argus task owning the current worktree as `complete`. This sets the task's status to `complete` and stamps `EndedAt`. It does **not** stop a running agent session — if an agent is still attached, the user should stop it separately first.
+
+## Context
+
+- Current directory: !`pwd`
+
+## Your task
+
+Call the `mcp__argus__task_complete` MCP tool with the working directory from the Context block above as the `cwd` argument:
+
+```
+mcp__argus__task_complete(cwd: "<pwd from context>")
+```
+
+Argus resolves the task from `cwd` by matching it against task worktree paths — the agent process does not know its own task ID, so `cwd` is the required hand-off.
+
+Do **not** pass `id` — the agent has no reliable way to know it.
+
+After the call, report the tool's response verbatim in one line. If the tool errors (e.g. "no task matches cwd"), show the error and stop; do not retry with guessed arguments. If the response says the task is already complete, surface that as-is and stop.

--- a/.claude/skills/argus-complete/SKILL.md
+++ b/.claude/skills/argus-complete/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools: mcp__argus__task_complete
 
 Mark the Argus task owning the current worktree as `complete`. This sets the task's status to `complete` and stamps `EndedAt`. It does **not** stop a running agent session — if an agent is still attached, the user should stop it separately first.
 
+This skill is **not** the same as `/archive`. `/archive` moves the task into the Archive section (a visibility flag, independent of status). `/argus-complete` transitions the workflow status to `complete`. Use `/argus-complete` when the work is finished; use `/archive` (separately, optionally) if you also want it removed from the active task list.
+
 ## Context
 
 - Current directory: !`pwd`

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ The MCP server exposes the following tools to connected agents:
 | `task_archive` | Archive or unarchive a task. Pass `cwd` (from the agent's `pwd`) to resolve the task by worktree, or `id`. Omit `archived` to toggle. |
 | `task_complete` | Mark a task as complete (sets status, stamps `EndedAt`). Pass `cwd` or `id`. Does NOT stop a running agent — call `task_stop` first if needed. No-op if already complete. |
 
-Task management tools enable an external agent (e.g. Claude Code running in another terminal) to programmatically launch and monitor Argus tasks via MCP. Sample skills at `.claude/skills/archive/SKILL.md` (calls `task_archive`) and `.claude/skills/argus-complete/SKILL.md` (calls `task_complete`) let an agent mark its own task done at the end of a session via `cwd` resolution.
+Task management tools enable an external agent (e.g. Claude Code running in another terminal) to programmatically launch and monitor Argus tasks via MCP. Sample skills at `.claude/skills/archive/SKILL.md` (calls `task_archive`, moves task to the Archive section) and `.claude/skills/argus-complete/SKILL.md` (calls `task_complete`, transitions status to "complete") let an agent finalize its own task at the end of a session via `cwd` resolution. The two are independent axes — completing a task does not archive it, and archiving does not change status.
 
 **Schedule Management** (recurring scheduled tasks):
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -266,8 +266,9 @@ The MCP server exposes the following tools to connected agents:
 | `task_get` | Get task details by `id` |
 | `task_stop` | Stop a running agent (moves task to "in review") |
 | `task_archive` | Archive or unarchive a task. Pass `cwd` (from the agent's `pwd`) to resolve the task by worktree, or `id`. Omit `archived` to toggle. |
+| `task_complete` | Mark a task as complete (sets status, stamps `EndedAt`). Pass `cwd` or `id`. Does NOT stop a running agent — call `task_stop` first if needed. No-op if already complete. |
 
-Task management tools enable an external agent (e.g. Claude Code running in another terminal) to programmatically launch and monitor Argus tasks via MCP. A sample `/archive` skill lives at `.claude/skills/archive/SKILL.md` — it calls `task_archive` with the current working directory so an agent can mark its own task done at the end of a session.
+Task management tools enable an external agent (e.g. Claude Code running in another terminal) to programmatically launch and monitor Argus tasks via MCP. Sample skills at `.claude/skills/archive/SKILL.md` (calls `task_archive`) and `.claude/skills/argus-complete/SKILL.md` (calls `task_complete`) let an agent mark its own task done at the end of a session via `cwd` resolution.
 
 **Schedule Management** (recurring scheduled tasks):
 | Tool | Description |

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1027,13 +1027,21 @@ func (s *Server) toolTaskComplete(id interface{}, args json.RawMessage) *Respons
 		return toolResult(id, fmt.Sprintf("Task %s (%s) already complete.", task.ID, task.Name))
 	}
 
+	// Read-then-write is not atomic — two concurrent task_complete calls can
+	// both read non-complete state and both stamp EndedAt; the second wins
+	// with a slightly later timestamp. Acceptable for a single-user local
+	// daemon.
+	prev := task.Status
 	task.SetStatus(model.StatusComplete)
+	// Mirror the TUI 'a' archive keybinding: completing a task means review
+	// is no longer pending, so clear the badge.
+	task.WaitingReview = false
 	if err := s.taskDB.Update(task); err != nil {
 		log.Printf("[mcp] task_complete failed: id=%s err=%v", task.ID, err)
 		return toolError(id, fmt.Sprintf("Failed to mark task complete: %v", err))
 	}
 
-	log.Printf("[mcp] task_complete ok: id=%s", task.ID)
+	log.Printf("[mcp] task_complete ok: id=%s prev=%s", task.ID, prev)
 	return toolResult(id, fmt.Sprintf("Marked task %s (%s) as complete.", task.ID, task.Name))
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -413,6 +413,19 @@ The agent process does not know its own task ID, so the task is resolved from th
 			},
 		},
 	},
+	{
+		Name: "task_complete",
+		Description: `Mark an Argus task as complete. Sets status to "complete" and stamps EndedAt.
+
+The agent process does not know its own task ID, so the task is resolved from the working directory: pass ` + "`cwd`" + ` and Argus finds the task whose worktree matches. Does NOT stop a running agent session — call ` + "`task_stop`" + ` first if needed. No-op when the task is already complete.`,
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"id":  map[string]interface{}{"type": "string", "description": "Task ID. If omitted, cwd is used to resolve the task."},
+				"cwd": map[string]interface{}{"type": "string", "description": "Working directory inside the task's worktree. Used when id is omitted."},
+			},
+		},
+	},
 }
 
 // clipboardToolDefs are exposed only when SetClipboard has been called AND
@@ -568,6 +581,8 @@ func (s *Server) handleToolsCall(req *Request) *Response {
 		return s.toolTaskStop(req.ID, params.Arguments)
 	case "task_archive":
 		return s.toolTaskArchive(req.ID, params.Arguments)
+	case "task_complete":
+		return s.toolTaskComplete(req.ID, params.Arguments)
 	case "argus_clipboard_set":
 		return s.toolClipboardSet(req.ID, params.Arguments)
 	case "schedule_list":
@@ -990,6 +1005,36 @@ func (s *Server) toolTaskArchive(id interface{}, args json.RawMessage) *Response
 	}
 	log.Printf("[mcp] task_archive ok: id=%s archived=%v", task.ID, newArchived)
 	return toolResult(id, fmt.Sprintf("%s task %s (%s).", action, task.ID, task.Name))
+}
+
+func (s *Server) toolTaskComplete(id interface{}, args json.RawMessage) *Response {
+	if !s.taskMgmtEnabled() {
+		return toolError(id, "task management not configured")
+	}
+
+	var p struct {
+		ID  string `json:"id"`
+		Cwd string `json:"cwd"`
+	}
+	json.Unmarshal(args, &p) //nolint:errcheck
+
+	task, err := s.resolveTask(p.ID, p.Cwd)
+	if err != nil {
+		return toolError(id, err.Error())
+	}
+
+	if task.Status == model.StatusComplete {
+		return toolResult(id, fmt.Sprintf("Task %s (%s) already complete.", task.ID, task.Name))
+	}
+
+	task.SetStatus(model.StatusComplete)
+	if err := s.taskDB.Update(task); err != nil {
+		log.Printf("[mcp] task_complete failed: id=%s err=%v", task.ID, err)
+		return toolError(id, fmt.Sprintf("Failed to mark task complete: %v", err))
+	}
+
+	log.Printf("[mcp] task_complete ok: id=%s", task.ID)
+	return toolResult(id, fmt.Sprintf("Marked task %s (%s) as complete.", task.ID, task.Name))
 }
 
 // toolClipboardSet stages text for the user to copy. Resolves the task via

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -505,14 +505,14 @@ func TestToolsList_WithTasks(t *testing.T) {
 	var list ToolsListResult
 	json.Unmarshal(result, &list) //nolint:errcheck
 
-	// 5 KB tools + 5 task tools = 10
-	testutil.Equal(t, len(list.Tools), 10)
+	// 5 KB tools + 6 task tools = 11
+	testutil.Equal(t, len(list.Tools), 11)
 
 	names := make(map[string]bool)
 	for _, tool := range list.Tools {
 		names[tool.Name] = true
 	}
-	for _, want := range []string{"task_create", "task_list", "task_get", "task_stop", "task_archive"} {
+	for _, want := range []string{"task_create", "task_list", "task_get", "task_stop", "task_archive", "task_complete"} {
 		if !names[want] {
 			t.Errorf("missing tool: %s", want)
 		}
@@ -742,7 +742,7 @@ func TestTaskCreate_RateLimit(t *testing.T) {
 func TestTaskTools_NotConfigured(t *testing.T) {
 	s := testServer() // no SetTaskManager
 
-	for _, tool := range []string{"task_create", "task_list", "task_get", "task_stop", "task_archive"} {
+	for _, tool := range []string{"task_create", "task_list", "task_get", "task_stop", "task_archive", "task_complete"} {
 		t.Run(tool, func(t *testing.T) {
 			resp := doRequest(t, s, "tools/call", ToolCallParams{
 				Name:      tool,
@@ -918,6 +918,88 @@ func TestTaskArchive(t *testing.T) {
 	})
 }
 
+func TestTaskComplete(t *testing.T) {
+	t.Run("by id", func(t *testing.T) {
+		s, taskDB, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_complete",
+			Arguments: json.RawMessage(`{"id": "abc123"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		testutil.Contains(t, cr.Content[0].Text, "Marked task")
+		got, _ := taskDB.Get("abc123")
+		testutil.Equal(t, got.Status, model.StatusComplete)
+		if got.EndedAt.IsZero() {
+			t.Error("EndedAt should be set when transitioning to complete")
+		}
+	})
+
+	t.Run("by cwd", func(t *testing.T) {
+		s, taskDB, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_complete",
+			Arguments: json.RawMessage(`{"cwd": "/tmp/worktrees/myapp/fix-login/internal/foo"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		got, _ := taskDB.Get("abc123")
+		testutil.Equal(t, got.Status, model.StatusComplete)
+	})
+
+	t.Run("already complete is no-op", func(t *testing.T) {
+		s, taskDB, _ := testServerWithTasks()
+		// def456 is seeded as StatusComplete; capture EndedAt to ensure it
+		// is not re-stamped on the no-op path.
+		seed, _ := taskDB.Get("def456")
+		seed.EndedAt = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		_ = taskDB.Update(seed)
+
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_complete",
+			Arguments: json.RawMessage(`{"id": "def456"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		testutil.Contains(t, cr.Content[0].Text, "already complete")
+		got, _ := taskDB.Get("def456")
+		testutil.Equal(t, got.EndedAt.Year(), 2020)
+	})
+
+	t.Run("missing id and cwd", func(t *testing.T) {
+		s, _, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_complete",
+			Arguments: json.RawMessage(`{}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "provide id or cwd")
+	})
+
+	t.Run("unknown id", func(t *testing.T) {
+		s, _, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_complete",
+			Arguments: json.RawMessage(`{"id": "nope"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "not found")
+	})
+}
+
 // --- Clipboard tool tests ---
 
 type mockClipboard struct {
@@ -948,8 +1030,8 @@ func TestToolsList_WithClipboard(t *testing.T) {
 	var list ToolsListResult
 	json.Unmarshal(result, &list) //nolint:errcheck
 
-	// 5 KB tools + 5 task tools + 1 clipboard tool = 11
-	testutil.Equal(t, len(list.Tools), 11)
+	// 5 KB tools + 6 task tools + 1 clipboard tool = 12
+	testutil.Equal(t, len(list.Tools), 12)
 
 	names := make(map[string]bool)
 	for _, tool := range list.Tools {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -975,6 +975,27 @@ func TestTaskComplete(t *testing.T) {
 		testutil.Equal(t, got.EndedAt.Year(), 2020)
 	})
 
+	t.Run("completing clears waiting_review", func(t *testing.T) {
+		s, taskDB, _ := testServerWithTasks()
+		seed, _ := taskDB.Get("abc123")
+		seed.WaitingReview = true
+		if err := taskDB.Update(seed); err != nil {
+			t.Fatalf("seed Update: %v", err)
+		}
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_complete",
+			Arguments: json.RawMessage(`{"id": "abc123"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		got, _ := taskDB.Get("abc123")
+		testutil.Equal(t, got.Status, model.StatusComplete)
+		testutil.Equal(t, got.WaitingReview, false)
+	})
+
 	t.Run("missing id and cwd", func(t *testing.T) {
 		s, _, _ := testServerWithTasks()
 		resp := doRequest(t, s, "tools/call", ToolCallParams{


### PR DESCRIPTION
## Summary

- New `task_complete` MCP tool: marks an Argus task complete via `id` or `cwd` resolution. Sets status to `complete`, stamps `EndedAt`, and clears `WaitingReview` (parity with `task_archive`). No-op if already complete; does NOT stop a running session — call `task_stop` first if needed.
- New `/argus-complete` Claude Code skill at `.claude/skills/argus-complete/SKILL.md` that calls the tool with the agent's pwd as `cwd`. Mirrored to `~/.dots/agents/skills/argus-complete/` for global discovery.
- README documents the new tool + skill and clarifies that `/archive` (visibility) and `/argus-complete` (status) are independent axes.

## Test plan

- [x] `go test -race -count=1 ./...` (full suite green)
- [x] `make vet`
- [x] New `TestTaskComplete` covers: by id, by cwd, already-complete no-op (preserves EndedAt), missing id+cwd, unknown id, WaitingReview clearing
- [ ] Restart argus daemon to pick up the new tool, then verify `/argus-complete` from inside a worktree

Co-Authored-By: Claude <noreply@anthropic.com>