### PR TITLE
Fix two tests that flake under -race on CI

### DIFF
--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -542,9 +542,16 @@ func TestSession_MultiWriter(t *testing.T) {
 	// syncBuffer (not bytes.Buffer) — the readLoop goroutine may still be
 	// flushing into AddWriter consumers when the test reads, so the buffer
 	// itself must be thread-safe to satisfy `go test -race`.
+	//
+	// Use AddWriterFrom(w, 0) rather than AddWriter so the snapshot+attach
+	// is atomic. AddWriter accepts a small "gap" window between snapshot
+	// and live-attach as an explicit tradeoff (see its docstring); on fast
+	// CI runners that window is wide enough that "multi-writer-test" can
+	// land in the ring buffer between snapshot and attach, leaving the new
+	// writer with only the trailing "\r\n".
 	var buf1, buf2 syncBuffer
-	sess.AddWriter(&buf1)
-	sess.AddWriter(&buf2)
+	sess.AddWriterFrom(&buf1, 0)
+	sess.AddWriterFrom(&buf2, 0)
 
 	// Wait for process to exit and output to propagate
 	select {

--- a/internal/tui/smoke_test.go
+++ b/internal/tui/smoke_test.go
@@ -414,10 +414,20 @@ func TestSmoke_NewTaskFormPaste(t *testing.T) {
 		sim.InjectKey(tcell.KeyRune, r, 0)
 	}
 	sim.PostEvent(tcell.NewEventPaste(false))
-	syncUI(t, app.tapp)
 
+	// Poll for the prompt to populate. syncUI's 50 ms eventSettle is enough
+	// on a quiet machine but not reliably enough under -race on CI, where
+	// draining 20 queued events through the tcell→tview boundary can take
+	// longer than the fixed wait.
 	var prompt string
-	readUI(t, app.tapp, func() { prompt = string(form.prompt) })
+	deadline := time.Now().Add(uiTimeout)
+	for time.Now().Before(deadline) {
+		syncUI(t, app.tapp)
+		readUI(t, app.tapp, func() { prompt = string(form.prompt) })
+		if prompt == "pasted prompt text" {
+			break
+		}
+	}
 	testutil.Equal(t, prompt, "pasted prompt text")
 }
 


### PR DESCRIPTION
Two test-stability fixes for flakes under `go test -race` on CI. Both are test-only (no production code touched) and independent of the plugin-substrate work — pulled out of #633 so that branch stays scoped to the substrate feature.

- **`TestSession_MultiWriter`** — use `AddWriterFrom(w, 0)` for an atomic snapshot+attach instead of `AddWriter`, closing the gap window where output could land in the ring buffer between snapshot and live-attach on fast CI runners.
- **`TestSmoke_NewTaskFormPaste`** — harden against the `-race` timing window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
