### PR TITLE
CI: upgrade all GitHub Actions off deprecated Node.js 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
         go-version: ['1.26']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -42,7 +42,7 @@ jobs:
           fi
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: "v2.11.4"
           only-new-issues: true
@@ -105,7 +105,7 @@ jobs:
           go run ./scripts/coverfilter -in coverage.out -min 88 -quiet >/dev/null
 
       - name: Upload Coverage Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: |
@@ -115,7 +115,7 @@ jobs:
 
       - name: Coverage Report
         if: github.event_name == 'pull_request'
-        uses: fgrosse/go-coverage-report@v1.2.0
+        uses: fgrosse/go-coverage-report@v1.3.0
         with:
           coverage-artifact-name: coverage
           coverage-file-name: coverage.out


### PR DESCRIPTION
GitHub is forcing Node.js 20 actions to Node.js 24 on June 2nd, 2026 and removing the node20 runtime from runners on September 16th, 2026 (https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Bump every action in ci.yml to its current major to clear the deprecation warning and get off the old runtime entirely.

  actions/checkout                v4      -> v6       (node20 -> node24)
  actions/setup-go                v5      -> v6       (node20 -> node24)
  golangci/golangci-lint-action   v7      -> v9       (node20 -> node24)
  actions/upload-artifact         v4      -> v7       (node20 -> node24)
  fgrosse/go-coverage-report      v1.2.0  -> v1.3.0   (composite)

All inputs in use are unchanged across these bumps (verified against each action's action.yml). golangci-lint-action v8 requires golangci-lint >= v2.1.0 (we pin v2.11.4) and only changed working-directory path handling, which is unset here; v9 is the node24 bump plus additive features. upload-artifact v4-v7 share the same artifact backend and go-coverage-report downloads by name via the GitHub API, so the bump is format-safe.

Co-Authored-By: Claude <noreply@anthropic.com>