### PR TITLE
Give In Review its own icon, distinct from idle in-progress

### DIFF
--- a/internal/tui/taskview/tasklist.go
+++ b/internal/tui/taskview/tasklist.go
@@ -962,10 +962,10 @@ func (tl *TaskListView) drawFilterInput(screen tcell.Screen, x, y, w int) {
 }
 
 // projectStatusIcon returns the aggregated status icon and style for a project's tasks.
-// Priority: any needs-input > any actively running > any in_review > idle in_progress > all complete > mixed > all pending.
+// Priority: any needs-input > any actively running > any in_review > idle+unvisited in_progress > idle in_progress > all complete > mixed > all pending.
 // Needs-input outranks "actively running" so a single blocked task in a busy project still surfaces to the user.
 func (tl *TaskListView) projectStatusIcon(tasks []*model.Task) (rune, tcell.Style) {
-	var hasNeedsInput, hasActivelyRunning, hasIdleInProgress, hasInReview, hasPending, hasComplete bool
+	var hasNeedsInput, hasActivelyRunning, hasIdleInProgress, hasIdleUnvisited, hasInReview, hasPending, hasComplete bool
 
 	for _, t := range tasks {
 		switch t.Status {
@@ -973,8 +973,9 @@ func (tl *TaskListView) projectStatusIcon(tasks []*model.Task) (rune, tcell.Styl
 			if tl.needsInput[t.ID] {
 				hasNeedsInput = true
 			} else if tl.idleUnvisited[t.ID] {
-				// Idle+unvisited InProgress tasks count as InReview at project level.
-				hasInReview = true
+				// Idle+unvisited InProgress tasks surface the moon+stars
+				// "needs a look" icon — distinct from an explicit in_review.
+				hasIdleUnvisited = true
 			} else {
 				hasIdleInProgress = true
 				if tl.running[t.ID] && !tl.idle[t.ID] {
@@ -996,6 +997,9 @@ func (tl *TaskListView) projectStatusIcon(tasks []*model.Task) (rune, tcell.Styl
 	case hasActivelyRunning:
 		return widget.SpinnerFrame(tl.animFrame), theme.StyleInProgress
 	case hasInReview:
+		return theme.IconReview, theme.StyleInReview
+	case hasIdleUnvisited:
+		// Idle InProgress tasks not yet revisited — moon+stars, needs a look.
 		return theme.IconMoonStars, theme.StyleInReview
 	case hasIdleInProgress:
 		// All in-progress tasks are idle (waiting for input).
@@ -1121,7 +1125,7 @@ func (tl *TaskListView) drawTaskRow(screen tcell.Screen, x, y, w int, task *mode
 			statusStyle = theme.StyleInProgress
 		}
 	case model.StatusInReview:
-		statusChar = theme.IconMoonStars
+		statusChar = theme.IconReview
 		statusStyle = theme.StyleInReview
 	case model.StatusComplete:
 		statusChar = '✓'

--- a/internal/tui/taskview/tasklist_test.go
+++ b/internal/tui/taskview/tasklist_test.go
@@ -252,7 +252,7 @@ func TestTaskListView_ProjectStatusIcon(t *testing.T) {
 		{
 			name:     "in review",
 			tasks:    []*model.Task{{ID: "1", Status: model.StatusInReview}},
-			wantChar: theme.IconMoonStars,
+			wantChar: theme.IconReview,
 		},
 		{
 			name: "mixed complete and pending",
@@ -277,7 +277,7 @@ func TestTaskListView_ProjectStatusIcon(t *testing.T) {
 			},
 			running:  map[string]bool{"1": true},
 			idle:     map[string]bool{"1": true},
-			wantChar: theme.IconMoonStars,
+			wantChar: theme.IconReview,
 		},
 		{
 			name: "running in progress plus in review shows spinner",

--- a/internal/tui/theme/theme.go
+++ b/internal/tui/theme/theme.go
@@ -31,6 +31,7 @@ const (
 	IconMoonStars   = rune(0x0F0594) // 󰖔 nf-md-weather_night — unvisited / needs attention
 	IconMoonOutline = rune(0xF186)   //  nf-fa-moon_o — visited / idle
 	IconNeedsInput  = rune(0xF059)   //  nf-fa-question_circle — idle AND blocked on a user prompt
+	IconReview      = rune(0x0F00BC) // 󰂼 nf-md-clipboard_check — in-review / ready to check off
 )
 
 // Styles for common UI elements.


### PR DESCRIPTION
## What

The task-list moon+stars glyph (`nf-md-weather_night`, `0F0594`) was rendered for **two** different states, both in the same blue:

- **In Review** tasks
- **In Progress** tasks that went idle and haven't been revisited

That made the two indistinguishable at a glance.

## Change

- Added `IconReview` = `nf-md-clipboard_check` (`0F00BC`, 󰂼) in `theme.go`.
- **In Review** now renders the clipboard-check ("work done, ready to check off") in both the per-task row and the project-aggregate icon.
- Moon+stars stays reserved for the idle-unvisited in-progress state.
- Split the project-aggregate bucketing so idle-unvisited in-progress no longer folds into the `in_review` bucket — it keeps moon+stars, matching the per-task row.

## Resulting per-state icons

| State | Glyph | Color |
|-------|-------|-------|
| Pending | `○` | gray |
| In Progress · running | animated spinner | orange |
| In Progress · idle, visited | moon outline 󰽦 | blue |
| In Progress · idle, unvisited | moon + stars 󰖔 | blue |
| In Progress · blocked on prompt | question circle  | orange |
| **In Review** | **clipboard-check 󰂼** | blue |
| Complete | `✓` | green |

## Testing

- Updated the two `tasklist_test.go` assertions for the new glyph.
- `make pre-pr`: build / vet / fmt-check / lint-pr pass; coverage gate green at 89.1% (≥88 floor). The `vuln` step flags two pre-existing Go stdlib advisories (`net/textproto`, `crypto/x509`; go1.26.3 → fixed in 1.26.4) reached via `internal/apiclient` — unrelated to this change and present on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>