### PR TITLE
Add ? help modal listing keybindings

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -58,6 +58,7 @@ const (
 	modeConfirmDeleteProject
 	modeRestartDaemonPrompt
 	modeAppleEventsPicker
+	modeHelp
 )
 
 // agentFocus tracks which panel has focus in the agent view.
@@ -102,6 +103,10 @@ type App struct {
 	// Confirm delete modal (created on demand)
 	confirmDeleteModal        *modal.ConfirmDeleteModal
 	confirmDeleteProjectModal *modal.ConfirmDeleteProjectModal
+
+	// Help overlay (created on demand)
+	helpModal    *modal.HelpModal
+	helpPrevPage string
 
 	// Restart-daemon prompt (created on demand when binary mtime mismatch
 	// is detected at startup). daemonStale is set by main before Run() and
@@ -1260,6 +1265,12 @@ func (a *App) handleGlobalKey(event *tcell.EventKey) *tcell.EventKey {
 		return nil
 	}
 
+	// Help overlay — delegate everything to the modal
+	if a.mode == modeHelp && a.helpModal != nil {
+		a.handleHelpKey(event)
+		return nil
+	}
+
 	// Confirm delete project modal
 	if a.mode == modeConfirmDeleteProject && a.confirmDeleteProjectModal != nil {
 		a.handleConfirmDeleteProjectKey(event)
@@ -1458,6 +1469,11 @@ func (a *App) handleGlobalKey(event *tcell.EventKey) *tcell.EventKey {
 		case '3':
 			if a.mode != modeAgent {
 				a.switchTab(widget.TabSettings)
+				return nil
+			}
+		case '?':
+			if a.mode != modeAgent {
+				a.openHelp()
 				return nil
 			}
 		}
@@ -2844,6 +2860,52 @@ func (a *App) closeConfirmDelete() {
 	a.pages.RemovePage("confirmdelete")
 	a.pages.SwitchToPage("tasks")
 	a.tapp.SetFocus(a.tasklist)
+}
+
+// openHelp shows the keybindings help overlay. The previous active page is
+// remembered so closeHelp can restore the user's context (Tasks, DAG, or
+// Settings tab).
+func (a *App) openHelp() {
+	if a.helpModal != nil {
+		return
+	}
+	a.helpPrevPage, _ = a.pages.GetFrontPage()
+	a.helpModal = modal.NewHelpModal()
+	a.mode = modeHelp
+	a.pages.AddPage("help", a.helpModal, true, true)
+	a.pages.SwitchToPage("help")
+	a.tapp.SetFocus(a.helpModal)
+}
+
+// handleHelpKey processes keys in the help overlay.
+func (a *App) handleHelpKey(event *tcell.EventKey) {
+	handler := a.helpModal.InputHandler()
+	handler(event, func(p tview.Primitive) {})
+	if a.helpModal.Closed() {
+		a.closeHelp()
+	}
+}
+
+// closeHelp dismisses the help overlay and restores the prior page.
+func (a *App) closeHelp() {
+	a.mode = modeTaskList
+	a.helpModal = nil
+	a.pages.RemovePage("help")
+	prev := a.helpPrevPage
+	a.helpPrevPage = ""
+	if prev == "" || prev == "help" {
+		prev = "tasks"
+	}
+	a.pages.SwitchToPage(prev)
+	// Restore focus to whichever widget owns the visible tab.
+	switch a.header.ActiveTab() {
+	case widget.TabSettings:
+		a.tapp.SetFocus(a.settings)
+	case widget.TabDAG:
+		a.tapp.SetFocus(a.dagWidget)
+	default:
+		a.tapp.SetFocus(a.tasklist)
+	}
 }
 
 // --- Fork task ---

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -898,6 +898,84 @@ func TestCloseConfirmDelete(t *testing.T) {
 	}
 }
 
+func TestOpenHelp(t *testing.T) {
+	d := testDB(t)
+	app := New(d, agent.NewRunner(nil), false)
+
+	app.openHelp()
+
+	if app.mode != modeHelp {
+		t.Errorf("mode = %v, want modeHelp", app.mode)
+	}
+	if app.helpModal == nil {
+		t.Error("helpModal should not be nil")
+	}
+	// Calling again is a no-op (no second modal allocated).
+	first := app.helpModal
+	app.openHelp()
+	if app.helpModal != first {
+		t.Error("openHelp must be idempotent while modal is visible")
+	}
+}
+
+func TestCloseHelp(t *testing.T) {
+	d := testDB(t)
+	app := New(d, agent.NewRunner(nil), false)
+
+	app.openHelp()
+	app.closeHelp()
+
+	if app.mode != modeTaskList {
+		t.Errorf("mode = %v, want modeTaskList", app.mode)
+	}
+	if app.helpModal != nil {
+		t.Error("helpModal should be nil after close")
+	}
+	if app.helpPrevPage != "" {
+		t.Errorf("helpPrevPage = %q, want empty", app.helpPrevPage)
+	}
+}
+
+func TestHandleHelpKeyClosesOnEscape(t *testing.T) {
+	d := testDB(t)
+	app := New(d, agent.NewRunner(nil), false)
+
+	app.openHelp()
+	app.handleHelpKey(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
+
+	if app.mode != modeTaskList {
+		t.Errorf("mode = %v, want modeTaskList", app.mode)
+	}
+	if app.helpModal != nil {
+		t.Error("helpModal should be nil after Esc")
+	}
+}
+
+func TestCloseHelpRestoresActiveTab(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tab  widget.Tab
+	}{
+		{"tasks", widget.TabTasks},
+		{"DAG", widget.TabDAG},
+		{"settings", widget.TabSettings},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := testDB(t)
+			app := New(d, agent.NewRunner(nil), false)
+			app.switchTab(tc.tab)
+			app.openHelp()
+			app.closeHelp()
+			if app.mode != modeTaskList {
+				t.Errorf("mode = %v, want modeTaskList", app.mode)
+			}
+			if app.header.ActiveTab() != tc.tab {
+				t.Errorf("active tab = %v, want %v after close", app.header.ActiveTab(), tc.tab)
+			}
+		})
+	}
+}
+
 func TestDeleteTask(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)

--- a/internal/tui/modal/help.go
+++ b/internal/tui/modal/help.go
@@ -1,0 +1,190 @@
+package modal
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/drn/argus/internal/tui/theme"
+	"github.com/drn/argus/internal/tui/widget"
+)
+
+// HelpModal shows a centered overlay listing keybindings grouped by context.
+// Esc, Ctrl+Q, or `?` closes it.
+type HelpModal struct {
+	*tview.Box
+	closed bool
+}
+
+// HelpBinding is a single key/action pair.
+type HelpBinding struct {
+	Key    string
+	Action string
+}
+
+// HelpSection groups bindings under a heading.
+type HelpSection struct {
+	Title    string
+	Bindings []HelpBinding
+}
+
+// HelpSections is the canonical inventory rendered by the modal. Source of
+// truth for the help overlay — mirror updates here when bindings change.
+var HelpSections = []HelpSection{
+	{
+		Title: "Task List",
+		Bindings: []HelpBinding{
+			{"n", "new task"},
+			{"Enter", "open agent view"},
+			{"j / k", "navigate up/down"},
+			{"s / S", "advance / revert status"},
+			{"a", "toggle archive"},
+			{"P", "toggle pin"},
+			{"r", "rename"},
+			{"c", "copy prompt"},
+			{"/", "filter"},
+			{"ctrl+f", "fork task"},
+			{"ctrl+d", "destroy task"},
+			{"ctrl+r", "prune completed"},
+			{"ctrl+p", "open PR"},
+			{"ctrl+o", "open repo"},
+			{"ctrl+l", "refresh screen"},
+			{"1 / 2 / 3", "switch tab (tasks / DAG / settings)"},
+			{"q", "quit"},
+		},
+	},
+	{
+		Title: "Agent View",
+		Bindings: []HelpBinding{
+			{"ctrl+q / Esc", "back (diff → files → list)"},
+			{"Cmd+← / Cmd+→", "switch panels"},
+			{"Cmd+↑ / Cmd+↓", "navigate tasks"},
+			{"Shift+↑ / Shift+↓", "scroll terminal"},
+			{"ctrl+l", "link picker"},
+			{"ctrl+p", "open PR"},
+			{"ctrl+y", "copy staged text"},
+		},
+	},
+	{
+		Title: "File Panel",
+		Bindings: []HelpBinding{
+			{"Enter", "open diff"},
+			{"s", "toggle split/unified"},
+			{"o", "reveal in Finder"},
+			{"e", "open in editor"},
+			{"t", "open terminal in worktree"},
+		},
+	},
+	{
+		Title: "Settings",
+		Bindings: []HelpBinding{
+			{"j / k", "navigate rows"},
+			{"n", "new project / backend / schedule"},
+			{"e", "edit"},
+			{"d", "delete / set default"},
+			{"t", "toggle schedule enabled"},
+			{"r", "run schedule now"},
+			{"i", "quick add projects"},
+			{"Enter / ◀ / ▶", "toggle / cycle settings"},
+		},
+	},
+	{
+		Title: "Modals & Forms",
+		Bindings: []HelpBinding{
+			{"Esc / ctrl+q", "close / cancel"},
+			{"Enter", "confirm / submit"},
+			{"Tab / Shift+Tab", "navigate fields"},
+		},
+	},
+}
+
+// NewHelpModal creates a help overlay.
+func NewHelpModal() *HelpModal {
+	return &HelpModal{Box: tview.NewBox()}
+}
+
+// Closed reports whether the user dismissed the modal.
+func (m *HelpModal) Closed() bool { return m.closed }
+
+// InputHandler closes the modal on Esc, Ctrl+Q, or `?`.
+func (m *HelpModal) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+	return m.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+		switch event.Key() {
+		case tcell.KeyEscape, tcell.KeyCtrlQ:
+			m.closed = true
+			return
+		}
+		if event.Key() == tcell.KeyRune && event.Rune() == '?' {
+			m.closed = true
+		}
+	})
+}
+
+// helpModalSize returns the modal's width and total drawn height based on
+// the available rect.
+func helpModalSize(width, height int) (w, h int) {
+	w = min(72, width-4)
+	if w < 24 {
+		w = width
+	}
+	h = 4 // border (2) + title gap (1) + hint (1)
+	for _, sec := range HelpSections {
+		h += 1 + len(sec.Bindings) + 1 // heading + rows + spacer
+	}
+	if h > height {
+		h = height
+	}
+	return w, h
+}
+
+// Draw renders the help modal centered in the available rect.
+func (m *HelpModal) Draw(screen tcell.Screen) {
+	m.Box.DrawForSubclass(screen, m)
+	x, y, width, height := m.GetInnerRect()
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	formW, formH := helpModalSize(width, height)
+	if formW < 8 || formH < 4 {
+		return
+	}
+	formX := x + (width-formW)/2
+	formY := y + (height-formH)/2
+	if formY < y {
+		formY = y
+	}
+
+	widget.FillArea(screen, formX, formY, formW, formH, ' ', tcell.StyleDefault)
+	inner := widget.DrawBorderedPanel(screen, formX, formY, formW, formH, "Keybindings", theme.StyleFocusedBorder)
+	if inner.W <= 0 || inner.H <= 0 {
+		return
+	}
+
+	// Column layout: key column ~18 chars, action takes the rest.
+	keyCol := 18
+	if keyCol > inner.W/2 {
+		keyCol = inner.W / 2
+	}
+
+	row := inner.Y
+	maxRow := inner.Y + inner.H - 2 // reserve a row for the hint
+	for _, sec := range HelpSections {
+		if row >= maxRow {
+			break
+		}
+		widget.DrawText(screen, inner.X, row, inner.W, sec.Title, theme.StyleTitle)
+		row++
+		for _, b := range sec.Bindings {
+			if row >= maxRow {
+				break
+			}
+			widget.DrawText(screen, inner.X+2, row, keyCol, b.Key, theme.StyleNormal)
+			widget.DrawText(screen, inner.X+2+keyCol, row, inner.W-keyCol-2, b.Action, theme.StyleDimmed)
+			row++
+		}
+		row++ // section spacer
+	}
+
+	// Footer hint pinned to the last inner row.
+	widget.DrawText(screen, inner.X, inner.Y+inner.H-1, inner.W, "[esc / ?] close", theme.StyleDimmed)
+}

--- a/internal/tui/modal/help.go
+++ b/internal/tui/modal/help.go
@@ -1,6 +1,8 @@
 package modal
 
 import (
+	"fmt"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 
@@ -9,10 +11,14 @@ import (
 )
 
 // HelpModal shows a centered overlay listing keybindings grouped by context.
-// Esc, Ctrl+Q, or `?` closes it.
+// Esc, Ctrl+Q, or `?` closes it. j/k, ↑/↓, PgUp/PgDn, g/G scroll. Mouse wheel
+// scrolls too.
 type HelpModal struct {
 	*tview.Box
-	closed bool
+	closed    bool
+	scroll    int
+	maxScroll int
+	pageStep  int
 }
 
 // HelpBinding is a single key/action pair.
@@ -97,6 +103,30 @@ var HelpSections = []HelpSection{
 	},
 }
 
+// helpRow is one rendered line of help content.
+type helpRow struct {
+	key     string
+	action  string
+	heading bool
+	spacer  bool
+}
+
+// helpRows flattens HelpSections into a list of rendered rows. Spacers go
+// between sections (not after the last one).
+func helpRows() []helpRow {
+	var rows []helpRow
+	for i, sec := range HelpSections {
+		if i > 0 {
+			rows = append(rows, helpRow{spacer: true})
+		}
+		rows = append(rows, helpRow{action: sec.Title, heading: true})
+		for _, b := range sec.Bindings {
+			rows = append(rows, helpRow{key: b.Key, action: b.Action})
+		}
+	}
+	return rows
+}
+
 // NewHelpModal creates a help overlay.
 func NewHelpModal() *HelpModal {
 	return &HelpModal{Box: tview.NewBox()}
@@ -105,31 +135,80 @@ func NewHelpModal() *HelpModal {
 // Closed reports whether the user dismissed the modal.
 func (m *HelpModal) Closed() bool { return m.closed }
 
-// InputHandler closes the modal on Esc, Ctrl+Q, or `?`.
+// InputHandler closes on Esc/Ctrl+Q/?, scrolls on j/k, ↑/↓, PgUp/PgDn, g/G.
+// Out-of-range scroll values are clamped on the next Draw.
 func (m *HelpModal) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
 	return m.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
 		switch event.Key() {
 		case tcell.KeyEscape, tcell.KeyCtrlQ:
 			m.closed = true
 			return
+		case tcell.KeyUp:
+			m.scroll--
+			return
+		case tcell.KeyDown:
+			m.scroll++
+			return
+		case tcell.KeyPgUp, tcell.KeyCtrlU:
+			m.scroll -= m.pageStep
+			return
+		case tcell.KeyPgDn, tcell.KeyCtrlD:
+			m.scroll += m.pageStep
+			return
+		case tcell.KeyHome:
+			m.scroll = 0
+			return
+		case tcell.KeyEnd:
+			m.scroll = 1 << 30
+			return
 		}
-		if event.Key() == tcell.KeyRune && event.Rune() == '?' {
-			m.closed = true
+		if event.Key() == tcell.KeyRune {
+			switch event.Rune() {
+			case '?':
+				m.closed = true
+			case 'j':
+				m.scroll++
+			case 'k':
+				m.scroll--
+			case 'g':
+				m.scroll = 0
+			case 'G':
+				m.scroll = 1 << 30
+			}
 		}
 	})
 }
 
-// helpModalSize returns the modal's width and total drawn height based on
-// the available rect.
+// MouseHandler scrolls on wheel up/down. Click captures focus so the modal
+// keeps receiving keyboard events when something behind it would otherwise
+// steal focus.
+func (m *HelpModal) MouseHandler() func(action tview.MouseAction, event *tcell.EventMouse, setFocus func(p tview.Primitive)) (consumed bool, capture tview.Primitive) {
+	return m.WrapMouseHandler(func(action tview.MouseAction, event *tcell.EventMouse, setFocus func(p tview.Primitive)) (consumed bool, capture tview.Primitive) {
+		switch action {
+		case tview.MouseScrollUp:
+			m.scroll -= 3
+			return true, nil
+		case tview.MouseScrollDown:
+			m.scroll += 3
+			return true, nil
+		case tview.MouseLeftDown, tview.MouseLeftClick:
+			setFocus(m)
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+// helpModalSize returns the modal's width and total drawn height for the
+// available rect. Height is the natural full-content height clamped to the
+// available space; scrolling handles the overflow.
 func helpModalSize(width, height int) (w, h int) {
 	w = min(72, width-4)
 	if w < 24 {
 		w = width
 	}
-	h = 4 // border (2) + title gap (1) + hint (1)
-	for _, sec := range HelpSections {
-		h += 1 + len(sec.Bindings) + 1 // heading + rows + spacer
-	}
+	// border (2) + content + hint (1)
+	h = 3 + len(helpRows())
 	if h > height {
 		h = height
 	}
@@ -160,31 +239,53 @@ func (m *HelpModal) Draw(screen tcell.Screen) {
 		return
 	}
 
-	// Column layout: key column ~18 chars, action takes the rest.
 	keyCol := 18
 	if keyCol > inner.W/2 {
 		keyCol = inner.W / 2
 	}
 
-	row := inner.Y
-	maxRow := inner.Y + inner.H - 2 // reserve a row for the hint
-	for _, sec := range HelpSections {
-		if row >= maxRow {
+	rows := helpRows()
+	visible := inner.H - 1 // reserve last row for hint
+	if visible < 1 {
+		visible = 1
+	}
+	if visible > len(rows) {
+		visible = len(rows)
+	}
+	maxScroll := len(rows) - visible
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if m.scroll > maxScroll {
+		m.scroll = maxScroll
+	}
+	if m.scroll < 0 {
+		m.scroll = 0
+	}
+	m.maxScroll = maxScroll
+	m.pageStep = visible
+
+	for i := 0; i < visible; i++ {
+		idx := m.scroll + i
+		if idx >= len(rows) {
 			break
 		}
-		widget.DrawText(screen, inner.X, row, inner.W, sec.Title, theme.StyleTitle)
-		row++
-		for _, b := range sec.Bindings {
-			if row >= maxRow {
-				break
-			}
-			widget.DrawText(screen, inner.X+2, row, keyCol, b.Key, theme.StyleNormal)
-			widget.DrawText(screen, inner.X+2+keyCol, row, inner.W-keyCol-2, b.Action, theme.StyleDimmed)
-			row++
+		r := rows[idx]
+		rowY := inner.Y + i
+		switch {
+		case r.spacer:
+			// blank
+		case r.heading:
+			widget.DrawText(screen, inner.X, rowY, inner.W, r.action, theme.StyleTitle)
+		default:
+			widget.DrawText(screen, inner.X+2, rowY, keyCol, r.key, theme.StyleNormal)
+			widget.DrawText(screen, inner.X+2+keyCol, rowY, inner.W-keyCol-2, r.action, theme.StyleDimmed)
 		}
-		row++ // section spacer
 	}
 
-	// Footer hint pinned to the last inner row.
-	widget.DrawText(screen, inner.X, inner.Y+inner.H-1, inner.W, "[esc / ?] close", theme.StyleDimmed)
+	hint := "[esc / ?] close"
+	if maxScroll > 0 {
+		hint = fmt.Sprintf("[esc / ?] close   [↑↓ / jk] scroll   %d-%d / %d", m.scroll+1, m.scroll+visible, len(rows))
+	}
+	widget.DrawText(screen, inner.X, inner.Y+inner.H-1, inner.W, hint, theme.StyleDimmed)
 }

--- a/internal/tui/modal/help_test.go
+++ b/internal/tui/modal/help_test.go
@@ -1,0 +1,95 @@
+package modal
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/drn/argus/internal/testutil"
+)
+
+func TestHelpModal_Defaults(t *testing.T) {
+	m := NewHelpModal()
+	testutil.False(t, m.Closed())
+}
+
+func TestHelpModal_InputHandler(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		key        tcell.Key
+		rune       rune
+		wantClosed bool
+	}{
+		{"esc closes", tcell.KeyEscape, 0, true},
+		{"ctrl+q closes", tcell.KeyCtrlQ, 0, true},
+		{"? closes", tcell.KeyRune, '?', true},
+		{"unrelated rune no-op", tcell.KeyRune, 'x', false},
+		{"enter no-op", tcell.KeyEnter, 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewHelpModal()
+			ev := tcell.NewEventKey(tc.key, tc.rune, tcell.ModNone)
+			m.InputHandler()(ev, nil)
+			testutil.Equal(t, m.Closed(), tc.wantClosed)
+		})
+	}
+}
+
+func TestHelpModal_Draw(t *testing.T) {
+	sim := drawAt(t, 100, 40)
+	m := NewHelpModal()
+	m.SetRect(0, 0, 100, 40)
+	m.Draw(sim)
+	sim.Sync()
+
+	body := screenString(sim)
+	testutil.Contains(t, body, "Keybindings")
+	testutil.Contains(t, body, "Task List")
+	testutil.Contains(t, body, "Agent View")
+	testutil.Contains(t, body, "File Panel")
+	testutil.Contains(t, body, "Settings")
+	testutil.Contains(t, body, "[esc / ?] close")
+	// Sample a few bindings to catch regressions in the section list.
+	testutil.Contains(t, body, "new task")
+	testutil.Contains(t, body, "fork task")
+}
+
+func TestHelpModal_DrawZeroSizeNoOp(t *testing.T) {
+	sim := drawAt(t, 80, 24)
+	m := NewHelpModal()
+	m.SetRect(0, 0, 0, 0)
+	m.Draw(sim) // must not panic
+}
+
+func TestHelpModal_DrawTinyArea(t *testing.T) {
+	sim := drawAt(t, 80, 24)
+	m := NewHelpModal()
+	m.SetRect(0, 0, 6, 2) // below the 8x4 minimum — should short-circuit
+	m.Draw(sim)
+}
+
+func TestHelpModal_DrawClampsToAvailableHeight(t *testing.T) {
+	sim := drawAt(t, 80, 24)
+	m := NewHelpModal()
+	m.SetRect(0, 0, 80, 8) // height clamped; only the first sections fit
+	m.Draw(sim)
+	sim.Sync()
+	body := screenString(sim)
+	testutil.Contains(t, body, "Keybindings")
+	// Hint must still render on the last inner row.
+	testutil.Contains(t, body, "close")
+}
+
+func TestHelpSections_NonEmpty(t *testing.T) {
+	testutil.True(t, len(HelpSections) > 0)
+	for _, sec := range HelpSections {
+		t.Run(sec.Title, func(t *testing.T) {
+			testutil.True(t, sec.Title != "")
+			testutil.True(t, len(sec.Bindings) > 0)
+			for _, b := range sec.Bindings {
+				testutil.True(t, b.Key != "")
+				testutil.True(t, b.Action != "")
+			}
+		})
+	}
+}

--- a/internal/tui/modal/help_test.go
+++ b/internal/tui/modal/help_test.go
@@ -1,9 +1,11 @@
 package modal
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
 
 	"github.com/drn/argus/internal/testutil"
 )
@@ -78,6 +80,136 @@ func TestHelpModal_DrawClampsToAvailableHeight(t *testing.T) {
 	testutil.Contains(t, body, "Keybindings")
 	// Hint must still render on the last inner row.
 	testutil.Contains(t, body, "close")
+}
+
+func TestHelpModal_ScrollKeys(t *testing.T) {
+	// Draw at a height that forces scrolling: total content is len(helpRows())
+	// rows, give the modal much less.
+	render := func(m *HelpModal) {
+		sim := drawAt(t, 80, 12)
+		m.SetRect(0, 0, 80, 12)
+		m.Draw(sim)
+	}
+
+	for _, tc := range []struct {
+		name string
+		fire func(m *HelpModal)
+		// after firing + redraw, scroll must satisfy this predicate.
+		check func(t *testing.T, m *HelpModal)
+	}{
+		{
+			"down arrow scrolls one row",
+			func(m *HelpModal) {
+				m.InputHandler()(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone), nil)
+			},
+			func(t *testing.T, m *HelpModal) { testutil.Equal(t, m.scroll, 1) },
+		},
+		{
+			"j scrolls one row",
+			func(m *HelpModal) {
+				m.InputHandler()(tcell.NewEventKey(tcell.KeyRune, 'j', tcell.ModNone), nil)
+			},
+			func(t *testing.T, m *HelpModal) { testutil.Equal(t, m.scroll, 1) },
+		},
+		{
+			"k at top clamps to 0",
+			func(m *HelpModal) {
+				m.InputHandler()(tcell.NewEventKey(tcell.KeyRune, 'k', tcell.ModNone), nil)
+			},
+			func(t *testing.T, m *HelpModal) { testutil.Equal(t, m.scroll, 0) },
+		},
+		{
+			"PgDn scrolls one page",
+			func(m *HelpModal) {
+				m.InputHandler()(tcell.NewEventKey(tcell.KeyPgDn, 0, tcell.ModNone), nil)
+			},
+			func(t *testing.T, m *HelpModal) { testutil.True(t, m.scroll == m.pageStep) },
+		},
+		{
+			"G jumps to bottom",
+			func(m *HelpModal) {
+				m.InputHandler()(tcell.NewEventKey(tcell.KeyRune, 'G', tcell.ModNone), nil)
+			},
+			func(t *testing.T, m *HelpModal) { testutil.Equal(t, m.scroll, m.maxScroll) },
+		},
+		{
+			"End jumps to bottom",
+			func(m *HelpModal) {
+				m.InputHandler()(tcell.NewEventKey(tcell.KeyEnd, 0, tcell.ModNone), nil)
+			},
+			func(t *testing.T, m *HelpModal) { testutil.Equal(t, m.scroll, m.maxScroll) },
+		},
+		{
+			"g returns to top after scrolling",
+			func(m *HelpModal) {
+				m.scroll = 5
+				m.InputHandler()(tcell.NewEventKey(tcell.KeyRune, 'g', tcell.ModNone), nil)
+			},
+			func(t *testing.T, m *HelpModal) { testutil.Equal(t, m.scroll, 0) },
+		},
+		{
+			"Home returns to top after scrolling",
+			func(m *HelpModal) {
+				m.scroll = 5
+				m.InputHandler()(tcell.NewEventKey(tcell.KeyHome, 0, tcell.ModNone), nil)
+			},
+			func(t *testing.T, m *HelpModal) { testutil.Equal(t, m.scroll, 0) },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewHelpModal()
+			render(m) // populate maxScroll/pageStep
+			tc.fire(m)
+			render(m) // re-clamp scroll
+			tc.check(t, m)
+			testutil.False(t, m.Closed())
+		})
+	}
+}
+
+func TestHelpModal_MouseWheelScrolls(t *testing.T) {
+	m := NewHelpModal()
+	m.SetRect(0, 0, 80, 12)
+	sim := drawAt(t, 80, 12)
+	m.Draw(sim) // initialize maxScroll/pageStep
+
+	handler := m.MouseHandler()
+	// Wheel down 3 lines.
+	consumed, _ := handler(tview.MouseScrollDown, tcell.NewEventMouse(0, 0, tcell.ButtonNone, tcell.ModNone), nil)
+	testutil.True(t, consumed)
+	m.Draw(sim)
+	testutil.Equal(t, m.scroll, 3)
+
+	// Wheel up 3 lines — back to top.
+	consumed, _ = handler(tview.MouseScrollUp, tcell.NewEventMouse(0, 0, tcell.ButtonNone, tcell.ModNone), nil)
+	testutil.True(t, consumed)
+	m.Draw(sim)
+	testutil.Equal(t, m.scroll, 0)
+}
+
+func TestHelpModal_DrawShowsScrollPositionWhenOverflow(t *testing.T) {
+	sim := drawAt(t, 80, 12) // forces clamp/overflow
+	m := NewHelpModal()
+	m.SetRect(0, 0, 80, 12)
+	m.Draw(sim)
+	sim.Sync()
+	body := screenString(sim)
+	// The hint marker is unique to the scroll-position footer.
+	testutil.Contains(t, body, "[↑↓ / jk]")
+}
+
+func TestHelpModal_DrawHidesScrollHintWhenFits(t *testing.T) {
+	// Give the modal enough room that every row fits.
+	sim := drawAt(t, 100, 80)
+	m := NewHelpModal()
+	m.SetRect(0, 0, 100, 80)
+	m.Draw(sim)
+	sim.Sync()
+	body := screenString(sim)
+	testutil.Contains(t, body, "[esc / ?] close")
+	if strings.Contains(body, "[↑↓ / jk]") {
+		t.Errorf("scroll position indicator should not render when all rows fit")
+	}
 }
 
 func TestHelpSections_NonEmpty(t *testing.T) {

--- a/internal/tui/smoke_test.go
+++ b/internal/tui/smoke_test.go
@@ -360,6 +360,33 @@ func TestSmoke_TabSwitching(t *testing.T) {
 	}
 }
 
+func TestSmoke_HelpModalOpensOnQuestionKey(t *testing.T) {
+	d := testDB(t)
+	app := New(d, agent.NewRunner(nil), false)
+
+	sim, stop := wireApp(t, app)
+	defer stop()
+
+	sim.InjectKey(tcell.KeyRune, '?', 0)
+	syncUI(t, app.tapp)
+
+	var open bool
+	readUI(t, app.tapp, func() { open = app.helpModal != nil && app.mode == modeHelp })
+	if !open {
+		t.Fatal("? should open the help modal")
+	}
+
+	// Esc closes it and restores the task list mode.
+	sim.InjectKey(tcell.KeyEscape, 0, 0)
+	syncUI(t, app.tapp)
+
+	var closed bool
+	readUI(t, app.tapp, func() { closed = app.helpModal == nil && app.mode == modeTaskList })
+	if !closed {
+		t.Fatal("Esc should close the help modal")
+	}
+}
+
 func TestSmoke_NewTaskFormPaste(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)


### PR DESCRIPTION
The status bar advertised "? help" but the key did nothing — Keybindings.
Help was defined in config and never read. 
Wire it up: pressing ? on any non-agent tab opens a centered modal with bindings grouped by context (Task List, Agent View, File Panel, Settings, Modals). Esc / ctrl+q / ? closes. Mode is restored to the originating tab so focus returns where the user was.

<img width="1802" height="847" alt="image" src="https://github.com/user-attachments/assets/4846ad89-906f-47d8-b189-61f6270addda" />
