### PR TITLE
Add Daemon.Ports RPC for port discovery

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -64,6 +64,7 @@ type Daemon struct {
 	sockPath  string               // set by Serve, used by cleanup
 	pidPath   string               // set by Serve, used by cleanup
 	mcpPort   int                  // actual MCP HTTP port in use (set after listen)
+	apiPort   int                  // actual REST API HTTP port in use (set after listen)
 	mcpServer *mcp.Server          // set when KB is enabled, shut down in cleanup
 	kbIndexer *kb.Indexer          // set when KB is enabled, stopped in cleanup
 	apiServer *api.Server          // set when API is enabled, shut down in cleanup
@@ -441,6 +442,9 @@ func (d *Daemon) Serve(sockPath string) error {
 			if err != nil {
 				slog.Error("api server error", "err", err)
 			} else {
+				d.mu.Lock()
+				d.apiPort = apiPort
+				d.mu.Unlock()
 				slog.Info("api server listening", "port", apiPort)
 			}
 		}

--- a/internal/daemon/rpc.go
+++ b/internal/daemon/rpc.go
@@ -37,6 +37,21 @@ func (s *RPCService) BootInfo(_ *Empty, resp *BootInfoResp) error {
 	return nil
 }
 
+// Ports returns the live MCP and REST API HTTP ports the daemon is bound to.
+// Plugins (e.g. hera) call this over the Unix socket to discover the current
+// ports instead of hardcoding — bindWithRetry means neither port is stable
+// across restarts. Zero means that server is not enabled or failed to bind.
+//
+// The port fields are written once in Serve under d.mu and read here under
+// the same lock; mirrors KBStatus's treatment of mcpPort.
+func (s *RPCService) Ports(_ *Empty, resp *PortsResp) error {
+	s.daemon.mu.Lock()
+	resp.MCPPort = s.daemon.mcpPort
+	resp.APIPort = s.daemon.apiPort
+	s.daemon.mu.Unlock()
+	return nil
+}
+
 // StartSession starts a new agent session.
 func (s *RPCService) StartSession(req *StartReq, resp *StartResp) error {
 	slog.Info("rpc.StartSession", "task", req.TaskID, "session", req.SessionID, "project", req.Project, "resume", req.Resume, "cols", req.Cols, "rows", req.Rows, "worktree", req.Worktree)

--- a/internal/daemon/rpc_test.go
+++ b/internal/daemon/rpc_test.go
@@ -347,6 +347,45 @@ func TestRPC_RPCShutdown(t *testing.T) {
 	}
 }
 
+// TestRPC_Ports verifies Daemon.Ports returns the daemon's currently-bound
+// MCP and API HTTP ports. Plugins discover these to call into argus without
+// hardcoding (bindWithRetry means neither is stable across restarts).
+func TestRPC_Ports(t *testing.T) {
+	d, sockPath := testDaemon(t)
+	go d.Serve(sockPath) //nolint:errcheck
+	t.Cleanup(func() { d.Shutdown() })
+	waitForSocket(t, sockPath)
+
+	// Stage the port fields directly — KB and API are disabled in tests, so
+	// the live servers never bind. We're verifying the field copy, not the
+	// HTTP listeners themselves.
+	d.mu.Lock()
+	d.mcpPort = 7743
+	d.apiPort = 7745
+	d.mu.Unlock()
+
+	c := dialRPC(t, sockPath)
+	var resp PortsResp
+	testutil.NoError(t, c.Call("Daemon.Ports", &Empty{}, &resp))
+	testutil.Equal(t, resp.MCPPort, 7743)
+	testutil.Equal(t, resp.APIPort, 7745)
+}
+
+// TestRPC_Ports_Zero verifies the response carries zero values when neither
+// server is bound (the default in tests — KB and API both disabled).
+func TestRPC_Ports_Zero(t *testing.T) {
+	d, sockPath := testDaemon(t)
+	go d.Serve(sockPath) //nolint:errcheck
+	t.Cleanup(func() { d.Shutdown() })
+	waitForSocket(t, sockPath)
+
+	c := dialRPC(t, sockPath)
+	var resp PortsResp
+	testutil.NoError(t, c.Call("Daemon.Ports", &Empty{}, &resp))
+	testutil.Equal(t, resp.MCPPort, 0)
+	testutil.Equal(t, resp.APIPort, 0)
+}
+
 // TestDaemon_HandleStream verifies the full stream path: a client subscribes
 // to a session's output, receives the bytes the session produces, and gets
 // EOF when the session exits. Also exercises registerStream/unregisterStream

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -15,6 +15,17 @@ type BootInfoResp struct {
 	BootedAt    time.Time // wall-clock time the daemon started
 }
 
+// PortsResp returns the live HTTP ports the daemon is bound to. Both servers
+// pick their port via bindWithRetry on startup, so neither value is stable
+// across daemon restarts. Plugins that need to call the REST API or MCP
+// server use Daemon.Ports to discover the current ports instead of hardcoding
+// or scanning. A zero value means that server is not running (e.g. KB
+// disabled → MCPPort=0; API disabled → APIPort=0).
+type PortsResp struct {
+	MCPPort int
+	APIPort int
+}
+
 // StartReq is the RPC request to start a new agent session.
 type StartReq struct {
 	TaskID    string


### PR DESCRIPTION
Plugins (hera) need to discover argus's live MCP and REST API ports without hardcoding — bindWithRetry means neither port is stable across daemon restarts. The MCP port was already exposed as a side effect of StartSession.resp.Port; the REST API port wasn't exposed at all.

Stores apiPort on Daemon alongside the existing mcpPort field, both written once during Serve startup under d.mu. Adds Daemon.Ports JSON-RPC method returning both, mirroring KBStatus's lock-paired read pattern.