### PR TITLE
Restore ctrl+p to open PR via gh in agent view

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The sections below are the dense usage docs — keybindings, REST endpoints, con
 | `Cmd+←` / `Cmd+→`     | Switch panels                                                             |
 | `Cmd+↑` / `Cmd+↓`     | Navigate between tasks                                                    |
 | `ctrl+l`              | Open link picker (fuzzy search all session URLs)                          |
+| `ctrl+p`              | Open PR for the worktree branch in browser (via `gh pr view --web`)       |
 | `ctrl+y`              | Copy agent-staged text (only when payload pending; otherwise sent to PTY) |
 | `Shift+↑` / `Shift+↓` | Scroll terminal (with acceleration)                                       |
 

--- a/context/knowledge/gotchas/keybindings.md
+++ b/context/knowledge/gotchas/keybindings.md
@@ -4,6 +4,7 @@
 - **`ctrl+q` in diff mode must exit diff AND refocus terminal.** Otherwise user needs a second keypress.
 - **`ctrl+d` exits agent view when session is dead.** Without this, Ctrl+D after agent exit is silently dropped.
 - **`ctrl+l` opens fuzzy link picker (works while agent runs).** Uses `tcell.KeyCtrlL` — reliable across all terminals (unlike `ctrl+/` which has inconsistent encodings). Overrides the typical "clear screen" behavior; the agent PTY never sees it. Reads session log in a background goroutine; the `QueueUpdateDraw` callback must guard `a.mode == modeAgent` because the user may leave agent view during I/O.
+- **`ctrl+p` shells out to `gh pr view --web` in the current worktree.** No PR URL is tracked locally — gh discovers the PR from the branch + remote. Intercepted before PTY pass-through; the agent never sees `0x10`. No-op when `worktreeDir` is empty. `prOpener` is a package-level seam so tests stub the exec.
 - **Escape in agent view:** Refocuses terminal from diff/files but does NOT exit agent view. Always returns `nil` to consume the event.
 - **Mouse clicks must update `agentFocus`, not just tview focus.** Custom `MouseHandler` overrides needed.
 - **In diff mode: Up/Down switch files, j/k scroll diff.**

--- a/context/knowledge/gotchas/web-remote.md
+++ b/context/knowledge/gotchas/web-remote.md
@@ -10,6 +10,7 @@ Non-obvious invariants for the SPA + REST API + push notifications stack.
 - **Discovery is one-shot at startup.** If Tailscale connects (or its IP changes after `logout`/`login`) after the daemon is already running, the Tailscale listener is absent until the daemon is restarted. Symptom: PWA shows the offline screen on every device while `curl http://127.0.0.1:7743/` works locally. Acceptable for a single-user tool — restarting the daemon takes seconds.
 - **`tailscale serve` keeps working** because it forwards to localhost; the localhost listener is always present regardless of Tailscale state.
 - **`bindWithRetry` wraps the underlying syscall error with `%w`.** `errors.Is(err, syscall.EADDRINUSE)` continues to work for callers; daemon log scrapers see the actual cause (`bind: address already in use`, `bind: can't assign requested address`) instead of just the formatted-port summary.
+- **Port-fallback tests must occupy `127.0.0.1:N`, not `0.0.0.0:N`.** On macOS, `0.0.0.0:N` and `127.0.0.1:N` are distinct address-family bindings — occupying the former does NOT collide with the latter. Pre-cb983cb when the API bound `0.0.0.0` the wildcard listener self-collided either way; post-cb983cb (localhost only) a `0.0.0.0`-occupied port leaves `127.0.0.1:N` free, so `bindWithRetry` succeeds at the original port and the fallback assertion fails. Lesson: when changing a service's bind address, re-check existing port-collision tests against address-family rules — a passing test under the old bind may silently break.
 
 ## Auth & EventSource
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1822,10 +1822,11 @@ func pickFreePort(t *testing.T) int {
 }
 
 func TestListenAndServe_PortFallback(t *testing.T) {
-	// Occupy a port on 0.0.0.0 (same address ListenAndServe binds to) to
-	// force the retry-with-port+1 path. Binding 127.0.0.1:N would not
-	// collide with 0.0.0.0:N on macOS due to address-family separation.
-	occupied, err := net.Listen("tcp", "0.0.0.0:0")
+	// Occupy a port on 127.0.0.1 — the same address ListenAndServe binds
+	// to (cb983cb dropped 0.0.0.0 binding). Occupying 0.0.0.0:N here would
+	// not collide with 127.0.0.1:N on macOS due to address-family
+	// separation, so the bindWithRetry path would never trigger.
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
 	testutil.NoError(t, err)
 	t.Cleanup(func() { _ = occupied.Close() })
 	port := occupied.Addr().(*net.TCPAddr).Port

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1375,6 +1375,9 @@ func (a *App) handleAgentKey(event *tcell.EventKey) *tcell.EventKey {
 	case tcell.KeyCtrlL: // Overrides typical "clear screen" — intercepted before PTY
 		a.openAgentLinks()
 		return nil
+	case tcell.KeyCtrlP: // Open PR for the worktree's branch via gh
+		a.openPR()
+		return nil
 	case tcell.KeyCtrlY:
 		// Conditional intercept: only steal ctrl+y from the PTY when an
 		// agent has staged a clipboard payload. Without a payload, fall
@@ -1655,6 +1658,16 @@ var terminalOpener = func(worktreeDir string) error {
 	return exec.Command("tmux", "new-window", "-c", worktreeDir).Start()
 }
 
+// prOpener is the package-level seam for "open the PR for this worktree's
+// branch in a browser via gh". Tests stub this out so they don't actually
+// shell out. gh discovers the PR from the current branch + remote, so no
+// PR URL needs to be tracked locally.
+var prOpener = func(worktreeDir string) error {
+	cmd := exec.Command("gh", "pr", "view", "--web")
+	cmd.Dir = worktreeDir
+	return cmd.Start()
+}
+
 func (a *App) openInEditor() {
 	f := a.filePanel.SelectedFile()
 	if f == nil || a.worktreeDir == "" {
@@ -1668,6 +1681,15 @@ func (a *App) openTerminal() {
 		return
 	}
 	_ = terminalOpener(a.worktreeDir)
+}
+
+func (a *App) openPR() {
+	if a.worktreeDir == "" {
+		return
+	}
+	if err := prOpener(a.worktreeDir); err != nil {
+		uxlog.Log("[tui] open PR failed: %v", err)
+	}
 }
 
 // tcellKeyToBytes converts a tcell key event to raw terminal bytes for PTY input.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1673,14 +1673,18 @@ func (a *App) openInEditor() {
 	if f == nil || a.worktreeDir == "" {
 		return
 	}
-	_ = editorOpener(a.worktreeDir, f.Path)
+	if err := editorOpener(a.worktreeDir, f.Path); err != nil {
+		uxlog.Log("[tui] open in editor failed: %v", err)
+	}
 }
 
 func (a *App) openTerminal() {
 	if a.worktreeDir == "" {
 		return
 	}
-	_ = terminalOpener(a.worktreeDir)
+	if err := terminalOpener(a.worktreeDir); err != nil {
+		uxlog.Log("[tui] open terminal failed: %v", err)
+	}
 }
 
 func (a *App) openPR() {

--- a/internal/tui/main_test.go
+++ b/internal/tui/main_test.go
@@ -11,11 +11,12 @@ import (
 // inside the test (with t.Cleanup to restore).
 //
 // Without these defaults, running `go test ./internal/tui/` in any
-// developer terminal would shell out to tmux/open whenever an exercised
-// path reaches openInEditor / openTerminal / openURL / openPRInBrowser.
+// developer terminal would shell out to tmux/open/gh whenever an exercised
+// path reaches openInEditor / openTerminal / openURL / openPR.
 func TestMain(m *testing.M) {
 	browserOpener = func(string) error { return nil }
 	editorOpener = func(string, string) error { return nil }
 	terminalOpener = func(string) error { return nil }
+	prOpener = func(string) error { return nil }
 	os.Exit(m.Run())
 }

--- a/internal/tui/newtaskform_autocomplete_test.go
+++ b/internal/tui/newtaskform_autocomplete_test.go
@@ -221,7 +221,9 @@ func TestApp_HandleAgentKey_CtrlPNoWorktree(t *testing.T) {
 	prOpener = func(string) error { called = true; return nil }
 	t.Cleanup(func() { prOpener = orig })
 
-	app.handleAgentKey(tcell.NewEventKey(tcell.KeyCtrlP, 0, 0))
+	if ev := app.handleAgentKey(tcell.NewEventKey(tcell.KeyCtrlP, 0, 0)); ev != nil {
+		t.Fatal("ctrl+p should be consumed even with empty worktreeDir")
+	}
 	if called {
 		t.Fatal("prOpener should not run when worktreeDir is empty")
 	}

--- a/internal/tui/newtaskform_autocomplete_test.go
+++ b/internal/tui/newtaskform_autocomplete_test.go
@@ -192,7 +192,39 @@ func TestApp_HandleAgentKey_CtrlPOpensPR(t *testing.T) {
 	app := New(d, runner, false)
 	app.mode = modeAgent
 	app.agentState.Reset("t1", "n")
+	app.worktreeDir = t.TempDir()
+
+	var gotDir string
+	orig := prOpener
+	prOpener = func(dir string) error {
+		gotDir = dir
+		return nil
+	}
+	t.Cleanup(func() { prOpener = orig })
+
+	if ev := app.handleAgentKey(tcell.NewEventKey(tcell.KeyCtrlP, 0, 0)); ev != nil {
+		t.Fatal("ctrl+p should be consumed")
+	}
+	testutil.Equal(t, gotDir, app.worktreeDir)
+}
+
+func TestApp_HandleAgentKey_CtrlPNoWorktree(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false)
+	app.mode = modeAgent
+	app.agentState.Reset("t1", "n")
+	// worktreeDir intentionally empty.
+
+	called := false
+	orig := prOpener
+	prOpener = func(string) error { called = true; return nil }
+	t.Cleanup(func() { prOpener = orig })
+
 	app.handleAgentKey(tcell.NewEventKey(tcell.KeyCtrlP, 0, 0))
+	if called {
+		t.Fatal("prOpener should not run when worktreeDir is empty")
+	}
 }
 
 // --- handleGlobalKey paths ---


### PR DESCRIPTION
Reviews-tab removal in 7bc69d7 dropped the ctrl+p PR-open keybind alongside the
rest of the PR-tracking machinery (`Task.PRURL`, `internal/github/`, scan
throttle, Reviews tab UI). This restores ctrl+p without resurrecting any of
that storage — the handler shells out to `gh pr view --web` in the task's
worktree and lets `gh` discover the PR from the branch + remote.

## TUI

- New `prOpener` package-level seam parallels existing `editorOpener` /
  `terminalOpener` so tests can stub the exec.
- `App.openPR()` guards on empty `worktreeDir` and logs failures via uxlog.
- Wired `KeyCtrlP` into `handleAgentKey` next to ctrl+l so it's intercepted
  before PTY pass-through (the agent never sees `0x10`).
- Normalized peer openers (`openInEditor` / `openTerminal`) to log opener
  errors via uxlog instead of `_ = opener(...)`, eliminating the
  error-handling asymmetry flagged in review.
- `TestMain` now stubs `prOpener` alongside the other openers so incidental
  test paths don't shell out to `gh`.

## Tests

- Rewrote the now-meaningful `TestApp_HandleAgentKey_CtrlPOpensPR` to verify
  the seam is invoked with the correct worktree dir.
- Added `TestApp_HandleAgentKey_CtrlPNoWorktree` covering the empty-worktree
  guard AND asserting the event is still consumed (so a future refactor
  that flips the no-worktree path to PTY pass-through gets caught).

## Pre-existing test fix (unrelated to ctrl+p)

`TestListenAndServe_PortFallback` was failing deterministically on
origin/master after the cb983cb 0.0.0.0 → localhost bind change. The test
was occupying `0.0.0.0:N` to force the fallback path, but on macOS that
does not collide with `127.0.0.1:N` (distinct address families), so the API
bound the original port and the assertion failed. Fixed inline per the
/ship policy on pre-existing flakes; also captured the durable invariant in
`gotchas/web-remote.md`.

## Docs

- README Agent View table gets a `ctrl+p` row.
- `gotchas/keybindings.md` documents the intercept-before-PTY rule and the
  empty-worktree no-op.
- `gotchas/web-remote.md` records the port-fallback / bind-address-change
  lesson.

Co-Authored-By: Claude <noreply@anthropic.com>