### PR TITLE
Color the attention bar icon with the needs-input (orange) style

### DIFF
--- a/internal/tui/widget/attentionbar.go
+++ b/internal/tui/widget/attentionbar.go
@@ -8,8 +8,9 @@ import (
 	"github.com/rivo/tview"
 )
 
-// AttentionMaxRows caps how tall the bar will grow when many tasks are idle.
-// Past this, additional entries are summarised on the last line as "+N more".
+// AttentionMaxRows caps how tall the bar will grow when many tasks are
+// blocked on a user prompt. Past this, additional entries are summarised on
+// the last line as "+N more".
 const AttentionMaxRows = 5
 
 // AttentionEntry is a single row in the attention bar.
@@ -17,9 +18,9 @@ type AttentionEntry struct {
 	TaskName string
 }
 
-// AttentionBar is a bordered box that lists tasks needing user attention.
+// AttentionBar is a bordered box that lists tasks blocked on a user prompt.
 // It sits above the agent view's git status panel and grows vertically with
-// the number of idle+unvisited tasks. When the entry list is empty the bar
+// the number of needs-input tasks. When the entry list is empty the bar
 // reports zero desired height so its parent flex item can be collapsed.
 type AttentionBar struct {
 	*tview.Box
@@ -80,12 +81,12 @@ func (b *AttentionBar) Draw(screen tcell.Screen) {
 		return
 	}
 
-	inner := DrawBorderedPanel(screen, x, y, width, height, " Idle ", theme.StyleInReview)
+	inner := DrawBorderedPanel(screen, x, y, width, height, " Needs input ", theme.StyleInReview)
 	if inner.W <= 0 || inner.H <= 0 {
 		return
 	}
 
-	style := theme.StyleInReview
+	nameStyle := theme.StyleInReview
 	rows := len(b.entries)
 	overflow := 0
 	if rows > AttentionMaxRows {
@@ -94,8 +95,13 @@ func (b *AttentionBar) Draw(screen tcell.Screen) {
 	}
 	row := inner.Y
 	for i := 0; i < rows && row < inner.Y+inner.H; i++ {
-		line := string(theme.IconMoonStars) + " " + b.entries[i].TaskName
-		DrawText(screen, inner.X, row, inner.W, truncateAttention(line, inner.W), style)
+		// Render the '?' icon in the needs-input (orange) style so it
+		// matches the task-list badge, and the name in the in-review
+		// (blue) panel style so the row reads as part of the panel.
+		screen.SetContent(inner.X, row, theme.IconNeedsInput, nil, theme.StyleNeedsInput)
+		if inner.W > 2 {
+			DrawText(screen, inner.X+2, row, inner.W-2, truncateAttention(b.entries[i].TaskName, inner.W-2), nameStyle)
+		}
 		row++
 	}
 	if overflow > 0 && row < inner.Y+inner.H {

--- a/internal/tui/widget/attentionbar_test.go
+++ b/internal/tui/widget/attentionbar_test.go
@@ -108,8 +108,18 @@ func TestAttentionBar_DrawShowsTaskNames(t *testing.T) {
 		t.Errorf("expected border top-left corner in output, got:\n%s", got)
 	}
 	// Icon rune should be present.
-	if !strings.ContainsRune(got, theme.IconMoonStars) {
-		t.Errorf("expected IconMoonStars in output, got:\n%s", got)
+	if !strings.ContainsRune(got, theme.IconNeedsInput) {
+		t.Errorf("expected IconNeedsInput in output, got:\n%s", got)
+	}
+	// The icon cell at the first inner column of the first entry row
+	// must render in the needs-input (orange) style so it matches the
+	// task-list badge. Inner col 1 / row 1 accounts for the border.
+	r, _, style, _ := screen.GetContent(1, 1)
+	if r != theme.IconNeedsInput {
+		t.Errorf("icon cell rune = %q, want IconNeedsInput", r)
+	}
+	if style != theme.StyleNeedsInput {
+		t.Errorf("icon cell style = %v, want StyleNeedsInput", style)
 	}
 }
 


### PR DESCRIPTION
## Summary

Small follow-up polish on #628. The agent-view attention bar already rendered
`IconNeedsInput` after #628 landed, but the icon was painted in the in-review
(blue) panel style. That made the row read as "generic needs attention"
instead of pairing visually with the orange "blocked on a user prompt"
badge the task list already uses.

Two changes:

1. Render the `?` icon cell in `theme.StyleNeedsInput` (orange) and keep the
   task name in `theme.StyleInReview` (blue) so the row reads as part of
   the surrounding panel while the icon matches the task-list badge.
2. Rename the panel title `" Idle "` → `" Needs input "` and clean up the
   leading doc comments to match the post-#628 semantics (the bar shows
   tasks blocked on a user prompt, not idle-and-unvisited tasks).

## Test plan

- [x] `go test ./internal/tui/widget/ -run TestAttentionBar` passes — the
      existing icon-cell test was extended to assert on the orange style.
- [x] Visual confirm in a running argus session
