### PR TITLE
Check screen.Init error in statusbar tests (errcheck)

### DIFF
--- a/internal/tui/widget/statusbar_test.go
+++ b/internal/tui/widget/statusbar_test.go
@@ -13,7 +13,7 @@ func TestStatusBar_InfoMessage(t *testing.T) {
 	sb.SetRect(0, 0, 80, 1)
 
 	screen := tcell.NewSimulationScreen("UTF-8")
-	screen.Init()
+	testutil.NoError(t, screen.Init())
 	screen.SetSize(80, 1)
 	defer screen.Fini()
 
@@ -38,7 +38,7 @@ func TestStatusBar_ErrorTakesPrecedenceOverInfo(t *testing.T) {
 	})
 
 	screen := tcell.NewSimulationScreen("UTF-8")
-	screen.Init()
+	testutil.NoError(t, screen.Init())
 	screen.SetSize(80, 1)
 
 	// Info message shows when no error.
@@ -71,7 +71,7 @@ func TestStatusBar_PluginMode_RendersBarHintsAndExitHint(t *testing.T) {
 	sb.SetRect(0, 0, 80, 1)
 
 	screen := tcell.NewSimulationScreen("UTF-8")
-	screen.Init()
+	testutil.NoError(t, screen.Init())
 	screen.SetSize(80, 1)
 	defer screen.Fini()
 
@@ -96,7 +96,7 @@ func TestStatusBar_PluginMode_ExitHintSurvivesManyLongHints(t *testing.T) {
 	sb.SetRect(0, 0, 80, 1)
 
 	screen := tcell.NewSimulationScreen("UTF-8")
-	screen.Init()
+	testutil.NoError(t, screen.Init())
 	screen.SetSize(80, 1)
 	defer screen.Fini()
 
@@ -122,7 +122,7 @@ func TestStatusBar_PluginMode_EmptyHintsShowsAffordance(t *testing.T) {
 	sb.SetRect(0, 0, 80, 1)
 
 	screen := tcell.NewSimulationScreen("UTF-8")
-	screen.Init()
+	testutil.NoError(t, screen.Init())
 	screen.SetSize(80, 1)
 	defer screen.Fini()
 
@@ -144,7 +144,7 @@ func TestStatusBar_PluginMode_OffRestoresTabHints(t *testing.T) {
 	sb.SetTab(TabTasks)
 
 	screen := tcell.NewSimulationScreen("UTF-8")
-	screen.Init()
+	testutil.NoError(t, screen.Init())
 	screen.SetSize(w, 1)
 	defer screen.Fini()
 
@@ -176,7 +176,7 @@ func TestStatusBar_PluginMode_NarrowWidthClampsAndTruncatesAffordance(t *testing
 	sb.SetRect(0, 0, w, 1)
 
 	screen := tcell.NewSimulationScreen("UTF-8")
-	screen.Init()
+	testutil.NoError(t, screen.Init())
 	screen.SetSize(w, 1)
 	defer screen.Fini()
 
@@ -210,7 +210,7 @@ func TestStatusBar_PluginMode_ZeroWidthIsNoOp(t *testing.T) {
 	sb := NewStatusBar()
 	sb.SetRect(0, 0, 0, 1)
 	screen := tcell.NewSimulationScreen("UTF-8")
-	screen.Init()
+	testutil.NoError(t, screen.Init())
 	screen.SetSize(1, 1)
 	defer screen.Fini()
 	sb.SetPluginMode(true, "Ludwig", []PluginHint{{Key: "j", Label: "down"}})


### PR DESCRIPTION
Master's push CI went red after the #633 squash: `only-new-issues` counts the whole squash as new, surfacing three latent errcheck failures in `statusbar_test.go` (74/99/125 — unchecked `screen.Init()`). Wraps all eight sibling call sites in `testutil.NoError(t, ...)` so future patches touching them don't trip the same gate. Widget tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)