### PR TITLE
Plugin views: substrate primitive for plugin-owned UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Thumbs.db
 
 # Test coverage
 coverage.out
+coverage.filtered.out
 
 # Playwright web-tests artifacts
 web-tests/node_modules/

--- a/context/knowledge/gotchas/misc.md
+++ b/context/knowledge/gotchas/misc.md
@@ -1,3 +1,8 @@
+## Streampane Widget
+
+- **StreamPane drops keystrokes when the input-back channel is full.** The widget's `send()` does a non-blocking `select` — matching the PTY writer backpressure pattern elsewhere in argus. Tests that pre-fill `back` and assert no drop will hang; assert "no panic / no second send" instead.
+- **StreamPane `Touched()` increments only on non-empty chunks.** Empty chunks are a no-op so callers can poll the counter for damage without spurious redraws when the source feeds heartbeat-style zero-byte signals.
+
 ## Database Patterns
 
 - **New columns use `ALTER TABLE ... ADD COLUMN ... DEFAULT ''` after `CREATE TABLE IF NOT EXISTS`.** Error for duplicate column silently ignored.

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/coder/websocket v1.8.14 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gdamore/encoding v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfa
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=

--- a/internal/api/plugin_views.go
+++ b/internal/api/plugin_views.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/drn/argus/internal/tui/views"
+)
+
+// pluginViewJSON is the wire shape for /api/plugins/views responses and the
+// POST request body. created_at is RFC3339 nano per the rest of the API.
+type pluginViewJSON struct {
+	ID          int64  `json:"id"`
+	Scope       string `json:"scope"`
+	Title       string `json:"title"`
+	Hotkey      string `json:"hotkey,omitempty"`
+	CallbackURL string `json:"callback_url"`
+	CreatedAt   string `json:"created_at,omitempty"`
+}
+
+// pluginViewCreateReq is the POST body. The scope column is reserved for the
+// post-PR-1 scope-token swap; today scope is always "" because requireMaster
+// is the gate. See the TODO on each handler.
+type pluginViewCreateReq struct {
+	Title       string `json:"title"`
+	Hotkey      string `json:"hotkey"`
+	CallbackURL string `json:"callback_url"`
+}
+
+func toPluginViewJSON(v *views.View) pluginViewJSON {
+	return pluginViewJSON{
+		ID:          v.ID,
+		Scope:       v.Scope,
+		Title:       v.Title,
+		Hotkey:      v.Hotkey,
+		CallbackURL: v.CallbackURL,
+		CreatedAt:   v.CreatedAt.UTC().Format("2006-01-02T15:04:05.999999999Z07:00"),
+	}
+}
+
+// handleCreatePluginView registers a new plugin-owned top-level view.
+//
+// TODO(post-PR-1): swap requireMaster for "master OR scope". The scope column
+// on plugin_views is reserved for that follow-up; today every registration
+// comes from the master token and lands with scope="".
+func (s *Server) handleCreatePluginView(w http.ResponseWriter, r *http.Request) {
+	if requireMaster(w, r) {
+		return
+	}
+	var req pluginViewCreateReq
+	r.Body = http.MaxBytesReader(w, r.Body, 4*1024)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+	reg := views.New(s.db)
+	v, err := reg.Register("", req.Title, req.Hotkey, req.CallbackURL)
+	if err != nil {
+		switch {
+		case errors.Is(err, views.ErrTitleRequired),
+			errors.Is(err, views.ErrCallbackURLRequired):
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		case errors.Is(err, views.ErrViewExists):
+			writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+		default:
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		return
+	}
+	writeJSON(w, http.StatusCreated, toPluginViewJSON(v))
+}
+
+// handleListPluginViews returns every registered view ordered by insertion.
+//
+// TODO(post-PR-1): swap requireMaster for "master OR scope" and filter by the
+// caller's scope. Today the master token sees every row.
+func (s *Server) handleListPluginViews(w http.ResponseWriter, r *http.Request) {
+	if requireMaster(w, r) {
+		return
+	}
+	reg := views.New(s.db)
+	all := reg.List()
+	out := make([]pluginViewJSON, 0, len(all))
+	for _, v := range all {
+		out = append(out, toPluginViewJSON(v))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"views": out})
+}
+
+// handleDeletePluginView removes the view by ID.
+//
+// The spec sketch called for DELETE /api/plugins/views/{scope}/{title}, but
+// Go's net/http.ServeMux canonicalises `//` segments and 307-redirects, which
+// makes the spec-shape unusable while every row has scope="". Using {id}
+// matches the existing /api/tokens/{id} precedent and works today + after
+// PR 1's scope-token swap lands.
+//
+// TODO(post-PR-1): swap requireMaster for "master OR scope" and reject delete
+// requests whose caller's scope doesn't match the row's scope.
+func (s *Server) handleDeletePluginView(w http.ResponseWriter, r *http.Request) {
+	if requireMaster(w, r) {
+		return
+	}
+	idStr := r.PathValue("id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || id <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+		return
+	}
+	all, err := s.db.PluginViews()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	var match *pluginViewJSON
+	for _, row := range all {
+		if row.ID == id {
+			j := toPluginViewJSON(&views.View{
+				ID: row.ID, Scope: row.Scope, Title: row.Title,
+				Hotkey: row.Hotkey, CallbackURL: row.CallbackURL, CreatedAt: row.CreatedAt,
+			})
+			match = &j
+			break
+		}
+	}
+	if match == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "view not found"})
+		return
+	}
+	reg := views.New(s.db)
+	if err := reg.Unregister(match.Scope, match.Title); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"deleted": match.ID})
+}

--- a/internal/api/plugin_views_test.go
+++ b/internal/api/plugin_views_test.go
@@ -1,0 +1,180 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/drn/argus/internal/testutil"
+	"github.com/drn/argus/internal/tui/views"
+)
+
+// TestPluginViews_PostCreates pins the POST /api/plugins/views shape. Body
+// is {title, hotkey, callback_url}; response is 201 + the persisted row.
+func TestPluginViews_PostCreates(t *testing.T) {
+	srv, d := testServer(t)
+	mux := srv.routes()
+
+	req := masterReq("POST", "/api/plugins/views",
+		`{"title":"Ludwig","hotkey":"ctrl+l","callback_url":"ws://127.0.0.1:5111/view"}`)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusCreated)
+
+	var got pluginViewJSON
+	testutil.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	testutil.Equal(t, got.Title, "Ludwig")
+	testutil.Equal(t, got.Hotkey, "ctrl+l")
+	testutil.Equal(t, got.CallbackURL, "ws://127.0.0.1:5111/view")
+	if got.ID <= 0 {
+		t.Fatalf("expected positive ID, got %d", got.ID)
+	}
+
+	// Round-trip through the DB to confirm persistence.
+	all, _ := d.PluginViews()
+	testutil.Equal(t, len(all), 1)
+}
+
+func TestPluginViews_PostRejectsNonMaster(t *testing.T) {
+	srv, _ := testServer(t)
+	mux := srv.routes()
+
+	req := authedReq("POST", "/api/plugins/views", `{"title":"X","callback_url":"ws://x"}`)
+	req.Header.Set("X-Argus-Auth", "device")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusForbidden)
+}
+
+func TestPluginViews_PostInvalidJSON(t *testing.T) {
+	srv, _ := testServer(t)
+	mux := srv.routes()
+
+	req := masterReq("POST", "/api/plugins/views", `{ broken`)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusBadRequest)
+}
+
+func TestPluginViews_PostMissingTitle(t *testing.T) {
+	srv, _ := testServer(t)
+	mux := srv.routes()
+
+	req := masterReq("POST", "/api/plugins/views", `{"title":"","callback_url":"ws://x"}`)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusBadRequest)
+}
+
+func TestPluginViews_PostMissingCallbackURL(t *testing.T) {
+	srv, _ := testServer(t)
+	mux := srv.routes()
+
+	req := masterReq("POST", "/api/plugins/views", `{"title":"X"}`)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusBadRequest)
+}
+
+func TestPluginViews_PostDuplicateConflict(t *testing.T) {
+	srv, _ := testServer(t)
+	mux := srv.routes()
+
+	body := `{"title":"Ludwig","callback_url":"ws://a"}`
+	req := masterReq("POST", "/api/plugins/views", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusCreated)
+
+	req = masterReq("POST", "/api/plugins/views", body)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusConflict)
+}
+
+func TestPluginViews_GetLists(t *testing.T) {
+	srv, d := testServer(t)
+	mux := srv.routes()
+
+	r := views.New(d)
+	_, _ = r.Register("", "Alpha", "ctrl+a", "ws://a")
+	_, _ = r.Register("", "Beta", "ctrl+b", "ws://b")
+
+	req := masterReq("GET", "/api/plugins/views", "")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusOK)
+
+	var resp struct {
+		Views []pluginViewJSON `json:"views"`
+	}
+	testutil.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	testutil.Equal(t, len(resp.Views), 2)
+	testutil.Equal(t, resp.Views[0].Title, "Alpha")
+	testutil.Equal(t, resp.Views[1].Title, "Beta")
+}
+
+func TestPluginViews_GetRejectsNonMaster(t *testing.T) {
+	srv, _ := testServer(t)
+	mux := srv.routes()
+
+	req := authedReq("GET", "/api/plugins/views", "")
+	req.Header.Set("X-Argus-Auth", "device")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusForbidden)
+}
+
+func TestPluginViews_DeleteRemoves(t *testing.T) {
+	srv, d := testServer(t)
+	mux := srv.routes()
+
+	r := views.New(d)
+	v, err := r.Register("", "Doomed", "", "ws://doom")
+	testutil.NoError(t, err)
+
+	req := masterReq("DELETE", "/api/plugins/views/"+itoa(v.ID), "")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusOK)
+
+	all, _ := d.PluginViews()
+	testutil.Equal(t, len(all), 0)
+}
+
+func TestPluginViews_DeleteNotFound(t *testing.T) {
+	srv, _ := testServer(t)
+	mux := srv.routes()
+
+	req := masterReq("DELETE", "/api/plugins/views/99999", "")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusNotFound)
+}
+
+func TestPluginViews_DeleteBadID(t *testing.T) {
+	srv, _ := testServer(t)
+	mux := srv.routes()
+
+	req := masterReq("DELETE", "/api/plugins/views/not-an-int", "")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusBadRequest)
+}
+
+func TestPluginViews_DeleteRejectsNonMaster(t *testing.T) {
+	srv, _ := testServer(t)
+	mux := srv.routes()
+
+	req := authedReq("DELETE", "/api/plugins/views/1", "")
+	req.Header.Set("X-Argus-Auth", "device")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	testutil.Equal(t, w.Code, http.StatusForbidden)
+}
+
+func itoa(n int64) string {
+	return strconv.FormatInt(n, 10)
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -120,6 +120,13 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("POST /api/tasks/{id}/inbox/ack", s.handleAckInbox)
 	mux.HandleFunc("POST /api/tasks/{id}/messages", s.handleSendMessage)
 
+	// Plugin-registered top-level views. POST/GET/DELETE are master-only
+	// today; see internal/api/plugin_views.go for the post-PR-1 swap TODO
+	// that broadens auth to "master OR scope" once scope-tokens land.
+	mux.HandleFunc("POST /api/plugins/views", s.handleCreatePluginView)
+	mux.HandleFunc("GET /api/plugins/views", s.handleListPluginViews)
+	mux.HandleFunc("DELETE /api/plugins/views/{id}", s.handleDeletePluginView)
+
 	return mux
 }
 

--- a/internal/db/plugin_views.go
+++ b/internal/db/plugin_views.go
@@ -1,0 +1,118 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"time"
+)
+
+// PluginView is one plugin-registered top-level UI surface. Stored in the
+// plugin_views table; see schema.go for the column shape.
+type PluginView struct {
+	ID          int64
+	Scope       string
+	Title       string
+	Hotkey      string
+	CallbackURL string
+	CreatedAt   time.Time
+}
+
+// AddPluginView inserts a new plugin view, stamps its ID + CreatedAt, and
+// returns the persisted row. Caller is responsible for uniqueness — SQLite
+// enforces UNIQUE(scope, title); the resulting error is surfaced as-is so
+// the higher-level registry can map it to a sentinel.
+func (d *DB) AddPluginView(scope, title, hotkey, callbackURL string) (*PluginView, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	now := time.Now().UTC()
+	res, err := d.conn.Exec(
+		`INSERT INTO plugin_views (scope, title, hotkey, callback_url, created_at) VALUES (?, ?, ?, ?, ?)`,
+		scope, title, hotkey, callbackURL, now.Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return nil, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+	return &PluginView{
+		ID:          id,
+		Scope:       scope,
+		Title:       title,
+		Hotkey:      hotkey,
+		CallbackURL: callbackURL,
+		CreatedAt:   now,
+	}, nil
+}
+
+// GetPluginView returns the row matching (scope, title) or (nil, nil) if no
+// match. The scope+title pair is unique per the schema.
+func (d *DB) GetPluginView(scope, title string) (*PluginView, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	var v PluginView
+	var createdAt string
+	err := d.conn.QueryRow(
+		`SELECT id, scope, title, hotkey, callback_url, created_at FROM plugin_views WHERE scope = ? AND title = ?`,
+		scope, title,
+	).Scan(&v.ID, &v.Scope, &v.Title, &v.Hotkey, &v.CallbackURL, &createdAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	v.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdAt)
+	return &v, nil
+}
+
+// PluginViews returns every registered view ordered by insertion order.
+func (d *DB) PluginViews() ([]PluginView, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	rows, err := d.conn.Query(
+		`SELECT id, scope, title, hotkey, callback_url, created_at FROM plugin_views ORDER BY id`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PluginView
+	for rows.Next() {
+		var v PluginView
+		var createdAt string
+		if err := rows.Scan(&v.ID, &v.Scope, &v.Title, &v.Hotkey, &v.CallbackURL, &createdAt); err != nil {
+			continue
+		}
+		v.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdAt)
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// DeletePluginView removes the (scope, title) row. Returns true if a row was
+// actually deleted, false if no match existed.
+func (d *DB) DeletePluginView(scope, title string) (bool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	res, err := d.conn.Exec(`DELETE FROM plugin_views WHERE scope = ? AND title = ?`, scope, title)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// DeletePluginViewsByScope removes every row matching scope. Returns the
+// count deleted.
+func (d *DB) DeletePluginViewsByScope(scope string) (int64, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	res, err := d.conn.Exec(`DELETE FROM plugin_views WHERE scope = ?`, scope)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}

--- a/internal/db/plugin_views_test.go
+++ b/internal/db/plugin_views_test.go
@@ -1,0 +1,118 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/drn/argus/internal/testutil"
+)
+
+func TestPluginViews_AddGetListDelete(t *testing.T) {
+	d, err := OpenInMemory()
+	testutil.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	row, err := d.AddPluginView("scope-a", "Alpha", "ctrl+a", "ws://a")
+	testutil.NoError(t, err)
+	if row.ID <= 0 {
+		t.Fatalf("expected positive ID, got %d", row.ID)
+	}
+	testutil.Equal(t, row.Scope, "scope-a")
+	testutil.Equal(t, row.Title, "Alpha")
+	testutil.Equal(t, row.Hotkey, "ctrl+a")
+	testutil.Equal(t, row.CallbackURL, "ws://a")
+	if row.CreatedAt.IsZero() {
+		t.Fatal("expected CreatedAt to be stamped")
+	}
+
+	got, err := d.GetPluginView("scope-a", "Alpha")
+	testutil.NoError(t, err)
+	testutil.Equal(t, got.CallbackURL, "ws://a")
+	if got.CreatedAt.IsZero() {
+		t.Fatal("expected CreatedAt to round-trip from db")
+	}
+
+	miss, err := d.GetPluginView("scope-a", "Missing")
+	testutil.NoError(t, err)
+	testutil.Nil(t, miss)
+
+	_, err = d.AddPluginView("scope-b", "Beta", "ctrl+b", "ws://b")
+	testutil.NoError(t, err)
+	all, err := d.PluginViews()
+	testutil.NoError(t, err)
+	testutil.Equal(t, len(all), 2)
+	testutil.Equal(t, all[0].Title, "Alpha")
+	testutil.Equal(t, all[1].Title, "Beta")
+
+	ok, err := d.DeletePluginView("scope-a", "Alpha")
+	testutil.NoError(t, err)
+	testutil.True(t, ok)
+
+	ok, err = d.DeletePluginView("scope-a", "Alpha")
+	testutil.NoError(t, err)
+	testutil.False(t, ok)
+}
+
+func TestPluginViews_UniqueScopeTitleRejected(t *testing.T) {
+	d, err := OpenInMemory()
+	testutil.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	_, err = d.AddPluginView("scope-a", "Alpha", "", "ws://a")
+	testutil.NoError(t, err)
+
+	_, err = d.AddPluginView("scope-a", "Alpha", "", "ws://b")
+	if err == nil {
+		t.Fatal("expected UNIQUE constraint to reject duplicate")
+	}
+}
+
+func TestPluginViews_DeleteByScope(t *testing.T) {
+	d, err := OpenInMemory()
+	testutil.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	_, _ = d.AddPluginView("scope-a", "A1", "", "ws://1")
+	_, _ = d.AddPluginView("scope-a", "A2", "", "ws://2")
+	_, _ = d.AddPluginView("scope-b", "B1", "", "ws://3")
+
+	n, err := d.DeletePluginViewsByScope("scope-a")
+	testutil.NoError(t, err)
+	testutil.Equal(t, n, int64(2))
+
+	all, err := d.PluginViews()
+	testutil.NoError(t, err)
+	testutil.Equal(t, len(all), 1)
+	testutil.Equal(t, all[0].Scope, "scope-b")
+}
+
+func TestPluginViews_DeleteByScope_NoMatchReturnsZero(t *testing.T) {
+	d, err := OpenInMemory()
+	testutil.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	n, err := d.DeletePluginViewsByScope("nope")
+	testutil.NoError(t, err)
+	testutil.Equal(t, n, int64(0))
+}
+
+func TestPluginViews_OperationsErrOnClosedDB(t *testing.T) {
+	d, err := OpenInMemory()
+	testutil.NoError(t, err)
+	_ = d.Close()
+
+	if _, err := d.AddPluginView("s", "t", "", "ws://x"); err == nil {
+		t.Fatal("expected error on closed DB")
+	}
+	if _, err := d.GetPluginView("s", "t"); err == nil {
+		t.Fatal("expected error on closed DB")
+	}
+	if _, err := d.PluginViews(); err == nil {
+		t.Fatal("expected error on closed DB")
+	}
+	if _, err := d.DeletePluginView("s", "t"); err == nil {
+		t.Fatal("expected error on closed DB")
+	}
+	if _, err := d.DeletePluginViewsByScope("s"); err == nil {
+		t.Fatal("expected error on closed DB")
+	}
+}

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -234,5 +234,24 @@ func (d *DB) createTables() error {
 	d.conn.Exec(`CREATE INDEX IF NOT EXISTS idx_msg_in_reply_to ON task_messages(in_reply_to)`)               //nolint:errcheck
 	d.conn.Exec(`CREATE INDEX IF NOT EXISTS idx_msg_from_created ON task_messages(from_task_id, created_at)`) //nolint:errcheck
 
+	// Plugin-registered top-level views. Each row is one full-screen UI surface
+	// owned by a plugin: the TUI opens a WebSocket to callback_url when the
+	// hotkey fires, streams ANSI bytes from the plugin into a streampane, and
+	// forwards keystrokes back. scope is reserved for the post-PR-1 scope-token
+	// gating swap; today every row is registered under the master token.
+	if _, err := d.conn.Exec(`
+		CREATE TABLE IF NOT EXISTS plugin_views (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			scope        TEXT NOT NULL DEFAULT '',
+			title        TEXT NOT NULL,
+			hotkey       TEXT NOT NULL DEFAULT '',
+			callback_url TEXT NOT NULL,
+			created_at   TEXT NOT NULL,
+			UNIQUE(scope, title)
+		)
+	`); err != nil {
+		return fmt.Errorf("creating plugin_views table: %w", err)
+	}
+
 	return nil
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -59,6 +59,7 @@ const (
 	modeConfirmDeleteProject
 	modeRestartDaemonPrompt
 	modeAppleEventsPicker
+	modePluginView
 )
 
 // agentFocus tracks which panel has focus in the agent view.
@@ -236,6 +237,15 @@ type App struct {
 	// driven, so the one CSI 2J flash per resize is the right tradeoff.
 	lastScreenW int
 	lastScreenH int
+
+	// Plugin-registered top-level views. See plugin_views.go for the
+	// mount/activate/deactivate lifecycle. pluginConnFactory is overridable
+	// so smoke tests can replace the real WebSocket dialer with an in-
+	// process stub.
+	pluginMounts      []*pluginViewMount
+	pluginHotkeys     map[tcell.Key]*pluginViewMount
+	activePlugin      *pluginViewMount
+	pluginConnFactory pluginConnectorFactory
 }
 
 // New creates the tui application shell.
@@ -413,6 +423,7 @@ func (a *App) buildUI() {
 		AddPage("agent", a.agentPage, true, false).
 		AddPage("dag", a.dagPage, true, false).
 		AddPage("settings", a.settingsPage, true, false)
+	a.loadPluginViews()
 	// Every Pages mutation (AddPage / RemovePage / SwitchToPage / Show / Hide)
 	// is a layout change that needs a tcell Sync to wipe ghost cells under
 	// tmux/iTerm2. Wiring it once here covers every modal open/close, every
@@ -464,6 +475,9 @@ func (a *App) afterDraw(screen tcell.Screen) {
 	a.lastScreenH = h
 	uxlog.Log("[tui] afterDraw resize %dx%d — Sync", w, h)
 	screen.Sync()
+	// Forward the resize to the active plugin view (if any). Best-effort —
+	// errors land in uxlog rather than the user's terminal.
+	a.resizePluginViewIfActive()
 }
 
 // SetDaemonStale records that the connected daemon's binary differs from the
@@ -1255,6 +1269,29 @@ func (a *App) refreshTasksWithIDs(runningIDs, idleIDs []string) {
 
 // handleGlobalKey processes key events at the application level.
 func (a *App) handleGlobalKey(event *tcell.EventKey) *tcell.EventKey {
+	// Plugin-view mode — Esc exits, every other keystroke forwards to the
+	// plugin via the streampane's InputBack channel. The streampane's
+	// InputHandler does the actual forwarding; we just need to intercept
+	// Esc here before the streampane consumes it. See plugin_views.go.
+	if a.mode == modePluginView {
+		if event.Key() == tcell.KeyEscape {
+			a.deactivatePluginView()
+			return nil
+		}
+		return event
+	}
+
+	// Plugin-view hotkey activation — checked before form handlers so the
+	// hotkey works from any non-modal context. tview.Pages already routes
+	// the form modes via earlier branches below, so they get to absorb the
+	// keystroke first when active.
+	if event.Key() != tcell.KeyRune {
+		if m, ok := a.pluginHotkeys[event.Key()]; ok && a.mode == modeTaskList {
+			a.activatePluginView(m)
+			return nil
+		}
+	}
+
 	// New task form mode — delegate everything to the form
 	if a.mode == modeNewTask && a.newTaskForm != nil {
 		a.handleNewTaskKey(event)

--- a/internal/tui/plugin_views.go
+++ b/internal/tui/plugin_views.go
@@ -1,0 +1,209 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/drn/argus/internal/db"
+	"github.com/drn/argus/internal/tui/streampane"
+	"github.com/drn/argus/internal/tui/views"
+	"github.com/drn/argus/internal/uxlog"
+)
+
+// pluginConnector is the minimum surface the App uses from a real
+// views.Connector. Abstracted so smoke tests can replace the real WebSocket
+// dial with an in-process no-op.
+type pluginConnector interface {
+	Dial(ctx context.Context) error
+	SendResize(cols, rows int) error
+	SendFocus() error
+	SendBlur() error
+	Close() error
+}
+
+// pluginConnectorFactory builds a Connector wired to the given URL and byte
+// sinks. The default factory returns a real views.Connector. Tests assign a
+// factory that returns a stub so they can observe the lifecycle without
+// touching the network.
+type pluginConnectorFactory func(url string, onBytes func([]byte), in <-chan []byte) pluginConnector
+
+func defaultPluginConnectorFactory(url string, onBytes func([]byte), in <-chan []byte) pluginConnector {
+	return views.NewConnector(url, onBytes, in)
+}
+
+// pluginViewMount is one registered plugin view mounted as a tview.Page. Each
+// mount carries its own bytes pipes; the actual WebSocket connector is
+// created lazily on hotkey activation and torn down on Esc.
+type pluginViewMount struct {
+	view     *views.View
+	pane     *streampane.StreamPane
+	pageName string
+	hotkey   tcell.Key
+
+	bytesIn chan []byte // ANSI from plugin → streampane source
+	keysOut chan []byte // keystrokes from pane → plugin
+
+	conn pluginConnector // nil when the view is not active
+}
+
+// loadPluginViews reads the registry and mounts every registered view as a
+// tview.Page. Idempotent — calling twice is safe; later calls rebuild the
+// list and replace any prior mounts. Called from buildUI; the app's tick
+// loop does not refresh dynamically because plugin registrations are rare
+// and a new view requires a TUI restart to surface today.
+func (a *App) loadPluginViews() {
+	if a.pluginConnFactory == nil {
+		a.pluginConnFactory = defaultPluginConnectorFactory
+	}
+	// Remote-TUI mode is a.db = *apistore.Store, which the views.Registry
+	// cannot use directly. The remote-TUI flow will mount plugin views over
+	// the REST API in a follow-up; for now, no-op cleanly.
+	local, ok := a.db.(*db.DB)
+	if !ok {
+		return
+	}
+
+	reg := views.New(local)
+	all := reg.List()
+
+	// Tear down any previous mounts before rebuilding (defensive — buildUI
+	// only calls this once but the test harness rebuilds the App in place).
+	for _, m := range a.pluginMounts {
+		a.pages.RemovePage(m.pageName)
+		close(m.bytesIn)
+		close(m.keysOut)
+	}
+	a.pluginMounts = a.pluginMounts[:0]
+	a.pluginHotkeys = make(map[tcell.Key]*pluginViewMount)
+
+	for _, v := range all {
+		key, ok := views.ParseHotkey(v.Hotkey)
+		if !ok {
+			uxlog.Log("[plugin-view] skipped %q: invalid hotkey %q", v.Title, v.Hotkey)
+			continue
+		}
+		bytesIn := make(chan []byte, 64)
+		keysOut := make(chan []byte, 64)
+		pane := streampane.New(bytesIn)
+		pane.SetTitle(v.Title)
+		pane.SetInputBack(keysOut)
+		pane.OnNeedRedraw = func() {
+			if a.tapp != nil {
+				a.tapp.QueueUpdateDraw(func() {})
+			}
+		}
+		pageName := fmt.Sprintf("plugin-view:%d", v.ID)
+		a.pages.AddPage(pageName, pane, true, false)
+
+		m := &pluginViewMount{
+			view:     v,
+			pane:     pane,
+			pageName: pageName,
+			hotkey:   tcell.Key(key),
+			bytesIn:  bytesIn,
+			keysOut:  keysOut,
+		}
+		a.pluginMounts = append(a.pluginMounts, m)
+		a.pluginHotkeys[tcell.Key(key)] = m
+	}
+}
+
+// activatePluginView opens a plugin view: switches Pages, dials the WS,
+// emits resize+focus envelopes. Idempotent — re-activating an already-active
+// view re-sends the resize envelope so a stale plugin can recover.
+func (a *App) activatePluginView(m *pluginViewMount) {
+	if a.activePlugin != nil && a.activePlugin == m {
+		// Re-send resize as a recovery hint and bail.
+		if a.activePlugin.conn != nil {
+			cols, rows := a.pluginViewportSize()
+			_ = a.activePlugin.conn.SendResize(cols, rows)
+		}
+		return
+	}
+	if a.activePlugin != nil {
+		a.deactivatePluginView()
+	}
+
+	a.activePlugin = m
+	a.mode = modePluginView
+	a.pages.SwitchToPage(m.pageName)
+	a.tapp.SetFocus(m.pane)
+
+	conn := a.pluginConnFactory(m.view.CallbackURL, func(b []byte) {
+		// Forward plugin → streampane source. Non-blocking — drop on
+		// backpressure to match the rest of argus's PTY plumbing.
+		select {
+		case m.bytesIn <- b:
+		default:
+		}
+	}, m.keysOut)
+	m.conn = conn
+
+	go func(c pluginConnector) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := c.Dial(ctx); err != nil {
+			uxlog.Log("[plugin-view] dial %q failed: %v", m.view.Title, err)
+			return
+		}
+		cols, rows := a.pluginViewportSize()
+		if err := c.SendResize(cols, rows); err != nil {
+			uxlog.Log("[plugin-view] send resize failed: %v", err)
+		}
+		if err := c.SendFocus(); err != nil {
+			uxlog.Log("[plugin-view] send focus failed: %v", err)
+		}
+	}(conn)
+}
+
+// deactivatePluginView closes the active plugin view: sends blur, closes the
+// WS, switches back to the tasks page.
+func (a *App) deactivatePluginView() {
+	if a.activePlugin == nil {
+		return
+	}
+	m := a.activePlugin
+	a.activePlugin = nil
+
+	if m.conn != nil {
+		_ = m.conn.SendBlur()
+		_ = m.conn.Close()
+		m.conn = nil
+	}
+
+	a.mode = modeTaskList
+	a.pages.SwitchToPage("tasks")
+	a.tapp.SetFocus(a.tasklist)
+}
+
+// pluginViewportSize returns the cols/rows the active plugin view should
+// render into. Falls back to the screen size when the streampane hasn't been
+// drawn yet.
+func (a *App) pluginViewportSize() (int, int) {
+	if a.activePlugin != nil {
+		x, y, w, h := a.activePlugin.pane.GetRect()
+		_ = x
+		_ = y
+		if w > 2 && h > 2 {
+			return w - 2, h - 2 // subtract border
+		}
+	}
+	if a.screen != nil {
+		w, h := a.screen.Size()
+		return w, h
+	}
+	return 80, 24
+}
+
+// resizePluginViewIfActive forwards a resize envelope to the active plugin
+// view (if any). Called from afterDraw when the terminal dimensions change.
+func (a *App) resizePluginViewIfActive() {
+	if a.activePlugin == nil || a.activePlugin.conn == nil {
+		return
+	}
+	cols, rows := a.pluginViewportSize()
+	_ = a.activePlugin.conn.SendResize(cols, rows)
+}

--- a/internal/tui/plugin_views_test.go
+++ b/internal/tui/plugin_views_test.go
@@ -1,0 +1,263 @@
+package tui
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/drn/argus/internal/agent"
+	"github.com/drn/argus/internal/testutil"
+	"github.com/drn/argus/internal/tui/views"
+	"github.com/gdamore/tcell/v2"
+)
+
+// fakePluginConnector is the stub the smoke test installs in place of a real
+// views.Connector. It records every lifecycle call so the test can assert the
+// dial / focus / resize / blur / close sequence without dialing a real
+// WebSocket.
+type fakePluginConnector struct {
+	mu             sync.Mutex
+	dialed         atomic.Bool
+	resizes        [][2]int
+	focusedCount   atomic.Int32
+	blurredCount   atomic.Int32
+	closedCount    atomic.Int32
+	dialErr        error
+	keysSeen       [][]byte
+	onBytes        func([]byte)
+	bytesToReceive [][]byte
+}
+
+func (f *fakePluginConnector) Dial(ctx context.Context) error {
+	if f.dialErr != nil {
+		return f.dialErr
+	}
+	f.dialed.Store(true)
+	for _, b := range f.bytesToReceive {
+		if f.onBytes != nil {
+			f.onBytes(b)
+		}
+	}
+	return nil
+}
+
+func (f *fakePluginConnector) SendResize(cols, rows int) error {
+	f.mu.Lock()
+	f.resizes = append(f.resizes, [2]int{cols, rows})
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakePluginConnector) SendFocus() error {
+	f.focusedCount.Add(1)
+	return nil
+}
+
+func (f *fakePluginConnector) SendBlur() error {
+	f.blurredCount.Add(1)
+	return nil
+}
+
+func (f *fakePluginConnector) Close() error {
+	f.closedCount.Add(1)
+	return nil
+}
+
+func TestSmoke_PluginView_HotkeyMountsAndEscExits(t *testing.T) {
+	d := testDB(t)
+
+	r := views.New(d)
+	_, err := r.Register("", "Ludwig", "ctrl+l", "ws://127.0.0.1:5111/ws")
+	testutil.NoError(t, err)
+
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, true)
+
+	fake := &fakePluginConnector{}
+	app.pluginConnFactory = func(url string, onBytes func([]byte), in <-chan []byte) pluginConnector {
+		fake.onBytes = onBytes
+		return fake
+	}
+	// Re-mount with the test factory in place. buildUI already called
+	// loadPluginViews once with the default factory; rerun to wire the fake.
+	app.loadPluginViews()
+
+	sim, stop := wireApp(t, app)
+	defer stop()
+
+	// Sanity-check before injecting the hotkey.
+	var mountCount int
+	var hotkeyHit bool
+	readUI(t, app.tapp, func() {
+		mountCount = len(app.pluginMounts)
+		_, hotkeyHit = app.pluginHotkeys[tcell.KeyCtrlL]
+	})
+	if mountCount == 0 {
+		t.Fatalf("expected at least 1 plugin mount, got 0")
+	}
+	if !hotkeyHit {
+		t.Fatalf("Ctrl+L not in pluginHotkeys map; map=%v", app.pluginHotkeys)
+	}
+
+	// Inject the hotkey — Ctrl+L from the task list.
+	sim.InjectKey(tcell.KeyCtrlL, 0, 0)
+	syncUI(t, app.tapp)
+
+	var mode viewMode
+	var activeURL string
+	readUI(t, app.tapp, func() {
+		mode = app.mode
+		if app.activePlugin != nil {
+			activeURL = app.activePlugin.view.CallbackURL
+		}
+	})
+	testutil.Equal(t, mode, modePluginView)
+	testutil.Equal(t, activeURL, "ws://127.0.0.1:5111/ws")
+
+	// The connector should have been dialed + focus envelope sent.
+	waitFor(t, 1*time.Second, func() bool {
+		return fake.dialed.Load() && fake.focusedCount.Load() == 1
+	})
+	if got := fake.focusedCount.Load(); got != 1 {
+		t.Fatalf("focus count = %d, want 1", got)
+	}
+	fake.mu.Lock()
+	resizes := append([][2]int(nil), fake.resizes...)
+	fake.mu.Unlock()
+	if len(resizes) == 0 {
+		t.Fatal("expected at least one resize envelope sent on activate")
+	}
+
+	// Esc exits.
+	sim.InjectKey(tcell.KeyEscape, 0, 0)
+	syncUI(t, app.tapp)
+
+	readUI(t, app.tapp, func() { mode = app.mode })
+	testutil.Equal(t, mode, modeTaskList)
+	if fake.blurredCount.Load() != 1 {
+		t.Fatalf("blur count = %d, want 1 after Esc", fake.blurredCount.Load())
+	}
+	if fake.closedCount.Load() == 0 {
+		t.Fatal("connector.Close was not invoked on Esc")
+	}
+}
+
+// waitFor polls cond every 5ms until it returns true or the timeout fires.
+// Mirrors the helper in internal/tui/views/connector_test.go.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %v", timeout)
+}
+
+func TestSmoke_PluginView_InvalidHotkeySkipped(t *testing.T) {
+	d := testDB(t)
+	r := views.New(d)
+	// Bogus hotkey — parser rejects "alt+l".
+	_, err := r.Register("", "Bogus", "alt+l", "ws://127.0.0.1:5111/ws")
+	testutil.NoError(t, err)
+
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, true)
+
+	// loadPluginViews should have skipped the bogus hotkey, leaving no
+	// mounts and no entries in the hotkey map.
+	if len(app.pluginMounts) != 0 {
+		t.Fatalf("expected 0 mounts, got %d", len(app.pluginMounts))
+	}
+	if len(app.pluginHotkeys) != 0 {
+		t.Fatalf("expected empty hotkey map, got %v", app.pluginHotkeys)
+	}
+}
+
+func TestSmoke_PluginView_RemoteModeIsNoOp(t *testing.T) {
+	// Remote-TUI mode has a.db that isn't *db.DB. loadPluginViews must
+	// short-circuit cleanly and leave the mount slice / hotkey map empty.
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, true)
+
+	// Sanity: with no registered views, mounts are empty.
+	if len(app.pluginMounts) != 0 {
+		t.Fatalf("expected empty mounts on fresh app, got %d", len(app.pluginMounts))
+	}
+}
+
+func TestDefaultPluginConnectorFactory_ReturnsNonNil(t *testing.T) {
+	in := make(chan []byte)
+	c := defaultPluginConnectorFactory("ws://127.0.0.1:1", nil, in)
+	if c == nil {
+		t.Fatal("expected non-nil connector")
+	}
+	// Don't Dial — port 1 is unreachable. Close should be a clean no-op.
+	testutil.NoError(t, c.Close())
+}
+
+func TestResizePluginViewIfActive_NoOpWhenInactive(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, true)
+	app.resizePluginViewIfActive() // must not panic
+}
+
+func TestDeactivatePluginView_NoOpWhenInactive(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, true)
+	app.deactivatePluginView() // must not panic
+}
+
+func TestPluginViewportSize_FallbacksWhenNoScreen(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, true)
+	// No screen → 80x24 default.
+	cols, rows := app.pluginViewportSize()
+	testutil.Equal(t, cols, 80)
+	testutil.Equal(t, rows, 24)
+}
+
+func TestActivatePluginView_ReactivationResendsResize(t *testing.T) {
+	d := testDB(t)
+	r := views.New(d)
+	_, err := r.Register("", "Ludwig", "ctrl+l", "ws://127.0.0.1:5111/ws")
+	testutil.NoError(t, err)
+
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, true)
+	fake := &fakePluginConnector{}
+	app.pluginConnFactory = func(url string, onBytes func([]byte), in <-chan []byte) pluginConnector {
+		fake.onBytes = onBytes
+		return fake
+	}
+	app.loadPluginViews()
+
+	sim, stop := wireApp(t, app)
+	defer stop()
+
+	sim.InjectKey(tcell.KeyCtrlL, 0, 0)
+	syncUI(t, app.tapp)
+	waitFor(t, 1*time.Second, func() bool { return fake.dialed.Load() })
+
+	fake.mu.Lock()
+	firstCount := len(fake.resizes)
+	fake.mu.Unlock()
+
+	// Re-activate the same view; should re-send resize without re-dialing.
+	readUI(t, app.tapp, func() { app.activatePluginView(app.pluginMounts[0]) })
+
+	fake.mu.Lock()
+	secondCount := len(fake.resizes)
+	fake.mu.Unlock()
+	if secondCount <= firstCount {
+		t.Fatalf("resize count did not grow on re-activation: %d → %d", firstCount, secondCount)
+	}
+}

--- a/internal/tui/streampane/streampane.go
+++ b/internal/tui/streampane/streampane.go
@@ -1,0 +1,275 @@
+// Package streampane provides a read-mostly tview widget that renders bytes
+// arriving on a channel. It is used by layouts that include a `streampane`
+// node (PR 6) and by plugin-registered settings sections of type `stream`
+// (PR 7).
+//
+// The widget owns one consumer goroutine that drains the source channel into
+// a bounded internal byte buffer. Draw strips ANSI escape sequences and
+// renders the trailing lines that fit inside a bordered panel. Damage
+// tracking via [StreamPane.Touched] lets the surrounding tick loop know when
+// a redraw would surface new content.
+//
+// When an input-back channel is wired via [StreamPane.SetInputBack], the
+// widget routes typed runes and a small handful of mapped keys back to the
+// plugin, plus pasted text. Without an input-back channel the widget is
+// fully read-only.
+package streampane
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/drn/argus/internal/tui/theme"
+	"github.com/drn/argus/internal/tui/widget"
+)
+
+// DefaultMaxBytes is the default cap on the internal byte buffer.
+const DefaultMaxBytes = 256 * 1024
+
+// Option configures a StreamPane at construction time.
+type Option func(*StreamPane)
+
+// WithMaxBytes overrides [DefaultMaxBytes].
+func WithMaxBytes(n int) Option {
+	return func(sp *StreamPane) {
+		if n > 0 {
+			sp.maxBytes = n
+		}
+	}
+}
+
+// StreamPane renders ANSI text streamed from a channel.
+type StreamPane struct {
+	*tview.Box
+
+	mu       sync.Mutex
+	buf      []byte
+	maxBytes int
+	title    string
+
+	touched uint64 // accessed via sync/atomic
+
+	source    <-chan []byte
+	inputBack chan<- []byte
+
+	closeOnce sync.Once
+	closeCh   chan struct{}
+	done      chan struct{}
+
+	// OnNeedRedraw, when set, is invoked once per new byte chunk so the
+	// surrounding app can queue a redraw. Safe to leave nil.
+	OnNeedRedraw func()
+}
+
+// New constructs a StreamPane that consumes ANSI bytes from source.
+//
+// Source is consumed by an internal goroutine. The caller may close source
+// to signal end-of-stream; the goroutine exits cleanly and the widget keeps
+// displaying whatever bytes were already buffered.
+func New(source <-chan []byte, opts ...Option) *StreamPane {
+	sp := &StreamPane{
+		Box:      tview.NewBox(),
+		maxBytes: DefaultMaxBytes,
+		source:   source,
+		closeCh:  make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt(sp)
+	}
+	go sp.consume()
+	return sp
+}
+
+// SetTitle sets the title rendered in the top border.
+func (sp *StreamPane) SetTitle(t string) {
+	sp.mu.Lock()
+	sp.title = t
+	sp.mu.Unlock()
+}
+
+// SetInputBack wires the channel that receives keystrokes and pasted text
+// when the pane is focused. Pass a nil channel to disable input forwarding.
+func (sp *StreamPane) SetInputBack(ch chan<- []byte) {
+	sp.mu.Lock()
+	sp.inputBack = ch
+	sp.mu.Unlock()
+}
+
+// Touched returns a monotonic counter that increments every time a new
+// non-empty chunk arrives from the source. Callers compare against a
+// previous value to detect undrawn content.
+func (sp *StreamPane) Touched() uint64 {
+	return atomic.LoadUint64(&sp.touched)
+}
+
+// Close stops the consumer goroutine. Safe to call multiple times.
+func (sp *StreamPane) Close() {
+	sp.closeOnce.Do(func() { close(sp.closeCh) })
+}
+
+func (sp *StreamPane) consume() {
+	defer close(sp.done)
+	for {
+		select {
+		case <-sp.closeCh:
+			return
+		case chunk, ok := <-sp.source:
+			if !ok {
+				return
+			}
+			if len(chunk) == 0 {
+				continue
+			}
+			sp.appendBytes(chunk)
+			atomic.AddUint64(&sp.touched, 1)
+			if sp.OnNeedRedraw != nil {
+				sp.OnNeedRedraw()
+			}
+		}
+	}
+}
+
+func (sp *StreamPane) appendBytes(b []byte) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.buf = append(sp.buf, b...)
+	if len(sp.buf) > sp.maxBytes {
+		// Drop the oldest bytes — keep the trailing maxBytes window.
+		excess := len(sp.buf) - sp.maxBytes
+		sp.buf = sp.buf[excess:]
+	}
+}
+
+// Draw paints the pane onto screen.
+func (sp *StreamPane) Draw(screen tcell.Screen) {
+	sp.DrawForSubclass(screen, sp)
+	x, y, w, h := sp.GetRect()
+	if w <= 0 || h <= 0 {
+		return
+	}
+
+	sp.mu.Lock()
+	title := sp.title
+	buf := append([]byte(nil), sp.buf...)
+	sp.mu.Unlock()
+
+	style := theme.StyleDimmed
+	if sp.HasFocus() {
+		style = tcell.StyleDefault
+	}
+	inner := widget.DrawBorderedPanel(screen, x, y, w, h, title, style)
+	if inner.W <= 0 || inner.H <= 0 {
+		return
+	}
+
+	lines := wrapStripped(buf, inner.W)
+	start := 0
+	if len(lines) > inner.H {
+		start = len(lines) - inner.H
+	}
+	for i := start; i < len(lines); i++ {
+		widget.DrawText(screen, inner.X, inner.Y+(i-start), inner.W, lines[i], tcell.StyleDefault)
+	}
+}
+
+// wrapStripped strips ANSI sequences from b and breaks the result into
+// display lines no wider than width. Newlines force a line break; runes
+// past width wrap to a new line. Returns lines in chronological order.
+func wrapStripped(b []byte, width int) []string {
+	if width <= 0 {
+		return nil
+	}
+	clean := widget.AnsiRe.ReplaceAll(b, nil)
+
+	var (
+		lines   []string
+		current []rune
+	)
+	for _, by := range clean {
+		switch by {
+		case '\n':
+			lines = append(lines, string(current))
+			current = current[:0]
+		case '\r':
+			// drop
+		default:
+			if by < 0x20 {
+				continue
+			}
+			current = append(current, rune(by))
+			if len(current) >= width {
+				lines = append(lines, string(current))
+				current = current[:0]
+			}
+		}
+	}
+	if len(current) > 0 {
+		lines = append(lines, string(current))
+	}
+	return lines
+}
+
+// PasteHandler forwards pasted text to the configured InputBack channel.
+// Without an input-back channel the handler is a non-blocking no-op.
+func (sp *StreamPane) PasteHandler() func(pastedText string, setFocus func(p tview.Primitive)) {
+	return sp.WrapPasteHandler(func(pastedText string, _ func(p tview.Primitive)) {
+		sp.send([]byte(pastedText))
+	})
+}
+
+// InputHandler routes runes / mapped keys to the InputBack channel. Returns
+// nil when no input-back channel is configured, which leaves the widget
+// effectively read-only.
+func (sp *StreamPane) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+	sp.mu.Lock()
+	hasBack := sp.inputBack != nil
+	sp.mu.Unlock()
+	if !hasBack {
+		return nil
+	}
+	return sp.WrapInputHandler(func(event *tcell.EventKey, _ func(p tview.Primitive)) {
+		sp.send(eventBytes(event))
+	})
+}
+
+// send writes b to the input-back channel without blocking. If the channel
+// is full (downstream slow) the bytes are dropped — matching how PTY
+// writers handle backpressure elsewhere in argus.
+func (sp *StreamPane) send(b []byte) {
+	if len(b) == 0 {
+		return
+	}
+	sp.mu.Lock()
+	ch := sp.inputBack
+	sp.mu.Unlock()
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- b:
+	default:
+	}
+}
+
+// eventBytes maps a tcell key event to the bytes a remote plugin would
+// expect. Only the small set documented in the plugin contract is mapped
+// here; everything else is rendered as a rune if printable.
+func eventBytes(ev *tcell.EventKey) []byte {
+	switch ev.Key() {
+	case tcell.KeyRune:
+		return []byte(string(ev.Rune()))
+	case tcell.KeyEnter:
+		return []byte{'\r'}
+	case tcell.KeyTab:
+		return []byte{'\t'}
+	case tcell.KeyBackspace, tcell.KeyBackspace2:
+		return []byte{0x7f}
+	case tcell.KeyEscape:
+		return []byte{0x1b}
+	}
+	return nil
+}

--- a/internal/tui/streampane/streampane_test.go
+++ b/internal/tui/streampane/streampane_test.go
@@ -1,0 +1,435 @@
+package streampane
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/drn/argus/internal/testutil"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+func TestNew_ReturnsBoxSubclass(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	defer sp.Close()
+	testutil.NotNil(t, sp.Box)
+}
+
+func TestStreamPane_TouchedIncrementsOnNewBytes(t *testing.T) {
+	src := make(chan []byte, 1)
+	sp := New(src)
+	defer sp.Close()
+
+	before := sp.Touched()
+	src <- []byte("hello")
+	waitForTouched(t, sp, before+1)
+}
+
+func TestStreamPane_TouchedDoesNotIncrementOnEmptyChunks(t *testing.T) {
+	src := make(chan []byte, 2)
+	sp := New(src)
+	defer sp.Close()
+
+	src <- []byte("hi")
+	waitForTouched(t, sp, 1)
+	got := sp.Touched()
+	src <- []byte("")
+	// Empty chunk should be a no-op; give the goroutine a moment.
+	time.Sleep(20 * time.Millisecond)
+	testutil.Equal(t, sp.Touched(), got)
+}
+
+func TestStreamPane_DrawShowsBytes(t *testing.T) {
+	src := make(chan []byte, 1)
+	sp := New(src)
+	defer sp.Close()
+	sp.SetTitle("Logs")
+
+	src <- []byte("hello world\n")
+	waitForTouched(t, sp, 1)
+
+	sim := newSimScreen(t, 30, 6)
+	sp.SetRect(0, 0, 30, 6)
+	sp.Draw(sim)
+	sim.Show()
+
+	row := readRow(sim, 1, 30)
+	testutil.Contains(t, row, "hello world")
+}
+
+func TestStreamPane_DrawRendersTitleInBorder(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	defer sp.Close()
+	sp.SetTitle("MyTitle")
+
+	sim := newSimScreen(t, 20, 4)
+	sp.SetRect(0, 0, 20, 4)
+	sp.Draw(sim)
+	sim.Show()
+
+	top := readRow(sim, 0, 20)
+	testutil.Contains(t, top, "MyTitle")
+}
+
+func TestStreamPane_DrawStripsAnsi(t *testing.T) {
+	src := make(chan []byte, 1)
+	sp := New(src)
+	defer sp.Close()
+
+	src <- []byte("\x1b[31mred\x1b[0m\n")
+	waitForTouched(t, sp, 1)
+
+	sim := newSimScreen(t, 20, 4)
+	sp.SetRect(0, 0, 20, 4)
+	sp.Draw(sim)
+	sim.Show()
+
+	row := readRow(sim, 1, 20)
+	testutil.Contains(t, row, "red")
+	if strings.Contains(row, "\x1b") {
+		t.Errorf("escape sequence leaked into output: %q", row)
+	}
+}
+
+func TestStreamPane_BoundedBufferDropsOldest(t *testing.T) {
+	src := make(chan []byte, 4)
+	sp := New(src, WithMaxBytes(16))
+	defer sp.Close()
+
+	src <- []byte("aaaaaaaa\n")
+	src <- []byte("bbbbbbbb\n")
+	src <- []byte("cccccccc\n")
+	waitForTouched(t, sp, 3)
+
+	// Internal buffer must not exceed the cap.
+	sp.mu.Lock()
+	got := len(sp.buf)
+	sp.mu.Unlock()
+	if got > 16 {
+		t.Fatalf("buffer length %d exceeds cap 16", got)
+	}
+}
+
+func TestStreamPane_CloseIsIdempotent(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	sp.Close()
+	sp.Close() // must not panic
+}
+
+func TestStreamPane_CloseStopsConsumer(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	sp.Close()
+
+	// After close, sending to src should NOT cause Touched to advance.
+	// Use a non-blocking send to a buffered channel and confirm the
+	// consumer goroutine is gone (no reads, no advancement).
+	select {
+	case <-sp.done:
+		// consumer exited
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("consumer goroutine did not exit after Close")
+	}
+}
+
+func TestStreamPane_SourceClosedStopsConsumer(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	defer sp.Close()
+
+	close(src)
+	select {
+	case <-sp.done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("consumer did not exit after source close")
+	}
+}
+
+func TestStreamPane_OnRedrawFiresAfterBytes(t *testing.T) {
+	src := make(chan []byte, 1)
+	sp := New(src)
+	defer sp.Close()
+
+	var (
+		mu    sync.Mutex
+		count int
+	)
+	sp.OnNeedRedraw = func() {
+		mu.Lock()
+		defer mu.Unlock()
+		count++
+	}
+
+	src <- []byte("x")
+	waitForTouched(t, sp, 1)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if count < 1 {
+		t.Fatalf("expected OnNeedRedraw to fire at least once, got %d", count)
+	}
+}
+
+func TestStreamPane_InputBackReceivesKey(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	defer sp.Close()
+	back := make(chan []byte, 4)
+	sp.SetInputBack(back)
+
+	handler := sp.InputHandler()
+	if handler == nil {
+		t.Fatal("expected non-nil InputHandler when InputBack is set")
+	}
+	handler(tcell.NewEventKey(tcell.KeyRune, 'a', tcell.ModNone), func(_ tview.Primitive) {})
+
+	select {
+	case got := <-back:
+		testutil.Equal(t, string(got), "a")
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("InputBack did not receive keystroke")
+	}
+}
+
+func TestStreamPane_InputBackForwardsEnter(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	defer sp.Close()
+	back := make(chan []byte, 4)
+	sp.SetInputBack(back)
+
+	handler := sp.InputHandler()
+	handler(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone), func(_ tview.Primitive) {})
+
+	select {
+	case got := <-back:
+		testutil.Equal(t, string(got), "\r")
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("InputBack did not receive enter")
+	}
+}
+
+func TestStreamPane_InputHandlerNilWhenNoInputBack(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	defer sp.Close()
+	if sp.InputHandler() != nil {
+		t.Fatal("expected nil InputHandler when no InputBack set")
+	}
+}
+
+func TestStreamPane_PasteHandlerForwardsToInputBack(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	defer sp.Close()
+	back := make(chan []byte, 4)
+	sp.SetInputBack(back)
+
+	ph := sp.PasteHandler()
+	if ph == nil {
+		t.Fatal("expected non-nil PasteHandler")
+	}
+	ph("pasted", func(_ tview.Primitive) {})
+
+	select {
+	case got := <-back:
+		testutil.Equal(t, string(got), "pasted")
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("paste did not reach InputBack")
+	}
+}
+
+func TestStreamPane_DrawHandlesZeroRect(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	defer sp.Close()
+	sim := newSimScreen(t, 10, 4)
+	// Default rect is non-zero; explicitly set zero-area and verify
+	// Draw returns without painting.
+	sp.SetRect(0, 0, 0, 0)
+	sp.Draw(sim)
+}
+
+func TestStreamPane_DrawHandlesTinyRect(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	defer sp.Close()
+	sim := newSimScreen(t, 10, 4)
+	// Tiny — too small for a bordered inner rect.
+	sp.SetRect(0, 0, 1, 1)
+	sp.Draw(sim)
+}
+
+func TestStreamPane_DrawWrapsLongLines(t *testing.T) {
+	src := make(chan []byte, 1)
+	sp := New(src)
+	defer sp.Close()
+	// Source longer than inner width — should wrap.
+	src <- []byte("abcdefghij")
+	waitForTouched(t, sp, 1)
+
+	sim := newSimScreen(t, 6, 6) // inner width = 4
+	sp.SetRect(0, 0, 6, 6)
+	sp.Draw(sim)
+	sim.Show()
+}
+
+func TestStreamPane_DrawScrollsLastLines(t *testing.T) {
+	src := make(chan []byte, 1)
+	sp := New(src)
+	defer sp.Close()
+	// More lines than the inner height; last lines should be retained.
+	src <- []byte("one\ntwo\nthree\nfour\nfive\n")
+	waitForTouched(t, sp, 1)
+
+	sim := newSimScreen(t, 20, 4) // inner height = 2
+	sp.SetRect(0, 0, 20, 4)
+	sp.Draw(sim)
+	sim.Show()
+
+	row := readRow(sim, 1, 20)
+	if !strings.Contains(row, "four") && !strings.Contains(row, "five") {
+		t.Errorf("expected trailing lines in viewport, got %q", row)
+	}
+}
+
+func TestStreamPane_DrawWhenFocused(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	defer sp.Close()
+	sp.SetRect(0, 0, 10, 4)
+	sp.Focus(nil)
+	sim := newSimScreen(t, 10, 4)
+	sp.Draw(sim)
+}
+
+func TestStreamPane_DrawIgnoresControlCharsAndCR(t *testing.T) {
+	src := make(chan []byte, 1)
+	sp := New(src)
+	defer sp.Close()
+	src <- []byte("hi\x01\x02\rthere\n")
+	waitForTouched(t, sp, 1)
+
+	sim := newSimScreen(t, 20, 4)
+	sp.SetRect(0, 0, 20, 4)
+	sp.Draw(sim)
+	sim.Show()
+	row := readRow(sim, 1, 20)
+	testutil.Contains(t, row, "hithere")
+}
+
+func TestWrapStripped_ZeroWidthIsNoOp(t *testing.T) {
+	got := wrapStripped([]byte("abc"), 0)
+	testutil.Equal(t, len(got), 0)
+}
+
+func TestStreamPane_SendDropsWhenBackFull(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	defer sp.Close()
+	back := make(chan []byte, 1)
+	sp.SetInputBack(back)
+	// Fill the back channel.
+	back <- []byte("blocker")
+	// This should not block, and should drop the keystroke.
+	handler := sp.InputHandler()
+	handler(tcell.NewEventKey(tcell.KeyRune, 'x', tcell.ModNone), func(_ tview.Primitive) {})
+}
+
+func TestStreamPane_SendNoOpWithoutInputBack(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	defer sp.Close()
+	// Direct send should be a no-op when inputBack is nil.
+	sp.send([]byte("ignored"))
+}
+
+func TestStreamPane_SendEmptyBytes(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src)
+	defer sp.Close()
+	back := make(chan []byte, 1)
+	sp.SetInputBack(back)
+	sp.send(nil)
+	select {
+	case <-back:
+		t.Fatal("expected no send for empty bytes")
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestEventBytes_AllCases(t *testing.T) {
+	cases := []struct {
+		key  tcell.Key
+		r    rune
+		want string
+	}{
+		{tcell.KeyRune, 'z', "z"},
+		{tcell.KeyEnter, 0, "\r"},
+		{tcell.KeyTab, 0, "\t"},
+		{tcell.KeyBackspace, 0, "\x7f"},
+		{tcell.KeyBackspace2, 0, "\x7f"},
+		{tcell.KeyEscape, 0, "\x1b"},
+		{tcell.KeyF1, 0, ""}, // unmapped — no bytes
+	}
+	for _, tc := range cases {
+		t.Run(tcell.KeyNames[tc.key], func(t *testing.T) {
+			ev := tcell.NewEventKey(tc.key, tc.r, tcell.ModNone)
+			testutil.Equal(t, string(eventBytes(ev)), tc.want)
+		})
+	}
+}
+
+func TestWithMaxBytes_ZeroIsIgnored(t *testing.T) {
+	src := make(chan []byte)
+	sp := New(src, WithMaxBytes(0))
+	defer sp.Close()
+	testutil.Equal(t, sp.maxBytes, DefaultMaxBytes)
+}
+
+// --- helpers ---
+
+func waitForTouched(t *testing.T, sp *StreamPane, want uint64) {
+	t.Helper()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if sp.Touched() >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("Touched did not reach %d (got %d)", want, sp.Touched())
+}
+
+func newSimScreen(t *testing.T, w, h int) tcell.SimulationScreen {
+	t.Helper()
+	s := tcell.NewSimulationScreen("")
+	if err := s.Init(); err != nil {
+		t.Fatal(err)
+	}
+	s.SetSize(w, h)
+	return s
+}
+
+func readRow(s tcell.SimulationScreen, row, w int) string {
+	cells, cw, _ := s.GetContents()
+	if row < 0 || row*cw >= len(cells) {
+		return ""
+	}
+	var b strings.Builder
+	for col := 0; col < w; col++ {
+		idx := row*cw + col
+		if idx >= len(cells) {
+			break
+		}
+		for _, r := range cells[idx].Runes {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/internal/tui/views/connector.go
+++ b/internal/tui/views/connector.go
@@ -1,0 +1,206 @@
+package views
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// Plugin-view WebSocket protocol:
+//
+//   - Plugin → argus: binary frames carry ANSI bytes for streampane.
+//   - Argus → plugin: binary frames carry keystrokes; text frames carry JSON
+//     control envelopes (resize/focus/blur).
+//   - Argus reserves Esc for "exit plugin view back to argus" — Esc is
+//     intercepted before the keystroke pump runs, so it never reaches the
+//     plugin.
+type envelopeType string
+
+const (
+	envelopeResize envelopeType = "resize"
+	envelopeFocus  envelopeType = "focus"
+	envelopeBlur   envelopeType = "blur"
+)
+
+type controlEnvelope struct {
+	Type envelopeType `json:"type"`
+	Cols int          `json:"cols,omitempty"`
+	Rows int          `json:"rows,omitempty"`
+}
+
+// Connector dials a plugin's WebSocket and shuttles bytes both ways. The
+// caller wires the byte sinks at construction; Dial spins up read+write pumps
+// that run until Close or the remote disconnects.
+type Connector struct {
+	url string
+
+	// onBytes is called with each binary frame the plugin emits. The
+	// streampane's source channel is the natural sink. Always called from
+	// a single goroutine, so receivers don't need their own mutex.
+	onBytes func([]byte)
+	// inBytes carries keystrokes from the TUI → plugin as binary frames.
+	// Closing the channel signals the write pump to exit cleanly.
+	inBytes <-chan []byte
+
+	mu      sync.Mutex
+	conn    *websocket.Conn
+	closeCh chan struct{}
+	once    sync.Once
+
+	// dialer is the function used by Dial to open the WebSocket. The default
+	// is websocket.Dial; tests can override to inject a controlled handshake.
+	dialer func(ctx context.Context, url string) (*websocket.Conn, *websocketResp, error)
+}
+
+// websocketResp mirrors the http.Response that websocket.Dial returns. Kept
+// internal so callers don't depend on the net/http import here.
+type websocketResp struct{}
+
+// NewConnector constructs a Connector wired to the given URL and byte sinks.
+//
+// onBytes is invoked from the read pump for each binary frame from the
+// plugin. inBytes is consumed by the write pump as binary frames sent to the
+// plugin; closing inBytes triggers a clean shutdown of the write pump.
+func NewConnector(url string, onBytes func([]byte), inBytes <-chan []byte) *Connector {
+	return &Connector{
+		url:     url,
+		onBytes: onBytes,
+		inBytes: inBytes,
+		closeCh: make(chan struct{}),
+		dialer: func(ctx context.Context, url string) (*websocket.Conn, *websocketResp, error) {
+			c, _, err := websocket.Dial(ctx, url, nil)
+			if err != nil {
+				return nil, nil, err
+			}
+			return c, &websocketResp{}, nil
+		},
+	}
+}
+
+// Dial opens the WebSocket and starts the read/write pumps. Returns the dial
+// error untouched on failure. On success, the pumps run until Close is
+// invoked or the remote disconnects.
+func (c *Connector) Dial(ctx context.Context) error {
+	conn, _, err := c.dialer(ctx, c.url)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.conn = conn
+	c.mu.Unlock()
+	go c.readPump()
+	go c.writePump()
+	return nil
+}
+
+// SendResize emits a {"type":"resize","cols":N,"rows":M} envelope as a TEXT
+// frame. Sent on initial connect + every terminal resize while the plugin
+// view is active.
+func (c *Connector) SendResize(cols, rows int) error {
+	return c.sendEnvelope(controlEnvelope{Type: envelopeResize, Cols: cols, Rows: rows})
+}
+
+// SendFocus emits the {"type":"focus"} envelope.
+func (c *Connector) SendFocus() error {
+	return c.sendEnvelope(controlEnvelope{Type: envelopeFocus})
+}
+
+// SendBlur emits the {"type":"blur"} envelope. Sent just before Close.
+func (c *Connector) SendBlur() error {
+	return c.sendEnvelope(controlEnvelope{Type: envelopeBlur})
+}
+
+// Close terminates the WebSocket and stops the pumps. Idempotent.
+func (c *Connector) Close() error {
+	var err error
+	c.once.Do(func() {
+		close(c.closeCh)
+		c.mu.Lock()
+		conn := c.conn
+		c.mu.Unlock()
+		if conn != nil {
+			err = conn.Close(websocket.StatusNormalClosure, "client closing")
+		}
+	})
+	return err
+}
+
+func (c *Connector) sendEnvelope(env controlEnvelope) error {
+	c.mu.Lock()
+	conn := c.conn
+	c.mu.Unlock()
+	if conn == nil {
+		return errors.New("connector not dialed")
+	}
+	body, err := json.Marshal(env)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return conn.Write(ctx, websocket.MessageText, body)
+}
+
+func (c *Connector) readPump() {
+	for {
+		select {
+		case <-c.closeCh:
+			return
+		default:
+		}
+		c.mu.Lock()
+		conn := c.conn
+		c.mu.Unlock()
+		if conn == nil {
+			return
+		}
+		typ, data, err := conn.Read(context.Background())
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			return
+		}
+		if typ != websocket.MessageBinary {
+			// Control text frames flow plugin→argus too, but the current
+			// protocol reserves them for argus→plugin. Drop unknown text.
+			continue
+		}
+		if c.onBytes != nil && len(data) > 0 {
+			c.onBytes(data)
+		}
+	}
+}
+
+func (c *Connector) writePump() {
+	for {
+		select {
+		case <-c.closeCh:
+			return
+		case b, ok := <-c.inBytes:
+			if !ok {
+				return
+			}
+			if len(b) == 0 {
+				continue
+			}
+			c.mu.Lock()
+			conn := c.conn
+			c.mu.Unlock()
+			if conn == nil {
+				return
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			err := conn.Write(ctx, websocket.MessageBinary, b)
+			cancel()
+			if err != nil {
+				return
+			}
+		}
+	}
+}

--- a/internal/tui/views/connector_test.go
+++ b/internal/tui/views/connector_test.go
@@ -1,0 +1,256 @@
+package views
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/drn/argus/internal/testutil"
+)
+
+// pluginEcho is an httptest WebSocket handler used as a stand-in plugin.
+// envelopes is a channel the test can read to assert control envelopes;
+// keystrokes captures binary frames from the TUI; ANSI to push the test can
+// queue via the bytesToSend channel.
+type pluginEcho struct {
+	mu          sync.Mutex
+	envelopes   []controlEnvelope
+	keystrokes  [][]byte
+	bytesToSend chan []byte // buffered ANSI to push from server → client
+	done        chan struct{}
+	closeOnce   sync.Once
+}
+
+func newPluginEcho() *pluginEcho {
+	return &pluginEcho{
+		bytesToSend: make(chan []byte, 16),
+		done:        make(chan struct{}),
+	}
+}
+
+func (p *pluginEcho) signalDone() {
+	p.closeOnce.Do(func() { close(p.done) })
+}
+
+func (p *pluginEcho) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		defer c.Close(websocket.StatusNormalClosure, "")
+		// Pump pending ANSI bytes asynchronously.
+		go func() {
+			for {
+				select {
+				case <-p.done:
+					return
+				case b := <-p.bytesToSend:
+					ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+					_ = c.Write(ctx, websocket.MessageBinary, b)
+					cancel()
+				}
+			}
+		}()
+		// Read until the client disconnects.
+		for {
+			typ, data, err := c.Read(context.Background())
+			if err != nil {
+				p.signalDone()
+				return
+			}
+			switch typ {
+			case websocket.MessageText:
+				var env controlEnvelope
+				if err := json.Unmarshal(data, &env); err == nil {
+					p.mu.Lock()
+					p.envelopes = append(p.envelopes, env)
+					p.mu.Unlock()
+				}
+			case websocket.MessageBinary:
+				cp := append([]byte(nil), data...)
+				p.mu.Lock()
+				p.keystrokes = append(p.keystrokes, cp)
+				p.mu.Unlock()
+			}
+		}
+	})
+}
+
+func (p *pluginEcho) getEnvelopes() []controlEnvelope {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]controlEnvelope(nil), p.envelopes...)
+}
+
+func (p *pluginEcho) getKeystrokes() [][]byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([][]byte, len(p.keystrokes))
+	for i, k := range p.keystrokes {
+		out[i] = append([]byte(nil), k...)
+	}
+	return out
+}
+
+// wsURL turns the http URL of an httptest.Server into a ws:// URL the
+// coder/websocket client accepts.
+func wsURL(srv *httptest.Server) string {
+	return "ws" + strings.TrimPrefix(srv.URL, "http")
+}
+
+// waitFor polls cond every 5ms until it returns true or the timeout fires.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %v", timeout)
+}
+
+func TestConnector_DialAndControlEnvelopes(t *testing.T) {
+	plugin := newPluginEcho()
+	srv := httptest.NewServer(plugin.handler())
+	t.Cleanup(srv.Close)
+
+	in := make(chan []byte, 4)
+	c := NewConnector(wsURL(srv), nil, in)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	testutil.NoError(t, c.Dial(ctx))
+	t.Cleanup(func() { _ = c.Close() })
+
+	testutil.NoError(t, c.SendResize(80, 24))
+	testutil.NoError(t, c.SendFocus())
+	testutil.NoError(t, c.SendBlur())
+
+	waitFor(t, time.Second, func() bool { return len(plugin.getEnvelopes()) >= 3 })
+	got := plugin.getEnvelopes()
+	testutil.Equal(t, got[0].Type, envelopeResize)
+	testutil.Equal(t, got[0].Cols, 80)
+	testutil.Equal(t, got[0].Rows, 24)
+	testutil.Equal(t, got[1].Type, envelopeFocus)
+	testutil.Equal(t, got[2].Type, envelopeBlur)
+}
+
+func TestConnector_KeystrokesForwardedAsBinary(t *testing.T) {
+	plugin := newPluginEcho()
+	srv := httptest.NewServer(plugin.handler())
+	t.Cleanup(srv.Close)
+
+	in := make(chan []byte, 4)
+	c := NewConnector(wsURL(srv), nil, in)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	testutil.NoError(t, c.Dial(ctx))
+	t.Cleanup(func() { _ = c.Close() })
+
+	in <- []byte("hello")
+	in <- []byte("world")
+
+	waitFor(t, time.Second, func() bool { return len(plugin.getKeystrokes()) >= 2 })
+	got := plugin.getKeystrokes()
+	testutil.Equal(t, string(got[0]), "hello")
+	testutil.Equal(t, string(got[1]), "world")
+}
+
+func TestConnector_ANSIDeliveredAsBinary(t *testing.T) {
+	plugin := newPluginEcho()
+	srv := httptest.NewServer(plugin.handler())
+	t.Cleanup(srv.Close)
+
+	var (
+		gotMu sync.Mutex
+		got   []byte
+	)
+	onBytes := func(b []byte) {
+		gotMu.Lock()
+		got = append(got, b...)
+		gotMu.Unlock()
+	}
+	in := make(chan []byte, 4)
+	c := NewConnector(wsURL(srv), onBytes, in)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	testutil.NoError(t, c.Dial(ctx))
+	t.Cleanup(func() { _ = c.Close() })
+
+	plugin.bytesToSend <- []byte("\x1b[2J\x1b[Hhello")
+
+	waitFor(t, time.Second, func() bool {
+		gotMu.Lock()
+		defer gotMu.Unlock()
+		return len(got) > 0
+	})
+	gotMu.Lock()
+	defer gotMu.Unlock()
+	testutil.Equal(t, string(got), "\x1b[2J\x1b[Hhello")
+}
+
+func TestConnector_DialErrorPropagates(t *testing.T) {
+	c := NewConnector("ws://127.0.0.1:1", nil, nil) // port 1 — unreachable
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	err := c.Dial(ctx)
+	if err == nil {
+		t.Fatal("expected dial error")
+	}
+}
+
+func TestConnector_SendBeforeDialFails(t *testing.T) {
+	c := NewConnector("ws://example.invalid", nil, nil)
+	if err := c.SendResize(80, 24); err == nil {
+		t.Fatal("expected send-before-dial error")
+	}
+}
+
+func TestConnector_CloseIsIdempotent(t *testing.T) {
+	plugin := newPluginEcho()
+	srv := httptest.NewServer(plugin.handler())
+	t.Cleanup(srv.Close)
+
+	in := make(chan []byte, 4)
+	c := NewConnector(wsURL(srv), nil, in)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	testutil.NoError(t, c.Dial(ctx))
+
+	testutil.NoError(t, c.Close())
+	// Second Close must be a clean no-op.
+	testutil.NoError(t, c.Close())
+}
+
+func TestConnector_WritePumpExitsOnInClose(t *testing.T) {
+	plugin := newPluginEcho()
+	srv := httptest.NewServer(plugin.handler())
+	t.Cleanup(srv.Close)
+
+	in := make(chan []byte, 1)
+	c := NewConnector(wsURL(srv), nil, in)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	testutil.NoError(t, c.Dial(ctx))
+	t.Cleanup(func() { _ = c.Close() })
+
+	in <- []byte("alpha")
+	waitFor(t, time.Second, func() bool { return len(plugin.getKeystrokes()) >= 1 })
+
+	// Closing the in channel should let the write pump exit; the next call to
+	// any SendXxx after a tick must still succeed because the read connection
+	// remains open.
+	close(in)
+	// Give the write pump a beat to drain.
+	time.Sleep(20 * time.Millisecond)
+	testutil.NoError(t, c.SendBlur())
+}

--- a/internal/tui/views/registry.go
+++ b/internal/tui/views/registry.go
@@ -1,0 +1,125 @@
+// Package views holds the plugin-registered top-level view registry.
+//
+// Each registered view is a full-screen UI surface owned by a plugin. The
+// plugin streams ANSI bytes over a WebSocket; the TUI pipes those bytes into
+// a streampane and forwards keystrokes back. The registry persists
+// registrations to the plugin_views table so they survive restarts.
+package views
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/drn/argus/internal/db"
+)
+
+// Sentinel errors returned by Registry. Use errors.Is for matching.
+var (
+	// ErrTitleRequired fires when a title is empty or whitespace-only.
+	ErrTitleRequired = errors.New("view title is required")
+	// ErrCallbackURLRequired fires when callback_url is empty.
+	ErrCallbackURLRequired = errors.New("view callback_url is required")
+	// ErrViewExists fires when a (scope, title) pair is already registered.
+	ErrViewExists = errors.New("view already registered for this scope/title")
+	// ErrViewNotFound fires when Unregister is called on a missing pair.
+	ErrViewNotFound = errors.New("view not found")
+)
+
+// View is one plugin-registered top-level UI surface.
+type View struct {
+	ID          int64
+	Scope       string
+	Title       string
+	Hotkey      string
+	CallbackURL string
+	CreatedAt   time.Time
+}
+
+// Registry persists plugin views via *db.DB. All methods are safe for
+// concurrent use — the underlying DB serializes writes.
+type Registry struct {
+	db *db.DB
+}
+
+// New constructs a Registry backed by database.
+func New(database *db.DB) *Registry {
+	return &Registry{db: database}
+}
+
+// Register stores a new view. Returns the persisted View on success. Empty
+// title or callback_url is rejected up front; (scope, title) collisions
+// surface as ErrViewExists.
+func (r *Registry) Register(scope, title, hotkey, callbackURL string) (*View, error) {
+	if strings.TrimSpace(title) == "" {
+		return nil, ErrTitleRequired
+	}
+	if strings.TrimSpace(callbackURL) == "" {
+		return nil, ErrCallbackURLRequired
+	}
+
+	if existing, _ := r.db.GetPluginView(scope, title); existing != nil {
+		return nil, ErrViewExists
+	}
+
+	row, err := r.db.AddPluginView(scope, title, hotkey, callbackURL)
+	if err != nil {
+		return nil, err
+	}
+	return toView(*row), nil
+}
+
+// Get returns the view at (scope, title) and whether it was found.
+func (r *Registry) Get(scope, title string) (*View, bool) {
+	row, err := r.db.GetPluginView(scope, title)
+	if err != nil || row == nil {
+		return nil, false
+	}
+	return toView(*row), true
+}
+
+// List returns every registered view ordered by insertion order. Nil on
+// underlying DB error (callers can render that as an empty list).
+func (r *Registry) List() []*View {
+	rows, err := r.db.PluginViews()
+	if err != nil {
+		return nil
+	}
+	out := make([]*View, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, toView(row))
+	}
+	return out
+}
+
+// Unregister removes the view at (scope, title). Returns ErrViewNotFound if
+// no matching row existed.
+func (r *Registry) Unregister(scope, title string) error {
+	ok, err := r.db.DeletePluginView(scope, title)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return ErrViewNotFound
+	}
+	return nil
+}
+
+// RevokeScope cascade-deletes every view owned by scope. Safe no-op when no
+// rows match — this is the hook a future scope-token revocation handler
+// calls to clean up the views the now-revoked plugin had registered.
+func (r *Registry) RevokeScope(scope string) error {
+	_, err := r.db.DeletePluginViewsByScope(scope)
+	return err
+}
+
+func toView(row db.PluginView) *View {
+	return &View{
+		ID:          row.ID,
+		Scope:       row.Scope,
+		Title:       row.Title,
+		Hotkey:      row.Hotkey,
+		CallbackURL: row.CallbackURL,
+		CreatedAt:   row.CreatedAt,
+	}
+}

--- a/internal/tui/views/registry.go
+++ b/internal/tui/views/registry.go
@@ -113,6 +113,37 @@ func (r *Registry) RevokeScope(scope string) error {
 	return err
 }
 
+// ParseHotkey turns a stored hotkey string (eg "ctrl+l") into a tcell.Key
+// constant. Only "ctrl+<letter>" is supported today, matching the substrate's
+// minimum-viable shape. Returns (key, true) on hit; (0, false) on miss.
+//
+// Letters are case-insensitive. "ctrl+l" and "Ctrl+L" both map to
+// tcell.KeyCtrlL.
+func ParseHotkey(s string) (tcellKey, bool) {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if !strings.HasPrefix(s, "ctrl+") {
+		return 0, false
+	}
+	rest := s[len("ctrl+"):]
+	if len(rest) != 1 {
+		return 0, false
+	}
+	c := rest[0]
+	if c < 'a' || c > 'z' {
+		return 0, false
+	}
+	// tcell encodes Ctrl+letter keys with the uppercase-letter ASCII value:
+	// KeyCtrlA == 'A' == 65, KeyCtrlB == 'B' == 66, ..., KeyCtrlZ == 'Z' == 90.
+	// NOT the C0 control codes (1..26) — those are the byte values the TTY
+	// emits, but tcell's Key constants are a different encoding. Confirmed
+	// by running `tcell.NewEventKey(tcell.KeyCtrlL, 0, 0).Key()` → 76.
+	return tcellKey(c - 'a' + 'A'), true
+}
+
+// tcellKey aliases the tcell.Key int so the views package doesn't pull tcell
+// into its public API. Callers compare against tcell.KeyCtrlA etc by raw int.
+type tcellKey int16
+
 func toView(row db.PluginView) *View {
 	return &View{
 		ID:          row.ID,

--- a/internal/tui/views/registry_test.go
+++ b/internal/tui/views/registry_test.go
@@ -1,0 +1,231 @@
+package views
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/drn/argus/internal/db"
+	"github.com/drn/argus/internal/testutil"
+)
+
+func newRegistry(t *testing.T) *Registry {
+	t.Helper()
+	database, err := db.OpenInMemory()
+	testutil.NoError(t, err)
+	t.Cleanup(func() { _ = database.Close() })
+	return New(database)
+}
+
+func TestRegister_Persists(t *testing.T) {
+	r := newRegistry(t)
+
+	v, err := r.Register("plugin-ludwig", "Ludwig", "ctrl+l", "ws://127.0.0.1:5111/view")
+	testutil.NoError(t, err)
+	testutil.Equal(t, v.Scope, "plugin-ludwig")
+	testutil.Equal(t, v.Title, "Ludwig")
+	testutil.Equal(t, v.Hotkey, "ctrl+l")
+	testutil.Equal(t, v.CallbackURL, "ws://127.0.0.1:5111/view")
+	if v.ID <= 0 {
+		t.Fatalf("expected positive ID, got %d", v.ID)
+	}
+}
+
+func TestRegister_RequiresTitle(t *testing.T) {
+	r := newRegistry(t)
+
+	_, err := r.Register("plugin-ludwig", "  ", "ctrl+l", "ws://127.0.0.1:5111/view")
+	if !errors.Is(err, ErrTitleRequired) {
+		t.Fatalf("expected ErrTitleRequired, got %v", err)
+	}
+}
+
+func TestRegister_RequiresCallbackURL(t *testing.T) {
+	r := newRegistry(t)
+
+	_, err := r.Register("plugin-ludwig", "Ludwig", "ctrl+l", "")
+	if !errors.Is(err, ErrCallbackURLRequired) {
+		t.Fatalf("expected ErrCallbackURLRequired, got %v", err)
+	}
+}
+
+func TestRegister_DuplicateRejected(t *testing.T) {
+	r := newRegistry(t)
+
+	_, err := r.Register("plugin-ludwig", "Ludwig", "ctrl+l", "ws://a")
+	testutil.NoError(t, err)
+
+	_, err = r.Register("plugin-ludwig", "Ludwig", "ctrl+l", "ws://b")
+	if !errors.Is(err, ErrViewExists) {
+		t.Fatalf("expected ErrViewExists, got %v", err)
+	}
+}
+
+func TestRegister_DifferentScopesSameTitleOK(t *testing.T) {
+	r := newRegistry(t)
+
+	_, err := r.Register("plugin-a", "Dashboard", "ctrl+d", "ws://a")
+	testutil.NoError(t, err)
+	_, err = r.Register("plugin-b", "Dashboard", "ctrl+e", "ws://b")
+	testutil.NoError(t, err)
+
+	all := r.List()
+	testutil.Equal(t, len(all), 2)
+}
+
+func TestGet_HitAndMiss(t *testing.T) {
+	r := newRegistry(t)
+
+	_, err := r.Register("plugin-ludwig", "Ludwig", "ctrl+l", "ws://a")
+	testutil.NoError(t, err)
+
+	got, ok := r.Get("plugin-ludwig", "Ludwig")
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	testutil.Equal(t, got.CallbackURL, "ws://a")
+
+	_, ok = r.Get("plugin-ludwig", "Missing")
+	if ok {
+		t.Fatal("expected miss")
+	}
+	_, ok = r.Get("other", "Ludwig")
+	if ok {
+		t.Fatal("expected miss for wrong scope")
+	}
+}
+
+func TestList_OrderedByID(t *testing.T) {
+	r := newRegistry(t)
+
+	_, _ = r.Register("scope-z", "Zeta", "", "ws://1")
+	_, _ = r.Register("scope-a", "Alpha", "", "ws://2")
+	_, _ = r.Register("scope-m", "Mike", "", "ws://3")
+
+	all := r.List()
+	testutil.Equal(t, len(all), 3)
+	testutil.Equal(t, all[0].Title, "Zeta")
+	testutil.Equal(t, all[1].Title, "Alpha")
+	testutil.Equal(t, all[2].Title, "Mike")
+}
+
+func TestUnregister_RemovesOne(t *testing.T) {
+	r := newRegistry(t)
+
+	_, _ = r.Register("plugin-ludwig", "A", "", "ws://1")
+	_, _ = r.Register("plugin-ludwig", "B", "", "ws://2")
+
+	testutil.NoError(t, r.Unregister("plugin-ludwig", "A"))
+
+	_, ok := r.Get("plugin-ludwig", "A")
+	if ok {
+		t.Fatal("A should be gone")
+	}
+	_, ok = r.Get("plugin-ludwig", "B")
+	if !ok {
+		t.Fatal("B should remain")
+	}
+}
+
+func TestUnregister_NotFound(t *testing.T) {
+	r := newRegistry(t)
+
+	err := r.Unregister("plugin-ludwig", "Missing")
+	if !errors.Is(err, ErrViewNotFound) {
+		t.Fatalf("expected ErrViewNotFound, got %v", err)
+	}
+}
+
+func TestRevokeScope_CascadeDeletes(t *testing.T) {
+	r := newRegistry(t)
+
+	_, _ = r.Register("plugin-ludwig", "A", "", "ws://1")
+	_, _ = r.Register("plugin-ludwig", "B", "", "ws://2")
+	_, _ = r.Register("other", "C", "", "ws://3")
+
+	testutil.NoError(t, r.RevokeScope("plugin-ludwig"))
+
+	all := r.List()
+	testutil.Equal(t, len(all), 1)
+	testutil.Equal(t, all[0].Scope, "other")
+}
+
+func TestRevokeScope_NoMatchesIsNoOp(t *testing.T) {
+	r := newRegistry(t)
+
+	_, _ = r.Register("plugin-ludwig", "A", "", "ws://1")
+
+	testutil.NoError(t, r.RevokeScope("does-not-exist"))
+
+	all := r.List()
+	testutil.Equal(t, len(all), 1)
+}
+
+func TestRegister_DBClosedError(t *testing.T) {
+	database, err := db.OpenInMemory()
+	testutil.NoError(t, err)
+	r := New(database)
+	_ = database.Close()
+
+	_, err = r.Register("plugin", "Title", "", "ws://x")
+	if err == nil {
+		t.Fatal("expected DB-closed error")
+	}
+	if errors.Is(err, ErrViewExists) || errors.Is(err, ErrTitleRequired) || errors.Is(err, ErrCallbackURLRequired) {
+		t.Fatalf("expected raw DB error, got sentinel: %v", err)
+	}
+	if !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("expected closed-DB hint in %v", err)
+	}
+}
+
+func TestList_PropagatesDBError(t *testing.T) {
+	database, err := db.OpenInMemory()
+	testutil.NoError(t, err)
+	r := New(database)
+	_ = database.Close()
+
+	all := r.List()
+	if all != nil {
+		t.Fatalf("expected nil on DB error, got %v", all)
+	}
+}
+
+func TestGet_PropagatesDBError(t *testing.T) {
+	database, err := db.OpenInMemory()
+	testutil.NoError(t, err)
+	r := New(database)
+	_ = database.Close()
+
+	_, ok := r.Get("scope", "title")
+	if ok {
+		t.Fatal("expected miss on DB error")
+	}
+}
+
+func TestUnregister_PropagatesDBError(t *testing.T) {
+	database, err := db.OpenInMemory()
+	testutil.NoError(t, err)
+	r := New(database)
+	_ = database.Close()
+
+	err = r.Unregister("scope", "title")
+	if err == nil {
+		t.Fatal("expected DB error")
+	}
+	if errors.Is(err, ErrViewNotFound) {
+		t.Fatalf("expected raw DB error, got ErrViewNotFound: %v", err)
+	}
+}
+
+func TestRevokeScope_PropagatesDBError(t *testing.T) {
+	database, err := db.OpenInMemory()
+	testutil.NoError(t, err)
+	r := New(database)
+	_ = database.Close()
+
+	err = r.RevokeScope("scope")
+	if err == nil {
+		t.Fatal("expected DB error")
+	}
+}

--- a/internal/tui/views/registry_test.go
+++ b/internal/tui/views/registry_test.go
@@ -218,6 +218,35 @@ func TestUnregister_PropagatesDBError(t *testing.T) {
 	}
 }
 
+func TestParseHotkey(t *testing.T) {
+	for _, tc := range []struct {
+		in       string
+		wantKey  int
+		wantOK   bool
+		wantName string
+	}{
+		// tcell uses uppercase-letter ASCII for Ctrl+letter constants:
+		// KeyCtrlA = 'A' = 65, KeyCtrlL = 'L' = 76, KeyCtrlZ = 'Z' = 90.
+		{"ctrl+l", 76, true, "ctrl+l (lowercase)"},
+		{"CTRL+L", 76, true, "CTRL+L (uppercase)"},
+		{"Ctrl+a", 65, true, "ctrl+a"},
+		{"ctrl+z", 90, true, "ctrl+z"},
+		{"ctrl+", 0, false, "ctrl+ trailing nothing"},
+		{"ctrl+ll", 0, false, "ctrl+ multi-letter"},
+		{"ctrl+1", 0, false, "ctrl+digit"},
+		{"alt+l", 0, false, "alt unsupported"},
+		{"l", 0, false, "missing ctrl+"},
+		{"", 0, false, "empty"},
+		{"   ", 0, false, "whitespace"},
+	} {
+		t.Run(tc.wantName, func(t *testing.T) {
+			k, ok := ParseHotkey(tc.in)
+			testutil.Equal(t, ok, tc.wantOK)
+			testutil.Equal(t, int(k), tc.wantKey)
+		})
+	}
+}
+
 func TestRevokeScope_PropagatesDBError(t *testing.T) {
 	database, err := db.OpenInMemory()
 	testutil.NoError(t, err)


### PR DESCRIPTION
## Summary

Plugins own their UI; argus is the display + input router. Each plugin registers a top-level view via the REST API; the TUI mounts it as a tview.Page wrapping a streampane. The hotkey opens a WebSocket, the plugin streams ANSI bytes for its entire UI, argus pipes those to the streampane. Keystrokes flow back the other way. Esc exits.

This replaces the abandoned PR 6 (drn/argus#623) approach of giving argus a layout JSON schema + multi-pane renderer. After building the first plugin (ludwig) on top of that substrate, the renderer would have been 800-1500 lines AND every plugin would have had to fit argus's layout vocabulary. Wrong primitive. Single full-screen surface is right — plugins get unlimited UI flexibility internally, argus stays minimal.

## What ships in this PR

1. **Streampane widget** (`internal/tui/streampane/`) — cherry-picked from the abandoned `argus/argus-plugin-layout` branch. Renders ANSI bytes from a channel, tracks damage via `Touched()`, supports an optional input-back channel for keystrokes. 100% coverage on the package.

2. **Plugin view registry**:
   - New `plugin_views` table in `internal/db/schema.go` (id, scope, title, hotkey, callback_url, created_at, UNIQUE(scope, title)).
   - New `internal/tui/views/` package with `Registry` type: `Register`, `Get`, `List`, `Unregister`, `RevokeScope` (cascade-delete by scope).
   - `views.ParseHotkey` parses `"ctrl+<letter>"` → tcell.Key constant.

3. **REST endpoints** (`internal/api/plugin_views.go`):
   - `POST /api/plugins/views` — body `{title, hotkey, callback_url}` → 201 + persisted view.
   - `GET /api/plugins/views` — lists all views.
   - `DELETE /api/plugins/views/{id}` — removes a view by ID.
   - All three master-token gated.

4. **WebSocket protocol** (`internal/tui/views/connector.go`):
   - Binary frames plugin→argus carry ANSI bytes.
   - Binary frames argus→plugin carry keystrokes.
   - Text frames argus→plugin carry JSON control envelopes: `{"type":"resize","cols":N,"rows":M}`, `{"type":"focus"}`, `{"type":"blur"}`.
   - Esc reserved by argus for "exit plugin view" — never reaches the plugin.

5. **Top-level Page mount** (`internal/tui/plugin_views.go` + small additions to `app.go`):
   - `loadPluginViews()` reads the registry, parses hotkeys, mounts each view as a `tview.Page` named `plugin-view:<id>`.
   - Hotkey routing in `handleGlobalKey` activates the matching view: switches Pages, dials the WS in a goroutine, sends resize+focus envelopes.
   - Esc in plugin-view mode sends blur, closes the WS, switches back to the tasks page.
   - Terminal resize while a plugin view is active forwards a fresh resize envelope.

## Deferred follow-ups

These are explicitly NOT in this PR. The orchestrator has the design context.

- **Stream settings section type** (originally step 5 of the substrate plan) — defers to a follow-up commit after PR 7 (settings registry) AND this PR both land upstream. The WebSocket protocol introduced here is what that follow-up will reuse: an "stream"-typed settings section will mount a streampane wired to the same protocol. ~50-100 LOC follow-up; the substrate is fully ready for it.

- **Scope-token gating on the `/api/plugins/views` endpoints** — defers to a follow-up after PR 1 (scope-token mechanism) lands upstream. Today every endpoint gates on `requireMaster` with an inline `TODO(post-PR-1)` comment marking the swap to "master OR scope". The `scope` column in the `plugin_views` table is reserved for that swap — it exists today but every registration lands with scope="" because the master token has no scope. Switching the gate is a one-commit change with no schema migration.

- **`docs/plugins.md` updates** are PR 8's responsibility in a separate PR. PR 8 should add: (a) the view-registry endpoints, (b) the WebSocket protocol, (c) replace the dropped layout JSON schema with a small "hello world" plugin example demonstrating end-to-end view registration.

- **Remote-TUI plugin view mounting** — `argus --remote URL --token` mode has `app.db` as `*apistore.Store` instead of `*db.DB`. `loadPluginViews` short-circuits cleanly today. Surfacing plugin views over the REST API in remote mode is a follow-up; not load-bearing for the substrate landing.

## Notes for reviewers

- The DELETE URL is `/{id}` rather than the `/{scope}/{title}` the spec sketched. Go's `net/http.ServeMux` canonicalises `//` segments and 307-redirects, which makes the spec shape unusable while every row has `scope=""`. `{id}` matches the existing `/api/tokens/{id}` precedent and works in both the master-only world today and the scope-gated world after PR 1.
- New dependency: `github.com/coder/websocket` (formerly `nhooyr.io/websocket`) — minimal, single-import, actively maintained. The TUI is the WebSocket *client* (it dials each plugin's URL); each plugin runs its own WebSocket *server*.
- Coverage: 100% on `internal/tui/streampane/` and `internal/tui/views/registry.go`; ~94% on `internal/tui/views/connector.go`; 90-100% per function on the DB and API layers. New `internal/tui/plugin_views.go` is 76-100% per function (uncovered paths are defensive nil/branch guards in the activate/resize lifecycle).

## Test plan

- [x] `make vet` clean
- [x] `make test` clean (`go test -race -count=1 ./...` clean)
- [x] Registry unit tests cover Register/Get/List/Unregister/RevokeScope (100% on the package).
- [x] HTTP endpoint tests cover POST/GET/DELETE shapes + `requireMaster` gate + duplicate + bad ID + invalid JSON.
- [x] WebSocket protocol test (`connector_test.go`) uses a real httptest WebSocket server: verifies resize/focus/blur envelopes are received as text frames, keystrokes arrive as binary frames, ANSI bytes flow into the byte sink.
- [x] Smoke test using SimulationScreen: register a view, inject Ctrl+L from the task list, verify the page mounts + connector is dialed + focus envelope fires + Esc tears it down.
- [ ] Manual: open a real plugin (ludwig) against this branch and confirm end-to-end (separate verification step on the ludwig branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
