### PR TITLE
Enable autocorrect on synthetic-keyboard compose textarea

### DIFF
--- a/internal/api/static/index.html
+++ b/internal/api/static/index.html
@@ -934,7 +934,7 @@ textarea.settings-input { min-height: 70px; resize: vertical; }
       <div class="compose-input-wrap">
         <textarea id="compose-input" rows="1"
           placeholder="Type or dictate to agent…"
-          autocapitalize="off" autocorrect="off" spellcheck="false"
+          autocapitalize="off" autocorrect="on" spellcheck="false"
           autocomplete="off" enterkeyhint="send"></textarea>
         <div class="ac-dropdown up" id="compose-ac-dropdown"></div>
       </div>

--- a/internal/api/static/index.html
+++ b/internal/api/static/index.html
@@ -932,6 +932,13 @@ textarea.settings-input { min-height: 70px; resize: vertical; }
     <div class="compose-bar" id="compose-bar" style="display:none">
       <button id="compose-keybar-toggle" type="button" aria-label="Toggle key bar" aria-pressed="false">⌨</button>
       <div class="compose-input-wrap">
+        <!-- autocorrect="on" is deliberate: this is the only field in the SPA
+             where prose is typed (the agent prompt). Every other input
+             (#task-search-input, #links-modal-filter, etc.) is autocorrect="off"
+             because it receives identifiers, not sentences. spellcheck stays
+             off so the textarea doesn't bloom red squiggles while the user
+             dictates. The Send-vs-IME contract in wireCompose() handles the
+             autocorrect-commit-then-Send path via the isComposing guard. -->
         <textarea id="compose-input" rows="1"
           placeholder="Type or dictate to agent…"
           autocapitalize="off" autocorrect="on" spellcheck="false"

--- a/internal/api/static/sw.js
+++ b/internal/api/static/sw.js
@@ -7,7 +7,7 @@
 //
 // Increment SW_VERSION on any shell change to bust the cache.
 
-const SW_VERSION = 'argus-shell-v25';
+const SW_VERSION = 'argus-shell-v26';
 const SHELL_ASSETS = [
   '/',
   '/manifest.webmanifest',

--- a/internal/api/static/sw.js
+++ b/internal/api/static/sw.js
@@ -7,7 +7,7 @@
 //
 // Increment SW_VERSION on any shell change to bust the cache.
 
-const SW_VERSION = 'argus-shell-v26';
+const SW_VERSION = 'argus-shell-v27';
 const SHELL_ASSETS = [
   '/',
   '/manifest.webmanifest',


### PR DESCRIPTION
## Summary

The mobile/PWA compose bar — the on-screen "synthetic keyboard" that touch users type into to send to the agent — had `autocorrect="off"` on its textarea, so iOS users got raw typos instead of corrected text. Flip the attribute to `"on"` and document the asymmetry vs other inputs (which intentionally stay off because they receive identifiers, not prose).

## Changes

- `internal/api/static/index.html`: `autocorrect="off"` → `"on"` on `#compose-input`, plus an in-situ comment explaining why this field differs from the other inputs and why `spellcheck` stays off.
- `internal/api/static/sw.js`: bump `SW_VERSION` v25 → v27 so installed PWAs pick up the shell change.

## Safety

The Send-vs-IME contract in `wireCompose()` already handles autocorrect commits via the `isComposing` guard added in b769911 (regression-tested in `compose.spec.ts`), so enabling autocorrect doesn't open a path where a soft-keyboard Send during an active prediction drops a literal `\n` into the textarea instead of submitting.

## Test plan

- [x] `make vet`
- [x] `make test` (full suite — 0 failures)
- [ ] Manual: type with autocorrect on iOS Safari PWA, confirm typos auto-fix and Send still submits during an active prediction.

Co-Authored-By: Claude <noreply@anthropic.com>