### PR TITLE
Open project repo on ctrl+o in the task list

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The sections below are the dense usage docs — keybindings, REST endpoints, con
 | `P`       | Toggle pin (★ section pinned to the top of the task list)       |
 | `c`       | Copy task prompt to clipboard                                   |
 | `ctrl+d`  | Destroy task (kill agent + remove worktree + delete branch)     |
+| `ctrl+o`  | Open the project's GitHub repo in browser (via `gh repo view --web`) |
 | `ctrl+r`  | Prune completed tasks                                           |
 | `j` / `k` | Navigate up/down                                                |
 | `1` / `2` | Switch tabs (Tasks / Settings)                                  |

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1319,6 +1319,23 @@ func (a *App) handleGlobalKey(event *tcell.EventKey) *tcell.EventKey {
 				return nil
 			}
 		}
+	case tcell.KeyCtrlO:
+		if a.mode == modeTaskList && a.header.ActiveTab() == widget.TabTasks {
+			if t := a.tasklist.SelectedTask(); t != nil {
+				dir := ""
+				if p, ok := a.db.Config().Projects[t.Project]; ok && p.Path != "" {
+					dir = p.Path
+				} else if t.Worktree != "" {
+					dir = t.Worktree
+				}
+				if dir != "" {
+					if err := repoOpener(dir); err != nil {
+						uxlog.Log("[tui] open repo failed: %v", err)
+					}
+					return nil
+				}
+			}
+		}
 	case tcell.KeyCtrlP:
 		if a.mode == modeTaskList && a.header.ActiveTab() == widget.TabTasks {
 			if t := a.tasklist.SelectedTask(); t != nil && t.Worktree != "" {
@@ -1728,6 +1745,15 @@ var terminalOpener = func(worktreeDir string) error {
 var prOpener = func(worktreeDir string) error {
 	cmd := exec.Command("gh", "pr", "view", "--web")
 	cmd.Dir = worktreeDir
+	return cmd.Start()
+}
+
+// repoOpener is the package-level seam for "open the GitHub repo page for
+// this project in a browser via gh". gh resolves the URL from the local
+// remote, so any directory inside the repo (project root or worktree) works.
+var repoOpener = func(dir string) error {
+	cmd := exec.Command("gh", "repo", "view", "--web")
+	cmd.Dir = dir
 	return cmd.Start()
 }
 

--- a/internal/tui/newtaskform_autocomplete_test.go
+++ b/internal/tui/newtaskform_autocomplete_test.go
@@ -327,3 +327,126 @@ var errStubPRFailed = stubError("pr open failed")
 type stubError string
 
 func (e stubError) Error() string { return string(e) }
+
+func TestApp_HandleGlobalKey_CtrlOOpensRepoFromProjectPath(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false)
+
+	projPath := t.TempDir()
+	testutil.NoError(t, d.SetProject("proj", config.Project{Path: projPath}))
+
+	wt := t.TempDir()
+	task := &model.Task{
+		ID:        "t1",
+		Name:      "task one",
+		Status:    model.StatusInProgress,
+		Project:   "proj",
+		Worktree:  wt,
+		CreatedAt: time.Now(),
+	}
+	testutil.NoError(t, d.Add(task))
+	app.refreshTasks()
+
+	var gotDir string
+	orig := repoOpener
+	repoOpener = func(dir string) error {
+		gotDir = dir
+		return nil
+	}
+	t.Cleanup(func() { repoOpener = orig })
+
+	if ev := app.handleGlobalKey(tcell.NewEventKey(tcell.KeyCtrlO, 0, 0)); ev != nil {
+		t.Fatal("ctrl+o should be consumed in task list")
+	}
+	// Project path is preferred over worktree.
+	testutil.Equal(t, gotDir, projPath)
+}
+
+func TestApp_HandleGlobalKey_CtrlOFallsBackToWorktree(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false)
+
+	// Task references a project name that's not in the config.
+	wt := t.TempDir()
+	task := &model.Task{
+		ID:        "t1",
+		Name:      "task one",
+		Status:    model.StatusInProgress,
+		Project:   "ghost",
+		Worktree:  wt,
+		CreatedAt: time.Now(),
+	}
+	testutil.NoError(t, d.Add(task))
+	app.refreshTasks()
+
+	var gotDir string
+	orig := repoOpener
+	repoOpener = func(dir string) error {
+		gotDir = dir
+		return nil
+	}
+	t.Cleanup(func() { repoOpener = orig })
+
+	if ev := app.handleGlobalKey(tcell.NewEventKey(tcell.KeyCtrlO, 0, 0)); ev != nil {
+		t.Fatal("ctrl+o should be consumed in task list")
+	}
+	testutil.Equal(t, gotDir, wt)
+}
+
+func TestApp_HandleGlobalKey_CtrlONoDir(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false)
+
+	// No project entry, no worktree.
+	task := &model.Task{
+		ID:        "t1",
+		Name:      "task one",
+		Status:    model.StatusPending,
+		Project:   "ghost",
+		CreatedAt: time.Now(),
+	}
+	testutil.NoError(t, d.Add(task))
+	app.refreshTasks()
+
+	called := false
+	orig := repoOpener
+	repoOpener = func(string) error { called = true; return nil }
+	t.Cleanup(func() { repoOpener = orig })
+
+	if ev := app.handleGlobalKey(tcell.NewEventKey(tcell.KeyCtrlO, 0, 0)); ev == nil {
+		t.Fatal("ctrl+o should fall through when no directory is available")
+	}
+	if called {
+		t.Fatal("repoOpener should not run when no directory is available")
+	}
+}
+
+// repoOpener errors (gh not installed, no remote, etc.) must be swallowed
+// and logged, not propagated. The event still gets consumed.
+func TestApp_HandleGlobalKey_CtrlOSwallowsRepoError(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false)
+
+	task := &model.Task{
+		ID:        "t1",
+		Name:      "task one",
+		Status:    model.StatusInProgress,
+		Project:   "proj",
+		Worktree:  t.TempDir(),
+		CreatedAt: time.Now(),
+	}
+	testutil.NoError(t, d.Add(task))
+	app.refreshTasks()
+
+	orig := repoOpener
+	repoOpener = func(string) error { return stubError("repo open failed") }
+	t.Cleanup(func() { repoOpener = orig })
+
+	if ev := app.handleGlobalKey(tcell.NewEventKey(tcell.KeyCtrlO, 0, 0)); ev != nil {
+		t.Fatal("ctrl+o should be consumed even when repoOpener errors")
+	}
+}


### PR DESCRIPTION
Adds a `ctrl+o` keybinding in the task list that opens the project's
GitHub repo in the browser via `gh repo view --web`, mirroring the
existing `ctrl+p` PR-open pattern.

A new `repoOpener` package-level seam wraps `gh repo view --web`. The
handler prefers the configured project path and falls back to the task's
worktree when the project is no longer in config; if neither is
available, the event falls through.

Includes 4 tests covering the happy path, fallback, no-dir fallthrough,
and opener-error swallowing.

Co-Authored-By: Claude <noreply@anthropic.com>