### PR TITLE
Forward Shift+Enter as newline-insert to the agent PTY

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1870,6 +1870,13 @@ func tcellKeyToBytes(ev *tcell.EventKey) []byte {
 
 	switch ev.Key() {
 	case tcell.KeyEnter:
+		// Shift+Enter / Alt+Enter → newline-insert (ESC + CR). TUIs
+		// running in the PTY (ink-based Claude Code, blessed, textual)
+		// treat CR as submit and ESC+CR as "insert newline" — the same
+		// sequence iTerm2 / Kitty emit for Shift+Enter when configured.
+		if ev.Modifiers()&(tcell.ModShift|tcell.ModAlt) != 0 {
+			return []byte{0x1b, '\r'}
+		}
 		return []byte{'\r'}
 	case tcell.KeyTab:
 		return []byte{'\t'}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -366,6 +366,8 @@ func TestTcellKeyToBytes(t *testing.T) {
 		want []byte
 	}{
 		{"enter", tcell.KeyEnter, 0, 0, []byte{'\r'}},
+		{"shift-enter", tcell.KeyEnter, 0, tcell.ModShift, []byte{0x1b, '\r'}},
+		{"alt-enter", tcell.KeyEnter, 0, tcell.ModAlt, []byte{0x1b, '\r'}},
 		{"tab", tcell.KeyTab, 0, 0, []byte{'\t'}},
 		{"shift-tab", tcell.KeyBacktab, 0, 0, []byte("\x1b[Z")},
 		{"backspace", tcell.KeyBackspace2, 0, 0, []byte{0x7f}},


### PR DESCRIPTION
## What

`tcellKeyToBytes` mapped `tcell.KeyEnter` to bare `\r` regardless of modifiers, so Shift+Enter and Alt+Enter were indistinguishable from plain Enter inside the agent terminal pane.

## Why

Claude Code (and other ink/blessed/textual TUIs running in the PTY) treats CR as submit. With argus dropping the modifier bits, there was no way to insert a newline mid-prompt — every keypress submitted.

## How

When `ModShift` or `ModAlt` is held with `KeyEnter`, emit `ESC + CR` (`\x1b\r`). This is the same byte sequence iTerm2 / Kitty / WezTerm already produce for Shift+Enter when the user has configured their terminal to distinguish it, so the in-PTY app sees an identical signal whether argus is in the loop or not.

Test cases added to `TestTcellKeyToBytes` for `shift-enter` and `alt-enter`.

## Verification

- `make test` — green
- `make vet` — clean