### PR TITLE
Wire ctrl+p to open PR from task list

### DIFF
--- a/context/knowledge/gotchas/keybindings.md
+++ b/context/knowledge/gotchas/keybindings.md
@@ -4,7 +4,7 @@
 - **`ctrl+q` in diff mode must exit diff AND refocus terminal.** Otherwise user needs a second keypress.
 - **`ctrl+d` exits agent view when session is dead.** Without this, Ctrl+D after agent exit is silently dropped.
 - **`ctrl+l` opens fuzzy link picker (works while agent runs).** Uses `tcell.KeyCtrlL` — reliable across all terminals (unlike `ctrl+/` which has inconsistent encodings). Overrides the typical "clear screen" behavior; the agent PTY never sees it. Reads session log in a background goroutine; the `QueueUpdateDraw` callback must guard `a.mode == modeAgent` because the user may leave agent view during I/O.
-- **`ctrl+p` shells out to `gh pr view --web` in the current worktree.** No PR URL is tracked locally — gh discovers the PR from the branch + remote. Intercepted before PTY pass-through; the agent never sees `0x10`. No-op when `worktreeDir` is empty. `prOpener` is a package-level seam so tests stub the exec.
+- **`ctrl+p` shells out to `gh pr view --web` in the current worktree.** No PR URL is tracked locally — gh discovers the PR from the branch + remote. Intercepted before PTY pass-through; the agent never sees `0x10`. No-op when `worktreeDir` is empty. `prOpener` is a package-level seam so tests stub the exec. From the task list (`modeTaskList` on the Tasks tab), uses the selected task's `Worktree` directly — no-op for pending tasks with no worktree yet.
 - **Escape in agent view:** Refocuses terminal from diff/files but does NOT exit agent view. Always returns `nil` to consume the event.
 - **Mouse clicks must update `agentFocus`, not just tview focus.** Custom `MouseHandler` overrides needed.
 - **In diff mode: Up/Down switch files, j/k scroll diff.**

--- a/context/knowledge/gotchas/pty-terminal.md
+++ b/context/knowledge/gotchas/pty-terminal.md
@@ -1,6 +1,7 @@
 ## PTY & Terminal Rendering
 
 - **`pty.Setsize` (which calls `os.File.Fd()`) races with `os.File.Close()`.** `Fd()` reads the internal fd field without synchronization, while `Close()` modifies it. `Read()`/`Write()` are safe (they use internal `fdMutex`). Fix: `ptmxClosed` bool flag under Session mutex; `waitLoop` sets flag + closes under lock; `Resize` checks flag under lock before calling `Setsize`.
+- **`Session.Done()` blocks on `readDone`, not just process exit.** `waitLoop` waits for `readLoop` to drain the kernel PTY buffer before closing `done`. Without this, `Done()` fires while bytes are still in transit — `RecentOutput()` returns partial or empty data, and CI tests polling for output flake out (was the original `TestSession_RecentOutput` flake). The guarantee relies on `readLoop`'s `defer close(s.readDone)`.
 - **PTY needs real terminal size at launch** (`pty.StartWithSize`), not 0x0. TUI apps won't render with zero dimensions. Start at actual panel width, not 80x24 — agents format initial output for launch PTY size.
 - **Single-reader-tee pattern is critical.** Two goroutines reading the same fd causes data loss.
 - **`AddWriter` must replay before registering.** Register first → live bytes arrive before replay → duplicate data → rendering corruption.

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -111,6 +111,8 @@ func (r *Runner) Start(task *model.Task, cfg config.Config, rows, cols uint16, r
 		}
 		// Capture last output before removing the session so callers
 		// can display error messages after the session is gone.
+		// sess.Done() blocks on readLoop draining, so the ring buffer
+		// is guaranteed to hold every byte the PTY produced.
 		lastOutput := sess.RecentOutput()
 		exitErr := sess.Err()
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -33,6 +33,7 @@ type Session struct {
 	buf         *RingBuffer
 	writers     []io.Writer // readLoop tees output to all attached writers
 	done        chan struct{}
+	readDone    chan struct{} // closed when readLoop returns; waitLoop blocks on this before closing done so all PTY output lands in the ring buffer
 	err         error
 	attached    bool
 	detachCh    chan struct{}
@@ -87,6 +88,7 @@ func StartSession(taskID string, cmd *exec.Cmd, rows, cols uint16) (*Session, er
 		ptmx:        ptmx,
 		buf:         NewRingBuffer(defaultBufSize),
 		done:        make(chan struct{}),
+		readDone:    make(chan struct{}),
 		detachCh:    make(chan struct{}),
 		ptyCols:     cols,
 		ptyRows:     rows,
@@ -106,7 +108,12 @@ func StartSession(taskID string, cmd *exec.Cmd, rows, cols uint16) (*Session, er
 
 // readLoop is the sole reader of the PTY. It always writes to the ring buffer,
 // tees output to all attached writers, and appends to the session log file.
+// Closes s.readDone on return so waitLoop can defer s.done's close until
+// every PTY byte has landed in the ring buffer — otherwise Done() can fire
+// while the kernel still has buffered output, and Attach/Recent-Output
+// readers see a half-drained session.
 func (s *Session) readLoop() {
+	defer close(s.readDone)
 	if s.logFile != nil {
 		defer s.logFile.Close()
 	}
@@ -159,13 +166,20 @@ func (s *Session) readLoop() {
 	}
 }
 
-// waitLoop waits for the process to exit and cleans up.
+// waitLoop waits for the process to exit and cleans up. Done() is signaled
+// only after readLoop has terminated, guaranteeing every PTY byte has been
+// written to the ring buffer before any Done() waiter wakes up.
+//
+// The `<-s.readDone` block depends on readLoop's `defer close(s.readDone)`
+// firing. The defer runs even on panic, so a crashing readLoop still
+// unblocks this goroutine; without that defer, Done() would deadlock.
 func (s *Session) waitLoop() {
 	s.err = s.Cmd.Wait()
 	s.mu.Lock()
 	s.ptmxClosed = true
 	s.ptmx.Close()
 	s.mu.Unlock()
+	<-s.readDone
 	close(s.done)
 }
 

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -40,9 +40,6 @@ func TestStartSession_EchoCommand(t *testing.T) {
 		t.Errorf("unexpected error: %v", sess.Err())
 	}
 
-	// Give readLoop time to capture output
-	time.Sleep(50 * time.Millisecond)
-
 	output := string(sess.RecentOutput())
 	if !strings.Contains(output, "hello from pty") {
 		t.Errorf("expected output to contain 'hello from pty', got %q", output)
@@ -221,7 +218,6 @@ func TestSession_TotalWritten(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout")
 	}
-	time.Sleep(50 * time.Millisecond)
 
 	if sess.TotalWritten() == 0 {
 		t.Error("expected TotalWritten > 0 after echo output")
@@ -283,23 +279,17 @@ func TestSession_RecentOutput(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Done() now fires only after readLoop has fully drained the PTY into
+	// the ring buffer (see waitLoop), so RecentOutput is immediately ready.
 	select {
 	case <-sess.Done():
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout")
 	}
-	// readLoop drains the PTY into the ring buffer asynchronously; wait for
-	// it to land rather than relying on a fixed sleep (was flaky on CI).
-	deadline := time.Now().Add(2 * time.Second)
-	var output string
-	for time.Now().Before(deadline) {
-		output = string(sess.RecentOutput())
-		if strings.Contains(output, "recent output test") {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
+	output := string(sess.RecentOutput())
+	if !strings.Contains(output, "recent output test") {
+		t.Errorf("RecentOutput() = %q, want it to contain 'recent output test'", output)
 	}
-	t.Errorf("RecentOutput() = %q, want it to contain 'recent output test'", output)
 }
 
 func TestSession_RecentOutputTail(t *testing.T) {
@@ -313,14 +303,6 @@ func TestSession_RecentOutputTail(t *testing.T) {
 	case <-sess.Done():
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout")
-	}
-	// Wait for readLoop to drain rather than fixed sleep (CI-flake fix).
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if strings.Contains(string(sess.RecentOutput()), "tail output test") {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
 	}
 
 	full := sess.RecentOutput()
@@ -475,7 +457,6 @@ func TestSession_Attach_WithReplay(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout")
 	}
-	time.Sleep(50 * time.Millisecond)
 
 	// Attach should replay buffered output
 	pr, pw := io.Pipe()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1282,6 +1282,15 @@ func (a *App) handleGlobalKey(event *tcell.EventKey) *tcell.EventKey {
 				return nil
 			}
 		}
+	case tcell.KeyCtrlP:
+		if a.mode == modeTaskList && a.header.ActiveTab() == widget.TabTasks {
+			if t := a.tasklist.SelectedTask(); t != nil && t.Worktree != "" {
+				if err := prOpener(t.Worktree); err != nil {
+					uxlog.Log("[tui] open PR failed: %v", err)
+				}
+				return nil
+			}
+		}
 	case tcell.KeyCtrlR:
 		if a.mode == modeTaskList && a.header.ActiveTab() == widget.TabTasks {
 			a.pruneCompletedTasks()

--- a/internal/tui/newtaskform_autocomplete_test.go
+++ b/internal/tui/newtaskform_autocomplete_test.go
@@ -2,11 +2,13 @@ package tui
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gdamore/tcell/v2"
 
 	"github.com/drn/argus/internal/agent"
 	"github.com/drn/argus/internal/config"
+	"github.com/drn/argus/internal/model"
 	"github.com/drn/argus/internal/skills"
 	"github.com/drn/argus/internal/testutil"
 )
@@ -230,3 +232,98 @@ func TestApp_HandleAgentKey_CtrlPNoWorktree(t *testing.T) {
 }
 
 // --- handleGlobalKey paths ---
+
+func TestApp_HandleGlobalKey_CtrlPOpensPRFromTaskList(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false)
+
+	wt := t.TempDir()
+	task := &model.Task{
+		ID:        "t1",
+		Name:      "task one",
+		Status:    model.StatusInProgress,
+		Project:   "proj",
+		Worktree:  wt,
+		CreatedAt: time.Now(),
+	}
+	testutil.NoError(t, d.Add(task))
+	app.refreshTasks()
+
+	var gotDir string
+	orig := prOpener
+	prOpener = func(dir string) error {
+		gotDir = dir
+		return nil
+	}
+	t.Cleanup(func() { prOpener = orig })
+
+	if ev := app.handleGlobalKey(tcell.NewEventKey(tcell.KeyCtrlP, 0, 0)); ev != nil {
+		t.Fatal("ctrl+p should be consumed in task list")
+	}
+	testutil.Equal(t, gotDir, wt)
+}
+
+func TestApp_HandleGlobalKey_CtrlPNoWorktree(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false)
+
+	// Task with no worktree yet (pending).
+	task := &model.Task{
+		ID:        "t1",
+		Name:      "task one",
+		Status:    model.StatusPending,
+		Project:   "proj",
+		CreatedAt: time.Now(),
+	}
+	testutil.NoError(t, d.Add(task))
+	app.refreshTasks()
+
+	called := false
+	orig := prOpener
+	prOpener = func(string) error { called = true; return nil }
+	t.Cleanup(func() { prOpener = orig })
+
+	// Event is NOT consumed when the worktree guard fails — falls through
+	// to the next handler, matching the ctrl+f pattern.
+	if ev := app.handleGlobalKey(tcell.NewEventKey(tcell.KeyCtrlP, 0, 0)); ev == nil {
+		t.Fatal("ctrl+p should fall through when selected task has no worktree")
+	}
+	if called {
+		t.Fatal("prOpener should not run when selected task has no worktree")
+	}
+}
+
+// prOpener errors (stale worktree on disk, gh not installed, etc.) must be
+// swallowed and logged, not propagated. The event still gets consumed.
+func TestApp_HandleGlobalKey_CtrlPSwallowsPRError(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false)
+
+	task := &model.Task{
+		ID:        "t1",
+		Name:      "task one",
+		Status:    model.StatusInProgress,
+		Project:   "proj",
+		Worktree:  t.TempDir(),
+		CreatedAt: time.Now(),
+	}
+	testutil.NoError(t, d.Add(task))
+	app.refreshTasks()
+
+	orig := prOpener
+	prOpener = func(string) error { return errStubPRFailed }
+	t.Cleanup(func() { prOpener = orig })
+
+	if ev := app.handleGlobalKey(tcell.NewEventKey(tcell.KeyCtrlP, 0, 0)); ev != nil {
+		t.Fatal("ctrl+p should be consumed even when prOpener errors")
+	}
+}
+
+var errStubPRFailed = stubError("pr open failed")
+
+type stubError string
+
+func (e stubError) Error() string { return string(e) }

--- a/internal/tui/widget/statusbar.go
+++ b/internal/tui/widget/statusbar.go
@@ -130,7 +130,7 @@ func (sb *StatusBar) Draw(screen tcell.Screen) {
 	default:
 		hints = []hint{
 			{"n", "new"}, {"RET", "attach"}, {"s", "status"}, {"r", "rename"},
-			{"^f", "fork"}, {"^d", "del"}, {"^r", "prune"}, {"2", "settings"},
+			{"^p", "PR"}, {"^f", "fork"}, {"^d", "del"}, {"^r", "prune"}, {"2", "settings"},
 			{"?", "help"}, {"q", "quit"},
 		}
 	}


### PR DESCRIPTION
Mirror the agent-view ctrl+p handler on the Tasks tab: when the cursor is on a task with a worktree, shell out to `gh pr view --web` via the existing `prOpener` seam. Advertise the binding in the status bar.

Also fix a pre-existing flake in TestSession_RecentOutput[Tail]: waitLoop closed `done` after closing ptmx but before readLoop finished draining the kernel PTY buffer, so `Done()` could fire while bytes were still in transit. On a loaded CI runner this left `RecentOutput()` empty for the full 2s polling window. Have waitLoop block on a new `readDone` channel before closing `done`, making "session done" mean "fully drained." Drops the polling band-aids from the affected tests.

Co-Authored-By: Claude <noreply@anthropic.com>