### PR TITLE
Forward mouse-wheel events to plugin views as SGR mouse bytes

### DIFF
--- a/internal/tui/terminalpane/terminalpane.go
+++ b/internal/tui/terminalpane/terminalpane.go
@@ -14,6 +14,7 @@
 package terminalpane
 
 import (
+	"fmt"
 	"image/color"
 	"io"
 	"sync"
@@ -263,6 +264,36 @@ func (tp *TerminalPane) InputHandler() func(event *tcell.EventKey, setFocus func
 	}
 	return tp.WrapInputHandler(func(event *tcell.EventKey, _ func(p tview.Primitive)) {
 		tp.send(eventBytes(event))
+	})
+}
+
+// MouseHandler forwards mouse-wheel events to the plugin as SGR mouse
+// sequences (ESC [ < Cb ; Cx ; Cy M — Cb 64 = wheel-up, 65 = wheel-down) so
+// plugins can scroll their own surfaces. Coordinates are 1-based relative to
+// the pane's inner rect (the same rect Draw paints: outer minus the 1-cell
+// border), clamped so a tick on the border still lands in range. Every other
+// action is left unconsumed — focus is already surrendered to the plugin
+// page. Without an input-back channel, wheel events are consumed but dropped
+// (same read-only posture as InputHandler).
+func (tp *TerminalPane) MouseHandler() func(action tview.MouseAction, event *tcell.EventMouse, setFocus func(p tview.Primitive)) (bool, tview.Primitive) {
+	return tp.WrapMouseHandler(func(action tview.MouseAction, event *tcell.EventMouse, _ func(p tview.Primitive)) (bool, tview.Primitive) {
+		var cb int
+		switch action {
+		case tview.MouseScrollUp:
+			cb = 64
+		case tview.MouseScrollDown:
+			cb = 65
+		default:
+			return false, nil
+		}
+		// Inner rect mirrors Draw: GetRect minus the border. With innerX =
+		// x+1, the 1-based inner-relative column is ex - (x+1) + 1 = ex - x.
+		x, y, w, h := tp.GetRect()
+		ex, ey := event.Position()
+		cx := min(max(ex-x, 1), max(w-2, 1))
+		cy := min(max(ey-y, 1), max(h-2, 1))
+		tp.send([]byte(fmt.Sprintf("\x1b[<%d;%d;%dM", cb, cx, cy)))
+		return true, nil
 	})
 }
 

--- a/internal/tui/terminalpane/terminalpane_test.go
+++ b/internal/tui/terminalpane/terminalpane_test.go
@@ -364,6 +364,91 @@ func TestTerminalPane_PasteHandlerForwardsToInputBack(t *testing.T) {
 	}
 }
 
+func TestTerminalPane_MouseHandlerForwardsWheel(t *testing.T) {
+	cases := []struct {
+		name   string
+		action tview.MouseAction
+		ex, ey int
+		want   string
+	}{
+		{"wheel up at inner origin", tview.MouseScrollUp, 1, 1, "\x1b[<64;1;1M"},
+		{"wheel down at inner origin", tview.MouseScrollDown, 1, 1, "\x1b[<65;1;1M"},
+		{"wheel up mid-pane", tview.MouseScrollUp, 20, 6, "\x1b[<64;20;6M"},
+		{"wheel down mid-pane", tview.MouseScrollDown, 20, 6, "\x1b[<65;20;6M"},
+		{"wheel up clamps top-left border", tview.MouseScrollUp, 0, 0, "\x1b[<64;1;1M"},
+		{"wheel down clamps bottom-right border", tview.MouseScrollDown, 41, 11, "\x1b[<65;40;10M"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := make(chan []byte)
+			tp := New(src)
+			defer tp.Close()
+			back := make(chan []byte, 4)
+			tp.SetInputBack(back)
+			// Outer rect 0,0,42,12 — inner is 1,1,40,10 after the border.
+			tp.SetRect(0, 0, 42, 12)
+
+			ev := tcell.NewEventMouse(tc.ex, tc.ey, tcell.ButtonNone, tcell.ModNone)
+			consumed, _ := tp.MouseHandler()(tc.action, ev, func(_ tview.Primitive) {})
+			if !consumed {
+				t.Fatal("expected wheel event to be consumed")
+			}
+			select {
+			case got := <-back:
+				testutil.Equal(t, string(got), tc.want)
+			case <-time.After(200 * time.Millisecond):
+				t.Fatal("InputBack did not receive wheel bytes")
+			}
+		})
+	}
+}
+
+func TestTerminalPane_MouseHandlerIgnoresNonWheelActions(t *testing.T) {
+	cases := []struct {
+		name   string
+		action tview.MouseAction
+	}{
+		{"left down", tview.MouseLeftDown},
+		{"left click", tview.MouseLeftClick},
+		{"move", tview.MouseMove},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := make(chan []byte)
+			tp := New(src)
+			defer tp.Close()
+			back := make(chan []byte, 4)
+			tp.SetInputBack(back)
+			tp.SetRect(0, 0, 42, 12)
+
+			ev := tcell.NewEventMouse(5, 5, tcell.ButtonNone, tcell.ModNone)
+			consumed, _ := tp.MouseHandler()(tc.action, ev, func(_ tview.Primitive) {})
+			if consumed {
+				t.Fatal("expected non-wheel action to be unconsumed")
+			}
+			select {
+			case got := <-back:
+				t.Fatalf("expected no bytes for non-wheel action, got %q", got)
+			case <-time.After(20 * time.Millisecond):
+			}
+		})
+	}
+}
+
+func TestTerminalPane_MouseHandlerWheelWithoutInputBack(t *testing.T) {
+	src := make(chan []byte)
+	tp := New(src)
+	defer tp.Close()
+	tp.SetRect(0, 0, 42, 12)
+
+	// No input-back channel: the wheel tick is consumed but dropped.
+	ev := tcell.NewEventMouse(5, 5, tcell.ButtonNone, tcell.ModNone)
+	consumed, _ := tp.MouseHandler()(tview.MouseScrollUp, ev, func(_ tview.Primitive) {})
+	if !consumed {
+		t.Fatal("expected wheel event to be consumed without InputBack")
+	}
+}
+
 func TestTerminalPane_CloseIsIdempotent(t *testing.T) {
 	src := make(chan []byte)
 	tp := New(src)


### PR DESCRIPTION
## What

Adds a MouseHandler to the plugin-view pane (internal/tui/terminalpane): tview MouseScrollUp/Down over the pane encode as standard SGR mouse sequences (ESC[<64|65;x;yM, pane-inner-relative 1-based coords, clamped) and flow down the existing inputBack byte channel to the plugin. All other mouse actions stay unconsumed. No changes to argus's own task terminal, keyenc, or plugin_views.go.

## Why

Plugins render full TUIs inside the pane but never receive mouse input — wheel events died in tview for lack of a handler. With this, hera-view (anutron/hera#16, merged) scrolls its agent/coord panes into history and pans its rail under the cursor. The encoding matches argus-sdk v0.0.3's DecodeSGRMouse, so any future plugin gets wheel support for free; plugins that ignore mouse bytes see nothing.

## Notes

Merging + rebuilding the running argus turns the mouse path on end-to-end; hera's side is inert until then (shift-arrow scrollback already works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)