### PR TITLE
Force TERM/COLORTERM on agent PTY spawn

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -327,15 +327,27 @@ func BuildCmd(task *model.Task, cfg config.Config, resume bool) (*exec.Cmd, func
 
 	cmd := exec.Command("sh", "-c", cmdStr)
 	cmd.Dir = task.Worktree
+	// Inherit the parent's env so PATH, HOME, and friends survive, then force
+	// the terminal-capability variables. The agent's controlling terminal is
+	// argus's PTY, rendered by the in-process x/vt emulator (truecolor-capable)
+	// — NOT whatever terminal the daemon happened to inherit. A launchd-started
+	// daemon has no TERM at all (the LaunchAgent plist only sets PATH), which
+	// made every agent it spawned render colorless after a daemon restart,
+	// while TUI-auto-started daemons (forked from the user's shell) produced
+	// colored agents. Forcing both keys makes agent color detection independent
+	// of daemon provenance; appending wins over earlier duplicates per
+	// exec.Cmd.Env semantics.
+	cmd.Env = append(os.Environ(),
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+	)
 	// Surface the task ID to the agent process so MCP sub-tasks (task_complete,
 	// task_set_result, argus_clipboard_set, …) can target it explicitly
-	// instead of resolving by cwd. Inherit the parent's env so PATH, HOME,
-	// and friends survive; appending wins over earlier duplicates per
-	// exec.Cmd.Env semantics. Empty task.ID can only happen pre-Add (which
+	// instead of resolving by cwd. Empty task.ID can only happen pre-Add (which
 	// CreateAndStart guards against), but we skip the export defensively
 	// rather than emit a literal "ARGUS_TASK_ID=" with no value.
 	if task.ID != "" {
-		cmd.Env = append(os.Environ(), "ARGUS_TASK_ID="+task.ID)
+		cmd.Env = append(cmd.Env, "ARGUS_TASK_ID="+task.ID)
 	}
 
 	committed = true

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -205,6 +205,37 @@ func TestBuildCmd_ExportsTaskID(t *testing.T) {
 	}
 }
 
+// TestBuildCmd_ForcesTerminalEnv confirms TERM/COLORTERM are forced onto the
+// spawned agent regardless of what the daemon inherited. The agent's terminal
+// is argus's truecolor x/vt emulator, but a launchd-started daemon has no TERM
+// at all — without the override, agents resumed after a daemon restart render
+// colorless (Claude falls back to reverse-video-only output).
+func TestBuildCmd_ForcesTerminalEnv(t *testing.T) {
+	// Simulate the launchd case: no TERM/COLORTERM in the parent env.
+	t.Setenv("TERM", "")
+	t.Setenv("COLORTERM", "")
+
+	cfg := testConfig()
+	task := &model.Task{ID: "task-id-7", Name: "x", Worktree: t.TempDir()}
+
+	cmd, _, err := BuildCmd(task, cfg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Later entries win per exec.Cmd.Env dedup semantics, so scan for the
+	// LAST value of each key.
+	last := map[string]string{}
+	for _, kv := range cmd.Env {
+		for _, key := range []string{"TERM=", "COLORTERM="} {
+			if len(kv) >= len(key) && kv[:len(key)] == key {
+				last[key] = kv[len(key):]
+			}
+		}
+	}
+	testutil.Equal(t, last["TERM="], "xterm-256color")
+	testutil.Equal(t, last["COLORTERM="], "truecolor")
+}
+
 // TestBuildCmd_NoEnvOverrideWhenIDEmpty defends the defensive skip: a task
 // row pre-Add has no ID, and emitting a literal "ARGUS_TASK_ID=" would be
 // worse than not exporting at all. CreateAndStart guards against this in


### PR DESCRIPTION
Agents inherit the daemon's environment, and a **launchd-started daemon has no TERM** (the LaunchAgent plist only sets PATH) — so every agent it spawns/resumes renders colorless: Claude detects no color support and falls back to reverse-video-only output (`[7m`/`[27m` and nothing else in the PTY logs). Daemons auto-started by the TUI inherit the user's shell env, which is why color survived some restarts and not others — "no color after rebooting argus" depended on who won the daemon respawn race.

The agent's controlling terminal is argus's in-process x/vt emulator, which supports truecolor regardless of daemon provenance, so `BuildCmd` now forces `TERM=xterm-256color` + `COLORTERM=truecolor` on every spawn (later entries win per `exec.Cmd.Env` dedup). Regression test simulates the TERM-less daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)