### PR TITLE
Add task_rename MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ The MCP server exposes the following tools to connected agents:
 | `task_get` | Get task details by `id` |
 | `task_stop` | Stop a running agent (moves task to "in review") |
 | `task_archive` | Archive or unarchive a task. Pass `cwd` (from the agent's `pwd`) to resolve the task by worktree, or `id`. Omit `archived` to toggle. |
-| `task_rename` | Rename a task. Updates only the display name (branch and worktree paths stay locked to the original slug). Pass `cwd` or `id` plus `name`. |
+| `task_rename` | Rename a task. Updates only the display name (branch and worktree paths stay locked to the original slug). Pass `cwd` or `id` plus `name`. No-op if the new name matches the current one. |
 | `task_complete` | Mark a task as complete (sets status, stamps `EndedAt`). Pass `cwd` or `id`. Does NOT stop a running agent — call `task_stop` first if needed. No-op if already complete. |
 
 Task management tools enable an external agent (e.g. Claude Code running in another terminal) to programmatically launch and monitor Argus tasks via MCP. Sample skills at `.claude/skills/archive/SKILL.md` (calls `task_archive`, moves task to the Archive section) and `.claude/skills/argus-complete/SKILL.md` (calls `task_complete`, transitions status to "complete") let an agent finalize its own task at the end of a session via `cwd` resolution. The two are independent axes — completing a task does not archive it, and archiving does not change status.

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ The MCP server exposes the following tools to connected agents:
 | `task_get` | Get task details by `id` |
 | `task_stop` | Stop a running agent (moves task to "in review") |
 | `task_archive` | Archive or unarchive a task. Pass `cwd` (from the agent's `pwd`) to resolve the task by worktree, or `id`. Omit `archived` to toggle. |
+| `task_rename` | Rename a task. Updates only the display name (branch and worktree paths stay locked to the original slug). Pass `cwd` or `id` plus `name`. |
 | `task_complete` | Mark a task as complete (sets status, stamps `EndedAt`). Pass `cwd` or `id`. Does NOT stop a running agent — call `task_stop` first if needed. No-op if already complete. |
 
 Task management tools enable an external agent (e.g. Claude Code running in another terminal) to programmatically launch and monitor Argus tasks via MCP. Sample skills at `.claude/skills/archive/SKILL.md` (calls `task_archive`, moves task to the Archive section) and `.claude/skills/argus-complete/SKILL.md` (calls `task_complete`, transitions status to "complete") let an agent finalize its own task at the end of a session via `cwd` resolution. The two are independent axes — completing a task does not archive it, and archiving does not change status.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -507,12 +507,13 @@ func (s *Server) handleRenameTask(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
 		return
 	}
-	task.Name = name
-	if err := s.db.Update(task); err != nil {
+	// Targeted rename — avoids racing concurrent status changes from the
+	// agent process. Mirrors the MCP task_rename and TUI rename modal paths.
+	if err := s.db.Rename(task.ID, name); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"name": task.Name})
+	writeJSON(w, http.StatusOK, map[string]string{"name": name})
 }
 
 // --- Set Status ---

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -75,6 +75,11 @@ type ScheduleRunner interface {
 // to prevent unbounded process spawning from a misbehaving MCP client.
 const maxConcurrentCreates = 5
 
+// maxTaskNameRunes caps task display names. SQLite TEXT is unbounded and
+// the request body limit (4 MiB) would let pathologically long names through;
+// 200 runes comfortably covers any human-typeable name across every UI.
+const maxTaskNameRunes = 200
+
 // Server is the MCP HTTP server.
 type Server struct {
 	db          KBQuerier
@@ -1150,6 +1155,12 @@ func (s *Server) toolTaskRename(id interface{}, args json.RawMessage) *Response 
 	if name == "" {
 		return toolError(id, "name is required")
 	}
+	// Defensive cap: the request body limit (4 MiB) is the only other
+	// ceiling, and a 4 MiB task name would render unusably across every UI
+	// surface. 200 runes comfortably covers any human-typeable name.
+	if len([]rune(name)) > maxTaskNameRunes {
+		return toolError(id, fmt.Sprintf("name exceeds %d runes", maxTaskNameRunes))
+	}
 
 	task, err := s.resolveTask(p.ID, p.Cwd)
 	if err != nil {
@@ -1157,7 +1168,7 @@ func (s *Server) toolTaskRename(id interface{}, args json.RawMessage) *Response 
 	}
 
 	if name == task.Name {
-		return toolResult(id, fmt.Sprintf("Task %s already named %q.", task.ID, task.Name))
+		return toolResult(id, fmt.Sprintf("Task %s (%s) already named %q.", task.ID, task.Name, name))
 	}
 
 	prev := task.Name

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -39,6 +39,9 @@ type TaskStore interface {
 	Tasks() ([]*model.Task, error)
 	Get(id string) (*model.Task, error)
 	Update(t *model.Task) error
+	// Rename updates only the name column — used by task_rename to avoid
+	// racing with concurrent status changes from the agent process.
+	Rename(id, name string) error
 }
 
 // TaskStopper can stop a running agent session.
@@ -519,6 +522,21 @@ The agent process does not know its own task ID, so the task is resolved from th
 		},
 	},
 	{
+		Name: "task_rename",
+		Description: `Rename an Argus task. Updates only the display name — branch and worktree paths stay locked to the original slug.
+
+Pass ` + "`id`" + ` to target a task explicitly, or ` + "`cwd`" + ` to resolve the task from a working directory inside its worktree (the agent process does not know its own task ID). ` + "`name`" + ` is required.`,
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"id":   map[string]interface{}{"type": "string", "description": "Task ID. If omitted, cwd is used to resolve the task."},
+				"cwd":  map[string]interface{}{"type": "string", "description": "Working directory inside the task's worktree. Used when id is omitted."},
+				"name": map[string]interface{}{"type": "string", "description": "New display name. Whitespace-trimmed; must be non-empty."},
+			},
+			"required": []string{"name"},
+		},
+	},
+	{
 		Name: "task_complete",
 		Description: `Mark an Argus task as complete. Sets status to "complete" and stamps EndedAt.
 
@@ -688,6 +706,8 @@ func (s *Server) handleToolsCall(req *Request) *Response {
 		return s.toolTaskStop(req.ID, params.Arguments)
 	case "task_archive":
 		return s.toolTaskArchive(req.ID, params.Arguments)
+	case "task_rename":
+		return s.toolTaskRename(req.ID, params.Arguments)
 	case "task_complete":
 		return s.toolTaskComplete(req.ID, params.Arguments)
 	case "argus_clipboard_set":
@@ -1112,6 +1132,42 @@ func (s *Server) toolTaskArchive(id interface{}, args json.RawMessage) *Response
 	}
 	log.Printf("[mcp] task_archive ok: id=%s archived=%v", task.ID, newArchived)
 	return toolResult(id, fmt.Sprintf("%s task %s (%s).", action, task.ID, task.Name))
+}
+
+func (s *Server) toolTaskRename(id interface{}, args json.RawMessage) *Response {
+	if !s.taskMgmtEnabled() {
+		return toolError(id, "task management not configured")
+	}
+
+	var p struct {
+		ID   string `json:"id"`
+		Cwd  string `json:"cwd"`
+		Name string `json:"name"`
+	}
+	json.Unmarshal(args, &p) //nolint:errcheck
+
+	name := strings.TrimSpace(p.Name)
+	if name == "" {
+		return toolError(id, "name is required")
+	}
+
+	task, err := s.resolveTask(p.ID, p.Cwd)
+	if err != nil {
+		return toolError(id, err.Error())
+	}
+
+	if name == task.Name {
+		return toolResult(id, fmt.Sprintf("Task %s already named %q.", task.ID, task.Name))
+	}
+
+	prev := task.Name
+	if err := s.taskDB.Rename(task.ID, name); err != nil {
+		log.Printf("[mcp] task_rename failed: id=%s err=%v", task.ID, err)
+		return toolError(id, fmt.Sprintf("Failed to rename task: %v", err))
+	}
+
+	log.Printf("[mcp] task_rename ok: id=%s prev=%q new=%q", task.ID, prev, name)
+	return toolResult(id, fmt.Sprintf("Renamed task %s: %q → %q.", task.ID, prev, name))
 }
 
 func (s *Server) toolTaskComplete(id interface{}, args json.RawMessage) *Response {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1291,6 +1291,20 @@ func TestTaskRename(t *testing.T) {
 		testutil.Equal(t, cr.IsError, true)
 		testutil.Contains(t, cr.Content[0].Text, "task not found")
 	})
+
+	t.Run("name too long rejected", func(t *testing.T) {
+		s, _, _ := testServerWithTasks()
+		long := strings.Repeat("a", maxTaskNameRunes+1)
+		args, _ := json.Marshal(map[string]string{"id": "abc123", "name": long})
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_rename",
+			Arguments: args,
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "exceeds")
+	})
 }
 
 // --- Clipboard tool tests ---

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -587,6 +587,16 @@ func (m *mockTaskDB) Update(t *model.Task) error {
 	return fmt.Errorf("not found")
 }
 
+func (m *mockTaskDB) Rename(id, name string) error {
+	for _, t := range m.tasks {
+		if t.ID == id {
+			t.Name = name
+			return nil
+		}
+	}
+	return fmt.Errorf("not found")
+}
+
 type mockStopper struct {
 	stopped []string
 }
@@ -659,14 +669,14 @@ func TestToolsList_WithTasks(t *testing.T) {
 	var list ToolsListResult
 	json.Unmarshal(result, &list) //nolint:errcheck
 
-	// 5 KB tools + 6 task tools = 11
-	testutil.Equal(t, len(list.Tools), 11)
+	// 5 KB tools + 7 task tools = 12
+	testutil.Equal(t, len(list.Tools), 12)
 
 	names := make(map[string]bool)
 	for _, tool := range list.Tools {
 		names[tool.Name] = true
 	}
-	for _, want := range []string{"task_create", "task_list", "task_get", "task_stop", "task_archive", "task_complete"} {
+	for _, want := range []string{"task_create", "task_list", "task_get", "task_stop", "task_archive", "task_rename", "task_complete"} {
 		if !names[want] {
 			t.Errorf("missing tool: %s", want)
 		}
@@ -896,7 +906,7 @@ func TestTaskCreate_RateLimit(t *testing.T) {
 func TestTaskTools_NotConfigured(t *testing.T) {
 	s := testServer() // no SetTaskManager
 
-	for _, tool := range []string{"task_create", "task_list", "task_get", "task_stop", "task_archive", "task_complete"} {
+	for _, tool := range []string{"task_create", "task_list", "task_get", "task_stop", "task_archive", "task_rename", "task_complete"} {
 		t.Run(tool, func(t *testing.T) {
 			resp := doRequest(t, s, "tools/call", ToolCallParams{
 				Name:      tool,
@@ -1175,6 +1185,114 @@ func TestTaskComplete(t *testing.T) {
 	})
 }
 
+func TestTaskRename(t *testing.T) {
+	t.Run("by id", func(t *testing.T) {
+		s, taskDB, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_rename",
+			Arguments: json.RawMessage(`{"id": "abc123", "name": "fix-login-v2"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		testutil.Contains(t, cr.Content[0].Text, "fix-login")
+		testutil.Contains(t, cr.Content[0].Text, "fix-login-v2")
+
+		got, _ := taskDB.Get("abc123")
+		testutil.Equal(t, got.Name, "fix-login-v2")
+	})
+
+	t.Run("by cwd", func(t *testing.T) {
+		s, taskDB, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_rename",
+			Arguments: json.RawMessage(`{"cwd": "/tmp/worktrees/myapp/fix-login/sub", "name": "renamed-via-cwd"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if cr.IsError {
+			t.Fatalf("unexpected error: %s", cr.Content[0].Text)
+		}
+		got, _ := taskDB.Get("abc123")
+		testutil.Equal(t, got.Name, "renamed-via-cwd")
+	})
+
+	t.Run("trims whitespace", func(t *testing.T) {
+		s, taskDB, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_rename",
+			Arguments: json.RawMessage(`{"id": "abc123", "name": "  spaced  "}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, false)
+		got, _ := taskDB.Get("abc123")
+		testutil.Equal(t, got.Name, "spaced")
+	})
+
+	t.Run("no-op when same name", func(t *testing.T) {
+		s, _, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_rename",
+			Arguments: json.RawMessage(`{"id": "abc123", "name": "fix-login"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, false)
+		testutil.Contains(t, cr.Content[0].Text, "already named")
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		s, _, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_rename",
+			Arguments: json.RawMessage(`{"id": "abc123"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "name is required")
+	})
+
+	t.Run("blank name rejected", func(t *testing.T) {
+		s, _, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_rename",
+			Arguments: json.RawMessage(`{"id": "abc123", "name": "   "}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "name is required")
+	})
+
+	t.Run("missing id and cwd", func(t *testing.T) {
+		s, _, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_rename",
+			Arguments: json.RawMessage(`{"name": "anything"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "provide id or cwd")
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		s, _, _ := testServerWithTasks()
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      "task_rename",
+			Arguments: json.RawMessage(`{"id": "nope", "name": "foo"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		testutil.Equal(t, cr.IsError, true)
+		testutil.Contains(t, cr.Content[0].Text, "task not found")
+	})
+}
+
 // --- Clipboard tool tests ---
 
 type mockClipboard struct {
@@ -1205,8 +1323,8 @@ func TestToolsList_WithClipboard(t *testing.T) {
 	var list ToolsListResult
 	json.Unmarshal(result, &list) //nolint:errcheck
 
-	// 5 KB tools + 6 task tools + 1 clipboard tool = 12
-	testutil.Equal(t, len(list.Tools), 12)
+	// 5 KB tools + 7 task tools + 1 clipboard tool = 13
+	testutil.Equal(t, len(list.Tools), 13)
 
 	names := make(map[string]bool)
 	for _, tool := range list.Tools {


### PR DESCRIPTION
Adds a task_rename tool to the Argus MCP server, mirroring the
task_archive / task_complete patterns. Resolves the target task by id
or by cwd (matching the agent's worktree path), so an agent can rename
its own task without knowing its task ID.

Uses the atomic db.Rename path so the update can't clobber concurrent
status changes from a running agent. Branch and worktree paths stay
locked to the original slug — only the display name changes.

Also migrates the HTTP API handleRenameTask off db.Update onto
db.Rename so the HTTP and MCP rename paths share the same safer
non-clobbering semantics. Caps task names at 200 runes as a defensive
ceiling beneath the 4 MiB request body limit.

Co-Authored-By: Claude <noreply@anthropic.com>