### PR TITLE
Add .iris.toml for iris-managed dogfooding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ web-tests/test-results/
 web-tests/playwright-report/
 web-tests/screenshots/
 web-tests/.cache/
+
+# Per-developer iris overrides (machine-specific)
+.iris.local.toml

--- a/.iris.toml
+++ b/.iris.toml
@@ -1,0 +1,16 @@
+# iris-managed-system config for argus.
+#
+# Lets `iris_set_dogfood` point the `dev` branch at a composed SHA and
+# rebuild/restart the local argus daemon. Dogfood is entirely local —
+# this file does not need to be merged upstream for dogfooding to work.
+#
+# Machine-specific overrides belong in .iris.local.toml (gitignored).
+
+default_branch = "master"
+dogfood_branch = "dev"
+
+# Build the dogfood checkout into the launchd binary location.
+build_command = "go build -o $HOME/.argus/argusd ./cmd/argus"
+
+# Restart the LaunchAgent (KeepAlive respawns it from ~/.argus/argusd).
+restart_command = "launchctl kickstart -k gui/$(id -u)/com.drn.argus.daemon"


### PR DESCRIPTION
Adds repo-level iris config so a fresh checkout or worktree can dogfood argus without manual setup – `iris_set_dogfood` reads `.iris.toml` to point `dev` at a composed SHA and rebuild/restart the local daemon.

Machine-specific values stay out of the repo: per-developer overrides go in `.iris.local.toml`, which this commit adds to `.gitignore`.

No runtime/behavioral change – config + gitignore only.
