### PR TITLE
Add one-shot scheduled tasks (run_once_at)

### DIFF
--- a/.claude/skills/argus-schedule/SKILL.md
+++ b/.claude/skills/argus-schedule/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: argus-schedule
-description: Manage recurring tasks in the local Argus daemon via its HTTP API. Use when the user wants to schedule a task locally in argus, create a cron-driven task, fire X every weekday/hour/morning, set up a recurring agent that needs local filesystem access (logs in ~/.argus, local databases, dotfiles), list or update existing argus schedules, or run an argus schedule now. Distinct from /schedule, which creates remote cloud routines without local access.
+description: Manage recurring or one-shot tasks in the local Argus daemon via its HTTP API. Use when the user wants to schedule a task locally in argus, create a cron-driven task, fire X every weekday/hour/morning, fire something once at a specific future time (one-shot via run_once_at), set up an agent that needs local filesystem access (logs in ~/.argus, local databases, dotfiles), list or update existing argus schedules, or run an argus schedule now. Distinct from /schedule, which creates remote cloud routines without local access.
 allowed-tools: Bash(curl *), Bash(cat *), Bash(jq *), Bash(test *), Bash(ls *)
 ---
 
@@ -63,13 +63,16 @@ Required from the user (ask one question collecting any missing pieces, do not i
 
 - **name** — short, human-readable. Will be suffixed with the fire timestamp on each run.
 - **project** — must match an existing argus project name from the projects list above. If the user gave a project that is not in the list, show the available names and stop.
-- **schedule** — cron expression. See the cron primer below.
+- **cadence** — exactly one of:
+  - **schedule** — cron expression for a recurring schedule. See the cron primer below.
+  - **run_once_at** — RFC3339 UTC timestamp (e.g. `2026-05-17T14:00:00Z`) for a single future run. Must be in the future. After firing, the row auto-disables — it stays in the list with `enabled=false` for inspection. The user can delete it once they have read the result.
 - **prompt** — what the agent should do at each fire. Multi-line is fine; pass it as a JSON string.
 - **backend** (optional) — overrides the default backend for this schedule. Only set if the user asked. Useful for forcing a cheaper model on a polling task.
 
 Build the JSON body with `jq` to handle quoting of multi-line prompts safely:
 
 ```
+# Recurring (cron):
 JSON=$(jq -n \
   --arg name "$NAME" \
   --arg project "$PROJECT" \
@@ -77,12 +80,22 @@ JSON=$(jq -n \
   --arg prompt "$PROMPT" \
   '{name:$name, project:$project, schedule:$schedule, prompt:$prompt, enabled:true}')
 
+# One-shot:
+JSON=$(jq -n \
+  --arg name "$NAME" \
+  --arg project "$PROJECT" \
+  --arg run_once_at "$WHEN_RFC3339" \
+  --arg prompt "$PROMPT" \
+  '{name:$name, project:$project, run_once_at:$run_once_at, prompt:$prompt, enabled:true}')
+
 curl -sS -X POST \
   -H "Authorization: Bearer $(cat ~/.argus/api-token)" \
   -H "Content-Type: application/json" \
   -d "$JSON" \
   http://localhost:7743/api/schedules | jq
 ```
+
+When the user gives a local time, convert to UTC RFC3339 before constructing `run_once_at`. Echo the converted UTC timestamp back for confirmation before posting.
 
 After the call, echo the returned `id`, `next_run_at`, and a one-line confirmation. Do not add `--data-raw` shortcuts that bypass jq — embedding raw user input into a shell-quoted JSON string is a quoting hazard.
 

--- a/README.md
+++ b/README.md
@@ -270,16 +270,16 @@ The MCP server exposes the following tools to connected agents:
 
 Task management tools enable an external agent (e.g. Claude Code running in another terminal) to programmatically launch and monitor Argus tasks via MCP. Sample skills at `.claude/skills/archive/SKILL.md` (calls `task_archive`, moves task to the Archive section) and `.claude/skills/argus-complete/SKILL.md` (calls `task_complete`, transitions status to "complete") let an agent finalize its own task at the end of a session via `cwd` resolution. The two are independent axes — completing a task does not archive it, and archiving does not change status.
 
-**Schedule Management** (recurring scheduled tasks):
+**Schedule Management** (recurring or one-shot scheduled tasks):
 | Tool | Description |
 |------|-------------|
 | `schedule_list` | List all schedules with name, project, cron expression, enabled state, and next/last fire timestamps |
-| `schedule_create` | Create a recurring schedule. Params: `name`, `project`, `prompt`, `schedule` (cron expression or `@every <duration>`); optional `backend`, `enabled` |
-| `schedule_update` | Partial update — pass `id` plus any fields to change. Useful for toggling `enabled` or rotating the prompt without rebuilding the schedule |
+| `schedule_create` | Create a schedule. Params: `name`, `project`, `prompt`, plus exactly one of `schedule` (cron expression or `@every <duration>`) or `run_once_at` (RFC3339 UTC timestamp for a single future run); optional `backend`, `enabled` |
+| `schedule_update` | Partial update — pass `id` plus any fields to change. Useful for toggling `enabled`, rotating the prompt, or converting between cron and one-shot (set the new field; the other clears automatically) |
 | `schedule_delete` | Remove a schedule by `id`. Tasks already created by previous fires are unaffected |
-| `schedule_run_now` | Fire a schedule immediately, out of cycle. Bookkeeping is updated so the next regular tick will not double-fire. Does NOT send a push notification — only cron-tick fires do |
+| `schedule_run_now` | Fire a schedule immediately, out of cycle. Bookkeeping is updated so the next regular tick will not double-fire. One-shot rows auto-disable after RunNow just as they would on natural-time fire. Does NOT send a push notification — only cron-tick fires do |
 
-Schedule tools mirror the HTTP `/api/schedules` surface so an agent can manage recurring tasks natively without going through curl. Project must match an existing Argus project; cron expressions accept the standard 5-field syntax, descriptors (`@hourly`, `@daily`, `@weekly`, `@monthly`, `@yearly`), and the `@every <duration>` shortcut. Minimum resolution is one minute.
+Schedule tools mirror the HTTP `/api/schedules` surface so an agent can manage recurring or one-shot tasks natively without going through curl. Project must match an existing Argus project. Cron expressions accept the standard 5-field syntax, descriptors (`@hourly`, `@daily`, `@weekly`, `@monthly`, `@yearly`), and the `@every <duration>` shortcut (minimum resolution: one minute). One-shot rows fire once at `run_once_at` then auto-disable — the row stays in the list with `enabled=false` for inspection; delete it manually when no longer needed.
 
 **Agent-Staged Clipboard:**
 | Tool | Description |

--- a/internal/api/schedules.go
+++ b/internal/api/schedules.go
@@ -260,8 +260,13 @@ func (s *Server) handleRunSchedule(w http.ResponseWriter, r *http.Request) {
 
 // applyScheduleRequest copies non-nil request fields onto the schedule
 // in-place. Used by both create (where every field starts zero) and update
-// (where unset fields stay as-is). Returns an error only when run_once_at
-// is malformed or in the past — Validate covers everything else.
+// (where unset fields stay as-is). Returns an error when run_once_at is
+// malformed/past, or when the caller passes both schedule and run_once_at
+// non-empty in a single request — exactly one cadence per call. When only
+// one is set, the OTHER cadence anchor is cleared automatically so the
+// caller doesn't have to know whether the row was previously recurring or
+// one-shot. Any future run_once_at is accepted; the next fire happens at
+// most one tick interval later, regardless of how close to now.
 func applyScheduleRequest(sched *model.ScheduledTask, req scheduleRequest) error {
 	if req.Name != nil {
 		sched.Name = strings.TrimSpace(*req.Name)
@@ -275,10 +280,16 @@ func applyScheduleRequest(sched *model.ScheduledTask, req scheduleRequest) error
 	if req.Backend != nil {
 		sched.Backend = strings.TrimSpace(*req.Backend)
 	}
+	// Reject ambiguous "both cadences in one call" up front. Validate would
+	// not catch this because the per-field clear logic below silently picks
+	// a winner.
+	bothSet := req.Schedule != nil && strings.TrimSpace(*req.Schedule) != "" &&
+		req.RunOnceAt != nil && strings.TrimSpace(*req.RunOnceAt) != ""
+	if bothSet {
+		return errors.New("specify either schedule (cron) or run_once_at, not both")
+	}
 	if req.Schedule != nil {
 		sched.Schedule = strings.TrimSpace(*req.Schedule)
-		// Setting a non-empty cron clears any stale one-shot anchor so the
-		// caller doesn't have to send both fields to switch cadences.
 		if sched.Schedule != "" {
 			sched.RunOnceAt = time.Time{}
 		}

--- a/internal/api/schedules.go
+++ b/internal/api/schedules.go
@@ -40,6 +40,7 @@ type scheduleJSON struct {
 	Prompt     string `json:"prompt"`
 	Backend    string `json:"backend,omitempty"`
 	Schedule   string `json:"schedule"`
+	RunOnceAt  string `json:"run_once_at,omitempty"`
 	Enabled    bool   `json:"enabled"`
 	CreatedAt  string `json:"created_at"`
 	LastRunAt  string `json:"last_run_at,omitempty"`
@@ -69,19 +70,24 @@ func toScheduleJSON(s *model.ScheduledTask) scheduleJSON {
 	if !s.NextRunAt.IsZero() {
 		js.NextRunAt = s.NextRunAt.Format("2006-01-02T15:04:05Z07:00")
 	}
+	if !s.RunOnceAt.IsZero() {
+		js.RunOnceAt = s.RunOnceAt.Format("2006-01-02T15:04:05Z07:00")
+	}
 	return js
 }
 
 // scheduleRequest is the wire shape for create/update bodies. All fields are
 // pointers on update so the SPA can do partial updates (e.g. toggle enabled
-// without resending the prompt).
+// without resending the prompt). RunOnceAt is RFC3339 UTC; pass empty string
+// to clear it when switching from one-shot back to recurring.
 type scheduleRequest struct {
-	Name     *string `json:"name,omitempty"`
-	Project  *string `json:"project,omitempty"`
-	Prompt   *string `json:"prompt,omitempty"`
-	Backend  *string `json:"backend,omitempty"`
-	Schedule *string `json:"schedule,omitempty"`
-	Enabled  *bool   `json:"enabled,omitempty"`
+	Name      *string `json:"name,omitempty"`
+	Project   *string `json:"project,omitempty"`
+	Prompt    *string `json:"prompt,omitempty"`
+	Backend   *string `json:"backend,omitempty"`
+	Schedule  *string `json:"schedule,omitempty"`
+	RunOnceAt *string `json:"run_once_at,omitempty"`
+	Enabled   *bool   `json:"enabled,omitempty"`
 }
 
 func (s *Server) handleListSchedules(w http.ResponseWriter, r *http.Request) {
@@ -119,17 +125,31 @@ func (s *Server) handleCreateSchedule(w http.ResponseWriter, r *http.Request) {
 	sched := &model.ScheduledTask{
 		Enabled: true, // default new schedules to enabled
 	}
-	applyScheduleRequest(sched, req)
+	if err := applyScheduleRequest(sched, req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
 	if err := sched.Validate(); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
+	// Pre-populate NextRunAt so the UI shows it before the first tick lands.
+	sched.NextRunAt = sched.NextFire(time.Now())
 	if err := s.db.AddSchedule(sched); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
-	uxlog.Log("[schedules] created %s (%s) schedule=%q project=%q enabled=%v", sched.ID, sched.Name, sched.Schedule, sched.Project, sched.Enabled)
+	uxlog.Log("[schedules] created %s (%s) schedule=%q run_once_at=%s project=%q enabled=%v", sched.ID, sched.Name, sched.Schedule, formatRunOnce(sched.RunOnceAt), sched.Project, sched.Enabled)
 	writeJSON(w, http.StatusCreated, toScheduleJSON(sched))
+}
+
+// formatRunOnce returns a stable string for log lines: RFC3339 UTC when set,
+// "-" otherwise. Keeps log greps simple.
+func formatRunOnce(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.UTC().Format(time.RFC3339)
 }
 
 func (s *Server) handleUpdateSchedule(w http.ResponseWriter, r *http.Request) {
@@ -156,19 +176,22 @@ func (s *Server) handleUpdateSchedule(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
-	applyScheduleRequest(sched, req)
+	if err := applyScheduleRequest(sched, req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
 	if err := sched.Validate(); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
-	if req.Schedule != nil {
-		// Schedule expression changed — recompute next-run. Anchor on
-		// LastRunAt when the schedule has fired before (so an unchanged
-		// cadence preserves alignment with prior fires); otherwise anchor
-		// on now. `cron.Schedule.Next(time.Time{})` returns a year-0001
-		// date, which the scheduler tick would read as "due now" and fire
-		// on the very next tick — violating the "no first-tick fire"
-		// invariant.
+	if req.Schedule != nil || req.RunOnceAt != nil {
+		// Cadence changed — recompute next-run. Anchor on LastRunAt when the
+		// schedule has fired before (so an unchanged cadence preserves
+		// alignment with prior fires); otherwise anchor on now.
+		// `cron.Schedule.Next(time.Time{})` returns a year-0001 date, which
+		// the scheduler tick would read as "due now" and fire on the very
+		// next tick — violating the "no first-tick fire" invariant.
+		// NextFire returns RunOnceAt directly for one-shots.
 		anchor := sched.LastRunAt
 		if anchor.IsZero() {
 			anchor = time.Now()
@@ -237,8 +260,9 @@ func (s *Server) handleRunSchedule(w http.ResponseWriter, r *http.Request) {
 
 // applyScheduleRequest copies non-nil request fields onto the schedule
 // in-place. Used by both create (where every field starts zero) and update
-// (where unset fields stay as-is).
-func applyScheduleRequest(sched *model.ScheduledTask, req scheduleRequest) {
+// (where unset fields stay as-is). Returns an error only when run_once_at
+// is malformed or in the past — Validate covers everything else.
+func applyScheduleRequest(sched *model.ScheduledTask, req scheduleRequest) error {
 	if req.Name != nil {
 		sched.Name = strings.TrimSpace(*req.Name)
 	}
@@ -253,8 +277,32 @@ func applyScheduleRequest(sched *model.ScheduledTask, req scheduleRequest) {
 	}
 	if req.Schedule != nil {
 		sched.Schedule = strings.TrimSpace(*req.Schedule)
+		// Setting a non-empty cron clears any stale one-shot anchor so the
+		// caller doesn't have to send both fields to switch cadences.
+		if sched.Schedule != "" {
+			sched.RunOnceAt = time.Time{}
+		}
+	}
+	if req.RunOnceAt != nil {
+		raw := strings.TrimSpace(*req.RunOnceAt)
+		var newAt time.Time
+		if raw != "" {
+			t, err := time.Parse(time.RFC3339, raw)
+			if err != nil {
+				return errors.New("run_once_at must be RFC3339 (e.g. 2026-05-17T14:00:00Z): " + err.Error())
+			}
+			if !t.After(time.Now()) {
+				return errors.New("run_once_at must be in the future")
+			}
+			newAt = t
+		}
+		sched.RunOnceAt = newAt
+		if !newAt.IsZero() {
+			sched.Schedule = ""
+		}
 	}
 	if req.Enabled != nil {
 		sched.Enabled = *req.Enabled
 	}
+	return nil
 }

--- a/internal/api/schedules_test.go
+++ b/internal/api/schedules_test.go
@@ -93,12 +93,17 @@ func TestScheduleHandlers_CreateValidates(t *testing.T) {
 	srv, _ := testServer(t)
 	handler := authMiddleware(srv.token, srv.db, nil, srv.routes())
 
+	future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
 	cases := map[string]string{
-		"missing-name":     `{"project":"p","prompt":"go","schedule":"@daily"}`,
-		"missing-project":  `{"name":"x","prompt":"go","schedule":"@daily"}`,
-		"missing-prompt":   `{"name":"x","project":"p","schedule":"@daily"}`,
-		"missing-schedule": `{"name":"x","project":"p","prompt":"go"}`,
-		"bad-schedule":     `{"name":"x","project":"p","prompt":"go","schedule":"foo bar baz"}`,
+		"missing-name":      `{"project":"p","prompt":"go","schedule":"@daily"}`,
+		"missing-project":   `{"name":"x","prompt":"go","schedule":"@daily"}`,
+		"missing-prompt":    `{"name":"x","project":"p","schedule":"@daily"}`,
+		"missing-cadence":   `{"name":"x","project":"p","prompt":"go"}`,
+		"bad-schedule":      `{"name":"x","project":"p","prompt":"go","schedule":"foo bar baz"}`,
+		"run-once-past":     `{"name":"x","project":"p","prompt":"go","run_once_at":"` + past + `"}`,
+		"run-once-bad-fmt":  `{"name":"x","project":"p","prompt":"go","run_once_at":"tomorrow"}`,
+		"both-cadences-set": `{"name":"x","project":"p","prompt":"go","schedule":"@daily","run_once_at":"` + future + `"}`,
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -108,6 +113,91 @@ func TestScheduleHandlers_CreateValidates(t *testing.T) {
 			testutil.Equal(t, w.Code, http.StatusBadRequest)
 		})
 	}
+}
+
+func TestScheduleHandlers_CreateOneShot(t *testing.T) {
+	srv, _ := testServer(t)
+	handler := authMiddleware(srv.token, srv.db, nil, srv.routes())
+
+	future := time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
+	body := `{"name":"once","project":"argus","prompt":"go","run_once_at":"` + future + `"}`
+	req := authedReq("POST", "/api/schedules", body)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusCreated)
+
+	var created scheduleJSON
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	testutil.Equal(t, created.Schedule, "")
+	if created.RunOnceAt == "" {
+		t.Error("expected run_once_at echoed back")
+	}
+	if created.NextRunAt == "" {
+		t.Error("expected next_run_at populated for one-shot")
+	}
+
+	// Verify DB row matches.
+	stored, _ := srv.db.GetSchedule(created.ID)
+	if stored.RunOnceAt.IsZero() {
+		t.Fatal("expected RunOnceAt persisted to DB")
+	}
+	if !stored.IsOneShot() {
+		t.Fatal("expected IsOneShot=true after persist")
+	}
+}
+
+func TestScheduleHandlers_UpdateCadenceSwitch(t *testing.T) {
+	srv, _ := testServer(t)
+	handler := authMiddleware(srv.token, srv.db, nil, srv.routes())
+
+	// Seed a recurring schedule.
+	body := `{"name":"r","project":"argus","prompt":"go","schedule":"@daily"}`
+	req := authedReq("POST", "/api/schedules", body)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	var created scheduleJSON
+	_ = json.Unmarshal(w.Body.Bytes(), &created)
+
+	t.Run("recurring to one-shot clears schedule", func(t *testing.T) {
+		future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+		req := authedReq("PUT", "/api/schedules/"+created.ID, `{"run_once_at":"`+future+`"}`)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		testutil.Equal(t, w.Code, http.StatusOK)
+
+		stored, _ := srv.db.GetSchedule(created.ID)
+		testutil.Equal(t, stored.Schedule, "")
+		if !stored.IsOneShot() {
+			t.Fatal("expected one-shot after switch")
+		}
+	})
+
+	t.Run("one-shot to recurring clears run_once_at", func(t *testing.T) {
+		req := authedReq("PUT", "/api/schedules/"+created.ID, `{"schedule":"@hourly"}`)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		testutil.Equal(t, w.Code, http.StatusOK)
+
+		stored, _ := srv.db.GetSchedule(created.ID)
+		testutil.Equal(t, stored.Schedule, "@hourly")
+		if stored.IsOneShot() {
+			t.Fatal("expected one-shot anchor cleared after switch")
+		}
+	})
+
+	t.Run("update with both cadences rejected", func(t *testing.T) {
+		future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+		body := `{"schedule":"@daily","run_once_at":"` + future + `"}`
+		req := authedReq("PUT", "/api/schedules/"+created.ID, body)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		testutil.Equal(t, w.Code, http.StatusBadRequest)
+		if !strings.Contains(w.Body.String(), "either") {
+			t.Errorf("expected error mentioning 'either', got %s", w.Body.String())
+		}
+	})
 }
 
 // Regression: editing the schedule expression of a never-run schedule must

--- a/internal/db/schedules.go
+++ b/internal/db/schedules.go
@@ -18,7 +18,7 @@ func (d *DB) Schedules() ([]*model.ScheduledTask, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	rows, err := d.conn.Query(`SELECT id, name, project, prompt, backend, schedule, enabled, created_at, last_run_at, next_run_at, last_task_id, last_error FROM scheduled_tasks ORDER BY name`)
+	rows, err := d.conn.Query(`SELECT id, name, project, prompt, backend, schedule, run_once_at, enabled, created_at, last_run_at, next_run_at, last_task_id, last_error FROM scheduled_tasks ORDER BY name`)
 	if err != nil {
 		return nil, fmt.Errorf("query schedules: %w", err)
 	}
@@ -40,7 +40,7 @@ func (d *DB) GetSchedule(id string) (*model.ScheduledTask, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	row := d.conn.QueryRow(`SELECT id, name, project, prompt, backend, schedule, enabled, created_at, last_run_at, next_run_at, last_task_id, last_error FROM scheduled_tasks WHERE id=?`, id)
+	row := d.conn.QueryRow(`SELECT id, name, project, prompt, backend, schedule, run_once_at, enabled, created_at, last_run_at, next_run_at, last_task_id, last_error FROM scheduled_tasks WHERE id=?`, id)
 	s, err := scanSchedule(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrScheduleNotFound
@@ -61,8 +61,8 @@ func (d *DB) AddSchedule(s *model.ScheduledTask) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	_, err := d.conn.Exec(`INSERT INTO scheduled_tasks (id, name, project, prompt, backend, schedule, enabled, created_at, last_run_at, next_run_at, last_task_id, last_error) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.ID, s.Name, s.Project, s.Prompt, s.Backend, s.Schedule, boolToInt(s.Enabled), formatTime(s.CreatedAt), formatTime(s.LastRunAt), formatTime(s.NextRunAt), s.LastTaskID, s.LastError)
+	_, err := d.conn.Exec(`INSERT INTO scheduled_tasks (id, name, project, prompt, backend, schedule, run_once_at, enabled, created_at, last_run_at, next_run_at, last_task_id, last_error) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.Name, s.Project, s.Prompt, s.Backend, s.Schedule, formatTime(s.RunOnceAt), boolToInt(s.Enabled), formatTime(s.CreatedAt), formatTime(s.LastRunAt), formatTime(s.NextRunAt), s.LastTaskID, s.LastError)
 	if err != nil {
 		return fmt.Errorf("insert schedule: %w", err)
 	}
@@ -74,8 +74,8 @@ func (d *DB) UpdateSchedule(s *model.ScheduledTask) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	res, err := d.conn.Exec(`UPDATE scheduled_tasks SET name=?, project=?, prompt=?, backend=?, schedule=?, enabled=?, last_run_at=?, next_run_at=?, last_task_id=?, last_error=? WHERE id=?`,
-		s.Name, s.Project, s.Prompt, s.Backend, s.Schedule, boolToInt(s.Enabled), formatTime(s.LastRunAt), formatTime(s.NextRunAt), s.LastTaskID, s.LastError, s.ID)
+	res, err := d.conn.Exec(`UPDATE scheduled_tasks SET name=?, project=?, prompt=?, backend=?, schedule=?, run_once_at=?, enabled=?, last_run_at=?, next_run_at=?, last_task_id=?, last_error=? WHERE id=?`,
+		s.Name, s.Project, s.Prompt, s.Backend, s.Schedule, formatTime(s.RunOnceAt), boolToInt(s.Enabled), formatTime(s.LastRunAt), formatTime(s.NextRunAt), s.LastTaskID, s.LastError, s.ID)
 	if err != nil {
 		return fmt.Errorf("update schedule: %w", err)
 	}
@@ -109,14 +109,15 @@ func scanSchedule(scanner interface {
 }) (*model.ScheduledTask, error) {
 	var s model.ScheduledTask
 	var enabled int
-	var createdAt, lastRunAt, nextRunAt string
-	if err := scanner.Scan(&s.ID, &s.Name, &s.Project, &s.Prompt, &s.Backend, &s.Schedule, &enabled, &createdAt, &lastRunAt, &nextRunAt, &s.LastTaskID, &s.LastError); err != nil {
+	var createdAt, lastRunAt, nextRunAt, runOnceAt string
+	if err := scanner.Scan(&s.ID, &s.Name, &s.Project, &s.Prompt, &s.Backend, &s.Schedule, &runOnceAt, &enabled, &createdAt, &lastRunAt, &nextRunAt, &s.LastTaskID, &s.LastError); err != nil {
 		return nil, err
 	}
 	s.Enabled = enabled != 0
 	s.CreatedAt = parseTime(createdAt)
 	s.LastRunAt = parseTime(lastRunAt)
 	s.NextRunAt = parseTime(nextRunAt)
+	s.RunOnceAt = parseTime(runOnceAt)
 	return &s, nil
 }
 

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -165,7 +165,8 @@ func (d *DB) createTables() error {
 			project      TEXT NOT NULL,
 			prompt       TEXT NOT NULL,
 			backend      TEXT NOT NULL DEFAULT '',
-			schedule     TEXT NOT NULL,
+			schedule     TEXT NOT NULL DEFAULT '',
+			run_once_at  TEXT NOT NULL DEFAULT '',
 			enabled      INTEGER NOT NULL DEFAULT 1,
 			created_at   TEXT NOT NULL,
 			last_run_at  TEXT NOT NULL DEFAULT '',
@@ -176,6 +177,9 @@ func (d *DB) createTables() error {
 	`); err != nil {
 		return fmt.Errorf("creating scheduled_tasks table: %w", err)
 	}
+
+	// Add run_once_at column to existing scheduled_tasks tables. Idempotent.
+	d.conn.Exec(`ALTER TABLE scheduled_tasks ADD COLUMN run_once_at TEXT NOT NULL DEFAULT ''`) //nolint:errcheck
 
 	return nil
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -496,18 +496,18 @@ var scheduleToolDefs = []Tool{
 	},
 	{
 		Name: "schedule_update",
-		Description: `Partial update of a scheduled task. Only fields you pass are changed; omit a field to leave it as-is. Changing the schedule expression recomputes next_run_at. Useful for toggling enabled without resending the prompt. To convert between recurring and one-shot, set the new field and the old one will be cleared (passing both is rejected).`,
+		Description: `Partial update of a scheduled task. Only fields you pass are changed; omit a field to leave it as-is. Changing the cadence (schedule or run_once_at) recomputes next_run_at. To convert between recurring and one-shot, set the new field — the other clears automatically. Passing both schedule and run_once_at non-empty in the same call is rejected with an error.`,
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
 				"id":          map[string]interface{}{"type": "string", "description": "Schedule ID (from schedule_list)."},
-				"name":        map[string]interface{}{"type": "string"},
-				"project":     map[string]interface{}{"type": "string"},
-				"prompt":      map[string]interface{}{"type": "string"},
+				"name":        map[string]interface{}{"type": "string", "description": "Display name. Each fire suffixes this with the UTC timestamp."},
+				"project":     map[string]interface{}{"type": "string", "description": "Project name (must exist in Argus config)."},
+				"prompt":      map[string]interface{}{"type": "string", "description": "Instructions delivered to the agent at each fire."},
 				"schedule":    map[string]interface{}{"type": "string", "description": "Cron expression. Pass empty string to clear when switching to a one-shot."},
 				"run_once_at": map[string]interface{}{"type": "string", "description": "RFC3339 UTC timestamp. Pass empty string to clear when switching to a recurring schedule."},
-				"backend":     map[string]interface{}{"type": "string"},
-				"enabled":     map[string]interface{}{"type": "boolean"},
+				"backend":     map[string]interface{}{"type": "string", "description": "Backend override (e.g. 'claude-haiku'). Empty string clears the override."},
+				"enabled":     map[string]interface{}{"type": "boolean", "description": "Toggle on/off without resending the prompt. Re-enabling a one-shot whose RunOnceAt is in the past does NOT cause it to fire again — LastRunAt is the definitive guard."},
 			},
 			"required": []string{"id"},
 		},
@@ -1249,6 +1249,12 @@ func (s *Server) toolScheduleUpdate(id interface{}, args json.RawMessage) *Respo
 	if err != nil {
 		return toolError(id, fmt.Sprintf("schedule not found: %s", p.ID))
 	}
+	// Reject ambiguous "both cadences in one call" up front. Per-field
+	// auto-clear below would otherwise silently pick a winner by ordering.
+	if p.Schedule != nil && strings.TrimSpace(*p.Schedule) != "" &&
+		p.RunOnceAt != nil && strings.TrimSpace(*p.RunOnceAt) != "" {
+		return toolError(id, "specify either schedule (cron) or run_once_at, not both")
+	}
 	cadenceChanged := false
 	if p.Name != nil {
 		sched.Name = strings.TrimSpace(*p.Name)
@@ -1265,8 +1271,9 @@ func (s *Server) toolScheduleUpdate(id interface{}, args json.RawMessage) *Respo
 			cadenceChanged = true
 		}
 		sched.Schedule = newExpr
-		// Setting a non-empty cron expression clears any one-shot anchor —
-		// Validate() rejects both being set, and we want a clean transition.
+		// Setting a non-empty cron expression clears any one-shot anchor.
+		// The both-set guard above ensures this clear is never hiding an
+		// explicit user-supplied run_once_at.
 		if newExpr != "" {
 			sched.RunOnceAt = time.Time{}
 		}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -479,33 +479,35 @@ var scheduleToolDefs = []Tool{
 	},
 	{
 		Name: "schedule_create",
-		Description: `Create a recurring scheduled task. The cron expression is parsed by robfig/cron/v3 ParseStandard: 5-field cron (e.g. "0 9 * * 1-5" for 9am weekdays), descriptors (@hourly, @daily, @weekly, @monthly, @yearly), or @every <duration> (e.g. "@every 1h"). Minimum resolution is one minute. Project must match an existing Argus project. New schedules default to enabled.`,
+		Description: `Create a scheduled task. Pass either ` + "`schedule`" + ` (cron expression for recurring runs) OR ` + "`run_once_at`" + ` (RFC3339 UTC timestamp for a single future run) — exactly one. The cron expression is parsed by robfig/cron/v3 ParseStandard: 5-field cron (e.g. "0 9 * * 1-5" for 9am weekdays UTC), descriptors (@hourly, @daily, @weekly, @monthly, @yearly), or @every <duration> (e.g. "@every 1h"). Minimum cron resolution is one minute. One-shot rows fire once at run_once_at then auto-disable (the row stays in the list with enabled=false for inspection). Project must match an existing Argus project. New schedules default to enabled.`,
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
-				"name":     map[string]interface{}{"type": "string", "description": "Display name. Each fire suffixes this with the UTC timestamp."},
-				"project":  map[string]interface{}{"type": "string", "description": "Project name (must exist in Argus config)."},
-				"prompt":   map[string]interface{}{"type": "string", "description": "Instructions delivered to the agent at each fire."},
-				"schedule": map[string]interface{}{"type": "string", "description": "Cron expression. See description for accepted formats."},
-				"backend":  map[string]interface{}{"type": "string", "description": "Optional backend override for this schedule (e.g. 'claude-haiku')."},
-				"enabled":  map[string]interface{}{"type": "boolean", "description": "Optional. Defaults to true."},
+				"name":         map[string]interface{}{"type": "string", "description": "Display name. Each fire suffixes this with the UTC timestamp."},
+				"project":      map[string]interface{}{"type": "string", "description": "Project name (must exist in Argus config)."},
+				"prompt":       map[string]interface{}{"type": "string", "description": "Instructions delivered to the agent at each fire."},
+				"schedule":     map[string]interface{}{"type": "string", "description": "Cron expression. Mutually exclusive with run_once_at."},
+				"run_once_at":  map[string]interface{}{"type": "string", "description": "RFC3339 UTC timestamp (e.g. \"2026-05-17T14:00:00Z\"). Must be in the future. Mutually exclusive with schedule."},
+				"backend":      map[string]interface{}{"type": "string", "description": "Optional backend override for this schedule (e.g. 'claude-haiku')."},
+				"enabled":      map[string]interface{}{"type": "boolean", "description": "Optional. Defaults to true."},
 			},
-			"required": []string{"name", "project", "prompt", "schedule"},
+			"required": []string{"name", "project", "prompt"},
 		},
 	},
 	{
 		Name: "schedule_update",
-		Description: `Partial update of a scheduled task. Only fields you pass are changed; omit a field to leave it as-is. Changing the schedule expression recomputes next_run_at. Useful for toggling enabled without resending the prompt.`,
+		Description: `Partial update of a scheduled task. Only fields you pass are changed; omit a field to leave it as-is. Changing the schedule expression recomputes next_run_at. Useful for toggling enabled without resending the prompt. To convert between recurring and one-shot, set the new field and the old one will be cleared (passing both is rejected).`,
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
-				"id":       map[string]interface{}{"type": "string", "description": "Schedule ID (from schedule_list)."},
-				"name":     map[string]interface{}{"type": "string"},
-				"project":  map[string]interface{}{"type": "string"},
-				"prompt":   map[string]interface{}{"type": "string"},
-				"schedule": map[string]interface{}{"type": "string"},
-				"backend":  map[string]interface{}{"type": "string"},
-				"enabled":  map[string]interface{}{"type": "boolean"},
+				"id":          map[string]interface{}{"type": "string", "description": "Schedule ID (from schedule_list)."},
+				"name":        map[string]interface{}{"type": "string"},
+				"project":     map[string]interface{}{"type": "string"},
+				"prompt":      map[string]interface{}{"type": "string"},
+				"schedule":    map[string]interface{}{"type": "string", "description": "Cron expression. Pass empty string to clear when switching to a one-shot."},
+				"run_once_at": map[string]interface{}{"type": "string", "description": "RFC3339 UTC timestamp. Pass empty string to clear when switching to a recurring schedule."},
+				"backend":     map[string]interface{}{"type": "string"},
+				"enabled":     map[string]interface{}{"type": "boolean"},
 			},
 			"required": []string{"id"},
 		},
@@ -1175,12 +1177,13 @@ func (s *Server) toolScheduleCreate(id interface{}, args json.RawMessage) *Respo
 		return toolError(id, "schedule management not configured")
 	}
 	var p struct {
-		Name     string `json:"name"`
-		Project  string `json:"project"`
-		Prompt   string `json:"prompt"`
-		Schedule string `json:"schedule"`
-		Backend  string `json:"backend"`
-		Enabled  *bool  `json:"enabled"`
+		Name      string `json:"name"`
+		Project   string `json:"project"`
+		Prompt    string `json:"prompt"`
+		Schedule  string `json:"schedule"`
+		RunOnceAt string `json:"run_once_at"`
+		Backend   string `json:"backend"`
+		Enabled   *bool  `json:"enabled"`
 	}
 	json.Unmarshal(args, &p) //nolint:errcheck
 
@@ -1191,6 +1194,16 @@ func (s *Server) toolScheduleCreate(id interface{}, args json.RawMessage) *Respo
 		Schedule: strings.TrimSpace(p.Schedule),
 		Backend:  strings.TrimSpace(p.Backend),
 		Enabled:  true, // default
+	}
+	if raw := strings.TrimSpace(p.RunOnceAt); raw != "" {
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			return toolError(id, fmt.Sprintf("run_once_at must be RFC3339 (e.g. 2026-05-17T14:00:00Z): %v", err))
+		}
+		if !t.After(time.Now()) {
+			return toolError(id, "run_once_at must be in the future")
+		}
+		sched.RunOnceAt = t
 	}
 	if p.Enabled != nil {
 		sched.Enabled = *p.Enabled
@@ -1204,9 +1217,13 @@ func (s *Server) toolScheduleCreate(id interface{}, args json.RawMessage) *Respo
 		log.Printf("[mcp] schedule_create failed: %v", err)
 		return toolError(id, fmt.Sprintf("Failed to create schedule: %v", err))
 	}
-	log.Printf("[mcp] schedule_create ok: id=%s name=%s schedule=%q", sched.ID, sched.Name, sched.Schedule)
-	return toolResult(id, fmt.Sprintf("Schedule created.\n\n- **ID**: %s\n- **Name**: %s\n- **Schedule**: %s\n- **Project**: %s\n- **Enabled**: %v\n- **Next run**: %s",
-		sched.ID, sched.Name, sched.Schedule, sched.Project, sched.Enabled, formatScheduleTime(sched.NextRunAt)))
+	cadence := sched.Schedule
+	if sched.IsOneShot() {
+		cadence = "once @ " + sched.RunOnceAt.UTC().Format(time.RFC3339)
+	}
+	log.Printf("[mcp] schedule_create ok: id=%s name=%s cadence=%q", sched.ID, sched.Name, cadence)
+	return toolResult(id, fmt.Sprintf("Schedule created.\n\n- **ID**: %s\n- **Name**: %s\n- **Cadence**: %s\n- **Project**: %s\n- **Enabled**: %v\n- **Next run**: %s",
+		sched.ID, sched.Name, cadence, sched.Project, sched.Enabled, formatScheduleTime(sched.NextRunAt)))
 }
 
 func (s *Server) toolScheduleUpdate(id interface{}, args json.RawMessage) *Response {
@@ -1214,13 +1231,14 @@ func (s *Server) toolScheduleUpdate(id interface{}, args json.RawMessage) *Respo
 		return toolError(id, "schedule management not configured")
 	}
 	var p struct {
-		ID       string  `json:"id"`
-		Name     *string `json:"name"`
-		Project  *string `json:"project"`
-		Prompt   *string `json:"prompt"`
-		Schedule *string `json:"schedule"`
-		Backend  *string `json:"backend"`
-		Enabled  *bool   `json:"enabled"`
+		ID        string  `json:"id"`
+		Name      *string `json:"name"`
+		Project   *string `json:"project"`
+		Prompt    *string `json:"prompt"`
+		Schedule  *string `json:"schedule"`
+		RunOnceAt *string `json:"run_once_at"`
+		Backend   *string `json:"backend"`
+		Enabled   *bool   `json:"enabled"`
 	}
 	json.Unmarshal(args, &p) //nolint:errcheck
 
@@ -1231,7 +1249,7 @@ func (s *Server) toolScheduleUpdate(id interface{}, args json.RawMessage) *Respo
 	if err != nil {
 		return toolError(id, fmt.Sprintf("schedule not found: %s", p.ID))
 	}
-	scheduleChanged := false
+	cadenceChanged := false
 	if p.Name != nil {
 		sched.Name = strings.TrimSpace(*p.Name)
 	}
@@ -1244,9 +1262,36 @@ func (s *Server) toolScheduleUpdate(id interface{}, args json.RawMessage) *Respo
 	if p.Schedule != nil {
 		newExpr := strings.TrimSpace(*p.Schedule)
 		if newExpr != sched.Schedule {
-			scheduleChanged = true
+			cadenceChanged = true
 		}
 		sched.Schedule = newExpr
+		// Setting a non-empty cron expression clears any one-shot anchor —
+		// Validate() rejects both being set, and we want a clean transition.
+		if newExpr != "" {
+			sched.RunOnceAt = time.Time{}
+		}
+	}
+	if p.RunOnceAt != nil {
+		raw := strings.TrimSpace(*p.RunOnceAt)
+		var newAt time.Time
+		if raw != "" {
+			t, err := time.Parse(time.RFC3339, raw)
+			if err != nil {
+				return toolError(id, fmt.Sprintf("run_once_at must be RFC3339 (e.g. 2026-05-17T14:00:00Z): %v", err))
+			}
+			if !t.After(time.Now()) {
+				return toolError(id, "run_once_at must be in the future")
+			}
+			newAt = t
+		}
+		if !sched.RunOnceAt.Equal(newAt) {
+			cadenceChanged = true
+		}
+		sched.RunOnceAt = newAt
+		// Setting a non-zero one-shot anchor clears any cron expression.
+		if !newAt.IsZero() {
+			sched.Schedule = ""
+		}
 	}
 	if p.Backend != nil {
 		sched.Backend = strings.TrimSpace(*p.Backend)
@@ -1257,10 +1302,10 @@ func (s *Server) toolScheduleUpdate(id interface{}, args json.RawMessage) *Respo
 	if err := sched.Validate(); err != nil {
 		return toolError(id, err.Error())
 	}
-	if scheduleChanged {
+	if cadenceChanged {
 		// Anchor on LastRunAt when previously fired so an unchanged cadence
 		// preserves alignment; otherwise anchor on now. Mirrors the API's
-		// recompute path.
+		// recompute path. NextFire returns RunOnceAt directly for one-shots.
 		anchor := sched.LastRunAt
 		if anchor.IsZero() {
 			anchor = time.Now()
@@ -1272,9 +1317,13 @@ func (s *Server) toolScheduleUpdate(id interface{}, args json.RawMessage) *Respo
 		log.Printf("[mcp] schedule_update failed: id=%s err=%v", sched.ID, err)
 		return toolError(id, fmt.Sprintf("Failed to update schedule: %v", err))
 	}
-	log.Printf("[mcp] schedule_update ok: id=%s schedule=%q enabled=%v", sched.ID, sched.Schedule, sched.Enabled)
-	return toolResult(id, fmt.Sprintf("Schedule updated.\n\n- **ID**: %s\n- **Name**: %s\n- **Schedule**: %s\n- **Enabled**: %v\n- **Next run**: %s",
-		sched.ID, sched.Name, sched.Schedule, sched.Enabled, formatScheduleTime(sched.NextRunAt)))
+	cadence := sched.Schedule
+	if sched.IsOneShot() {
+		cadence = "once @ " + sched.RunOnceAt.UTC().Format(time.RFC3339)
+	}
+	log.Printf("[mcp] schedule_update ok: id=%s cadence=%q enabled=%v", sched.ID, cadence, sched.Enabled)
+	return toolResult(id, fmt.Sprintf("Schedule updated.\n\n- **ID**: %s\n- **Name**: %s\n- **Cadence**: %s\n- **Enabled**: %v\n- **Next run**: %s",
+		sched.ID, sched.Name, cadence, sched.Enabled, formatScheduleTime(sched.NextRunAt)))
 }
 
 func (s *Server) toolScheduleDelete(id interface{}, args json.RawMessage) *Response {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1417,6 +1417,82 @@ func TestScheduleCreate(t *testing.T) {
 		}
 		testutil.Equal(t, found.Enabled, false)
 	})
+
+	t.Run("one-shot run_once_at", func(t *testing.T) {
+		future := time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
+		body := fmt.Sprintf(`{"name":"once","project":"myapp","prompt":"go","run_once_at":%q}`, future)
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "schedule_create",
+			Arguments: json.RawMessage(body),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		var found *model.ScheduledTask
+		for _, sch := range store.schedules {
+			if sch.Name == "once" {
+				found = sch
+				break
+			}
+		}
+		if found == nil {
+			t.Fatal("one-shot schedule not found")
+		}
+		if !found.IsOneShot() {
+			t.Error("expected IsOneShot=true")
+		}
+		testutil.Equal(t, found.Schedule, "")
+		if found.RunOnceAt.IsZero() {
+			t.Error("expected RunOnceAt populated")
+		}
+		testutil.Contains(t, cr.Content[0].Text, "once @")
+	})
+
+	t.Run("run_once_at in the past rejected", func(t *testing.T) {
+		past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+		body := fmt.Sprintf(`{"name":"old","project":"myapp","prompt":"go","run_once_at":%q}`, past)
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "schedule_create",
+			Arguments: json.RawMessage(body),
+		})
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "future")
+	})
+
+	t.Run("run_once_at malformed rejected", func(t *testing.T) {
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "schedule_create",
+			Arguments: json.RawMessage(`{"name":"bad","project":"myapp","prompt":"go","run_once_at":"tomorrow"}`),
+		})
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "RFC3339")
+	})
+
+	t.Run("both schedule and run_once_at rejected", func(t *testing.T) {
+		future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+		body := fmt.Sprintf(`{"name":"both","project":"myapp","prompt":"go","schedule":"@daily","run_once_at":%q}`, future)
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "schedule_create",
+			Arguments: json.RawMessage(body),
+		})
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "either")
+	})
+
+	t.Run("missing both cadences rejected", func(t *testing.T) {
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "schedule_create",
+			Arguments: json.RawMessage(`{"name":"x","project":"myapp","prompt":"go"}`),
+		})
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "required")
+	})
 }
 
 func TestScheduleUpdate(t *testing.T) {
@@ -1477,6 +1553,64 @@ func TestScheduleUpdate(t *testing.T) {
 		cr := callResult(t, resp)
 		testutil.Equal(t, cr.IsError, true)
 		testutil.Contains(t, cr.Content[0].Text, "schedule not found")
+	})
+
+	t.Run("convert recurring to one-shot clears schedule", func(t *testing.T) {
+		future := time.Now().Add(3 * time.Hour).UTC().Format(time.RFC3339)
+		body := fmt.Sprintf(`{"id":"existing-1","run_once_at":%q}`, future)
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "schedule_update",
+			Arguments: json.RawMessage(body),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		got, _ := store.GetSchedule("existing-1")
+		testutil.Equal(t, got.Schedule, "")
+		if !got.IsOneShot() {
+			t.Error("expected IsOneShot=true after conversion")
+		}
+	})
+
+	t.Run("convert one-shot to recurring clears run_once_at", func(t *testing.T) {
+		// Seed a one-shot row to convert.
+		future := time.Now().Add(time.Hour)
+		store.schedules = append(store.schedules, &model.ScheduledTask{
+			ID:        "to-convert",
+			Name:      "to-convert",
+			Project:   "myapp",
+			Prompt:    "x",
+			RunOnceAt: future,
+			Enabled:   true,
+		})
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "schedule_update",
+			Arguments: json.RawMessage(`{"id":"to-convert","schedule":"@daily"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		got, _ := store.GetSchedule("to-convert")
+		testutil.Equal(t, got.Schedule, "@daily")
+		if got.IsOneShot() {
+			t.Error("expected one-shot anchor cleared after conversion")
+		}
+	})
+
+	t.Run("run_once_at past rejected on update", func(t *testing.T) {
+		past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+		body := fmt.Sprintf(`{"id":"existing-1","run_once_at":%q}`, past)
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "schedule_update",
+			Arguments: json.RawMessage(body),
+		})
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "future")
 	})
 }
 

--- a/internal/model/schedule.go
+++ b/internal/model/schedule.go
@@ -8,13 +8,18 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
-// ScheduledTask defines a recurring task: at each cron firing the daemon
+// ScheduledTask defines a scheduled task that fires either on a recurring
+// cron expression OR once at a specific timestamp. At each fire the daemon
 // creates a fresh task in Project using Prompt (and optionally Backend), the
 // same way the new-task form or vault watcher does.
 //
 // Schedule is parsed by github.com/robfig/cron/v3 with ParseStandard
 // (5-field cron + descriptors @hourly/@daily/@weekly/@monthly/@yearly and
-// @every <duration>).
+// @every <duration>). One-shot rows leave Schedule empty and set RunOnceAt;
+// after firing, the scheduler sets Enabled=false so the row is preserved
+// for inspection but never fires again.
+//
+// Exactly one of Schedule and RunOnceAt must be set. Validate enforces this.
 type ScheduledTask struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`
@@ -22,6 +27,7 @@ type ScheduledTask struct {
 	Prompt    string    `json:"prompt"`
 	Backend   string    `json:"backend,omitempty"`
 	Schedule  string    `json:"schedule"`
+	RunOnceAt time.Time `json:"run_once_at,omitempty"`
 	Enabled   bool      `json:"enabled"`
 	CreatedAt time.Time `json:"created_at"`
 
@@ -30,6 +36,12 @@ type ScheduledTask struct {
 	NextRunAt  time.Time `json:"next_run_at,omitempty"`
 	LastTaskID string    `json:"last_task_id,omitempty"`
 	LastError  string    `json:"last_error,omitempty"`
+}
+
+// IsOneShot returns true if this row fires once at RunOnceAt rather than
+// on a recurring cron expression.
+func (s *ScheduledTask) IsOneShot() bool {
+	return !s.RunOnceAt.IsZero()
 }
 
 // scheduleParser is a package-global parser configured to accept the standard
@@ -50,8 +62,9 @@ func ParseSchedule(expr string) (cron.Schedule, error) {
 	return scheduleParser.Parse(expr)
 }
 
-// Validate returns nil if the schedule's required fields are set and Schedule
-// parses cleanly.
+// Validate returns nil if the schedule's required fields are set, exactly
+// one of Schedule and RunOnceAt is provided, and Schedule (when used) parses
+// cleanly.
 func (s *ScheduledTask) Validate() error {
 	if strings.TrimSpace(s.Name) == "" {
 		return errors.New("name is required")
@@ -62,15 +75,33 @@ func (s *ScheduledTask) Validate() error {
 	if strings.TrimSpace(s.Prompt) == "" {
 		return errors.New("prompt is required")
 	}
-	if _, err := ParseSchedule(s.Schedule); err != nil {
-		return err
+	hasCron := strings.TrimSpace(s.Schedule) != ""
+	hasOnce := !s.RunOnceAt.IsZero()
+	if hasCron && hasOnce {
+		return errors.New("specify either schedule (cron) or run_once_at, not both")
+	}
+	if !hasCron && !hasOnce {
+		return errors.New("schedule (cron) or run_once_at is required")
+	}
+	if hasCron {
+		if _, err := ParseSchedule(s.Schedule); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-// NextFire returns the next time this schedule fires after `after`. Returns
-// the zero time when the schedule cannot be parsed.
+// NextFire returns the next time this schedule fires after `after`. For
+// recurring rows it consults the cron expression. For one-shot rows it
+// returns RunOnceAt itself when still in the future, else the zero time.
+// Returns the zero time when the schedule cannot be parsed.
 func (s *ScheduledTask) NextFire(after time.Time) time.Time {
+	if s.IsOneShot() {
+		if s.RunOnceAt.After(after) {
+			return s.RunOnceAt
+		}
+		return time.Time{}
+	}
 	sched, err := ParseSchedule(s.Schedule)
 	if err != nil {
 		return time.Time{}

--- a/internal/model/schedule_test.go
+++ b/internal/model/schedule_test.go
@@ -38,6 +38,11 @@ func TestScheduledTaskValidate(t *testing.T) {
 		t.Fatalf("good schedule rejected: %v", err)
 	}
 
+	goodOnce := &ScheduledTask{Name: "x", Project: "p", Prompt: "go", RunOnceAt: time.Now().Add(time.Hour)}
+	if err := goodOnce.Validate(); err != nil {
+		t.Fatalf("good one-shot rejected: %v", err)
+	}
+
 	cases := []struct {
 		name string
 		s    *ScheduledTask
@@ -47,6 +52,12 @@ func TestScheduledTaskValidate(t *testing.T) {
 		{"missing-project", &ScheduledTask{Name: "x", Prompt: "go", Schedule: "@daily"}, "project"},
 		{"missing-prompt", &ScheduledTask{Name: "x", Project: "p", Schedule: "@daily"}, "prompt"},
 		{"bad-schedule", &ScheduledTask{Name: "x", Project: "p", Prompt: "go", Schedule: "bogus"}, ""},
+		{"missing-cadence", &ScheduledTask{Name: "x", Project: "p", Prompt: "go"}, "schedule"},
+		{
+			"both-cadences",
+			&ScheduledTask{Name: "x", Project: "p", Prompt: "go", Schedule: "@daily", RunOnceAt: time.Now().Add(time.Hour)},
+			"either schedule",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -72,5 +83,35 @@ func TestNextFire(t *testing.T) {
 	bad := &ScheduledTask{Schedule: "garbage"}
 	if !bad.NextFire(now).IsZero() {
 		t.Fatal("expected zero time for bad schedule")
+	}
+
+	t.Run("one-shot future", func(t *testing.T) {
+		anchor := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+		fire := anchor.Add(2 * time.Hour)
+		s := &ScheduledTask{RunOnceAt: fire}
+		got := s.NextFire(anchor)
+		if !got.Equal(fire) {
+			t.Fatalf("expected %v, got %v", fire, got)
+		}
+	})
+
+	t.Run("one-shot past returns zero", func(t *testing.T) {
+		anchor := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+		fire := anchor.Add(-time.Hour)
+		s := &ScheduledTask{RunOnceAt: fire}
+		if !s.NextFire(anchor).IsZero() {
+			t.Fatal("expected zero for past one-shot")
+		}
+	})
+}
+
+func TestIsOneShot(t *testing.T) {
+	cron := &ScheduledTask{Schedule: "@daily"}
+	if cron.IsOneShot() {
+		t.Error("cron schedule should not be one-shot")
+	}
+	once := &ScheduledTask{RunOnceAt: time.Now().Add(time.Hour)}
+	if !once.IsOneShot() {
+		t.Error("non-zero RunOnceAt should be one-shot")
 	}
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -227,13 +227,21 @@ func (s *Scheduler) tickOne(sched *model.ScheduledTask, now time.Time) {
 }
 
 // tickOneShot handles a one-shot scheduled task. Fires when now >= RunOnceAt
-// and the row is enabled, then auto-disables so it cannot fire again. Already-
-// disabled rows are left untouched so the user can inspect a past one-shot
-// without it firing on next-tick if the system clock jumps backward.
+// and the row is enabled, then auto-disables so it cannot fire again.
+//
+// LastRunAt is the definitive "already fired" guard: once set, the row is
+// preserved for inspection and never fires again — even if the user toggles
+// Enabled back to true. Without this guard, re-enabling a row whose
+// RunOnceAt is in the past would silently produce a duplicate task on the
+// next tick.
 //
 // NextRunAt mirrors RunOnceAt for the UI until the row fires; afterwards it
-// is cleared so the "next run" column shows blank.
+// stays cleared because we early-return before the populate path.
 func (s *Scheduler) tickOneShot(sched *model.ScheduledTask, now time.Time) {
+	// Already fired — preserved for inspection only.
+	if !sched.LastRunAt.IsZero() {
+		return
+	}
 	shouldFire := sched.Enabled && !now.Before(sched.RunOnceAt)
 
 	if shouldFire {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -107,11 +107,18 @@ func (s *Scheduler) Stop() {
 
 // RunNow fires the schedule with the given ID immediately, regardless of
 // when its next scheduled fire is. Bookkeeping is updated so the regular
-// tick won't fire again immediately afterwards.
+// tick won't fire again immediately afterwards. For one-shot rows, RunNow
+// also disables the row after firing — same auto-disable behaviour as the
+// natural-time fire path.
 func (s *Scheduler) RunNow(id string) (*model.Task, error) {
 	sched, err := s.db.GetSchedule(id)
 	if err != nil {
 		return nil, err
+	}
+	if sched.IsOneShot() {
+		s.fireMu.Lock()
+		defer s.fireMu.Unlock()
+		return s.fire(sched, nil, s.now())
 	}
 	parsed, perr := model.ParseSchedule(sched.Schedule)
 	if perr != nil {
@@ -143,7 +150,14 @@ func (s *Scheduler) tick() {
 
 // tickOne handles a single schedule: validate the cron expression, decide
 // whether to fire, fire if due, and persist next/last bookkeeping.
+//
+// One-shot rows (RunOnceAt set) take a separate path: they fire once when
+// now >= RunOnceAt, then auto-disable. They never recompute NextRunAt.
 func (s *Scheduler) tickOne(sched *model.ScheduledTask, now time.Time) {
+	if sched.IsOneShot() {
+		s.tickOneShot(sched, now)
+		return
+	}
 	parsed, err := model.ParseSchedule(sched.Schedule)
 	if err != nil {
 		// Persist the parse error and skip; a malformed schedule shouldn't
@@ -212,11 +226,58 @@ func (s *Scheduler) tickOne(sched *model.ScheduledTask, now time.Time) {
 	}
 }
 
+// tickOneShot handles a one-shot scheduled task. Fires when now >= RunOnceAt
+// and the row is enabled, then auto-disables so it cannot fire again. Already-
+// disabled rows are left untouched so the user can inspect a past one-shot
+// without it firing on next-tick if the system clock jumps backward.
+//
+// NextRunAt mirrors RunOnceAt for the UI until the row fires; afterwards it
+// is cleared so the "next run" column shows blank.
+func (s *Scheduler) tickOneShot(sched *model.ScheduledTask, now time.Time) {
+	shouldFire := sched.Enabled && !now.Before(sched.RunOnceAt)
+
+	if shouldFire {
+		s.fireMu.Lock()
+		latest, gErr := s.db.GetSchedule(sched.ID)
+		if gErr == nil {
+			*sched = *latest
+		}
+		stillDue := sched.Enabled && sched.IsOneShot() && !now.Before(sched.RunOnceAt)
+		if !stillDue {
+			s.fireMu.Unlock()
+			return
+		}
+		task, fErr := s.fire(sched, nil, now)
+		s.fireMu.Unlock()
+		if fErr != nil {
+			return
+		}
+		if task != nil {
+			if cb := s.fireCallback(); cb != nil {
+				cb(task)
+			}
+		}
+		return
+	}
+
+	// Not firing — populate NextRunAt for the UI when still pending.
+	desired := sched.RunOnceAt
+	if !sched.NextRunAt.Equal(desired) || sched.LastError != "" {
+		sched.NextRunAt = desired
+		sched.LastError = ""
+		if err := s.db.UpdateSchedule(sched); err != nil {
+			uxlog.Log("[scheduler] persist one-shot next_run_at %s: %v", sched.ID, err)
+		}
+	}
+}
+
 // fire creates the task for the given schedule and updates bookkeeping.
 // The caller is responsible for honouring sched.Enabled — fire itself does
-// not consult Enabled because RunNow bypasses that check. Callers MUST
-// hold fireMu so concurrent invocations against the same row cannot
-// double-fire.
+// not consult Enabled because RunNow bypasses that check. For recurring
+// rows, callers pass the parsed cron schedule for NextRunAt computation;
+// for one-shot rows, parsed is nil and the row auto-disables on success.
+// Callers MUST hold fireMu so concurrent invocations against the same row
+// cannot double-fire.
 func (s *Scheduler) fire(sched *model.ScheduledTask, parsed cron.Schedule, now time.Time) (*model.Task, error) {
 	// Generate a unique-per-fire name so worktree creation can't collide
 	// with the previous fire still being open.
@@ -230,7 +291,13 @@ func (s *Scheduler) fire(sched *model.ScheduledTask, parsed cron.Schedule, now t
 	if err != nil {
 		sched.LastError = err.Error()
 		sched.LastRunAt = now
-		sched.NextRunAt = parsed.Next(now)
+		if parsed != nil {
+			sched.NextRunAt = parsed.Next(now)
+		} else {
+			// One-shot: keep RunOnceAt visible in the UI on failure so the
+			// user can see what was scheduled.
+			sched.NextRunAt = sched.RunOnceAt
+		}
 		if uErr := s.db.UpdateSchedule(sched); uErr != nil {
 			uxlog.Log("[scheduler] persist fire error %s: %v", sched.ID, uErr)
 		}
@@ -241,7 +308,14 @@ func (s *Scheduler) fire(sched *model.ScheduledTask, parsed cron.Schedule, now t
 	sched.LastRunAt = now
 	sched.LastTaskID = task.ID
 	sched.LastError = ""
-	sched.NextRunAt = parsed.Next(now)
+	if parsed != nil {
+		sched.NextRunAt = parsed.Next(now)
+	} else {
+		// One-shot fired successfully: disable so it cannot fire again, and
+		// clear NextRunAt so the UI shows no future run.
+		sched.Enabled = false
+		sched.NextRunAt = time.Time{}
+	}
 	if uErr := s.db.UpdateSchedule(sched); uErr != nil {
 		uxlog.Log("[scheduler] persist post-fire %s: %v", sched.ID, uErr)
 	}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -465,6 +465,43 @@ func TestOneShotFireFailurePreservesEnabled(t *testing.T) {
 	}
 }
 
+func TestOneShotReenabledDoesNotRefire(t *testing.T) {
+	s, d, rec, clk := newTestScheduler(t)
+	sched := &model.ScheduledTask{
+		Name:      "once",
+		Project:   "p",
+		Prompt:    "do",
+		RunOnceAt: clk.now.Add(time.Minute),
+		Enabled:   true,
+	}
+	if err := d.AddSchedule(sched); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fire it.
+	clk.Advance(2 * time.Minute)
+	s.tick()
+	testutil.Equal(t, len(rec.calls), 1)
+
+	// Manually re-enable. RunOnceAt is unchanged (still in the past).
+	got, _ := d.GetSchedule(sched.ID)
+	got.Enabled = true
+	if err := d.UpdateSchedule(got); err != nil {
+		t.Fatal(err)
+	}
+
+	// Subsequent ticks must not fire again — LastRunAt guards.
+	clk.Advance(time.Hour)
+	s.tick()
+	testutil.Equal(t, len(rec.calls), 1)
+
+	// And NextRunAt must stay cleared on the fired row.
+	got, _ = d.GetSchedule(sched.ID)
+	if !got.NextRunAt.IsZero() {
+		t.Fatalf("expected NextRunAt cleared on fired row, got %v", got.NextRunAt)
+	}
+}
+
 func TestOneShotRunNow(t *testing.T) {
 	s, d, rec, clk := newTestScheduler(t)
 	sched := &model.ScheduledTask{

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -379,3 +379,109 @@ func TestSchedulerRunNowWithBackendOverride(t *testing.T) {
 	}
 	testutil.Equal(t, rec.calls[0].Backend, "codex")
 }
+
+func TestOneShotFiresOnceThenAutoDisables(t *testing.T) {
+	s, d, rec, clk := newTestScheduler(t)
+	fireAt := clk.now.Add(5 * time.Minute)
+	sched := &model.ScheduledTask{
+		Name:      "once",
+		Project:   "p",
+		Prompt:    "do once",
+		RunOnceAt: fireAt,
+		Enabled:   true,
+	}
+	if err := d.AddSchedule(sched); err != nil {
+		t.Fatal(err)
+	}
+
+	// First tick: not yet due. NextRunAt is populated to mirror RunOnceAt.
+	s.tick()
+	testutil.Equal(t, len(rec.calls), 0)
+	got, _ := d.GetSchedule(sched.ID)
+	if !got.NextRunAt.Equal(fireAt) {
+		t.Fatalf("expected NextRunAt to mirror RunOnceAt before fire, got %v", got.NextRunAt)
+	}
+	testutil.Equal(t, got.Enabled, true)
+
+	// Advance past RunOnceAt and tick — fires exactly once.
+	clk.Advance(10 * time.Minute)
+	s.tick()
+	testutil.Equal(t, len(rec.calls), 1)
+
+	got, _ = d.GetSchedule(sched.ID)
+	testutil.Equal(t, got.Enabled, false)
+	if !got.NextRunAt.IsZero() {
+		t.Fatalf("expected NextRunAt cleared after one-shot fire, got %v", got.NextRunAt)
+	}
+	if got.LastTaskID == "" {
+		t.Error("expected LastTaskID set after fire")
+	}
+
+	// Subsequent ticks must not fire again — Enabled=false guards.
+	clk.Advance(time.Hour)
+	s.tick()
+	testutil.Equal(t, len(rec.calls), 1)
+}
+
+func TestOneShotDisabledDoesNotFire(t *testing.T) {
+	s, d, rec, clk := newTestScheduler(t)
+	sched := &model.ScheduledTask{
+		Name:      "once-off",
+		Project:   "p",
+		Prompt:    "do",
+		RunOnceAt: clk.now.Add(-time.Minute), // already in the past
+		Enabled:   false,
+	}
+	if err := d.AddSchedule(sched); err != nil {
+		t.Fatal(err)
+	}
+	s.tick()
+	testutil.Equal(t, len(rec.calls), 0)
+}
+
+func TestOneShotFireFailurePreservesEnabled(t *testing.T) {
+	s, d, rec, clk := newTestScheduler(t)
+	rec.failNext = errors.New("create failed")
+	sched := &model.ScheduledTask{
+		Name:      "once-fail",
+		Project:   "p",
+		Prompt:    "do",
+		RunOnceAt: clk.now.Add(-time.Minute), // already due
+		Enabled:   true,
+	}
+	if err := d.AddSchedule(sched); err != nil {
+		t.Fatal(err)
+	}
+	s.tick()
+	got, _ := d.GetSchedule(sched.ID)
+	// Failed fire: Enabled stays true so the user (or next tick) can retry.
+	// LastError is populated for visibility.
+	testutil.Equal(t, got.Enabled, true)
+	if got.LastError == "" {
+		t.Error("expected LastError populated after failed fire")
+	}
+	if got.NextRunAt.IsZero() {
+		t.Error("expected NextRunAt to remain populated after failed one-shot fire")
+	}
+}
+
+func TestOneShotRunNow(t *testing.T) {
+	s, d, rec, clk := newTestScheduler(t)
+	sched := &model.ScheduledTask{
+		Name:      "once-rn",
+		Project:   "p",
+		Prompt:    "do",
+		RunOnceAt: clk.now.Add(time.Hour), // future — RunNow bypasses
+		Enabled:   true,
+	}
+	if err := d.AddSchedule(sched); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.RunNow(sched.ID); err != nil {
+		t.Fatal(err)
+	}
+	testutil.Equal(t, len(rec.calls), 1)
+
+	got, _ := d.GetSchedule(sched.ID)
+	testutil.Equal(t, got.Enabled, false) // auto-disabled even via RunNow
+}


### PR DESCRIPTION
## Summary

- New `RunOnceAt` field on `ScheduledTask`, mutually exclusive with cron `Schedule`. Fires once at the timestamp, then auto-disables. `LastRunAt` is the definitive guard: re-enabling a fired one-shot does NOT re-fire it.
- HTTP `/api/schedules` create/update accept `run_once_at` (RFC3339 UTC). Past or malformed timestamps rejected. Setting one cadence clears the other automatically; passing both non-empty in a single call is rejected.
- MCP `schedule_create` + `schedule_update` accept `run_once_at` with the same semantics. Tool descriptions disambiguate cadence-switch behaviour.
- DB schema gains `run_once_at TEXT NOT NULL DEFAULT ''` via idempotent ALTER.
- Scheduler grows a separate `tickOneShot` path; `fire()` branches on a nil `parsed` for one-shots and auto-disables on success.
- README + `/argus-schedule` skill updated.

## Test plan

- [x] `go test -race -count=1 ./...` (full suite green)
- [x] `make vet`
- [x] Coverage: model XOR validation, scheduler one-shot fire + auto-disable, fire-failure preserves enabled, RunNow auto-disable, re-enable-after-fire safety, MCP one-shot create + past/bad/both rejection + cadence-switch update, HTTP one-shot create + cadence-switch + both-rejection
- [ ] Restart argus daemon, then create a one-shot via `/argus-schedule` and confirm it fires within one tick of the timestamp

## Notes

Addresses /review feedback in 2nd commit: LastRunAt-as-fired-guard prevents duplicate fires from re-enable, both-cadence rejection unified across HTTP+MCP, parameter descriptions filled in, and a scheduler comment corrected.

Co-Authored-By: Claude <noreply@anthropic.com>