### PR TITLE
Make settings arrows traverse rail/pane before tab switch

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1306,6 +1306,8 @@ func (a *App) handleGlobalKey(event *tcell.EventKey) *tcell.EventKey {
 		}
 	case tcell.KeyLeft:
 		if a.mode != modeAgent {
+			// Settings consumes left/right to navigate its rail↔pane; only
+			// fall through to tab switching when the rail (left-most pane) is focused.
 			if a.header.ActiveTab() == widget.TabSettings && a.settings.HandleKey(event) {
 				return nil
 			}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1306,6 +1306,9 @@ func (a *App) handleGlobalKey(event *tcell.EventKey) *tcell.EventKey {
 		}
 	case tcell.KeyLeft:
 		if a.mode != modeAgent {
+			if a.header.ActiveTab() == widget.TabSettings && a.settings.HandleKey(event) {
+				return nil
+			}
 			cur := a.header.ActiveTab()
 			if cur > widget.TabTasks {
 				a.switchTab(cur - 1)
@@ -1314,6 +1317,9 @@ func (a *App) handleGlobalKey(event *tcell.EventKey) *tcell.EventKey {
 		}
 	case tcell.KeyRight:
 		if a.mode != modeAgent {
+			if a.header.ActiveTab() == widget.TabSettings && a.settings.HandleKey(event) {
+				return nil
+			}
 			cur := a.header.ActiveTab()
 			if cur < widget.TabSettings {
 				a.switchTab(cur + 1)

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -361,6 +361,9 @@ func TestArrowTabNavigation(t *testing.T) {
 
 	// Right arrow on Settings rail → moves focus to right pane, stays on Settings.
 	result = app.handleGlobalKey(ev)
+	if result != nil {
+		t.Error("right arrow on settings rail should be consumed")
+	}
 	if app.header.ActiveTab() != widget.TabSettings {
 		t.Errorf("tab = %v, want widget.TabSettings (right consumed by settings)", app.header.ActiveTab())
 	}
@@ -374,6 +377,9 @@ func TestArrowTabNavigation(t *testing.T) {
 	// Left arrow on Settings pane → moves focus back to rail, stays on Settings.
 	ev = tcell.NewEventKey(tcell.KeyLeft, 0, 0)
 	result = app.handleGlobalKey(ev)
+	if result != nil {
+		t.Error("left arrow on settings pane should be consumed")
+	}
 	if app.header.ActiveTab() != widget.TabSettings {
 		t.Errorf("tab = %v, want widget.TabSettings (left consumed by settings pane)", app.header.ActiveTab())
 	}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -349,7 +349,7 @@ func TestArrowTabNavigation(t *testing.T) {
 		t.Fatalf("initial tab = %v, want widget.TabTasks", app.header.ActiveTab())
 	}
 
-	// Right arrow → Settings
+	// Right arrow → Settings (from Tasks tab)
 	ev := tcell.NewEventKey(tcell.KeyRight, 0, 0)
 	result := app.handleGlobalKey(ev)
 	if result != nil {
@@ -359,17 +359,29 @@ func TestArrowTabNavigation(t *testing.T) {
 		t.Errorf("tab = %v, want widget.TabSettings", app.header.ActiveTab())
 	}
 
-	// Right arrow at Settings — stays on Settings (no wrap)
+	// Right arrow on Settings rail → moves focus to right pane, stays on Settings.
+	result = app.handleGlobalKey(ev)
+	if app.header.ActiveTab() != widget.TabSettings {
+		t.Errorf("tab = %v, want widget.TabSettings (right consumed by settings)", app.header.ActiveTab())
+	}
+
+	// Right arrow on Settings pane — stays on Settings (rightmost tab, no wrap).
 	result = app.handleGlobalKey(ev)
 	if app.header.ActiveTab() != widget.TabSettings {
 		t.Errorf("tab = %v, want widget.TabSettings (no wrap)", app.header.ActiveTab())
 	}
 
-	// Left arrow → Tasks
+	// Left arrow on Settings pane → moves focus back to rail, stays on Settings.
 	ev = tcell.NewEventKey(tcell.KeyLeft, 0, 0)
 	result = app.handleGlobalKey(ev)
+	if app.header.ActiveTab() != widget.TabSettings {
+		t.Errorf("tab = %v, want widget.TabSettings (left consumed by settings pane)", app.header.ActiveTab())
+	}
+
+	// Left arrow on Settings rail → switches to Tasks tab.
+	result = app.handleGlobalKey(ev)
 	if result != nil {
-		t.Error("left arrow should be consumed")
+		t.Error("left arrow on rail should be consumed")
 	}
 	if app.header.ActiveTab() != widget.TabTasks {
 		t.Errorf("tab = %v, want widget.TabTasks", app.header.ActiveTab())

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -1084,7 +1084,7 @@ func (sv *SettingsView) handleEditSourceKey(ev *tcell.EventKey) bool {
 		sv.editingSource = false
 		sv.rebuildRows()
 		return true
-	case tcell.KeyDown, tcell.KeyUp:
+	case tcell.KeyDown, tcell.KeyUp, tcell.KeyLeft, tcell.KeyRight:
 		return true
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
 		if len(sv.editSourceBuf) > 0 {
@@ -1143,8 +1143,8 @@ func (sv *SettingsView) handleEditVaultKey(ev *tcell.EventKey) bool {
 		sv.vaultAC.Close()
 		sv.rebuildRows()
 		return true
-	case tcell.KeyDown, tcell.KeyUp:
-		return true // consume to avoid cursor movement while editing
+	case tcell.KeyDown, tcell.KeyUp, tcell.KeyLeft, tcell.KeyRight:
+		return true // consume to avoid cursor movement / tab switch while editing
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
 		if len(sv.editVaultBuf) > 0 {
 			_, size := utf8.DecodeLastRuneInString(sv.editVaultBuf)


### PR DESCRIPTION
## Summary

- Left/Right within the Settings tab now navigate between the left rail and the right pane; the tab switch to Tasks only fires when Left is pressed at the rail (left-most pane). Previously the global key handler intercepted both arrows before `SettingsView.HandleKey` could see them.
- Inline vault-path and source-path editors now swallow Left/Right alongside Up/Down so mid-edit arrow keys cannot escape the Settings tab and drop edit context.
- Updates `TestArrowTabNavigation` to assert the pane-aware behavior and tightens return-value assertions for consistency.

## Test plan

- [x] `make test` — all TUI tests pass
- [x] Manual: Tab to Settings, Right enters pane, Right again no-ops, Left returns to rail, Left from rail switches to Tasks

Co-Authored-By: Claude <noreply@anthropic.com>