### PR TITLE
Add paste-event diagnostic logging for multi-attachment drag

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1531,6 +1531,15 @@ func (a *App) handleAgentKey(event *tcell.EventKey) *tcell.EventKey {
 	if sess != nil && sess.Alive() {
 		b := tcellKeyToBytes(event)
 		if len(b) > 0 {
+			// Diagnose multi-file drag-drop tearing: log any key forwarded
+			// during the 200ms paste-settling window so we can see whether
+			// the outer terminal injects a stray Enter/space between two
+			// bracket-paste sequences (which would split a multi-file drop).
+			if lp := a.agentPane.LastPasteTime(); !lp.IsZero() {
+				if elapsed := time.Since(lp); elapsed < 200*time.Millisecond {
+					uxlog.Log("[paste] key forwarded %dms after paste: %q (key=%v)", elapsed.Milliseconds(), string(b), event.Key())
+				}
+			}
 			if _, err := sess.WriteInput(b); err != nil {
 				uxlog.Log("[tui] write to PTY failed: %v", err)
 			}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -39,6 +39,14 @@ import (
 // ListSessions returns stale data after a daemon restart cascade.
 const recentStartGrace = 5 * time.Second
 
+// pasteSettleWindow is how long after a bracketed paste the agent-key
+// forwarder treats arriving keystrokes as suspicious — long enough to span
+// the inter-paste gap a terminal might introduce when splitting a multi-file
+// drop across two pastes, short enough to not catch ordinary typing.
+// Diagnostic only; remove with the rest of the `[paste]` instrumentation
+// once multi-attachment drag-drop is characterized and fixed.
+const pasteSettleWindow = 200 * time.Millisecond
+
 // viewMode identifies the active view.
 type viewMode int
 
@@ -1531,12 +1539,13 @@ func (a *App) handleAgentKey(event *tcell.EventKey) *tcell.EventKey {
 	if sess != nil && sess.Alive() {
 		b := tcellKeyToBytes(event)
 		if len(b) > 0 {
-			// Diagnose multi-file drag-drop tearing: log any key forwarded
-			// during the 200ms paste-settling window so we can see whether
-			// the outer terminal injects a stray Enter/space between two
-			// bracket-paste sequences (which would split a multi-file drop).
+			// TODO(diagnostic): remove with the rest of the `[paste]`
+			// instrumentation once multi-attachment drag-drop is fixed.
+			// Logs any key forwarded during pasteSettleWindow so we can
+			// see whether the outer terminal injects a stray Enter between
+			// two bracket-paste sequences (splitting a multi-file drop).
 			if lp := a.agentPane.LastPasteTime(); !lp.IsZero() {
-				if elapsed := time.Since(lp); elapsed < 200*time.Millisecond {
+				if elapsed := time.Since(lp); elapsed < pasteSettleWindow {
 					uxlog.Log("[paste] key forwarded %dms after paste: %q (key=%v)", elapsed.Milliseconds(), string(b), event.Key())
 				}
 			}

--- a/internal/tui/terminal/terminalpane.go
+++ b/internal/tui/terminal/terminalpane.go
@@ -792,6 +792,10 @@ func (tp *TerminalPane) PasteHandler() func(pastedText string, setFocus func(p t
 		sess := tp.session
 		tp.lastPasteTime = time.Now()
 		tp.mu.Unlock()
+		// TODO(diagnostic): remove with the rest of the `[paste]`
+		// instrumentation once multi-attachment drag-drop is fixed.
+		// `[paste]` is intentionally a cross-file prefix (also fired from
+		// app.go) so `grep '\[paste\]' ux.log` collects the whole trace.
 		uxlog.Log("[paste] received %d bytes: %s", len(pastedText), quotePreview(pastedText, 256))
 		if sess != nil && sess.Alive() {
 			// Write the entire paste as a single PTY write, wrapped in
@@ -815,7 +819,8 @@ func (tp *TerminalPane) LastPasteTime() time.Time {
 
 // quotePreview returns a Go-quoted, length-bounded preview of s suitable for
 // logging arbitrary terminal byte sequences (escapes, control chars) without
-// corrupting the log.
+// corrupting the log. Byte-boundary truncation is intentional: fmt %q escapes
+// an orphaned UTF-8 lead byte as `\xNN` (no panic, slightly ugly log).
 func quotePreview(s string, max int) string {
 	if len(s) <= max {
 		return fmt.Sprintf("%q", s)

--- a/internal/tui/terminal/terminalpane.go
+++ b/internal/tui/terminal/terminalpane.go
@@ -180,6 +180,13 @@ type TerminalPane struct {
 	// "No active session".
 	pending bool
 
+	// lastPasteTime is the wall-clock time of the most recent PasteHandler
+	// invocation. Used by the app-level key forwarder to detect non-paste
+	// keystrokes that arrive between two bracket-paste sequences — a pattern
+	// produced by some terminal emulators on multi-file drag-drop that splits
+	// the drop across two pastes with an intervening newline.
+	lastPasteTime time.Time
+
 	// OnClick is called when the user clicks on the terminal pane.
 	// The app wires this to switch agentFocus back to the terminal.
 	OnClick func()
@@ -783,7 +790,9 @@ func (tp *TerminalPane) PasteHandler() func(pastedText string, setFocus func(p t
 	return tp.WrapPasteHandler(func(pastedText string, setFocus func(p tview.Primitive)) {
 		tp.mu.Lock()
 		sess := tp.session
+		tp.lastPasteTime = time.Now()
 		tp.mu.Unlock()
+		uxlog.Log("[paste] received %d bytes: %s", len(pastedText), quotePreview(pastedText, 256))
 		if sess != nil && sess.Alive() {
 			// Write the entire paste as a single PTY write, wrapped in
 			// bracket paste sequences so the agent's readline sees it as
@@ -792,6 +801,26 @@ func (tp *TerminalPane) PasteHandler() func(pastedText string, setFocus func(p t
 			sess.WriteInput([]byte(data))
 		}
 	})
+}
+
+// LastPasteTime returns the wall-clock time of the most recent PasteHandler
+// invocation, or the zero time if no paste has occurred. Used by the app key
+// forwarder to log keystrokes that arrive during the paste-settling window
+// while diagnosing multi-file drag-drop splitting.
+func (tp *TerminalPane) LastPasteTime() time.Time {
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+	return tp.lastPasteTime
+}
+
+// quotePreview returns a Go-quoted, length-bounded preview of s suitable for
+// logging arbitrary terminal byte sequences (escapes, control chars) without
+// corrupting the log.
+func quotePreview(s string, max int) string {
+	if len(s) <= max {
+		return fmt.Sprintf("%q", s)
+	}
+	return fmt.Sprintf("%q…(+%d bytes)", s[:max], len(s)-max)
 }
 
 // --- Diff mode ---

--- a/internal/tui/terminal/terminalpane_test.go
+++ b/internal/tui/terminal/terminalpane_test.go
@@ -1648,8 +1648,14 @@ func TestTerminalPane_PasteHandler_LiveSession(t *testing.T) {
 	rec := &pasteRecorder{mockAdapter: mockAdapter{alive: true}}
 	tp.SetSession(rec)
 
+	if !tp.LastPasteTime().IsZero() {
+		t.Fatalf("LastPasteTime should be zero before any paste, got %v", tp.LastPasteTime())
+	}
+
 	handler := tp.PasteHandler()
+	before := time.Now()
 	handler("hello world", func(p tview.Primitive) {})
+	after := time.Now()
 
 	got := string(rec.written)
 	if !strings.Contains(got, "\x1b[200~") {
@@ -1660,6 +1666,62 @@ func TestTerminalPane_PasteHandler_LiveSession(t *testing.T) {
 	}
 	if !strings.Contains(got, "\x1b[201~") {
 		t.Errorf("paste should be wrapped in end sequence: %q", got)
+	}
+
+	lp := tp.LastPasteTime()
+	if lp.Before(before) || lp.After(after) {
+		t.Errorf("LastPasteTime %v not in [%v, %v]", lp, before, after)
+	}
+}
+
+func TestQuotePreview(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{
+			name: "short ascii returns full quote",
+			in:   "hello",
+			max:  256,
+			want: `"hello"`,
+		},
+		{
+			name: "exactly max length returns full quote",
+			in:   "abcd",
+			max:  4,
+			want: `"abcd"`,
+		},
+		{
+			name: "control chars escape into quote",
+			in:   "\x1b[200~",
+			max:  256,
+			want: `"\x1b[200~"`,
+		},
+		{
+			name: "over max truncates with byte counter",
+			in:   "abcdefghij",
+			max:  4,
+			want: `"abcd"…(+6 bytes)`,
+		},
+		{
+			name: "utf8 split mid-rune escapes orphan byte",
+			// "é" = 0xC3 0xA9. max=1 splits between them; %q renders the
+			// lone 0xC3 as \xc3 (no panic, no garbage).
+			in:   "é",
+			max:  1,
+			want: `"\xc3"…(+1 bytes)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := quotePreview(tt.in, tt.max)
+			if got != tt.want {
+				t.Errorf("quotePreview(%q, %d) = %s, want %s", tt.in, tt.max, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds uxlog instrumentation to capture the exact byte sequence the outer terminal produces when multiple image files are dragged into an Argus agent task. Reproductions report that only one of N dropped images registers in the inner Claude Code session (e.g. only `[Image #2]` appears in the prompt); this PR is diagnostic-only so the next session can pin which of three patterns the outer terminal emits before the actual fix lands.

## What it logs

- `TerminalPane.PasteHandler` records each bracketed-paste arrival with its byte length and a Go-quoted, 256-byte-bounded preview (`quotePreview` escapes ESC and control bytes safely). It also stamps `lastPasteTime`.
- `App.handleAgentKey` checks `agentPane.LastPasteTime()` before forwarding each key; any byte sent within the `pasteSettleWindow` (200ms) is logged with the elapsed millis and tcell key code.

Together these surface the three candidate failure patterns:
1. one paste with both paths → bug is downstream in Claude Code's paste parser;
2. two pastes with an intervening Enter → tmux/Alacritty is splitting the drop with a newline that Claude treats as submit;
3. two back-to-back pastes → the inner CLI's paste handler replaces rather than appends.

## Hygiene

Both uxlog sites carry `TODO(diagnostic)` comments so cleanup after the real fix is a single `grep`. The `[paste]` log prefix is intentionally cross-file to make the diagnostic greppable as one trace.

## Tests

- `TestQuotePreview` covers no-truncate, exact-length, control-char escaping, byte truncation, and UTF-8 mid-rune split (orphan lead byte escapes safely as `\xNN`).
- `TestTerminalPane_PasteHandler_LiveSession` extended to assert `lastPasteTime` is set within the call's wall-clock window.

## Test plan

- [x] `make test` (all packages green, race detector enabled)
- [ ] Drag two image files into a running agent task in tmux + Alacritty; capture `tail -f ~/.argus/ux.log | grep paste` and verify which of the three patterns above fires

Co-Authored-By: Claude <noreply@anthropic.com>