### PR TITLE
Resolve master CI failures and add pre-PR gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,25 @@ make vet                    # go vet ./...
 make test                   # go test -race -count=1 ./...
 make test-pkg PKG=./internal/db/  # single package, verbose
 make test-cover             # coverage profile + summary
+make test-cover-gate        # race suite + coverage floor (-min 88; matches CI gate)
 make test-watch             # gotestsum --watch (install: go install gotest.tools/gotestsum@latest)
 make fmt                    # goimports -w . (format the tree)
 make fmt-check              # fail if any file is not goimports-clean (matches CI)
 make vuln                   # govulncheck ./... (install: go install golang.org/x/vuln/cmd/govulncheck@latest)
 make lint-pr                # golangci-lint --new-from-rev=origin/master (matches CI; run before pushing)
+make pre-pr                 # full CI mirror: build+vet+fmt-check+lint-pr+vuln+test-cover-gate
 go build -o argus ./cmd/argus/    # build binary
 ```
+
+## Before Opening a PR
+
+**Run `make pre-pr` and get a clean pass before opening OR updating any PR.** It mirrors `.github/workflows/ci.yml` step-for-step (build → vet → fmt-check → lint-pr → vuln → test-cover-gate), so a green `make pre-pr` means CI will be green. This is non-negotiable: do not `git push` a PR branch until it passes.
+
+- **`make fmt-check` failing?** Run `make fmt` first — goimports rewrites the tree (the most common CI miss is an unformatted file).
+- **`make test-cover-gate` failing?** Filtered coverage dropped below the 88% floor. Add tests for the code you touched (or for under-covered platform-agnostic code) until it clears — the floor ratchets up and never down. Do NOT lower `-min`.
+- **`make lint-pr` failing?** `lint-pr` uses `--new-from-rev=origin/master`, so it only flags issues your diff introduced (including `staticcheck` deprecations like `SA1019` on new lines). Fix them; do not add blanket `//nolint`.
+
+Why this matters: the gate steps run in sequence and the first failure short-circuits the rest. A formatting miss alone will hide test/lint/coverage failures from CI until it's fixed, so running the **full** `make pre-pr` locally is the only way to surface every problem in one pass.
 
 ## Test-Driven Development
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ go build -o argus ./cmd/argus/    # build binary
 **Run `make pre-pr` and get a clean pass before opening OR updating any PR.** It mirrors `.github/workflows/ci.yml` step-for-step (build → vet → fmt-check → lint-pr → vuln → test-cover-gate), so a green `make pre-pr` means CI will be green. This is non-negotiable: do not `git push` a PR branch until it passes.
 
 - **`make fmt-check` failing?** Run `make fmt` first — goimports rewrites the tree (the most common CI miss is an unformatted file).
-- **`make test-cover-gate` failing?** Filtered coverage dropped below the 88% floor. Add tests for the code you touched (or for under-covered platform-agnostic code) until it clears — the floor ratchets up and never down. Do NOT lower `-min`.
+- **`make test-cover-gate` failing?** Filtered coverage dropped below the 88% floor. Add tests for the code you touched (or for under-covered platform-agnostic code) until it clears — the floor ratchets up and never down. Do NOT lower `-min`. Note that filtered coverage can drift ~0.2% between darwin (local) and linux (CI) because of platform-runtime branches in files like `internal/agent/sandbox.go`; target platform-agnostic code for the most reliable margin.
 - **`make lint-pr` failing?** `lint-pr` uses `--new-from-rev=origin/master`, so it only flags issues your diff introduced (including `staticcheck` deprecations like `SA1019` on new lines). Fix them; do not add blanket `//nolint`.
 
 Why this matters: the gate steps run in sequence and the first failure short-circuits the rest. A formatting miss alone will hide test/lint/coverage failures from CI until it's fixed, so running the **full** `make pre-pr` locally is the only way to surface every problem in one pass.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
-.PHONY: build vet test test-watch test-cover test-cover-gate test-pkg lint-pr fmt fmt-check vuln
+.PHONY: build vet test test-watch test-cover test-cover-gate test-pkg lint-pr fmt fmt-check vuln pre-pr
 
 build:
 	go build ./...
+
+# Full pre-PR gate — mirrors .github/workflows/ci.yml in order. Run this
+# (and get a clean pass) before opening or updating a PR. test-cover-gate
+# runs the race suite + coverage floor, so it subsumes `make test`.
+pre-pr: build vet fmt-check lint-pr vuln test-cover-gate
+	@echo "✓ pre-pr checks passed — safe to open/update the PR"
 
 vet:
 	go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ build:
 # Full pre-PR gate — mirrors .github/workflows/ci.yml in order. Run this
 # (and get a clean pass) before opening or updating a PR. test-cover-gate
 # runs the race suite + coverage floor, so it subsumes `make test`.
+# Note: `vuln` is `continue-on-error` in CI (advisory only — stdlib CVEs
+# need a Go bump), but is fatal here so local runs surface them early.
+# A red `make pre-pr` whose ONLY failure is `vuln` will still pass CI.
 pre-pr: build vet fmt-check lint-pr vuln test-cover-gate
 	@echo "✓ pre-pr checks passed — safe to open/update the PR"
 

--- a/internal/agent/create_test.go
+++ b/internal/agent/create_test.go
@@ -487,3 +487,48 @@ func TestCreateAndStart_StartedAtSetOnSuccess(t *testing.T) {
 	}
 	RemoveWorktreeAndBranch(task.Worktree, task.Branch, repo)
 }
+
+// TestStartPendingBlocked_GuardClauses pins the three argument guards that
+// reject the call before any worktree/DB/session side effect runs. The db is
+// never touched on these paths, so a nil database is safe.
+func TestStartPendingBlocked_GuardClauses(t *testing.T) {
+	tests := []struct {
+		name   string
+		runner SessionProvider
+		task   *model.Task
+		want   string
+	}{
+		{
+			name:   "nil runner",
+			runner: nil,
+			task:   &model.Task{ID: "x", Status: model.StatusPending},
+			want:   "nil runner",
+		},
+		{
+			name:   "nil task",
+			runner: &fakeRunner{},
+			task:   nil,
+			want:   "nil task",
+		},
+		{
+			name:   "non-pending status",
+			runner: &fakeRunner{},
+			task:   &model.Task{ID: "x", Status: model.StatusInReview},
+			want:   "already in status",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sess, err := StartPendingBlocked(nil, tc.runner, tc.task)
+			if sess != nil {
+				t.Errorf("expected nil session, got %v", sess)
+			}
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q should contain %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/agent/create_test.go
+++ b/internal/agent/create_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/drn/argus/internal/config"
 	"github.com/drn/argus/internal/db"
 	"github.com/drn/argus/internal/model"
+	"github.com/drn/argus/internal/testutil"
 )
 
 // initGitRepo creates a git repo with one commit in a fresh temp dir and
@@ -520,15 +521,11 @@ func TestStartPendingBlocked_GuardClauses(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			sess, err := StartPendingBlocked(nil, tc.runner, tc.task)
-			if sess != nil {
-				t.Errorf("expected nil session, got %v", sess)
-			}
+			testutil.Nil(t, sess)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
-			if !strings.Contains(err.Error(), tc.want) {
-				t.Errorf("error %q should contain %q", err, tc.want)
-			}
+			testutil.Contains(t, err.Error(), tc.want)
 		})
 	}
 }

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -445,6 +445,49 @@ func TestRunner_HasSession_MoreCases(t *testing.T) {
 	}
 }
 
+func TestRunner_PendingRestartIDs(t *testing.T) {
+	r := NewRunner(nil)
+
+	// Empty runner: no pending restarts.
+	testutil.Equal(t, len(r.PendingRestartIDs()), 0)
+	testutil.Equal(t, r.HasPendingRestart("a"), false)
+
+	// Inject two pending entries via the test helper.
+	r.SetPendingRestartForTest("a", true)
+	r.SetPendingRestartForTest("b", true)
+	testutil.Equal(t, r.HasPendingRestart("a"), true)
+
+	ids := r.PendingRestartIDs()
+	testutil.Equal(t, len(ids), 2)
+
+	// Removing one entry drops it from the set.
+	r.SetPendingRestartForTest("a", false)
+	testutil.Equal(t, r.HasPendingRestart("a"), false)
+	testutil.DeepEqual(t, r.PendingRestartIDs(), []string{"b"})
+
+	// A pending entry whose task also has a live session is filtered out —
+	// PendingRestartIDs only surfaces the kick gap (pending but no session).
+	cfg := config.Config{
+		Defaults: config.Defaults{Backend: "test"},
+		Backends: map[string]config.Backend{
+			"test": {Command: "sleep 60", PromptFlag: ""},
+		},
+		Projects: make(map[string]config.Project),
+	}
+	task := &model.Task{ID: "b", Name: "test", Worktree: t.TempDir()}
+	if _, err := r.Start(task, cfg, 24, 80, false); err != nil {
+		t.Fatal(err)
+	}
+	// "b" now has both a pending entry and a live session → filtered out.
+	testutil.Equal(t, len(r.PendingRestartIDs()), 0)
+
+	// Clear the pending entry before stopping. SetPendingRestartForTest
+	// injects entries with no task and consumed=false, so leaving it in place
+	// would send the exit goroutine down the kick-restart path with a nil task.
+	r.SetPendingRestartForTest("b", false)
+	_ = r.Stop("b")
+}
+
 func TestRunner_StopAll(t *testing.T) {
 	r := NewRunner(nil)
 	cfg := config.Config{
@@ -704,6 +747,22 @@ func TestRunner_KickRerender_NoLoopOnImmediateCrash(t *testing.T) {
 
 	// Wait for the original to exit.
 	<-starts
+
+	// onFinish fires while the session is STILL in the map (pinned by
+	// TestRunner_OnFinishFiresBeforeRemoval); the original exit goroutine only
+	// removes it from the map — and reads pendingRestart — AFTER the callback
+	// returns. So we must wait for that removal before (a) injecting the
+	// pendingRestart entry (otherwise the original goroutine could claim it and
+	// fire a third restart) and (b) the second Start (otherwise it fails with
+	// "session already exists"). Poll rather than sleep a fixed interval — the
+	// gap between onFinish and removal is unbounded on slow/contended CI runners.
+	deadline := time.Now().Add(5 * time.Second)
+	for r.HasSession(task.ID) {
+		if time.Now().After(deadline) {
+			t.Fatal("timeout waiting for original session removal")
+		}
+		time.Sleep(time.Millisecond)
+	}
 
 	// Inject a pendingRestart entry directly with consumed=true to simulate
 	// the state "the previous restart goroutine already claimed this entry

--- a/internal/apiclient/client_test.go
+++ b/internal/apiclient/client_test.go
@@ -224,6 +224,46 @@ func TestClient_RenameTask(t *testing.T) {
 	testutil.Contains(t, seenBody, `"name":"new-name"`)
 }
 
+func TestClient_ErrorPaths(t *testing.T) {
+	// A server that 500s every route exercises the error-return arm of each
+	// Client method uniformly — the happy paths are covered by the dedicated
+	// tests above, but the `if err != nil { return ..., err }` branches were
+	// not, leaving these methods at 75%.
+	f := newFixture(t)
+	f.mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+	})
+	ctx := context.Background()
+	c := f.c
+
+	checks := []struct {
+		name string
+		call func() error
+	}{
+		{"GitStatus", func() error { _, e := c.GitStatus(ctx, "t1"); return e }},
+		{"GitDiff", func() error { _, e := c.GitDiff(ctx, "t1", "f"); return e }},
+		{"FileTree", func() error { _, e := c.FileTree(ctx, "t1", ""); return e }},
+		{"GetClipboard", func() error { _, e := c.GetClipboard(ctx, "t1"); return e }},
+		{"GetLinks", func() error { _, e := c.GetLinks(ctx, "t1"); return e }},
+		{"ListProjects", func() error { _, e := c.ListProjects(ctx); return e }},
+		{"ListProjectsFull", func() error { _, e := c.ListProjectsFull(ctx); return e }},
+		{"ListBackends", func() error { _, e := c.ListBackends(ctx); return e }},
+		{"ListInbox", func() error { _, e := c.ListInbox(ctx, "t1", InboxFilter{}); return e }},
+		{"SendMessage", func() error { _, e := c.SendMessage(ctx, "t1", SendMessageReq{To: "x", Body: "y"}); return e }},
+		{"AckInbox", func() error { _, e := c.AckInbox(ctx, "t1", []string{"m1"}); return e }},
+		{"ListSchedules", func() error { _, e := c.ListSchedules(ctx); return e }},
+		{"CreateSchedule", func() error { _, e := c.CreateSchedule(ctx, ScheduleReq{}); return e }},
+		{"RunSchedule", func() error { _, e := c.RunSchedule(ctx, "s1"); return e }},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.call(); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
 func TestQueryHelper(t *testing.T) {
 	t.Run("returns empty when all values empty", func(t *testing.T) {
 		testutil.Equal(t, query("a", "", "b", ""), "")
@@ -249,4 +289,3 @@ func TestQueryHelper(t *testing.T) {
 		_ = query(odd...) //nolint:staticcheck // SA5012: the odd-count panic IS the contract under test
 	})
 }
-

--- a/internal/apiclient/client_test.go
+++ b/internal/apiclient/client_test.go
@@ -228,7 +228,7 @@ func TestClient_ErrorPaths(t *testing.T) {
 	// A server that 500s every route exercises the error-return arm of each
 	// Client method uniformly — the happy paths are covered by the dedicated
 	// tests above, but the `if err != nil { return ..., err }` branches were
-	// not, leaving these methods at 75%.
+	// previously uncovered.
 	f := newFixture(t)
 	f.mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)

--- a/internal/apiclient/messages.go
+++ b/internal/apiclient/messages.go
@@ -83,4 +83,3 @@ func (c *Client) AckInbox(ctx context.Context, id string, ids []string) (int, er
 	}
 	return resp.Acked, nil
 }
-

--- a/internal/apiclient/provider_test.go
+++ b/internal/apiclient/provider_test.go
@@ -191,6 +191,25 @@ func TestProvider_Stop(t *testing.T) {
 	testutil.NoError(t, p.Stop("t1"))
 }
 
+func TestProvider_ErrorPaths(t *testing.T) {
+	// Every route 500s, so each accessor must fall back to its zero value via
+	// the (previously uncovered) error branch rather than panicking.
+	f := newFixture(t)
+	f.mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+	})
+	p := NewProvider(f.c)
+
+	testutil.Equal(t, len(p.Running()), 0)
+	testutil.Equal(t, len(p.Idle()), 0)
+	running, idle := p.RunningAndIdle()
+	testutil.Equal(t, len(running), 0)
+	testutil.Equal(t, len(idle), 0)
+	testutil.False(t, p.HasSession("x"))
+	testutil.Equal(t, p.WorkDir("x"), "")
+	testutil.False(t, p.HasPendingRestart("x"))
+}
+
 func TestSession_WriteInput_UpdatesLastInput(t *testing.T) {
 	fs := newFakeServer(t)
 	p := NewProvider(fs.client())

--- a/internal/apiclient/provider_test.go
+++ b/internal/apiclient/provider_test.go
@@ -194,6 +194,7 @@ func TestProvider_Stop(t *testing.T) {
 func TestProvider_ErrorPaths(t *testing.T) {
 	// Every route 500s, so each accessor must fall back to its zero value via
 	// the (previously uncovered) error branch rather than panicking.
+	// newFixture is defined in client_test.go — both files are package apiclient.
 	f := newFixture(t)
 	f.mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)

--- a/internal/apistore/store.go
+++ b/internal/apistore/store.go
@@ -27,7 +27,6 @@ import (
 	"github.com/drn/argus/internal/tui/store"
 )
 
-
 // Compile-time assertion: Store implements tui/store.Store.
 var _ store.Store = (*Store)(nil)
 

--- a/internal/tui/dagview/render_test.go
+++ b/internal/tui/dagview/render_test.go
@@ -3,6 +3,8 @@ package dagview
 import (
 	"strings"
 	"testing"
+
+	"github.com/gdamore/tcell/v2"
 )
 
 // TestRender_LinearChain — three nodes stacked on top of each other with
@@ -79,6 +81,80 @@ func TestRender_StatusGlyphs(t *testing.T) {
 			t.Errorf("glyph(%q, archived=%v, failed=%v): got %q want %q",
 				tc.status, tc.archived, tc.failed, got, tc.want)
 		}
+	}
+}
+
+// TestStyle_AllBranches pins the foreground each status/flag combination
+// maps to. Style feeds both the string renderer and the screen painter, so a
+// regression here silently miscolors the whole DAG view.
+func TestStyle_AllBranches(t *testing.T) {
+	cases := []struct {
+		name                    string
+		status                  string
+		archived, failed, focus bool
+		wantFG                  tcell.Color
+	}{
+		{"archived wins", "in_progress", true, true, true, tcell.ColorGray},
+		{"failed", "complete", false, true, false, tcell.ColorRed},
+		{"pending", "pending", false, false, false, tcell.ColorGray},
+		{"in_progress focused", "in_progress", false, false, true, tcell.ColorAqua},
+		{"in_progress unfocused", "in_progress", false, false, false, tcell.ColorAqua},
+		{"in_review", "in_review", false, false, false, tcell.ColorYellow},
+		{"complete", "complete", false, false, false, tcell.ColorGreen},
+		{"unknown status", "weird", false, false, false, tcell.ColorDefault},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fg, _, _ := Style(tc.status, tc.archived, tc.failed, tc.focus).Decompose()
+			if fg != tc.wantFG {
+				t.Errorf("Style(%q, arch=%v, fail=%v, focus=%v) fg = %v, want %v",
+					tc.status, tc.archived, tc.failed, tc.focus, fg, tc.wantFG)
+			}
+		})
+	}
+}
+
+// TestDraw_PaintsToScreen exercises the screen-painting path (Draw → drawNode
+// → drawEdge), which is distinct from RenderToString's string buffer. A
+// fan-out layout forces the bent-corner edge glyphs; a failed + cursor node
+// covers the highlight/reverse and failed-style branches.
+func TestDraw_PaintsToScreen(t *testing.T) {
+	l := Compute([]Node{
+		{ID: "A", Name: "root", Status: "complete"},
+		{ID: "B", Name: "left", Status: "in_progress", DependsOn: []string{"A"}},
+		{ID: "C", Name: "right", Status: "pending", DependsOn: []string{"A"}},
+	})
+
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(120, 40)
+
+	parseFailed := func(id string) bool { return id == "B" }
+	w, h := Draw(screen, 0, 0, l, "A", true, parseFailed)
+	if w <= 0 || h <= 0 {
+		t.Fatalf("expected positive bounding box, got w=%d h=%d", w, h)
+	}
+	screen.Show() // flush SetContent writes into the front buffer GetContents reads
+
+	// Draw should have painted box-corner glyphs somewhere on the screen.
+	cells, _, _ := screen.GetContents()
+	var sawCorner bool
+	for _, c := range cells {
+		if len(c.Runes) > 0 && c.Runes[0] == '╭' {
+			sawCorner = true
+			break
+		}
+	}
+	if !sawCorner {
+		t.Error("expected at least one box corner glyph painted")
+	}
+
+	// Empty layout is a no-op returning a zero box.
+	if ew, eh := Draw(screen, 0, 0, Layout{}, "", false, nil); ew != 0 || eh != 0 {
+		t.Errorf("empty layout: got w=%d h=%d, want 0,0", ew, eh)
 	}
 }
 

--- a/internal/tui/dagview/render_test.go
+++ b/internal/tui/dagview/render_test.go
@@ -93,22 +93,28 @@ func TestStyle_AllBranches(t *testing.T) {
 		status                  string
 		archived, failed, focus bool
 		wantFG                  tcell.Color
+		wantBold                bool
 	}{
-		{"archived wins", "in_progress", true, true, true, tcell.ColorGray},
-		{"failed", "complete", false, true, false, tcell.ColorRed},
-		{"pending", "pending", false, false, false, tcell.ColorGray},
-		{"in_progress focused", "in_progress", false, false, true, tcell.ColorAqua},
-		{"in_progress unfocused", "in_progress", false, false, false, tcell.ColorAqua},
-		{"in_review", "in_review", false, false, false, tcell.ColorYellow},
-		{"complete", "complete", false, false, false, tcell.ColorGreen},
-		{"unknown status", "weird", false, false, false, tcell.ColorDefault},
+		{"archived wins", "in_progress", true, true, true, tcell.ColorGray, false},
+		{"failed", "complete", false, true, false, tcell.ColorRed, true},
+		{"pending", "pending", false, false, false, tcell.ColorGray, false},
+		{"in_progress focused", "in_progress", false, false, true, tcell.ColorAqua, true},
+		{"in_progress unfocused", "in_progress", false, false, false, tcell.ColorAqua, false},
+		{"in_review", "in_review", false, false, false, tcell.ColorYellow, false},
+		{"complete", "complete", false, false, false, tcell.ColorGreen, false},
+		{"unknown status", "weird", false, false, false, tcell.ColorDefault, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			fg, _, _ := Style(tc.status, tc.archived, tc.failed, tc.focus).Decompose()
+			fg, _, attrs := Style(tc.status, tc.archived, tc.failed, tc.focus).Decompose()
 			if fg != tc.wantFG {
 				t.Errorf("Style(%q, arch=%v, fail=%v, focus=%v) fg = %v, want %v",
 					tc.status, tc.archived, tc.failed, tc.focus, fg, tc.wantFG)
+			}
+			gotBold := attrs&tcell.AttrBold != 0
+			if gotBold != tc.wantBold {
+				t.Errorf("Style(%q, arch=%v, fail=%v, focus=%v) bold = %v, want %v",
+					tc.status, tc.archived, tc.failed, tc.focus, gotBold, tc.wantBold)
 			}
 		})
 	}


### PR DESCRIPTION
Master CI was failing at Format Check, which gated and masked two further
failures. This PR fixes all three plus adds a `make pre-pr` gate to prevent
recurrence.

- **Format Check**: three files landed unformatted on master (trailing/double
  blank lines); `make fmt` removed them.
- **Test race**: `TestRunner_KickRerender_NoLoopOnImmediateCrash` raced the
  runner's session map removal because `onFinish` fires while the session is
  still in the map (a documented invariant). Poll `HasSession` until removal
  before re-starting.
- **Coverage Gate (87.9% < 88.0% floor)**: recent merges had pushed filtered
  coverage below the floor but the gate never ran while Format Check was red.
  Added focused tests for previously-uncovered platform-agnostic code:
  `PendingRestartIDs` / `SetPendingRestartForTest`, `StartPendingBlocked`
  argument guards, apiclient Client + Provider HTTP-error branches, and the
  dagview `Style` / `Draw` → `drawNode` / `drawEdge` paint path. 88.7% locally.

Also adds a `make pre-pr` target that chains build → vet → fmt-check →
lint-pr → vuln → test-cover-gate (mirroring `.github/workflows/ci.yml`)
and a mandatory CLAUDE.md section requiring it before opening or updating
any PR — CI short-circuits on the first failed step, so running the full
gate locally is the only way to surface every problem in one pass.

Test-only change to production behavior; the source code edits are
goimports-driven whitespace deletions.

Co-Authored-By: Claude <noreply@anthropic.com>