### PR TITLE
Bootstrap OpenSpec base specs from the codebase (38 capabilities)

### DIFF
--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,0 +1,42 @@
+# Project context
+
+## What argus is
+
+Argus is a terminal-native orchestrator for LLM coding agents. It runs a swarm of Claude Code and Codex sessions side by side, each isolated in its own git worktree, all under a single keyboard-driven TUI — and mirrors that swarm to a phone (PWA), another laptop, another agent (MCP server), or external scripts (REST API).
+
+A persistent daemon keeps PTY sessions alive across TUI restarts and reboots. An idle detector promotes any agent waiting for input to "in review" so a glance at the task list shows who needs attention next.
+
+## Tech stack
+
+- **Language:** Go (module `github.com/drn/argus`, Go `1.26.0`).
+- **UI:** tcell/tview, with direct cell painting for the agent terminal pane via the `charmbracelet/x/vt` emulator.
+- **Persistence:** SQLite via `modernc.org/sqlite` (pure Go, no CGO) at `~/.argus/data.sql`.
+- **PTY:** `creack/pty`.
+- **Surfaces:** in-process runner, Unix-socket daemon, HTTP REST API + installable PWA (xterm.js) on port 7743, and an MCP server.
+
+## Build, test, and quality gates
+
+- **`make pre-pr` is the non-negotiable gate before opening OR updating any PR.** It mirrors `.github/workflows/ci.yml` step-for-step: build → vet → fmt-check → lint-pr → vuln → test-cover-gate. A green `make pre-pr` means CI will be green.
+- **Coverage floor:** filtered coverage must stay at or above the **88%** floor (`make test-cover-gate`, `-min 88`). The floor ratchets up, never down — do not lower `-min`. Target platform-agnostic code for the most reliable margin (filtered coverage can drift ~0.2% between darwin and linux).
+- **`make fmt`** runs goimports over the tree; **`make fmt-check`** fails CI if anything is unformatted (the most common CI miss).
+- **`make lint-pr`** uses `--new-from-rev=origin/master`, so it only flags issues your diff introduces. Fix them; do not add blanket `//nolint`.
+
+Common targets: `make build`, `make vet`, `make test` (`-race -count=1 ./...`), `make test-pkg PKG=...`, `make test-cover`, `make test-watch`.
+
+## Testing norms
+
+- **TDD red-green-refactor is the default workflow.** Write a failing test, write the minimum code to pass, then refactor while staying green.
+- **Assertions go through `internal/testutil`**, not raw `if got != want`: `Equal`, `DeepEqual`, `NoError`, `ErrorIs`, `Nil`, `Contains`.
+- **Every change must include tests.** No new function, branch, or error path without coverage. Table-driven tests use `t.Run` subtests; guard slow tests with `testing.Short()`.
+- **Tests must never touch real `~/.argus/` paths or the live daemon.** Use `t.TempDir()`, `t.Setenv("HOME", t.TempDir())` for anything resolving through `$HOME`, and `agent.NewRunner(nil)` instead of a real daemon client.
+
+## Conventions
+
+- **Data dir:** `~/.argus/` (SQLite `data.sql`, daemon socket, worktrees, logs).
+- **Breaking changes are fine.** Single user (the author) — no backwards-compatibility burden.
+- **No legacy migration code.** A schema change that needs data migration gets a one-off script, not in-tree migration logic. Legacy JSON persistence and `config.toml` support have been removed.
+- **Non-obvious invariants live in `context/knowledge/gotchas/`** (indexed by `context/knowledge/index.md`), read on demand rather than loaded automatically.
+
+## Load-bearing note on OpenSpec in this repo
+
+**OpenSpec specs in this repo are LOCAL DOCS only — nothing in CI, the Makefile, or the Go build depends on them.** The `openspec/` artifacts are authoring aids that get injected into PRs for the maintainer's workflow; no code reads them and they are strippable. Future change authors **MUST NOT** wire spec-validation (e.g. `openspec validate`) into the Go CI or any `make` target. The quality gate is and stays `make pre-pr` — build, vet, fmt-check, lint-pr, vuln, and the coverage gate. Keep spec tooling out of it.

--- a/openspec/specs/agent-execution/spec.md
+++ b/openspec/specs/agent-execution/spec.md
@@ -1,0 +1,259 @@
+# Agent Execution
+
+## Purpose
+
+Agent Execution governs how Argus turns a task into a running LLM coding agent: resolving which backend command to launch, building the shell command (with prompt, session pinning, and resume flags), spawning the process attached to a pseudo-terminal, and managing that process's lifecycle. It owns the single-reader model that tees PTY output to a replayable ring buffer and to any number of live consumers (TUI, daemon stream, SSE), plus attach/detach, idle detection, resize, and post-exit session-ID capture. The goal is that one task's agent runs in isolation, its output is never lost or duplicated across reconnecting viewers, and a viewer joining late sees a coherent stream.
+
+## Requirements
+
+### Requirement: Backend resolution precedence
+
+The system SHALL resolve the backend for a task using the precedence task backend, then project backend, then the configured default backend. When no backend can be resolved, or the resolved name is absent from the configured backends, the system SHALL return an error rather than launching.
+
+#### Scenario: Task backend wins over project and default
+- **WHEN** a task names a backend that exists in config, even though its project also names one
+- **THEN** the task's backend is selected
+
+#### Scenario: Project backend used when task has none
+- **WHEN** a task names no backend but belongs to a project that names one
+- **THEN** the project's backend is selected
+
+#### Scenario: Default used when neither task nor project specifies one
+- **WHEN** a task names no backend and its project (if any) names none
+- **THEN** the configured default backend is selected
+
+#### Scenario: Unknown or unset backend errors
+- **WHEN** the resolved backend name is empty, or names a backend not present in config
+- **THEN** an error is returned and no command is produced
+
+### Requirement: Command construction with prompt and worktree isolation
+
+The system SHALL build the agent command as a shell invocation whose working directory is the task's worktree. The prompt, when present, SHALL be passed using the backend's configured prompt flag, or — when no prompt flag is configured — as a positional argument guarded by a `--` end-of-options separator so prompts beginning with `-` are not parsed as flags. The system SHALL refuse to build a command for a task with no worktree, and SHALL refuse when the worktree directory does not exist or is unreachable, returning an actionable error and a nil command.
+
+#### Scenario: Prompt passed via configured prompt flag
+- **WHEN** the backend defines a prompt flag and the task has a prompt
+- **THEN** the command appends the prompt flag followed by the safely quoted prompt
+
+#### Scenario: Prompt passed positionally with separator when no flag
+- **WHEN** the backend defines no prompt flag and the task has a prompt
+- **THEN** the command appends `--` followed by the safely quoted prompt
+
+#### Scenario: Missing worktree is rejected
+- **WHEN** a task has no worktree set
+- **THEN** command construction fails with an error stating no worktree is set
+
+#### Scenario: Nonexistent worktree directory is rejected pre-launch
+- **WHEN** the task's worktree path does not exist
+- **THEN** command construction fails with an error naming the missing path, and returns a nil command and nil cleanup
+
+#### Scenario: Working directory and task environment are set
+- **WHEN** a command is built for a task with an ID
+- **THEN** the command's working directory is the worktree and the environment exports the task ID for sub-agent tooling
+
+### Requirement: Forced terminal capability environment
+
+The system SHALL force terminal-capability environment variables on every spawned agent so color rendering is independent of what the parent process inherited, since the agent's controlling terminal is Argus's truecolor emulator rather than the launching shell.
+
+#### Scenario: Color env forced even when parent has none
+- **WHEN** a command is built while the parent environment has no terminal-capability variables set
+- **THEN** the command's environment advertises a 256-color, truecolor-capable terminal
+
+### Requirement: Session pinning and resume by backend family
+
+The system SHALL pin a new session's ID for backends that accept a start-time session identifier (Claude-style), and SHALL omit it for backends that do not (codex, pi). On resume, the system SHALL reconnect to an existing conversation using the backend's own resume mechanism, and SHALL drop the prompt because the conversation is reloaded. When resume is requested for a Claude-style or pi backend but no session ID is known, the system SHALL start a fresh session rather than emit an empty resume flag.
+
+#### Scenario: New Claude-style session pins the ID
+- **WHEN** a new (non-resume) session is built for a Claude-style backend that has a session ID
+- **THEN** the command includes a start-time session-id flag carrying that ID
+
+#### Scenario: New codex/pi session never pins the ID
+- **WHEN** a new session is built for a codex or pi backend even though a session ID is present
+- **THEN** the command omits any start-time session-id flag
+
+#### Scenario: Resume reconnects and drops the prompt
+- **WHEN** a resume command is built for a backend with a known session ID
+- **THEN** the command uses that backend's resume form carrying the ID and does not append the prompt
+
+#### Scenario: Resume with no session ID starts fresh
+- **WHEN** resume is requested for a Claude-style or pi backend but no session ID is set
+- **THEN** the command is the plain base command with no resume flag
+
+### Requirement: Post-exit session-ID capture for capture-style backends
+
+The system SHALL recover a session identifier after exit for backends that mint their ID externally (codex, pi) by reading the backend's own state for the task's worktree, returning the most recently updated matching session. For backends that pin their ID at start (Claude-style) or are unrecognized, the system SHALL report no captured ID without error. A captured codex ID SHALL be validated as a UUID before being returned.
+
+#### Scenario: Codex ID recovered from its state for the worktree
+- **WHEN** capture runs for a codex-backed task whose worktree has a recorded session
+- **THEN** the most-recently-updated session ID for that worktree is returned
+
+#### Scenario: Pi ID recovered from the newest session file
+- **WHEN** capture runs for a pi-backed task whose worktree has session files
+- **THEN** the UUID from the newest matching session file is returned
+
+#### Scenario: Claude-style and unknown backends capture nothing
+- **WHEN** capture runs for a Claude-style or unrecognized backend
+- **THEN** an empty ID is returned with no error
+
+#### Scenario: Malformed captured codex ID is rejected
+- **WHEN** the recorded codex session ID is not a valid UUID
+- **THEN** capture returns an error rather than the malformed value
+
+### Requirement: Single-session-per-task management
+
+The runner SHALL manage at most one live session per task ID. Starting a session for a task that already has one SHALL fail. The runner SHALL expose whether a task has a live session and SHALL return the live handle when one exists rather than spawning a duplicate.
+
+#### Scenario: Duplicate start rejected
+- **WHEN** a start is requested for a task that already has a live session
+- **THEN** the start fails with an error and no second process is spawned
+
+#### Scenario: Reattach returns the existing session
+- **WHEN** a start-or-reattach is requested for a task with a live session
+- **THEN** the existing live handle is returned and flagged as reattached rather than a new one being spawned
+
+### Requirement: Process exit notification and last output
+
+When a managed session's process exits, the runner SHALL invoke its finish callback exactly once with the task ID, the exit error, whether the stop was explicitly requested, and the final buffered output. The session's exit signal SHALL only fire after all pending PTY output has been drained into the ring buffer, so the final output is complete.
+
+#### Scenario: Natural exit reports not-stopped with output
+- **WHEN** an agent process exits on its own after producing output
+- **THEN** the finish callback fires with stopped=false and the last buffered output available
+
+#### Scenario: Output complete at exit signal
+- **WHEN** a short-lived process emits output and exits
+- **THEN** the buffered output read after the exit signal contains everything the process produced
+
+### Requirement: Stop semantics
+
+The runner SHALL stop a live session by signaling termination and SHALL mark the stop as explicit so the finish callback reports it. Stopping a task with no live session SHALL return a not-found error. Stopping a session whose process has already exited SHALL be a no-op success. Stop-all SHALL terminate every live session and unblock any in-flight pre-launch work.
+
+#### Scenario: Stop unknown task errors
+- **WHEN** stop is requested for a task with no live session
+- **THEN** a session-not-found error is returned
+
+#### Scenario: Stop already-exited session is a no-op
+- **WHEN** stop is requested for a session whose process has already exited
+- **THEN** it returns success without error
+
+### Requirement: PTY output teed to ring buffer and live writers
+
+A single reader SHALL be the sole consumer of the PTY, writing every chunk to a fixed-size ring buffer and teeing it to all registered writers. A writer whose write fails SHALL be removed automatically without disrupting other writers. The ring buffer SHALL retain a bounded recent window and expose a monotonic total-bytes count that never decreases.
+
+#### Scenario: Multiple writers all receive output
+- **WHEN** several writers are registered before output is produced
+- **THEN** each registered writer receives the produced output
+
+#### Scenario: Failing writer is dropped
+- **WHEN** a registered writer returns an error on write
+- **THEN** that writer is removed from the set while others keep receiving output
+
+#### Scenario: Removed writer stops receiving output
+- **WHEN** a writer is removed and more output is produced
+- **THEN** the removed writer receives no further bytes
+
+### Requirement: Replay on attach without gaps or duplicates
+
+When a writer attaches, the system SHALL replay the buffered history the writer has not yet seen and then deliver live output. An offset-aware attach SHALL replay exactly the bytes from the caller's offset to the current high-water mark with no gap and no duplicate, even under concurrent attaches; an offset already at or beyond the high-water mark SHALL skip replay and deliver only live output. If replay fails, the writer SHALL NOT be registered.
+
+#### Scenario: Caught-up attach skips replay
+- **WHEN** a writer attaches at an offset equal to the current total bytes
+- **THEN** it receives no replay of prior bytes and only subsequent live output
+
+#### Scenario: Partial-replay attach gets exactly the suffix
+- **WHEN** a writer attaches at an offset some bytes behind the high-water mark
+- **THEN** it receives exactly those missing bytes as replay followed by live output
+
+#### Scenario: Replay failure prevents registration
+- **WHEN** a writer's replay write returns an error
+- **THEN** the writer is not added to the live writer set
+
+### Requirement: Attach exclusivity and detach
+
+A session SHALL allow only one full interactive attach at a time; a second attach SHALL fail. Attach SHALL block until detach, process exit, or an I/O error, returning no error on detach and the process error on exit. Detach SHALL be safe to call when not attached and safe to call more than once.
+
+#### Scenario: Second attach rejected
+- **WHEN** a session is already attached and a second attach is requested
+- **THEN** the second attach fails with an already-attached error
+
+#### Scenario: Detach returns attach cleanly
+- **WHEN** an attached session is detached
+- **THEN** the blocking attach returns with no error
+
+#### Scenario: Attach to exited process returns its result
+- **WHEN** attach is requested for a session whose process has already exited
+- **THEN** attach returns promptly with the process's exit result
+
+### Requirement: PTY sizing and resize
+
+A session SHALL start with the requested PTY dimensions, falling back to a default size when zero is supplied. Resize SHALL update the live PTY dimensions; after the process has exited, resize SHALL be a no-op success and SHALL preserve the last size the agent actually rendered for. The system SHALL expose both the current size and the immutable initial start size, and SHALL persist the session's size so a dead session's output can be re-emulated at the width it was formatted for.
+
+#### Scenario: Zero size falls back to default
+- **WHEN** a session is started with zero rows or cols
+- **THEN** the PTY is sized to the default dimensions
+
+#### Scenario: Resize updates live dimensions
+- **WHEN** a live session is resized
+- **THEN** the reported current size reflects the new dimensions
+
+#### Scenario: Initial size is immutable across resize
+- **WHEN** a session is resized after start
+- **THEN** the reported initial size still equals the start dimensions
+
+#### Scenario: Resize after exit is a safe no-op
+- **WHEN** resize is called after the process has exited and the PTY is closed
+- **THEN** it returns success without error
+
+### Requirement: Idle detection
+
+A session SHALL be reported idle only while it is alive and has produced no output for at least the idle threshold. A session that has never produced output SHALL NOT be reported idle (it is still starting), and an exited session SHALL NOT be reported idle. The runner SHALL distinguish, in one snapshot, which sessions are running versus idle.
+
+#### Scenario: Quiet live session becomes idle
+- **WHEN** a live session has produced output but none for longer than the idle threshold
+- **THEN** it is reported idle
+
+#### Scenario: Freshly started session is not idle
+- **WHEN** a session has just started and produced no output yet
+- **THEN** it is not reported idle
+
+#### Scenario: Dead session is not idle
+- **WHEN** a session's process has exited
+- **THEN** it is not reported idle
+
+### Requirement: Input forwarding records activity only on success
+
+The system SHALL forward raw input bytes to the agent's PTY and SHALL record the wall-clock time of input only when the write succeeds, so a failed write (e.g. after the PTY is closed) does not advance the last-input timestamp. The last-input time SHALL read as zero before any successful input.
+
+#### Scenario: Successful input advances last-input time
+- **WHEN** input is successfully written to a live session
+- **THEN** the last-input time becomes non-zero
+
+#### Scenario: No input means zero last-input time
+- **WHEN** no input has been written to a session
+- **THEN** the last-input time reads as zero
+
+### Requirement: In-place rerender restart
+
+The runner SHALL support stopping a live session and queuing a restart at new PTY dimensions, resuming the same conversation so the agent re-emits at the new width. While the restart is in flight the task SHALL be reported as still alive (pending restart) so consumers do not tear down state, and SHALL NOT be reported idle. Queuing a rerender restart SHALL require a live session and SHALL refuse if one is already pending for that task.
+
+#### Scenario: No live session cannot be kicked
+- **WHEN** a rerender restart is requested for a task with no live session
+- **THEN** a session-not-found error is returned
+
+#### Scenario: Duplicate rerender rejected
+- **WHEN** a rerender restart is requested while one is already pending for the task
+- **THEN** an error is returned and no second restart is queued
+
+#### Scenario: Pending restart counts as running, not idle
+- **WHEN** a task has a queued rerender restart between exit and respawn
+- **THEN** it is reported among running tasks and is not reported as idle
+
+### Requirement: Stale-session reconciliation at startup
+
+At startup, before any new sessions are started, the system SHALL flip every task persisted as in-progress to in-review, because such rows describe sessions that died with the prior process and the user should decide whether to resume or discard. Tasks in any other status SHALL be left unchanged.
+
+#### Scenario: In-progress rows become in-review
+- **WHEN** reconciliation runs and a task is persisted as in-progress
+- **THEN** that task is updated to in-review
+
+#### Scenario: Other statuses untouched
+- **WHEN** reconciliation runs over tasks that are pending or complete
+- **THEN** those tasks keep their status and are not counted as reconciled

--- a/openspec/specs/agent-view/spec.md
+++ b/openspec/specs/agent-view/spec.md
@@ -1,0 +1,212 @@
+# Agent View
+
+## Purpose
+
+The agent view is the runtime-agnostic state and supporting widgets behind the screen where a user watches and interacts with a running agent session. It tracks which panel has focus, terminal scrollback position, and the file-diff viewer's mode and scroll, independent of the tcell/tview rendering layer. It also provides a read-mostly streaming pane that renders bytes arriving on a channel — used for plugin and settings stream sections — with optional keystroke forwarding back to the source.
+
+## Requirements
+
+### Requirement: Agent view default and reset state
+
+The agent view state SHALL default to focusing the terminal panel with the diff viewer in side-by-side (split) mode and no task loaded. Resetting the state for a new task SHALL restore terminal focus, clear scroll position, last output, worktree directory, and git refresh timing, and return the diff viewer to its split default while recording the new task identity.
+
+#### Scenario: Fresh state defaults
+
+- **WHEN** a new agent view state is created
+- **THEN** focus is on the terminal panel, the diff viewer is in split mode, and no task is loaded
+
+#### Scenario: Reset for a new task
+
+- **WHEN** the state is reset with a new task ID and name after a prior task left non-default values
+- **THEN** the task ID and name are updated, focus returns to the terminal panel, scroll offset is zero, last output is cleared, worktree directory is empty, and the diff viewer is back in split mode
+
+### Requirement: Focus navigation between focusable panels
+
+The agent view SHALL allow focus to move between the terminal panel (leftmost focusable) and the files panel (rightmost focusable). Moving focus left from the terminal panel and right from the files panel SHALL be no-ops, so focus never leaves the focusable range.
+
+#### Scenario: Move right then left
+
+- **WHEN** focus is on the terminal panel and the user moves focus right
+- **THEN** focus is on the files panel, and moving focus left returns to the terminal panel
+
+#### Scenario: Edges are clamped
+
+- **WHEN** the user moves focus left from the terminal panel or right from the files panel
+- **THEN** focus stays unchanged
+
+### Requirement: Terminal scrollback bounds
+
+The agent view SHALL scroll the terminal view up toward older output and down toward the tail. Scrolling down SHALL never move the offset below zero. Scrolling up SHALL clamp the offset to the maximum scrollable distance only when the total line count is known and positive; when the line count is unknown the offset SHALL be allowed to grow freely.
+
+#### Scenario: Scroll up clamps to content extent when known
+
+- **WHEN** the user scrolls up by more lines than available against a known total line count larger than the display height
+- **THEN** the scroll offset is clamped to the total line count minus the display height
+
+#### Scenario: Scroll up grows freely when total is unknown
+
+- **WHEN** the user scrolls up while the total line count is unknown
+- **THEN** the scroll offset grows by the requested amount without clamping
+
+#### Scenario: Scroll up is bounded to zero for small content
+
+- **WHEN** the user scrolls up but the content fits entirely within the display height
+- **THEN** the scroll offset stays at zero
+
+#### Scenario: Scroll down never goes negative
+
+- **WHEN** the user scrolls down past the tail of the output
+- **THEN** the scroll offset settles at zero
+
+### Requirement: Git status refresh gating
+
+The agent view SHALL report that a git status refresh is needed only when a task is loaded and the configured minimum interval has elapsed since the last refresh. With no task loaded, a refresh SHALL never be reported as needed.
+
+#### Scenario: No task means no refresh
+
+- **WHEN** no task is loaded
+- **THEN** a git refresh is not needed
+
+#### Scenario: Stale or never-refreshed task needs refresh
+
+- **WHEN** a task is loaded and it has never been refreshed, or the last refresh is older than the minimum interval
+- **THEN** a git refresh is needed
+
+#### Scenario: Recently refreshed task does not refresh
+
+- **WHEN** a task is loaded and was refreshed within the minimum interval
+- **THEN** a git refresh is not needed
+
+### Requirement: Diff viewer enter, scroll, and exit
+
+The agent view SHALL enter diff mode for a named file with the diff scroll reset to the top, and SHALL scroll the diff up (clamped at zero) and down (clamped at the total diff lines minus the visible rows). Exiting diff mode SHALL clear the active flag, scroll position, and file name, but SHALL preserve the user's split-versus-unified preference across diff opens within the session.
+
+#### Scenario: Enter diff resets scroll
+
+- **WHEN** the user enters diff mode for a file
+- **THEN** the diff viewer becomes active with that file name and a scroll offset of zero
+
+#### Scenario: Diff scroll is bounded
+
+- **WHEN** the user scrolls the diff down past the last line or up past the top
+- **THEN** the scroll offset clamps to the total lines minus visible rows at the bottom and to zero at the top
+
+#### Scenario: Exit preserves split preference
+
+- **WHEN** the user toggles the diff to unified mode and then exits and re-enters diff mode
+- **THEN** the diff viewer is no longer active after exit, its file name and scroll are cleared, and the unified preference persists across the next diff open
+
+### Requirement: Stream pane buffers and renders streamed bytes
+
+A stream pane SHALL consume byte chunks arriving on its source channel into a bounded internal buffer that never exceeds its configured maximum, dropping the oldest bytes when the cap is exceeded. It SHALL render the trailing lines that fit inside a bordered panel, with newlines forcing line breaks and runes past the panel width wrapping to a new line. Multi-byte UTF-8 glyphs SHALL be preserved as whole runes, ANSI escape sequences SHALL be stripped, and control characters SHALL be dropped.
+
+#### Scenario: Rendered output strips ANSI and shows text
+
+- **WHEN** a chunk containing ANSI color sequences and text arrives and the pane is drawn
+- **THEN** the visible text appears without any escape sequences leaking into the output
+
+#### Scenario: Bounded buffer drops oldest bytes
+
+- **WHEN** more bytes arrive than the configured maximum buffer size
+- **THEN** the internal buffer is trimmed to the trailing window and never exceeds the cap
+
+#### Scenario: Only trailing lines are shown
+
+- **WHEN** more lines arrive than the panel's inner height
+- **THEN** the most recent lines are rendered in the viewport
+
+#### Scenario: UTF-8 glyphs survive intact
+
+- **WHEN** a chunk of multi-byte box-drawing glyphs is rendered
+- **THEN** each glyph is preserved as a single rune rather than decomposed into raw bytes
+
+#### Scenario: Zero or tiny rect is safe
+
+- **WHEN** the pane is drawn with a zero-area or border-only rectangle
+- **THEN** drawing completes without painting content and without error
+
+### Requirement: Stream pane damage signal and redraw notification
+
+A stream pane SHALL increment a monotonic damage counter each time a new non-empty chunk arrives, leaving the counter unchanged for empty chunks, so a surrounding tick loop can detect undrawn content. When a redraw callback is configured, it SHALL be invoked at least once per new non-empty chunk.
+
+#### Scenario: Counter advances on new content
+
+- **WHEN** a non-empty chunk arrives
+- **THEN** the damage counter increases
+
+#### Scenario: Empty chunk is a no-op
+
+- **WHEN** an empty chunk arrives
+- **THEN** the damage counter does not change
+
+#### Scenario: Redraw callback fires on new content
+
+- **WHEN** a redraw callback is configured and a non-empty chunk arrives
+- **THEN** the callback is invoked at least once
+
+### Requirement: Stream pane consumer lifecycle
+
+A stream pane SHALL drain its source channel with a single consumer that exits cleanly when the pane is closed or the source channel is closed, while retaining and continuing to display already-buffered bytes after the source closes. Closing the pane SHALL be idempotent.
+
+#### Scenario: Close stops the consumer
+
+- **WHEN** the pane is closed
+- **THEN** the consumer stops and no further chunks advance the damage counter
+
+#### Scenario: Source close stops the consumer
+
+- **WHEN** the source channel is closed
+- **THEN** the consumer exits cleanly while previously buffered bytes remain displayable
+
+#### Scenario: Close is idempotent
+
+- **WHEN** the pane is closed more than once
+- **THEN** no panic occurs
+
+### Requirement: Stream pane input forwarding
+
+A stream pane SHALL be read-only unless an input-back channel is wired. When an input-back channel is configured, the pane SHALL forward typed runes, mapped keys, and pasted text to that channel as encoded bytes; without an input-back channel its input handler SHALL be nil. Forwarding SHALL be non-blocking, dropping bytes when the channel is full and ignoring empty payloads.
+
+#### Scenario: Keystrokes forward when wired
+
+- **WHEN** an input-back channel is set and a rune or mapped key is entered
+- **THEN** the corresponding bytes are sent to the input-back channel
+
+#### Scenario: Pasted text forwards when wired
+
+- **WHEN** an input-back channel is set and text is pasted
+- **THEN** the pasted text bytes are sent to the input-back channel
+
+#### Scenario: Read-only without input-back
+
+- **WHEN** no input-back channel is configured
+- **THEN** the input handler is nil and direct sends are no-ops
+
+#### Scenario: Backpressure drops keystrokes
+
+- **WHEN** the input-back channel is full and a keystroke is entered
+- **THEN** the keystroke is dropped without blocking
+
+### Requirement: Settings stream section connector lifecycle
+
+A settings stream section SHALL, on focus, build a connector keyed by its scope and title, dial it within a bounded timeout, and on a successful dial send a focus signal and pump received bytes into the section's display channel using non-blocking sends that drop on backpressure. Opening a section whose key already has a connector SHALL defensively close the prior connector first. On blur, the section SHALL send a blur signal and close the connector, treating a section that was never opened as a no-op.
+
+#### Scenario: Focus dials and pumps bytes
+
+- **WHEN** a stream section gains focus
+- **THEN** its connector is dialed, a focus signal is sent, and received bytes are delivered to the section's display channel
+
+#### Scenario: Re-open replaces the prior connector
+
+- **WHEN** a section is opened again while a connector already exists for its key
+- **THEN** the prior connector is closed before the new one is registered
+
+#### Scenario: Blur tears down the connector
+
+- **WHEN** a previously opened section is blurred
+- **THEN** a blur signal is sent and the connector is closed
+
+#### Scenario: Blur without prior open is a no-op
+
+- **WHEN** a section that was never opened is closed
+- **THEN** no blur or close is invoked on any connector

--- a/openspec/specs/auto-naming/spec.md
+++ b/openspec/specs/auto-naming/spec.md
@@ -1,0 +1,67 @@
+# Task Auto-Naming
+
+## Purpose
+
+Newly created tasks start with a regex-derived slug taken from the prompt, which is often terse or awkward. Auto-naming asks an LLM (Haiku) for a clearer, human-readable name and applies it to the task in the background. The process is fire-and-forget and fail-open: any failure leaves the original slug untouched, and it never clobbers a name the user changed in the meantime.
+
+## Requirements
+
+### Requirement: Replace the auto-generated slug with an LLM-suggested name
+
+The system SHALL request a task name from the LLM for the given prompt and, when a different valid name is returned, persist it as the task's name.
+
+#### Scenario: LLM returns a better name
+
+- **WHEN** auto-naming runs for a task whose current name is the original auto-generated slug and the LLM returns a different non-empty name
+- **THEN** the task's persisted name is updated to the LLM-returned name
+
+#### Scenario: LLM returns the same name
+
+- **WHEN** the LLM returns a name equal to the original slug
+- **THEN** no rename occurs and the task's name is left unchanged
+
+### Requirement: Fail open on any LLM error
+
+The system SHALL keep the original auto-generated slug whenever the LLM call fails, and SHALL NOT propagate the error to the caller.
+
+#### Scenario: LLM call returns an error
+
+- **WHEN** the LLM name request returns an error
+- **THEN** the task's name remains the original slug and the operation completes without surfacing the error
+
+#### Scenario: LLM backend unavailable
+
+- **WHEN** the LLM backend is unavailable
+- **THEN** auto-naming is skipped and the task's name remains the original slug
+
+#### Scenario: Prompt is empty
+
+- **WHEN** the prompt passed to auto-naming is empty
+- **THEN** auto-naming is skipped and the task's name remains unchanged
+
+### Requirement: Never overwrite an externally changed name
+
+The system SHALL apply the LLM-suggested name only if the task's current name still equals the original slug it started from, so a name changed externally while the LLM call was in flight is preserved.
+
+#### Scenario: User renames during the LLM call
+
+- **WHEN** the task is renamed by the user before the LLM returns, so the current name no longer equals the original slug
+- **THEN** the LLM-suggested name is not applied and the user's chosen name is preserved
+
+### Requirement: Tolerate a deleted task
+
+The system SHALL handle the case where the task no longer exists when the LLM result is ready, completing without error and without writing any name.
+
+#### Scenario: Task deleted before the LLM returns
+
+- **WHEN** the task has been deleted before the LLM-suggested name is ready to apply
+- **THEN** the operation completes without panic and no name is written
+
+### Requirement: Bound the LLM call with a timeout
+
+The system SHALL invoke the LLM name request under a context with a deadline so the operation cannot run unbounded.
+
+#### Scenario: LLM call receives a deadline-bound context
+
+- **WHEN** auto-naming invokes the LLM name request
+- **THEN** the request is given a context that carries a deadline and the overall operation does not exceed the configured timeout

--- a/openspec/specs/clipboard-staging/spec.md
+++ b/openspec/specs/clipboard-staging/spec.md
@@ -1,0 +1,207 @@
+# Clipboard Staging
+
+## Purpose
+
+Clipboard staging provides an ephemeral, per-task buffer where an agent can stage text it wants the user to copy, decoupling the moment the agent produces the text from the moment the user performs the OS-clipboard write. This solves the iOS Safari constraint that a clipboard write must happen inside a synchronous user gesture: the agent stages text ahead of time, then the user takes a single tap (PWA) or keypress (TUI ctrl+y) that performs the real copy. Staged entries are intentionally short-lived — one slot per task, last-write-wins, no persistence across daemon restarts, and an automatic time-to-live expiry.
+
+## Requirements
+
+### Requirement: Per-task staging buffer
+
+The staging store SHALL hold at most one text payload per task, keyed by task ID, with last-write-wins semantics. Payloads for different tasks SHALL be isolated from one another. An empty task ID SHALL be rejected silently — staging a payload under an empty task ID SHALL store nothing and SHALL return no error, and reading or clearing an empty task ID SHALL report absence.
+
+#### Scenario: Stage then read
+
+- **WHEN** text is staged for a task and then read back for the same task
+- **THEN** the read returns that text and a present flag of true
+
+#### Scenario: Last write wins
+
+- **WHEN** two payloads are staged in sequence for the same task
+- **THEN** a subsequent read returns only the most recently staged text
+
+#### Scenario: Tasks are isolated
+
+- **WHEN** different payloads are staged for two distinct tasks
+- **THEN** reading each task returns its own payload and not the other's
+
+#### Scenario: Empty task ID rejected silently
+
+- **WHEN** a payload is staged under an empty task ID
+- **THEN** no error is returned and a subsequent read of the empty task ID reports absence
+
+### Requirement: Payload size limit
+
+The store SHALL reject any payload larger than 1 MiB and SHALL return a too-large error identifying the offered size and the maximum. A payload of exactly the maximum size SHALL be accepted. A rejected payload SHALL NOT be stored.
+
+#### Scenario: Oversize payload rejected and not stored
+
+- **WHEN** text larger than the maximum size is staged for a task
+- **THEN** a too-large error is returned and a subsequent read of that task reports absence
+
+#### Scenario: Maximum size accepted
+
+- **WHEN** text of exactly the maximum size is staged
+- **THEN** the stage succeeds with no error
+
+### Requirement: Time-to-live expiry
+
+A staged payload SHALL expire after a bounded time-to-live and SHALL be reported as absent once expired. Expiry SHALL be enforced lazily on read and also by an explicit prune operation. The default time-to-live SHALL be five minutes.
+
+#### Scenario: Read after expiry reports absence
+
+- **WHEN** a payload is staged and the clock advances past its time-to-live
+- **THEN** a read for that task returns absent
+
+#### Scenario: Prune removes expired entries
+
+- **WHEN** a payload has expired and a prune is performed
+- **THEN** a subsequent read for that task reports absence
+
+### Requirement: Clearing a staged payload
+
+Clearing a task SHALL remove any staged payload for that task. Clearing a task that has no staged payload SHALL be a no-op.
+
+#### Scenario: Clear removes the payload
+
+- **WHEN** a payload is staged for a task and then the task is cleared
+- **THEN** a subsequent read for that task reports absence
+
+#### Scenario: Clear with nothing staged is a no-op
+
+- **WHEN** a task with no staged payload is cleared
+- **THEN** the operation completes without error or effect
+
+### Requirement: Change notifications to subscribers
+
+The store SHALL support per-task subscriptions that are notified whenever the task's payload is set, cleared, or expired. A set notification SHALL carry the new text; a clear or expiry notification SHALL carry an empty string. Subscribers SHALL NOT be notified of the existing value at subscription time. Clearing a task that had nothing staged SHALL NOT notify subscribers. Unsubscribing SHALL stop further notifications. Subscriptions for one task SHALL NOT receive notifications for another task.
+
+#### Scenario: Set notifies subscribers with new text
+
+- **WHEN** payloads are staged for a subscribed task
+- **THEN** the subscriber is notified once per stage with the staged text in order
+
+#### Scenario: Clear notifies with empty string
+
+- **WHEN** a payload is staged for a subscribed task and then cleared
+- **THEN** the subscriber is notified with the staged text and then with an empty string
+
+#### Scenario: Clear without prior stage does not notify
+
+- **WHEN** a subscribed task with nothing staged is cleared
+- **THEN** the subscriber is not notified
+
+#### Scenario: Expiry notifies subscribers
+
+- **WHEN** a staged payload for a subscribed task expires and is observed via read or prune
+- **THEN** the subscriber is notified with an empty string
+
+#### Scenario: Unsubscribe stops delivery
+
+- **WHEN** a subscriber unsubscribes and a new payload is then staged
+- **THEN** the unsubscribed callback receives no further notifications
+
+### Requirement: REST staging endpoints are task-scoped and guarded
+
+The REST API SHALL expose per-task endpoints to read, stage, and clear a task's payload, all keyed by the task ID in the request path. Read SHALL return the staged text with status 200 when present and status 204 with no body when nothing is staged. A request for a task ID that does not exist in the database SHALL return status 404 for read, stage, and clear alike. Staging with a malformed JSON body SHALL return status 400. Staging a payload that exceeds the size limit SHALL return status 400.
+
+#### Scenario: Read with nothing staged
+
+- **WHEN** a read is requested for a known task that has nothing staged
+- **THEN** the response is status 204 with no body
+
+#### Scenario: Stage then read round-trip
+
+- **WHEN** text is staged for a known task and then read back
+- **THEN** the stage returns status 200 and the read returns status 200 with the staged text
+
+#### Scenario: Clear hides the payload
+
+- **WHEN** text is staged for a known task and then the task is cleared
+- **THEN** the clear returns status 200 and a subsequent read returns status 204
+
+#### Scenario: Unknown task returns not found
+
+- **WHEN** a read, stage, or clear targets a task ID not present in the database
+- **THEN** the response is status 404
+
+#### Scenario: Oversize body rejected
+
+- **WHEN** a stage request body exceeds the payload size limit
+- **THEN** the response is status 400
+
+#### Scenario: Malformed body rejected
+
+- **WHEN** a stage request carries a body that is not valid JSON
+- **THEN** the response is status 400
+
+### Requirement: Endpoints degrade gracefully without a configured store
+
+When no staging store has been wired into the API server, read SHALL return status 204 with no body, and stage and clear SHALL return status 503.
+
+#### Scenario: Read without a store
+
+- **WHEN** a read is requested and no staging store is configured
+- **THEN** the response is status 204
+
+#### Scenario: Stage and clear without a store
+
+- **WHEN** a stage or clear is requested and no staging store is configured
+- **THEN** the response is status 503
+
+### Requirement: Streamed clipboard event encoding
+
+The API SHALL encode a clipboard change as a JSON event for the streaming channel. A present payload SHALL be encoded with a text field carrying the payload, including when the text is empty. An absent payload SHALL be encoded as a cleared sentinel rather than as a text field.
+
+#### Scenario: Present payload encodes a text field
+
+- **WHEN** a clipboard event is encoded for a present payload
+- **THEN** the encoded JSON contains a text field with the payload value
+
+#### Scenario: Absent payload encodes a cleared sentinel
+
+- **WHEN** a clipboard event is encoded for an absent payload
+- **THEN** the encoded JSON is the cleared sentinel and carries no text field
+
+### Requirement: TUI copy of a staged payload
+
+In the TUI, the staged-clipboard copy action SHALL copy the cached staged payload to the OS clipboard, clear the task's staged state, and flash a confirmation notice. If no payload is staged, the action SHALL report that nothing was copied so the keypress falls through to normal terminal handling. Local staged state and the on-screen hint SHALL be cleared immediately, and the underlying clear of the task's staged payload SHALL proceed independently; a failure to clear SHALL be logged without disrupting the copy. If the OS clipboard write fails, no confirmation notice SHALL be shown.
+
+#### Scenario: Nothing staged falls through
+
+- **WHEN** the copy action runs with no staged payload cached
+- **THEN** it reports that nothing was copied
+
+#### Scenario: Copy clears local state and the staged payload
+
+- **WHEN** the copy action runs with a staged payload cached for a task
+- **THEN** it reports a successful copy, immediately clears the cached payload and the on-screen hint, and clears the task's staged payload
+
+#### Scenario: Clear failure does not disrupt copy
+
+- **WHEN** clearing the task's staged payload fails after a copy
+- **THEN** the failure is logged and the copy still reports success without panicking
+
+#### Scenario: OS write failure suppresses the notice
+
+- **WHEN** the OS clipboard write returns an error during a copy
+- **THEN** no success callback fires and no confirmation notice is shown
+
+### Requirement: TUI staged-payload hint tracking
+
+The TUI SHALL track the currently staged payload for the active task by polling the staging source and SHALL show a hint affordance only while a payload is present. When the staging source is unavailable (for example, when the TUI runs without a daemon-backed runner), tracking SHALL be a no-op and no hint SHALL be shown. When a previously present payload becomes absent, the tracked payload SHALL be cleared and the hint hidden.
+
+#### Scenario: No staging source available
+
+- **WHEN** the staging source is not available and the cache is refreshed
+- **THEN** the tracked payload stays empty and no hint is shown
+
+#### Scenario: Present payload shows the hint
+
+- **WHEN** the staging source reports a present payload for the active task and the cache is refreshed
+- **THEN** the tracked payload is updated to that text and the hint is shown
+
+#### Scenario: Absent payload hides the hint
+
+- **WHEN** a previously present payload becomes absent and the cache is refreshed
+- **THEN** the tracked payload is cleared and the hint is hidden

--- a/openspec/specs/config-management/spec.md
+++ b/openspec/specs/config-management/spec.md
@@ -1,0 +1,116 @@
+# Configuration Management
+
+## Purpose
+
+Configuration Management defines the in-memory configuration model for Argus and the sensible defaults the application falls back to when no explicit settings exist. It supplies the default backend roster, keybindings, UI preferences, network ports, and sandbox settings, and provides helpers for resolving optional settings and discovering local Obsidian (knowledge base) vaults. It is the single source of truth for what a fresh, unconfigured Argus instance behaves like.
+
+## Requirements
+
+### Requirement: Default configuration
+
+The system SHALL provide a baseline configuration with sensible defaults so that an instance with no stored settings is fully usable.
+
+#### Scenario: Default backend selection
+
+- **WHEN** a default configuration is produced
+- **THEN** the default backend SHALL be `claude`
+
+#### Scenario: Built-in backends present
+
+- **WHEN** a default configuration is produced
+- **THEN** it SHALL include backend entries for `claude`, `codex`, and `pi`, each with a command template
+
+#### Scenario: Projects map initialized
+
+- **WHEN** a default configuration is produced
+- **THEN** the projects collection SHALL be non-nil (an empty, ready-to-populate map) rather than nil
+
+#### Scenario: Default UI preferences
+
+- **WHEN** a default configuration is produced
+- **THEN** the UI theme SHALL be `default`, elapsed-time display and icons SHALL both be enabled, and the spinner style SHALL be `progress`
+
+#### Scenario: Default service ports
+
+- **WHEN** a default configuration is produced
+- **THEN** the knowledge base port SHALL default to `7742` and the REST API port SHALL default to `7743`
+
+### Requirement: Default keybindings
+
+The system SHALL provide a default set of single-key bindings for core actions.
+
+#### Scenario: Core action keys
+
+- **WHEN** default keybindings are produced
+- **THEN** the bindings SHALL be: new=`n`, attach=`enter`, status=`s`, delete=`d`, quit=`q`, help=`?`, filter=`/`, prompt=`p`, worktree=`w`
+
+### Requirement: Worktree cleanup default resolution
+
+The system SHALL resolve whether worktrees are auto-removed on task delete from an optional setting, defaulting to enabled when the setting is unset.
+
+#### Scenario: Unset defaults to cleanup enabled
+
+- **WHEN** the cleanup-worktrees preference is unset
+- **THEN** worktree cleanup SHALL be reported as enabled
+
+#### Scenario: Explicit enable
+
+- **WHEN** the cleanup-worktrees preference is explicitly set to true
+- **THEN** worktree cleanup SHALL be reported as enabled
+
+#### Scenario: Explicit disable
+
+- **WHEN** the cleanup-worktrees preference is explicitly set to false
+- **THEN** worktree cleanup SHALL be reported as disabled
+
+### Requirement: Default Metis vault path
+
+The system SHALL compute a default knowledge base vault path under the user's iCloud-synced Obsidian directory.
+
+#### Scenario: Path derived from home directory
+
+- **WHEN** the default Metis vault path is requested
+- **THEN** it SHALL be the user's home directory joined with the iCloud Obsidian Documents base and the `Metis` vault name
+
+### Requirement: Obsidian vault discovery
+
+The system SHALL discover Obsidian vaults within a base directory, identifying a vault by the presence of a `.obsidian` subdirectory, and return sorted absolute paths.
+
+#### Scenario: Discovers a child vault
+
+- **WHEN** a base directory contains a child directory holding a `.obsidian` subdirectory
+- **THEN** that child directory's path SHALL be returned
+
+#### Scenario: Discovers the base directory as a vault
+
+- **WHEN** the base directory itself holds a `.obsidian` subdirectory
+- **THEN** the base directory's path SHALL be returned, in addition to any qualifying children
+
+#### Scenario: Skips non-vault and hidden directories
+
+- **WHEN** the base contains directories without a `.obsidian` subdirectory or directories whose names begin with a dot, and plain files
+- **THEN** those entries SHALL be excluded from the results
+
+#### Scenario: Results are sorted
+
+- **WHEN** multiple vaults are discovered
+- **THEN** the returned paths SHALL be in ascending sorted order
+
+#### Scenario: Missing or empty base yields nil
+
+- **WHEN** the base directory does not exist or contains no vaults
+- **THEN** the result SHALL be nil
+
+### Requirement: iCloud vault discovery
+
+The system SHALL discover Obsidian vaults specifically under the user's iCloud-synced Obsidian base directory.
+
+#### Scenario: iCloud base absent
+
+- **WHEN** the user's iCloud Obsidian base directory does not exist
+- **THEN** the result SHALL be nil
+
+#### Scenario: Vaults present under iCloud base
+
+- **WHEN** the iCloud Obsidian base directory contains qualifying vaults
+- **THEN** their absolute paths SHALL be returned in sorted order

--- a/openspec/specs/daemon-client/spec.md
+++ b/openspec/specs/daemon-client/spec.md
@@ -1,0 +1,253 @@
+# Daemon Client
+
+## Purpose
+
+The daemon client is the TUI-side bridge to a long-lived daemon process that owns agent PTY sessions. It connects over a Unix socket, exposes the same session-management surface the TUI uses for in-process sessions, and proxies session control (start, stop, resize, input) over JSON-RPC. For each session it maintains a local copy of recent output, fed by a separate streaming connection, so the TUI can render terminal output even though the real PTY lives in the daemon. This lets agent sessions survive TUI restarts while the UI code stays agnostic about whether it is talking to a local runner or a remote daemon.
+
+## Requirements
+
+### Requirement: Establishing a daemon connection
+
+The client SHALL connect to the daemon by dialing its Unix socket and selecting the request/response protocol. A connection attempt that cannot reach the socket SHALL fail with an error rather than returning a usable client.
+
+#### Scenario: Socket does not exist
+
+- **WHEN** Connect is called with a socket path that has no listening daemon
+- **THEN** it SHALL return an error and no client
+
+#### Scenario: Successful connection to a live daemon
+
+- **WHEN** Connect is called against a running daemon socket
+- **THEN** it SHALL return a usable client whose session queries answer correctly (e.g. an unknown task reports no session)
+
+### Requirement: RPC calls are bounded by a timeout
+
+Every RPC the client issues SHALL complete within a bounded time so the TUI never hangs if the daemon becomes unresponsive. When a call exceeds its deadline, the client SHALL return a timeout error. Long-running operations that legitimately exceed the default deadline SHALL be allowed a larger deadline.
+
+#### Scenario: Daemon never responds
+
+- **WHEN** an RPC is issued against a connection whose far end never replies
+- **THEN** the call SHALL return a timeout error once the deadline elapses, instead of blocking indefinitely
+
+#### Scenario: Long-running self-update
+
+- **WHEN** the client issues the self-update RPC (which shells out to a build)
+- **THEN** it SHALL use an extended deadline rather than the short default
+
+### Requirement: Starting a session
+
+The client SHALL request the daemon to start a session for a task, conveying the task identity, prompt, project, backend, worktree, branch, requested terminal size, and whether to resume. On success it SHALL return a session handle reporting a non-zero process id and SHALL begin streaming the session's output locally. If the RPC fails or the daemon reports an error for the start, the client SHALL return an error and no handle.
+
+#### Scenario: Successful start
+
+- **WHEN** Start is called for a valid backend
+- **THEN** it SHALL return a session handle whose PID is non-zero, and the session's output SHALL become available locally as the process produces it
+
+#### Scenario: Daemon rejects the start
+
+- **WHEN** Start is called with a backend the daemon cannot run
+- **THEN** it SHALL return an error and no usable handle
+
+#### Scenario: Daemon unreachable during start
+
+- **WHEN** Start is called but the RPC connection is closed
+- **THEN** it SHALL return an error and no handle
+
+### Requirement: Looking up an existing session
+
+The client SHALL return a handle for a task if it already tracks one locally, or if the daemon reports a live session for that task. It SHALL return nothing when the daemon reports no live session, or when the lookup RPC fails.
+
+#### Scenario: Locally tracked session
+
+- **WHEN** Get is called for a task the client already has a session for
+- **THEN** it SHALL return that existing handle
+
+#### Scenario: Session known only to the daemon
+
+- **WHEN** Get is called for a task the client has no local handle for but the daemon reports alive
+- **THEN** it SHALL create and return a handle for that task
+
+#### Scenario: No live session
+
+- **WHEN** Get is called for a task the daemon reports as not alive
+- **THEN** it SHALL return nothing
+
+#### Scenario: Lookup RPC fails
+
+- **WHEN** Get is called but the lookup RPC fails
+- **THEN** it SHALL return nothing
+
+### Requirement: Querying running and idle sessions
+
+The client SHALL be able to report which task sessions the daemon considers running and which it considers idle, including a combined query returning both in one call. When the underlying query fails, the client SHALL report no sessions rather than partial or stale data.
+
+#### Scenario: No sessions exist
+
+- **WHEN** the running/idle queries are issued against a daemon with no sessions
+- **THEN** each query SHALL return an empty result
+
+#### Scenario: A live session exists
+
+- **WHEN** a session is running on the daemon
+- **THEN** the running query SHALL include that task's id
+
+#### Scenario: Query RPC fails
+
+- **WHEN** the running/idle query RPC fails
+- **THEN** the client SHALL return no task ids
+
+### Requirement: Stopping sessions
+
+The client SHALL stop a single session by task id, propagating any daemon-reported error. It SHALL also support stopping all sessions as a best-effort operation that ignores errors, suitable for shutdown.
+
+#### Scenario: Stop an unknown session
+
+- **WHEN** stopping a task that has no session on the daemon
+- **THEN** the client SHALL return an error
+
+#### Scenario: Stop a running session
+
+- **WHEN** stopping a task with a live session
+- **THEN** the client SHALL return no error and the session SHALL become not-alive
+
+#### Scenario: Stop-all with no sessions
+
+- **WHEN** StopAll is called with no sessions present
+- **THEN** it SHALL complete without error or panic
+
+### Requirement: Output streaming into a local buffer
+
+For each session, the client SHALL open a separate streaming connection to the daemon and copy received bytes into a local fixed-size buffer that backs the TUI's view of recent output. When reconnecting a stream, the client SHALL tell the daemon how many bytes it has already received so only the missed delta is replayed, avoiding duplicate content.
+
+#### Scenario: Output becomes available locally
+
+- **WHEN** a session produces output on the daemon
+- **THEN** that output SHALL appear in the session handle's recent-output buffer
+
+#### Scenario: Reconnect requests only the missed delta
+
+- **WHEN** the stream reconnects after some bytes were already buffered locally
+- **THEN** the stream subscription SHALL request output starting from the count already received rather than from the beginning
+
+### Requirement: Stream-loss versus process-exit distinction
+
+When a session's stream ends, the client SHALL ask the daemon whether the underlying process actually exited. A confirmed exit SHALL be reported as a session exit; a dropped stream while the process is still alive SHALL trigger limited retries; and an unreachable daemon or exhausted retries SHALL be reported as a stream-loss rather than an exit, so the task is not wrongly marked complete.
+
+#### Scenario: Process actually exited
+
+- **WHEN** a session's process exits on the daemon
+- **THEN** the registered exit callback SHALL fire for that task
+
+#### Scenario: Daemon unreachable while streaming
+
+- **WHEN** the stream cannot be maintained and the daemon is unreachable
+- **THEN** the exit callback SHALL fire with the stream-lost indicator set, not a normal exit
+
+#### Scenario: Session closed externally during streaming
+
+- **WHEN** the session is closed externally (e.g. client shutdown) rather than by process exit
+- **THEN** the exit callback SHALL report stream-loss with the stopped flag unset
+
+#### Scenario: Liveness check when stream ends
+
+- **WHEN** the stream ends and the daemon reports the session is not alive
+- **THEN** the client SHALL treat it as a process exit; if the daemon is unreachable it SHALL instead treat it as stream-loss
+
+### Requirement: Forwarding terminal input
+
+A session handle SHALL forward written input to the daemon for delivery to the PTY, reporting the number of bytes accepted, and SHALL track the wall-clock time of the most recent input. Input written after a session is closed SHALL not block indefinitely. Consecutive inputs MAY be coalesced into fewer RPCs, but coalescing SHALL stop at a bracketed-paste end boundary so two back-to-back paste cycles are never merged into a single write.
+
+#### Scenario: Write reports byte count and advances last-input time
+
+- **WHEN** input is written to a live session handle
+- **THEN** the call SHALL report the number of bytes written and the handle's last-input time SHALL advance from its zero value
+
+#### Scenario: Coalescing plain input
+
+- **WHEN** multiple plain (non-paste) inputs are pending
+- **THEN** they SHALL be combined into a single buffer with nothing left pending
+
+#### Scenario: Flush at paste boundary
+
+- **WHEN** a buffer already ends with a bracketed-paste end sequence and more input is pending
+- **THEN** coalescing SHALL stop and the still-pending input SHALL remain for a later flush
+
+#### Scenario: Two back-to-back pastes stay separate
+
+- **WHEN** two complete bracketed-paste cycles are queued back to back
+- **THEN** each cycle SHALL be drained as its own buffer rather than merged into one
+
+### Requirement: Session state and liveness reporting
+
+A session handle SHALL report its process id, liveness, idle state, current and initial PTY size, working directory, and recent-output metrics, refreshing daemon-sourced values on demand. When the daemon cannot be reached for a refresh, the handle SHALL fail silently rather than panic, leaving prior cached values intact.
+
+#### Scenario: Reporting PTY size and working directory
+
+- **WHEN** a session was started with a given terminal size and worktree
+- **THEN** the handle SHALL report that current and initial PTY size and a non-empty working directory
+
+#### Scenario: Liveness reflects done state
+
+- **WHEN** the session's done channel has not been closed
+- **THEN** the handle SHALL report alive, and its done channel SHALL not be readable
+
+#### Scenario: Refresh against an unreachable daemon
+
+- **WHEN** a state refresh is attempted but the RPC connection is closed
+- **THEN** the refresh SHALL silently swallow the error without panicking
+
+### Requirement: Clipboard staging proxy
+
+The client SHALL fetch and clear agent-staged clipboard text for a task via the daemon. A fetch SHALL report unavailability when nothing is staged or the RPC fails, and a clear SHALL propagate any daemon-reported or transport error.
+
+#### Scenario: Nothing staged
+
+- **WHEN** clipboard text is requested for a task with nothing staged
+- **THEN** the client SHALL report not-available with empty text
+
+#### Scenario: Staged text is returned then cleared
+
+- **WHEN** text has been staged for a task
+- **THEN** a fetch SHALL return that text as available, and after a clear a subsequent fetch SHALL report not-available
+
+#### Scenario: Transport failure on clipboard ops
+
+- **WHEN** the RPC connection is closed during a clipboard fetch or clear
+- **THEN** the fetch SHALL report not-available and the clear SHALL return an error
+
+### Requirement: Client shutdown stops streaming and retries
+
+Closing the client SHALL signal all stream-connection goroutines to stop retrying and SHALL close every tracked session, so no stale stream goroutine continues to dial the socket after shutdown (e.g. across a daemon restart).
+
+#### Scenario: Close signals stream goroutines
+
+- **WHEN** the client is closed
+- **THEN** the shutdown signal SHALL become observable and in-flight stream connection loops SHALL stop and return
+
+#### Scenario: Stream loop exits when client already closed
+
+- **WHEN** a stream connection loop runs after the client has been closed
+- **THEN** it SHALL exit immediately without attempting to dial the daemon
+
+### Requirement: Daemon auto-start refuses to run under test binaries
+
+The client SHALL provide a way to auto-start the daemon when none is running. To avoid re-executing the test process as a daemon (a fork-bomb and a hazard to real on-disk state), auto-start SHALL refuse with a distinct error when invoked from a Go test binary.
+
+#### Scenario: Auto-start invoked under go test
+
+- **WHEN** auto-start is invoked from a test binary
+- **THEN** it SHALL return the test-binary refusal error and SHALL NOT fork a daemon process
+
+### Requirement: Waiting for daemon shutdown
+
+The client SHALL provide a helper that waits until the daemon socket no longer exists, up to a timeout, so callers can confirm a daemon has fully shut down.
+
+#### Scenario: Socket already gone
+
+- **WHEN** the wait helper is called for a socket path that does not exist
+- **THEN** it SHALL return promptly
+
+#### Scenario: Socket persists until timeout
+
+- **WHEN** the wait helper is called for a path that continues to exist
+- **THEN** it SHALL poll until the timeout elapses before returning

--- a/openspec/specs/daemon-lifecycle/spec.md
+++ b/openspec/specs/daemon-lifecycle/spec.md
@@ -1,0 +1,175 @@
+# Daemon Lifecycle
+
+## Purpose
+
+The daemon is the long-lived process that owns agent PTY sessions so they survive TUI restarts and serve web/PWA clients with no TUI attached. It exposes a single Unix-domain socket that multiplexes request/response RPC and raw output streaming, guarantees that exactly one daemon owns the socket at a time, reconciles orphaned task state on startup, shuts down gracefully on signal, and provides a TUI-independent entry point for creating tasks and starting their agent sessions.
+
+## Requirements
+
+### Requirement: Single-socket protocol dispatch
+
+The daemon SHALL accept all client connections on one Unix-domain socket and route each connection by its first byte: `R` selects JSON-RPC request/response, `S` selects raw output streaming. A connection whose first byte is neither SHALL be rejected and closed without further processing.
+
+#### Scenario: RPC connection
+- **WHEN** a client connects and sends the byte `R` followed by a JSON-RPC request
+- **THEN** the daemon serves it as a JSON-RPC call and returns the response on the same connection
+
+#### Scenario: Stream connection
+- **WHEN** a client connects and sends the byte `S` followed by a stream header
+- **THEN** the daemon treats the connection as an output stream for the named task
+
+#### Scenario: Unknown prefix
+- **WHEN** a client connects and sends a first byte other than `R` or `S`
+- **THEN** the daemon closes the connection without serving RPC or stream
+
+### Requirement: Singleton ownership of the socket
+
+The daemon SHALL ensure that at most one daemon owns the socket. On startup it SHALL terminate any prior daemon recorded in the PID file and acquire an exclusive advisory lock before binding; if another live daemon already holds the lock, the new daemon SHALL exit cleanly with an already-running signal rather than binding the socket.
+
+#### Scenario: Lock already held
+- **WHEN** the daemon starts but another process already holds the singleton lock
+- **THEN** it returns an already-running result, does not bind the socket, and signals readiness so any shutdown waiters do not block
+
+#### Scenario: Lock contended then released
+- **WHEN** one holder releases the singleton lock
+- **THEN** a subsequent acquire succeeds
+
+#### Scenario: Prior daemon in PID file
+- **WHEN** the PID file names a live prior daemon process at startup
+- **THEN** the new daemon signals that process to terminate (escalating to force-kill if it does not exit within the grace window) before taking over
+
+### Requirement: PID file and stale-file hygiene
+
+The daemon SHALL record its own PID in a PID file beside the socket and SHALL only remove the socket and PID file on shutdown if the PID file still names its own process, so that a newer daemon's files are never deleted by an older instance.
+
+#### Scenario: Cleanup when still owner
+- **WHEN** the daemon shuts down and the PID file still contains its PID
+- **THEN** it removes both the socket and PID file
+
+#### Scenario: Cleanup skipped when superseded
+- **WHEN** the daemon shuts down but the PID file now names a different process
+- **THEN** it leaves the socket and PID file in place
+
+#### Scenario: Missing or unparsable PID file
+- **WHEN** the PID file is absent or its contents are not a valid integer
+- **THEN** the PID read yields zero and no prior process is signaled
+
+### Requirement: Startup reconciliation of orphaned tasks
+
+On startup, before accepting connections, the daemon SHALL sweep the database for tasks left in the in-progress state by a previous run and reconcile them, since the new daemon owns no sessions for them. A reconciliation failure SHALL be logged and SHALL NOT prevent the daemon from serving.
+
+#### Scenario: Orphan sweep before accept
+- **WHEN** the daemon starts and the database contains in-progress tasks with no live session
+- **THEN** those rows are reconciled out of the in-progress state before the listener accepts the first connection
+
+### Requirement: Session-exit status transition
+
+When a session exits, the daemon SHALL flip its task out of the in-progress state: a naturally-exited session transitions the task to complete, a stopped (interrupted) session transitions it to in-review. The transition SHALL be a no-op if the task is not in the in-progress state, and SHALL be skipped when a kick-restart is already queued for that task.
+
+#### Scenario: Natural exit completes the task
+- **WHEN** an in-progress task's session exits naturally
+- **THEN** the task transitions to complete
+
+#### Scenario: Stopped session moves to review
+- **WHEN** an in-progress task's session is stopped
+- **THEN** the task transitions to in-review
+
+#### Scenario: Already-terminal task untouched
+- **WHEN** a session exits for a task that is no longer in-progress
+- **THEN** the task status is left unchanged
+
+#### Scenario: Pending restart suppresses transition
+- **WHEN** a session exits while a kick-restart is queued for the same task
+- **THEN** the status transition is skipped so it does not race the imminent restart
+
+### Requirement: Cached exit info on session end
+
+When a session exits, the daemon SHALL cache its exit information (error string, stopped flag, last output, pending-restart flag) so a client can query it once after the stream closes. The cached info SHALL be consumed on read, returning empty thereafter.
+
+#### Scenario: Consume-once exit info
+- **WHEN** a client queries exit info for a finished session
+- **THEN** the cached info is returned and removed, and a subsequent query returns empty
+
+### Requirement: Post-exit session ID capture
+
+After a session exits with no recorded session ID and a known worktree, the daemon SHALL attempt a backend-specific capture of the session UUID and persist it, so headless and web-only users can later resume backends (such as codex and pi) that mint their IDs only after exit. The capture SHALL be a no-op when the task is missing, already has a session ID, has no worktree, the backend yields no ID, or the capture fails — and SHALL never corrupt the task row.
+
+#### Scenario: Capture and persist for late-minting backend
+- **WHEN** a task with a worktree and no session ID exits and its backend exposes a session file
+- **THEN** the daemon captures the UUID and writes it back to the task row
+
+#### Scenario: Skip when ID already present
+- **WHEN** the task already has a session ID
+- **THEN** the daemon leaves the session ID unchanged
+
+#### Scenario: Capture error leaves row intact
+- **WHEN** the backend-specific capture fails
+- **THEN** the daemon logs and returns without modifying the task row
+
+### Requirement: Stream subscription and incremental replay
+
+On a stream connection the client SHALL send a header naming the task and an offset of already-received bytes; the daemon SHALL replay only the output past that offset before attaching the connection for live output, then keep the connection open until the session exits, the client disconnects, or the daemon shuts down. If the named session is absent, the daemon SHALL close the stream — except during a queued kick-restart, where it SHALL wait briefly for the new session to appear.
+
+#### Scenario: Subscribe with offset
+- **WHEN** a stream client sends a header naming a live session with a byte offset
+- **THEN** the daemon replays only output beyond that offset and then streams live bytes
+
+#### Scenario: Session absent
+- **WHEN** a stream client names a task that has no session and no queued restart
+- **THEN** the daemon closes the stream connection
+
+#### Scenario: Wait through kick-restart gap
+- **WHEN** a stream client connects while a kick-restart for the task is in flight and the new session has not yet appeared
+- **THEN** the daemon waits up to a bounded interval for the new session and attaches once it appears, abandoning the wait if the restart is dropped or the daemon shuts down
+
+### Requirement: Pending-restart liveness reporting
+
+While a kick-restart is queued for a task but its new session has not yet been created, the daemon SHALL report that task as alive in single-task status and in the session list, so client reconcilers do not prematurely mark a mid-restart task complete.
+
+#### Scenario: Status reports alive during gap
+- **WHEN** a client requests session status for a task with a queued restart and no current session
+- **THEN** the response reports the task as alive
+
+#### Scenario: List includes synthetic gap entry
+- **WHEN** a client lists sessions and a task has a queued restart with no current session
+- **THEN** the listing includes that task marked alive
+
+### Requirement: Headless task creation and session start
+
+The daemon SHALL provide a TUI-independent entry point that creates a task, its worktree, and starts its agent session transactionally — used by the HTTP API, MCP server, and scheduler. Any failure during creation SHALL unwind all prior side effects so no orphan worktree, branch, or task row remains. When the task lists unresolved dependencies, the task SHALL be persisted in the pending state with no agent process spawned.
+
+#### Scenario: Single task created and started
+- **WHEN** a headless caller requests a new task with no dependencies
+- **THEN** the worktree is created, the task is persisted, and its agent session is started
+
+#### Scenario: Dependent task deferred
+- **WHEN** a headless caller requests a task that depends on other tasks
+- **THEN** the task is persisted as pending and no agent process is started
+
+### Requirement: RPC session control
+
+The daemon SHALL expose RPC methods to start, stop, and stop-all sessions, write input to and resize a session's PTY, and query liveness — reporting a populated handle on success and an error string when the target session is not found.
+
+#### Scenario: Start then list then stop
+- **WHEN** a client starts a session, lists sessions, then stops it
+- **THEN** the start returns a non-zero PID, the session appears in the listing, and after the stop it no longer appears
+
+#### Scenario: Input or resize to missing session
+- **WHEN** a client writes input to or resizes a session that does not exist
+- **THEN** the response carries a not-found error rather than succeeding
+
+#### Scenario: Liveness ping
+- **WHEN** a client calls the responsiveness ping
+- **THEN** the daemon replies OK
+
+### Requirement: Graceful shutdown
+
+The daemon SHALL shut down gracefully on receiving SIGTERM or SIGINT, or on an RPC shutdown request, by stopping the accept loop and then, on the serving goroutine, stopping all sessions and dependent services before removing its files and releasing the lock. Shutdown SHALL be idempotent.
+
+#### Scenario: RPC shutdown returns and stops serving
+- **WHEN** a client invokes the shutdown RPC
+- **THEN** the daemon acknowledges, stops accepting connections, and the serve call returns without error
+
+#### Scenario: Repeated shutdown is safe
+- **WHEN** shutdown is requested more than once
+- **THEN** the second request is a no-op

--- a/openspec/specs/data-persistence/spec.md
+++ b/openspec/specs/data-persistence/spec.md
@@ -1,0 +1,272 @@
+# Data Persistence
+
+## Purpose
+
+The data persistence capability is the durable store for tasks, projects, backends, and scalar configuration. It owns a single SQLite database under the argus data directory, creates and evolves its schema on open, seeds sensible defaults on first run, and exposes thread-safe create/read/update/delete operations. All other capabilities depend on it as the source of truth for persisted state, so its contracts (ID generation, not-found signalling, transactional grouping, and concurrent-write safety) must be stable.
+
+## Requirements
+
+### Requirement: Database open and initialization
+
+The store SHALL open or create a SQLite database at a caller-supplied path, creating any missing parent directories, ensuring all required tables and indexes exist, and applying default seeding and backend fixups before returning a usable handle. If the directory cannot be created or the file is not a valid SQLite database, Open SHALL return an error rather than a partially-initialized handle.
+
+#### Scenario: Opening a fresh database
+
+- **WHEN** Open is called with a path whose parent directory does not yet exist
+- **THEN** the parent directory is created, the schema is initialized, defaults are seeded, and a usable database handle is returned
+
+#### Scenario: Reopening an already-initialized database
+
+- **WHEN** Open is called a second time on a path that was already initialized
+- **THEN** initialization is idempotent, seeding does not run again, and a usable handle is returned without error
+
+#### Scenario: Opening a corrupted or unreachable path
+
+- **WHEN** Open is called against a file that is not valid SQLite, or a path whose parent directory cannot be created
+- **THEN** Open returns an error and does not return a handle
+
+#### Scenario: In-memory store for ephemeral use
+
+- **WHEN** an in-memory database is requested
+- **THEN** the schema is created and defaults are seeded without any filesystem migration step, yielding a usable handle
+
+### Requirement: Schema creation is idempotent and self-evolving
+
+The store SHALL create all required tables and indexes if they do not already exist, and SHALL apply column additions and legacy-column removals in an idempotent way so that repeatedly initializing an existing database neither fails nor duplicates structure.
+
+#### Scenario: Re-running schema creation on an existing database
+
+- **WHEN** schema creation runs against a database that already has the tables
+- **THEN** existing data is preserved and no error is raised for already-present tables, columns, or indexes
+
+### Requirement: Default seeding on first run
+
+On first initialization the store SHALL seed default backends and default scalar configuration values. Seeding SHALL be safe to run multiple times: it inserts a default backend only when that backend is missing, and inserts default config values only when no configuration rows exist yet. Seeding SHALL replace known placeholder backend commands (such as `echo`, `cat`, or `true`) with the real default command.
+
+#### Scenario: Fresh database gets defaults
+
+- **WHEN** a fresh database is initialized
+- **THEN** the default backend (claude) is present and the default scalar config values are readable through the assembled configuration
+
+#### Scenario: Placeholder backend command is corrected
+
+- **WHEN** a backend named like a default exists with a placeholder command such as `echo`
+- **THEN** seeding rewrites that backend's command to the real default command
+
+#### Scenario: Seeding does not clobber existing config
+
+- **WHEN** seeding runs against a database that already contains configuration rows
+- **THEN** existing config rows are left unchanged
+
+### Requirement: Backend fixup on every open
+
+The store SHALL, on every open, reconcile known-outdated backend configurations toward the shipped defaults: inserting any default backend that is entirely missing, and correcting specific obsolete command forms while preserving unrelated user customizations.
+
+#### Scenario: Missing default backend is reinserted
+
+- **WHEN** a database is opened that lacks a backend present in the shipped defaults
+- **THEN** that default backend is inserted
+
+#### Scenario: Outdated command flags are corrected without losing user flags
+
+- **WHEN** a backend command is missing a required default flag but carries extra user-added flags
+- **THEN** the required default behavior is applied and the user's extra flags are retained
+
+#### Scenario: Already-correct backend is left untouched
+
+- **WHEN** a backend already matches the expected default form
+- **THEN** the fixup pass makes no change to it
+
+### Requirement: Task create and read
+
+The store SHALL persist a task and return it on lookup by ID. On insert, when the task has no ID the store SHALL assign a generated URL-safe identifier, and when it has no creation timestamp the store SHALL stamp the current time. A caller-supplied ID SHALL be preserved.
+
+#### Scenario: Adding a task without an ID
+
+- **WHEN** a task with an empty ID is added
+- **THEN** a non-empty generated ID and a non-zero creation timestamp are assigned, and the task is retrievable by that ID
+
+#### Scenario: Adding a task with a caller-supplied ID
+
+- **WHEN** a task is added with an explicit ID
+- **THEN** that ID is preserved and used as the lookup key
+
+#### Scenario: Round-tripping all task fields
+
+- **WHEN** a task with status, project, branch, sandboxed/archived/pinned flags, orchestration fields, and timestamps is added and then read back
+- **THEN** every persisted field, including the JSON-encoded dependency list and stored times, matches the values written
+
+### Requirement: Not-found signalling for missing tasks
+
+Every task mutation and the single-task read SHALL report a missing target via a recognizable not-found error rather than silently succeeding, so callers can distinguish "no such task" from a successful no-op.
+
+#### Scenario: Getting a non-existent task
+
+- **WHEN** a task is requested by an ID that does not exist
+- **THEN** a not-found error is returned
+
+#### Scenario: Updating a non-existent task
+
+- **WHEN** an update targets an ID with no matching row
+- **THEN** a not-found error is returned and no row is created
+
+#### Scenario: Partial-update of a non-existent task
+
+- **WHEN** a partial-column write (result, plan slug, dependencies, archived state, or rename) targets a missing ID
+- **THEN** a not-found error is returned
+
+### Requirement: Full and partial task updates
+
+The store SHALL support replacing all mutable columns of an existing task, and SHALL also offer targeted partial writes (name, result blob, plan slug, dependency list, archived flag) that update only the named column(s) so a concurrent full-row write cannot be clobbered by a stale read-modify-write.
+
+#### Scenario: Full update replaces mutable fields
+
+- **WHEN** an existing task is updated with changed fields
+- **THEN** the stored row reflects all the new values on the next read
+
+#### Scenario: Partial write leaves other fields intact
+
+- **WHEN** only the result blob (or plan slug, or dependency list) is written for a task whose status was concurrently changed
+- **THEN** the written column takes the new value and the unrelated status is preserved
+
+#### Scenario: Partial writes are last-write-wins idempotent
+
+- **WHEN** the same partial column is written twice with different values
+- **THEN** the most recent value is the one read back
+
+### Requirement: Conditional rename (compare-and-swap)
+
+The store SHALL offer a name update that succeeds only when the row's current name still equals an expected value, returning success/failure to the caller. A name that has drifted since the expected value was observed SHALL be treated as a no-op (no error), while a missing row SHALL be a not-found error. A plain rename SHALL update only the name and leave all other fields untouched.
+
+#### Scenario: Expected name still matches
+
+- **WHEN** a conditional rename is issued and the current name equals the expected value
+- **THEN** the name is updated and success is reported
+
+#### Scenario: Name drifted since observation
+
+- **WHEN** a conditional rename is issued but the current name no longer equals the expected value and the row still exists
+- **THEN** no change is made and a non-error "not applied" result is reported
+
+#### Scenario: Plain rename preserves other fields
+
+- **WHEN** a task is renamed
+- **THEN** only the name changes and fields such as status are preserved
+
+### Requirement: Archive write enforces pinned/archived mutual exclusivity
+
+The store SHALL provide a targeted archive write that, when archiving, also clears the pinned flag so that at most one of pinned/archived is ever set, and when unarchiving leaves the pinned flag untouched. Archiving a task SHALL also remove its queued messages and sidecar metadata in the same transaction.
+
+#### Scenario: Archiving a pinned task clears pinned
+
+- **WHEN** a pinned task is archived
+- **THEN** the row reads back archived and not pinned, and unrelated fields such as status are preserved
+
+#### Scenario: Unarchiving leaves pinned alone
+
+- **WHEN** a task is unarchived
+- **THEN** the pinned flag is left unchanged
+
+### Requirement: Task delete and prune
+
+The store SHALL delete a task by ID, removing its dependent message and sidecar-metadata rows in the same transaction, and SHALL report a not-found error when no row matched. The store SHALL also support pruning all completed tasks, returning the set of tasks it removed.
+
+#### Scenario: Deleting an existing task removes dependents atomically
+
+- **WHEN** an existing task is deleted
+- **THEN** the task row and its dependent rows are removed together and the task is no longer retrievable
+
+#### Scenario: Deleting a missing task
+
+- **WHEN** delete targets an ID with no row
+- **THEN** a not-found error is returned
+
+#### Scenario: Pruning completed tasks
+
+- **WHEN** prune is invoked while completed tasks exist
+- **THEN** all completed tasks are removed and returned, while non-completed tasks remain
+
+#### Scenario: Pruning with nothing to remove
+
+- **WHEN** prune is invoked and no task has completed status
+- **THEN** nothing is removed and an empty result is returned
+
+### Requirement: Task listing order and idempotency lookup
+
+The store SHALL list all tasks ordered by ascending creation time, and SHALL provide a lookup that returns the first non-archived task matching a (name, project) pair (or no match) for duplicate detection. Archived rows SHALL be excluded from the (name, project) lookup so a reused name is not blocked by a stale archived task.
+
+#### Scenario: Tasks are returned oldest-first
+
+- **WHEN** multiple tasks are listed
+- **THEN** they are ordered by ascending creation time
+
+#### Scenario: Name/project lookup finds a live task
+
+- **WHEN** a live (non-archived) task matches the queried name and project
+- **THEN** that task is returned
+
+#### Scenario: Name/project lookup ignores archived and mismatched rows
+
+- **WHEN** the only matching row is archived, or no row matches the name/project pair
+- **THEN** no match is returned with no error
+
+### Requirement: Projects and backends CRUD
+
+The store SHALL persist projects and backends keyed by name, supporting upsert (insert-or-replace) on write, listing ordered by name, and delete by name. Reads SHALL reconstruct structured values (such as a project's per-project sandbox settings) from their stored encoding.
+
+#### Scenario: Upserting and reading back a project
+
+- **WHEN** a project is written and then listed
+- **THEN** its path, branch, backend, and sandbox settings are reconstructed as written
+
+#### Scenario: Overwriting an existing backend
+
+- **WHEN** a backend is written with a name that already exists
+- **THEN** the existing row is replaced with the new command and prompt flag
+
+#### Scenario: Deleting a project or backend
+
+- **WHEN** delete is called for a named project or backend
+- **THEN** that row is removed from subsequent listings
+
+### Requirement: Scalar configuration assembly and overrides
+
+The store SHALL assemble a full configuration value by starting from defaults and applying persisted scalar overrides, projects, and backends. Stored string and boolean keys SHALL override their defaults; integer port values SHALL override only when they parse as a positive integer, otherwise the default is retained. Config writes SHALL upsert by key.
+
+#### Scenario: Stored overrides take effect
+
+- **WHEN** scalar config keys (defaults, keybindings, UI, sandbox, KB, API, source path) are set and the configuration is assembled
+- **THEN** each stored value overrides the corresponding default
+
+#### Scenario: Invalid port values fall back to defaults
+
+- **WHEN** a stored port value is non-numeric, zero, or negative
+- **THEN** the assembled configuration keeps the default port
+
+#### Scenario: Setting a config value upserts by key
+
+- **WHEN** a config key is written more than once
+- **THEN** the latest value is the one read back
+
+### Requirement: Transactional execution
+
+The store SHALL run a caller-supplied function inside a single database transaction, committing when the function returns no error and rolling back all of its writes when the function returns an error.
+
+#### Scenario: Successful transaction commits
+
+- **WHEN** a transactional function performs writes and returns no error
+- **THEN** all of its writes are durably committed
+
+#### Scenario: Failing transaction rolls back
+
+- **WHEN** a transactional function performs writes and then returns an error
+- **THEN** none of its writes persist and the prior state is intact
+
+### Requirement: Thread-safe access
+
+The store SHALL serialize concurrent access so that reads and writes from multiple goroutines do not corrupt state or cursors. Operations that emit downstream events SHALL do so only after releasing the internal lock to avoid re-entrant deadlock.
+
+#### Scenario: Concurrent operations remain consistent
+
+- **WHEN** multiple goroutines read and write through the store concurrently
+- **THEN** operations complete without data corruption and reads observe well-formed rows

--- a/openspec/specs/events-bus/spec.md
+++ b/openspec/specs/events-bus/spec.md
@@ -1,0 +1,137 @@
+# Events Bus
+
+## Purpose
+
+The events bus is the daemon-wide notification channel that lets external consumers (plugins, the web/PWA client) observe task, session, and messaging activity without polling. Emission sites across the daemon fire typed events through a single global entry point; the daemon persists each event to a bounded ring and fans it out to live Server-Sent-Events (SSE) subscribers. Consumers reconnect with a monotonic cursor to replay missed history, and are told to resnapshot when their cursor has aged out of the ring.
+
+## Requirements
+
+### Requirement: Global emission entry point
+
+The system SHALL expose a single `Emit(type, taskID, payload)` entry point that constructs an event and forwards it to the installed sink. When no sink is installed, emission SHALL be a silent no-op that never panics, so every call site can fire unconditionally.
+
+#### Scenario: Emit with no sink installed
+
+- **WHEN** `Emit` is called while no sink is registered
+- **THEN** the call returns without error, delivers nothing, and does not panic
+
+#### Scenario: Emit delivers a stamped event to the installed sink
+
+- **WHEN** `Emit` is called with a type, task ID, and payload while a sink is installed
+- **THEN** the sink receives exactly one event whose type and task ID match the inputs and whose timestamp is non-zero
+
+### Requirement: Payload encoding is best-effort
+
+The system SHALL JSON-encode the supplied payload onto the event. A nil payload SHALL produce an event with no payload bytes, and a payload that fails to marshal SHALL still produce an event but with no payload bytes — the encoding failure SHALL NOT propagate to the caller and SHALL NOT prevent the event from firing.
+
+#### Scenario: Nil payload omits payload bytes
+
+- **WHEN** `Emit` is called with a nil payload
+- **THEN** the delivered event has no payload bytes
+
+#### Scenario: Unmarshalable payload still fires the event
+
+- **WHEN** `Emit` is called with a payload that cannot be JSON-encoded
+- **THEN** exactly one event is still delivered, with no payload bytes, and no error is surfaced to the caller
+
+#### Scenario: Marshalable payload round-trips
+
+- **WHEN** `Emit` is called with a JSON-encodable payload
+- **THEN** the delivered event carries the payload as JSON that decodes back to the original values
+
+### Requirement: Sink installation is global and reversible
+
+The system SHALL maintain exactly one globally installed sink. Installing a sink SHALL return the previously installed sink so callers can save and restore it, and installing nil SHALL clear the sink so subsequent emissions become no-ops.
+
+#### Scenario: Installing nil clears the sink
+
+- **WHEN** a sink is installed and then nil is installed
+- **THEN** subsequent emissions deliver nothing to the previously installed sink
+
+#### Scenario: Install returns the prior sink
+
+- **WHEN** a sink B is installed while sink A was already installed
+- **THEN** the install call returns sink A
+
+### Requirement: Persist-then-broadcast on the daemon sink
+
+The daemon sink SHALL persist each emitted event to the events ring before broadcasting it to live subscribers, so that broadcast order matches commit order and broadcast events carry their assigned ID. If persistence fails, the sink SHALL log the failure and SHALL NOT broadcast and SHALL NOT panic.
+
+#### Scenario: Successful emit persists and broadcasts with an ID
+
+- **WHEN** the daemon sink emits an event and persistence succeeds
+- **THEN** the event is stored in the ring and the same event — bearing a positive assigned ID — is delivered to live subscribers
+
+#### Scenario: Persistence failure suppresses broadcast
+
+- **WHEN** the daemon sink emits an event but the underlying store is unavailable
+- **THEN** no event is broadcast to subscribers and the daemon does not panic
+
+### Requirement: SSE stream endpoint
+
+The system SHALL serve `GET /api/events/stream` as an SSE channel that responds with `Content-Type: text/event-stream`, encodes each event as an SSE block carrying the event type in the `event:` field and the JSON event in the `data:` field, and keeps the connection open. When the underlying writer does not support streaming, the endpoint SHALL respond with an error rather than attempting to stream.
+
+#### Scenario: Stream returns SSE content type and typed events
+
+- **WHEN** a client connects to `/api/events/stream`
+- **THEN** the response status is 200 with `Content-Type: text/event-stream` and each delivered block names the event type in its `event:` field and a decodable JSON event in its `data:` field
+
+### Requirement: Cursor replay with exclusive `since`
+
+The stream SHALL accept a `since` query cursor and replay all retained events strictly newer than that cursor before delivering live events. An absent, empty, negative, or unparseable `since` SHALL be treated as zero (replay all retained events).
+
+#### Scenario: Replays history newer than the cursor
+
+- **WHEN** a client connects with `since` set to an existing event's ID
+- **THEN** the stream replays only events with an ID strictly greater than that cursor
+
+#### Scenario: Replays all events from zero
+
+- **WHEN** a client connects with `since=0`
+- **THEN** the stream replays every retained event in ascending ID order, each bearing a positive ID
+
+#### Scenario: Invalid cursor falls back to zero
+
+- **WHEN** a client connects with a non-numeric `since` value
+- **THEN** the stream behaves as if `since=0` and replays all retained events
+
+### Requirement: Resync on aged-out cursor
+
+When a client connects with a positive `since` cursor that is older than the oldest event still retained in the ring, the stream SHALL emit a synthetic resync event as the very first event before any replay, signalling that history has rotated out and the client should resnapshot daemon state. The resync event SHALL NOT be persisted in the ring.
+
+#### Scenario: Cursor older than the ring triggers resync first
+
+- **WHEN** a client connects with a `since` cursor pointing at an event that has been evicted from the ring
+- **THEN** the first event delivered on the stream is a resync event
+
+### Requirement: Lossless, dupe-free live delivery after replay
+
+The stream SHALL deliver live events after replay without duplicating or reordering events relative to the replayed history. An event whose ID falls within the replayed range SHALL NOT be delivered again as a live event.
+
+#### Scenario: Live event delivered after replay
+
+- **WHEN** a client connected with a cursor at the latest event, and a new event is emitted after the subscription attaches
+- **THEN** the new live event is delivered on the stream
+
+#### Scenario: No duplicate across the replay/live boundary
+
+- **WHEN** an event is committed during the window between subscription and replay-boundary snapshot
+- **THEN** that event is delivered exactly once and not duplicated across the replay and live phases
+
+### Requirement: Bounded ring with slow-subscriber drop
+
+Each subscriber SHALL have a bounded backlog buffer, and the broadcaster SHALL drop events for any subscriber whose buffer is full rather than blocking the daemon. A subscriber that has dropped events recovers by reconnecting and replaying from its cursor (or via resync if the cursor has aged out).
+
+#### Scenario: Slow subscriber does not stall the daemon
+
+- **WHEN** a subscriber's backlog buffer is full and a new event is broadcast
+- **THEN** the event is dropped for that subscriber and the broadcast to other subscribers and the daemon proceeds without blocking
+
+### Requirement: Subscriber lifecycle cleanup on disconnect
+
+The stream SHALL register each connection as a subscriber on connect and SHALL deregister it when the client disconnects or the request context is cancelled, so that subscriber resources do not leak after a client goes away.
+
+#### Scenario: Disconnect deregisters the subscriber
+
+- **WHEN** a connected SSE client cancels its request and closes the connection
+- **THEN** the subscriber is removed and the active subscriber count returns to zero

--- a/openspec/specs/fork-create/spec.md
+++ b/openspec/specs/fork-create/spec.md
@@ -1,0 +1,122 @@
+# Fork / Create Task
+
+## Purpose
+
+This capability lets a user duplicate an existing task into a fresh worktree, carrying forward the source agent's recent output and code changes as on-disk context files so a new agent session can pick up where the previous one left off. The goal is continuity: a fork starts with the original prompt plus a curated summary of what the previous attempt did, optionally retargeted to a different project.
+
+## Requirements
+
+### Requirement: Fork confirmation and project selection
+
+The fork modal SHALL confirm intent before forking and SHALL let the user choose the destination project, defaulting to the source task's project. Pressing Enter (outside autocomplete) SHALL confirm; Escape or Ctrl+Q SHALL cancel. A typeahead SHALL match project names case-insensitively, and the resolved project SHALL be empty when the typed text matches no known project.
+
+#### Scenario: Confirm with Enter
+
+- **WHEN** the user presses Enter while the project autocomplete is closed
+- **THEN** the modal reports confirmed and not canceled
+
+#### Scenario: Cancel with Escape or Ctrl+Q
+
+- **WHEN** the user presses Escape or Ctrl+Q
+- **THEN** the modal reports canceled and not confirmed
+
+#### Scenario: Project defaults to source
+
+- **WHEN** the fork modal opens for a task whose project is "alpha"
+- **THEN** the resolved selected project is "alpha" without any typing
+
+#### Scenario: Change destination project via typeahead
+
+- **WHEN** the user clears the input, types a substring matching another project, and accepts the autocomplete match
+- **THEN** the resolved selected project becomes that matched project and the Enter that accepted the match does NOT also confirm the fork
+
+#### Scenario: Unknown project resolves empty
+
+- **WHEN** the typed project text matches no known project name (case-insensitively)
+- **THEN** the resolved selected project is the empty string
+
+### Requirement: Fork context extraction
+
+Forking SHALL extract context from the source task: its name, original prompt, status, and branch, plus the tail of its session output (ANSI/PTY chrome stripped) and the git diff of its worktree. The session-output tail SHALL be capped at 32 KiB and the git diff SHALL be capped at 64 KiB with a truncation marker appended when exceeded. Missing or unreadable sources SHALL yield empty context for that part rather than an error.
+
+#### Scenario: Metadata captured from source
+
+- **WHEN** context is extracted from a source task
+- **THEN** the extracted context carries the source task's name, original prompt, status string, and branch
+
+#### Scenario: Missing session log yields empty output
+
+- **WHEN** the source task has no readable session log
+- **THEN** the extracted recent output is the empty string
+
+#### Scenario: Oversized git diff is truncated
+
+- **WHEN** the source worktree's git diff exceeds the 64 KiB cap
+- **THEN** the captured diff is truncated to the cap and a truncation marker is appended
+
+#### Scenario: Diff only read from a valid worktree
+
+- **WHEN** the source worktree path is not within a known worktree root
+- **THEN** no git diff is captured and the captured diff is the empty string
+
+### Requirement: Context-file injection into the destination worktree
+
+When a fork is created, context files SHALL be written under a `.context/` directory in the destination worktree before the new agent starts. A `fork-source.md` file SHALL always be written containing the source name, status, branch (when present), and the original prompt. A `fork-output.md` file SHALL be written only when recent output was captured, and a `fork-diff.patch` file SHALL be written only when a git diff was captured.
+
+#### Scenario: All context files written
+
+- **WHEN** the extracted context includes recent output and a git diff
+- **THEN** `.context/fork-source.md`, `.context/fork-output.md`, and `.context/fork-diff.patch` are all written into the destination worktree
+
+#### Scenario: Empty parts are skipped
+
+- **WHEN** the extracted context has no recent output and no git diff
+- **THEN** `.context/fork-source.md` is written but `.context/fork-output.md` and `.context/fork-diff.patch` are NOT created
+
+### Requirement: Forked task prompt construction
+
+The forked task's prompt SHALL instruct the new agent to continue prior work, reference only the `.context/` files that were actually written, and include the source task's original prompt. When the destination project differs from the source project, the prompt SHALL include a note naming both the source and destination projects.
+
+#### Scenario: Prompt references only written files
+
+- **WHEN** the prompt is built with both recent output and a git diff present
+- **THEN** the prompt references `.context/fork-source.md`, `.context/fork-output.md`, and `.context/fork-diff.patch` and includes the original prompt
+
+#### Scenario: Prompt omits absent files
+
+- **WHEN** the prompt is built with no recent output and no git diff
+- **THEN** the prompt references `.context/fork-source.md` but does NOT reference `fork-output.md` or `fork-diff.patch`
+
+#### Scenario: Cross-project fork note
+
+- **WHEN** the destination project differs from the source project
+- **THEN** the prompt includes a note naming the source project and the destination project
+
+#### Scenario: Same-project fork has no note
+
+- **WHEN** the destination project equals the source project
+- **THEN** the prompt includes no project-change note
+
+### Requirement: Fork creation via REST API
+
+The REST API SHALL fork a task by source id, defaulting the new task's name to "<source>-fork", its prompt to the source prompt, and its project to the source project when those fields are omitted. The fork SHALL inherit the source task's backend. A fork request whose resolved project is empty SHALL be rejected, and a request for an unknown source id SHALL return not-found. On success the API SHALL create the task and emit a task-forked event carrying the parent-to-child linkage.
+
+#### Scenario: Defaults applied for omitted fields
+
+- **WHEN** a fork request omits name, prompt, and project for an existing source task
+- **THEN** the new task's name is the source name suffixed with "-fork", its prompt is the source prompt, its project is the source project, and it inherits the source backend
+
+#### Scenario: Empty project rejected
+
+- **WHEN** the fork request's project is empty and the source task has no project
+- **THEN** the API responds with a client error indicating the project is required
+
+#### Scenario: Unknown source not found
+
+- **WHEN** the fork request targets a task id that does not exist
+- **THEN** the API responds with not-found and creates no task
+
+#### Scenario: Fork event emitted on success
+
+- **WHEN** a fork is created successfully
+- **THEN** a task-forked event is emitted carrying the source task id and the new task id

--- a/openspec/specs/forms-and-modals/spec.md
+++ b/openspec/specs/forms-and-modals/spec.md
@@ -1,0 +1,254 @@
+# Forms and Modals
+
+## Purpose
+
+This capability covers the keyboard-driven modal overlays the TUI presents for creating and editing tasks, projects, and schedules, for renaming tasks, for bulk-importing git repositories, and for picking AppleEvent allowlist entries and links. Each modal is a centered overlay that collects input, reports a terminal outcome (submitted or canceled) to its host, and exposes the collected values. Every modal that accepts typed text must also accept bracketed paste so multi-character clipboard content is inserted as a single operation rather than being silently dropped.
+
+## Requirements
+
+### Requirement: Modal outcome reporting
+
+Every form and picker modal SHALL expose its terminal state so the host can tell whether the user submitted or dismissed it, and a freshly constructed modal SHALL report neither outcome until the user acts.
+
+#### Scenario: Newly constructed modal is neither done nor canceled
+
+- **WHEN** a form or picker modal is constructed
+- **THEN** it reports that it is neither submitted nor canceled
+
+#### Scenario: Escape or Ctrl+Q dismisses a modal
+
+- **WHEN** the user presses Escape or Ctrl+Q on a form or picker modal (and no autocomplete dropdown is consuming the key)
+- **THEN** the modal reports that it was canceled
+
+### Requirement: New-task form submission
+
+The new-task form SHALL produce a task only when a known project is selected and the prompt is non-empty, and SHALL surface an error and remain open otherwise. The submitted task SHALL carry the resolved project, the resolved branch, the selected backend, the trimmed prompt, an auto-generated name derived from the prompt, and pending status.
+
+#### Scenario: Submit with unknown project
+
+- **WHEN** the user submits the prompt field while the project text matches no known project
+- **THEN** the form sets an "Unknown project" error and does not mark itself done
+
+#### Scenario: Submit with empty prompt
+
+- **WHEN** the project resolves to a known project but the prompt is empty
+- **THEN** the form does not mark itself done
+
+#### Scenario: Successful submission
+
+- **WHEN** the project resolves and the prompt is non-empty and the user submits
+- **THEN** the form marks itself done and yields a pending task with the resolved project, resolved branch, selected backend, and trimmed prompt
+
+#### Scenario: Branch falls back to project default
+
+- **WHEN** the branch field is left empty and the resolved project has a configured default branch
+- **THEN** the resolved branch is the project's configured default branch
+
+### Requirement: Project typeahead resolution
+
+The new-task form SHALL resolve a typed project name to a known project by exact match or case-insensitive match, and SHALL resolve to no project when the text matches nothing. Changing the project SHALL reset the branch field to the new project's default branch and trigger a fresh branch load.
+
+#### Scenario: Case-insensitive project match
+
+- **WHEN** the typed project text differs only in letter case from a known project name
+- **THEN** the form resolves it to that known project
+
+#### Scenario: Unrecognized project text
+
+- **WHEN** the typed project text matches no known project name
+- **THEN** the form resolves to no project
+
+#### Scenario: Project change resets branch
+
+- **WHEN** the selected project changes
+- **THEN** the branch input is replaced with the new project's default branch and the branch options are reloaded
+
+### Requirement: Skill autocomplete in the prompt
+
+The new-task form SHALL offer skill autocomplete when the space-delimited token at the cursor begins with the backend-specific trigger character, using "$" for Codex backends and "/" for all others. Accepting a suggestion SHALL replace the triggering token with the trigger plus the skill name and a trailing space; pressing Tab in the prompt while the dropdown is open SHALL accept the suggestion without advancing focus.
+
+#### Scenario: Trigger character selects autocomplete prefix
+
+- **WHEN** the prompt cursor sits within a token starting with "/" on a non-Codex backend (or "$" on a Codex backend) that matches at least one skill
+- **THEN** the autocomplete dropdown opens with the matching skills
+
+#### Scenario: Accept replaces the token
+
+- **WHEN** the user accepts a skill suggestion
+- **THEN** the triggering token is replaced with the trigger character, the skill name, and a trailing space
+
+#### Scenario: Tab accepts without advancing focus
+
+- **WHEN** the prompt field is focused, the skill dropdown is open, and the user presses Tab
+- **THEN** the suggestion is accepted and focus stays on the prompt field
+
+### Requirement: Project form result normalization
+
+The project form SHALL return the entered project name and a project config whose path is trimmed, tilde-expanded, and absolutized, and whose branch is the selected option when a branch selector is active or the typed text otherwise. In edit mode the name field SHALL be read-only and the form SHALL skip it during navigation.
+
+#### Scenario: Path is absolutized in the result
+
+- **WHEN** the form is submitted with a non-empty path entry
+- **THEN** the returned project path is tilde-expanded and converted to an absolute path
+
+#### Scenario: Branch selector value wins
+
+- **WHEN** branch options have been loaded and a selection is made
+- **THEN** the returned branch is the selected branch option
+
+#### Scenario: Name is immutable in edit mode
+
+- **WHEN** the form is in edit mode and the user types into or pastes onto the name field
+- **THEN** the name value is unchanged
+
+### Requirement: Project form branch loading
+
+The project form SHALL render the branch field as a left/right selector once branch options are supplied and as a free-text input otherwise. It SHALL request branch options when focus reaches the branch field and the path has changed since the last load, and SHALL pre-select the option matching the current branch value.
+
+#### Scenario: Branch options trigger selector mode
+
+- **WHEN** branch options are supplied to the form
+- **THEN** the branch field renders as a left/right selector and pre-selects the option equal to the current branch value when one matches
+
+#### Scenario: No loader keeps text input
+
+- **WHEN** no branch loader is configured and focus reaches the branch field
+- **THEN** the branch field remains a free-text input that records typed characters into the result
+
+#### Scenario: Cycling selector options
+
+- **WHEN** the branch selector is focused and the user presses left or right
+- **THEN** the selected branch index cycles through the options and wraps at the ends
+
+### Requirement: Quick-add directory scan and selection
+
+The quick-add form SHALL operate in two phases: a directory-input phase that triggers a background scan on submit, and a selection phase that lists discovered git repositories with toggleable checkboxes. Submitting the directory phase with empty input SHALL surface an error; submitting the selection phase with nothing selected SHALL surface an error; an empty scan result SHALL surface a "no new repos" error and remain in the directory phase.
+
+#### Scenario: Empty directory input rejected
+
+- **WHEN** the user submits the directory phase with an empty path
+- **THEN** the form sets an error prompting for a directory and does not start a scan
+
+#### Scenario: Scan results advance to selection
+
+- **WHEN** a background scan returns one or more repositories
+- **THEN** the form moves to the selection phase listing those repositories with all pre-selected
+
+#### Scenario: Submitting with no selection rejected
+
+- **WHEN** the user submits the selection phase with no repository selected
+- **THEN** the form sets a "no repos selected" error and does not mark itself done
+
+#### Scenario: Select-all and deselect-all
+
+- **WHEN** the user presses the select-all or deselect-all key in the selection phase
+- **THEN** every listed repository becomes selected or deselected respectively
+
+### Requirement: Schedule form values
+
+The schedule form SHALL collect a name, project, backend, cron schedule, prompt, and enabled flag, defaulting the schedule to a daily expression and the enabled flag to on for new schedules. Project, backend, and enabled SHALL be cycling selectors; submission SHALL be available via Ctrl+S or by acting on the final selector, and the returned schedule SHALL trim the name and schedule fields while preserving the prompt verbatim.
+
+#### Scenario: New schedule defaults
+
+- **WHEN** a new schedule form is constructed
+- **THEN** the schedule field defaults to a daily expression and the enabled flag is on
+
+#### Scenario: Ctrl+S submits
+
+- **WHEN** the user presses Ctrl+S on the schedule form
+- **THEN** the form marks itself done
+
+#### Scenario: Selector fields cycle
+
+- **WHEN** a selector field (project, backend, or enabled) is focused and the user presses left or right
+- **THEN** the corresponding selection cycles and wraps
+
+### Requirement: Rename task form
+
+The rename-task form SHALL be a single text field pre-populated with the current name and with the cursor at the end. Pressing Enter SHALL mark it done; the host can clear the done flag to keep it open after a rejected rename, and the form SHALL expose the current name text.
+
+#### Scenario: Pre-populated name
+
+- **WHEN** the rename form is constructed with an existing name
+- **THEN** the field contains that name and the cursor is positioned at the end
+
+#### Scenario: Enter submits the new name
+
+- **WHEN** the user edits the field and presses Enter
+- **THEN** the form marks itself done and exposes the edited name
+
+### Requirement: Bracketed paste support
+
+Every modal that accepts typed text SHALL implement a paste handler that inserts the entire pasted text at the cursor in a single operation. Paste SHALL be ignored on selector fields and on read-only fields, and filter inputs that must stay single-line SHALL strip embedded newline and carriage-return characters from pasted text.
+
+#### Scenario: Paste inserts at the cursor
+
+- **WHEN** text is pasted into a focused text field
+- **THEN** the entire pasted text is inserted at the cursor position and the cursor advances past it
+
+#### Scenario: Paste ignored on a selector or read-only field
+
+- **WHEN** text is pasted while a selector field or a read-only field is focused
+- **THEN** the field value is unchanged
+
+#### Scenario: Single-line filter strips newlines
+
+- **WHEN** multi-line text is pasted into a single-line filter input
+- **THEN** newline and carriage-return characters are dropped and the remaining characters are appended
+
+### Requirement: AppleEvents allowlist picker
+
+The AppleEvents picker SHALL present a filterable, multi-select list of scriptable apps, pre-populated from a project's existing allowlist, with selections that persist across filter changes. When the trimmed filter is a syntactically valid dotted bundle identifier that matches no scanned app and is not already selected, the picker SHALL offer a synthetic "Add custom" row for it. The confirmed result SHALL be the selected bundle identifiers in a deterministic sorted order.
+
+#### Scenario: Selection survives filtering
+
+- **WHEN** a row is toggled selected and the filter is then changed to hide it
+- **THEN** the bundle identifier remains in the selected set
+
+#### Scenario: Custom bundle id suggestion
+
+- **WHEN** the filter is a valid dotted bundle identifier matching no scanned app and not already selected
+- **THEN** the picker appends a synthetic "Add custom" row that can be toggled
+
+#### Scenario: Result is sorted
+
+- **WHEN** the user confirms the picker
+- **THEN** the result lists the selected bundle identifiers in sorted order
+
+### Requirement: Fuzzy link picker
+
+The link picker SHALL present a filterable list of links matched by fuzzy subsequence matching against each link's URL and label, and SHALL report a selection only when a link is highlighted and confirmed. Confirming with no matches SHALL not produce a selection.
+
+#### Scenario: Fuzzy filter narrows the list
+
+- **WHEN** the user types a query
+- **THEN** the visible list is limited to links whose URL or label contains the query characters in order, case-insensitively
+
+#### Scenario: Confirm with matches selects
+
+- **WHEN** the user presses Enter while at least one link matches the current query
+- **THEN** the picker reports a selection and exposes the highlighted link
+
+#### Scenario: Confirm with no matches does nothing
+
+- **WHEN** the user presses Enter while no link matches the current query
+- **THEN** the picker does not report a selection
+
+### Requirement: Directory autocomplete
+
+Path and directory input fields SHALL offer directory completions resolved to absolute paths, expanding a leading tilde and excluding hidden directories. The dropdown SHALL open only when completions exist, SHALL not appear when the input already exactly matches the sole completion, and Tab SHALL trigger then accept a completion in a single keystroke when the dropdown is closed.
+
+#### Scenario: Completions are absolute and exclude hidden dirs
+
+- **WHEN** completions are computed for a directory input
+- **THEN** the matches are absolute paths and directories whose names begin with a dot are excluded
+
+#### Scenario: Tab triggers and accepts
+
+- **WHEN** the user presses Tab on a path field with the dropdown closed and completions are available
+- **THEN** the autocomplete is opened and the top match is accepted into the field
+
+#### Scenario: No dropdown for exact sole match
+
+- **WHEN** the input already exactly equals the only available completion
+- **THEN** no completion dropdown is shown

--- a/openspec/specs/git-integration/spec.md
+++ b/openspec/specs/git-integration/spec.md
@@ -1,0 +1,216 @@
+# Git Integration
+
+## Purpose
+
+Surface the git state of each task's worktree inside the TUI: which files changed, a diff summary, the per-branch diff against the merge-base, and per-file unified diffs rendered side-by-side. Git inspection runs entirely off the UI thread via background goroutines that deliver results as messages, so the interface never blocks on a slow `git` invocation. All operations are read-only inspection of a worktree; they never mutate repository state.
+
+## Requirements
+
+### Requirement: Worktree status, summary, and branch-diff capture
+
+The system SHALL collect a worktree's short status, a working-tree diff summary, and a per-branch diff against the merge-base in a single fetch, returning a result tagged with the originating task ID. When no worktree path is supplied the result SHALL be empty except for the task ID, and individual git command failures SHALL leave their corresponding fields empty rather than aborting the whole fetch.
+
+#### Scenario: No worktree path
+
+- **WHEN** a status fetch is requested with an empty worktree path and task ID "task-1"
+- **THEN** the result carries task ID "task-1" with empty status, diff, and branch-diff fields
+
+#### Scenario: Clean repository
+
+- **WHEN** a status fetch runs against a worktree with no changes
+- **THEN** the status field is empty and the result is tagged with the requesting task ID
+
+#### Scenario: Dirty worktree
+
+- **WHEN** a tracked file is modified and an untracked file is added in the worktree
+- **THEN** the status field references both files and the diff summary references the modified file
+
+#### Scenario: Branch with an extra commit
+
+- **WHEN** the worktree is on a branch that has one commit beyond the merge-base
+- **THEN** the branch-diff summary and the branch file list both reference the file changed by that commit
+
+### Requirement: Merge-base resolution with upstream and default-branch fallback
+
+The system SHALL determine the comparison base for branch diffs by first trying the branch's configured upstream, then falling back to a `master` branch, then a `main` branch. When none of these resolve (for example, the path is not a git repository), the system SHALL yield an empty base and skip branch-diff collection.
+
+#### Scenario: No merge base available
+
+- **WHEN** merge-base resolution runs against a path that is not a git repository
+- **THEN** the resolved base is empty
+
+#### Scenario: Falls back to master
+
+- **WHEN** a feature branch has no upstream configured but a `master` branch exists
+- **THEN** a non-empty merge-base is resolved
+
+#### Scenario: Falls back to main when master is absent
+
+- **WHEN** a feature branch has no upstream and only a `main` branch exists
+- **THEN** a non-empty merge-base is resolved
+
+### Requirement: Per-file diff with uncommitted, branch, and untracked fallbacks
+
+The system SHALL produce a unified diff for a single file, preferring the uncommitted (working-tree) diff; if that is empty it SHALL fall back to the committed branch diff against the merge-base; and if that is also empty it SHALL show the file's full contents as an added diff so untracked files are still viewable. An empty worktree path or empty file path SHALL yield an empty diff.
+
+#### Scenario: Empty inputs
+
+- **WHEN** a file diff is requested with an empty worktree path, or with an empty file path
+- **THEN** the returned diff is empty
+
+#### Scenario: Uncommitted modification
+
+- **WHEN** a tracked file has uncommitted edits
+- **THEN** the returned diff references the file and includes the changed content
+
+#### Scenario: Untracked file
+
+- **WHEN** a file diff is requested for an untracked file
+- **THEN** the returned diff references the file's contents as an addition
+
+#### Scenario: Branch-only commit
+
+- **WHEN** a file was changed only by a commit on the current branch with no uncommitted edits
+- **THEN** the returned diff against the merge-base references the file
+
+### Requirement: Directory file listing with path-traversal protection
+
+The system SHALL list the untracked and modified files within a directory of the worktree, respecting gitignore rules, and SHALL annotate each entry with its actual git status code. The resolved directory path MUST remain inside the worktree; any path that escapes the worktree (for example via `..`) SHALL be rejected with an empty result, as SHALL an empty worktree path or empty directory path.
+
+#### Scenario: Path traversal rejected
+
+- **WHEN** a directory listing is requested for a path that resolves outside the worktree (e.g. "../escape")
+- **THEN** the result contains no files
+
+#### Scenario: Empty inputs
+
+- **WHEN** a directory listing is requested with an empty worktree path, or with an empty directory path
+- **THEN** the result contains no files
+
+#### Scenario: Lists changed and untracked files
+
+- **WHEN** a subdirectory contains a modified tracked file and a new untracked file
+- **THEN** the result includes both files, each carrying its git status
+
+### Requirement: Parsing git status and name-status output
+
+The system SHALL parse `git status --short` and `git diff --name-status` output into changed-file entries carrying a status code, a path, and a directory flag (set when the path ends in a separator). Empty input SHALL produce no entries; malformed lines (status output shorter than the minimum length, or name-status lines lacking a tab separator) SHALL be skipped rather than producing garbage entries.
+
+#### Scenario: Parse short status
+
+- **WHEN** parsing short-status output containing a modified file, an untracked file, and an added file
+- **THEN** each produces an entry with the correct status code and path
+
+#### Scenario: Empty status input
+
+- **WHEN** parsing an empty status string
+- **THEN** no entries are produced
+
+#### Scenario: Malformed lines skipped
+
+- **WHEN** parsing name-status output that contains a line with no tab separator alongside a valid entry
+- **THEN** only the valid entry is produced
+
+### Requirement: Merging committed and uncommitted changed-file lists
+
+The system SHALL merge a base changed-file list with an overlay list into a single deduplicated list sorted by path, where the overlay entry wins when the same path appears in both. This lets the file view present the full picture of branch changes (committed) plus working-tree changes (uncommitted) without duplicates. Merging two empty lists SHALL yield nothing.
+
+#### Scenario: Overlay wins on conflict
+
+- **WHEN** the same path appears in both the base and overlay lists with different statuses
+- **THEN** the merged list contains one entry for that path carrying the overlay's status
+
+#### Scenario: Both lists empty
+
+- **WHEN** both the base and overlay lists are empty
+- **THEN** the merged result is empty
+
+### Requirement: Unified diff parsing into structured hunks
+
+The system SHALL parse raw unified-diff text into a structured form exposing the old and new file names (with `a/` and `b/` prefixes stripped) and a sequence of hunks, each carrying its header, old/new line ranges, and classified content lines (context, added, removed) with correct old/new line numbers. Hunk headers with missing or zero ranges SHALL default to a start of 1 and a count of 1; the "No newline at end of file" marker SHALL NOT be emitted as a content line; and tabs in content SHALL be expanded to spaces.
+
+#### Scenario: Parse a hunk
+
+- **WHEN** parsing a unified diff for "file.go" with one hunk containing context, removed, and added lines
+- **THEN** the parsed result reports both file names as "file.go" and a single hunk whose classified lines are recovered
+
+#### Scenario: Hunk-range defaults
+
+- **WHEN** parsing a hunk header that is malformed or specifies a zero start
+- **THEN** the hunk's old and new starts default to 1
+
+#### Scenario: No-newline marker excluded
+
+- **WHEN** parsing a diff that contains a "No newline at end of file" marker line
+- **THEN** that marker is not present as a content line in the hunk
+
+### Requirement: Side-by-side diff layout
+
+The system SHALL convert parsed diff hunks into side-by-side rows for display, emitting each hunk's header as a row, a separator between consecutive hunks, context lines on both sides, and pairing each run of removed lines against the following run of added lines so changes align left-to-right. The system SHALL also format line numbers to a fixed width (blank when zero, right-truncated to the last digits when too wide).
+
+#### Scenario: Build side-by-side rows
+
+- **WHEN** converting a parsed diff with a removed line, an added line, and a context line into side-by-side rows
+- **THEN** the first row is the hunk header and subsequent rows pair the change and carry the context
+
+#### Scenario: Line-number formatting
+
+- **WHEN** formatting line number 0 to width 4
+- **THEN** the result is four blank spaces
+
+#### Scenario: Wide line-number truncation
+
+- **WHEN** formatting line number 123456 to width 3
+- **THEN** the result is the last three digits ("456")
+
+### Requirement: Intra-line word diff
+
+The system SHALL compute the changed character ranges between an old and a new line by tokenizing into word and non-word chunks, matching them via longest-common-subsequence, and mapping the unmatched tokens back to rune-offset spans (merging consecutive unmatched tokens into a single span). Identical lines SHALL produce no spans.
+
+#### Scenario: Identical lines
+
+- **WHEN** computing the word diff of two identical lines
+- **THEN** no change spans are produced for either side
+
+#### Scenario: Single word change
+
+- **WHEN** the old line is "hello world" and the new line is "hello earth"
+- **THEN** the changed span on each side covers only the differing word
+
+#### Scenario: Consecutive unmatched tokens merged
+
+- **WHEN** several adjacent tokens differ between the old and new lines
+- **THEN** they are reported as a single merged change span
+
+### Requirement: Remote branch enumeration with priority ordering
+
+The system SHALL enumerate remote-tracking branch names for a repository, excluding any `HEAD` pseudo-ref, and SHALL order them with the preferred branches (`upstream/master`, `origin/master`, `upstream/main`, `origin/main`, in that order) first, followed by the remaining branches sorted alphabetically. An empty path, or a path that is not a git repository, SHALL yield nothing.
+
+#### Scenario: Priority ordering
+
+- **WHEN** enumerating branches that include `origin/master` and `origin/HEAD` plus other branches
+- **THEN** `origin/master` appears first and `origin/HEAD` is excluded
+
+#### Scenario: No git repository
+
+- **WHEN** enumerating branches for an empty path or a path that is not a git repository
+- **THEN** the result is empty
+
+### Requirement: Git status panel rendering
+
+The git status panel SHALL render a bordered "Git Status" view showing a "Loading..." placeholder before any data is set; once loaded it SHALL show non-empty Files, Diff, and Branch sections, render an empty-state message when all sections are empty, and color status lines by their status code (modified, added/untracked, deleted). Long lines SHALL be truncated with an ellipsis to fit the panel width.
+
+#### Scenario: Initial and loaded state
+
+- **WHEN** the panel is created and then given status, diff, and branch content
+- **THEN** it transitions from not-loaded to loaded and retains the parsed section line counts
+
+#### Scenario: Clearing the panel
+
+- **WHEN** the panel is cleared after holding content
+- **THEN** it returns to the not-loaded state with no section lines
+
+#### Scenario: Long line truncation
+
+- **WHEN** a line wider than the available width is rendered
+- **THEN** it is truncated and the final visible character is an ellipsis

--- a/openspec/specs/idle-detection/spec.md
+++ b/openspec/specs/idle-detection/spec.md
@@ -1,0 +1,170 @@
+# Idle / Needs-Input Detection
+
+## Purpose
+
+When an agent session stops generating and waits for the user, the orchestrator must recognize that the session is blocked so the UI can surface it and so destructive maintenance actions never silently dismiss a pending question. This capability defines how recent agent output is inspected to decide whether the agent is waiting on user input, and how that decision gates a width-driven session restart ("rerender kick") that would otherwise discard an in-flight prompt.
+
+## Requirements
+
+### Requirement: Needs-input detection from recent output
+
+The system SHALL determine whether an agent is blocked waiting for the user by inspecting only the most recent window of its output. Detection MUST fire on either of two signals: the agent's numbered-selection prompt UI, or the agent's last visible transcript line ending with a question mark. Empty output SHALL never be treated as needs-input.
+
+#### Scenario: Empty buffer is not blocked
+
+- **WHEN** the output buffer is empty
+- **THEN** the system reports the agent is not waiting for input
+
+#### Scenario: Plain output is not blocked
+
+- **WHEN** the recent output contains only ordinary work output with no selection prompt and no trailing question
+- **THEN** the system reports the agent is not waiting for input
+
+### Requirement: Selection-prompt UI is recognized regardless of wording or surrounding markup
+
+The system SHALL treat the agent's numbered-selection widget as a needs-input signal whenever the visible text shows the selection cursor immediately followed (with zero or more spaces/tabs) by the first numbered option. Detection MUST be based on this shared UI shape, not on any specific prompt wording, so permission prompts, edit confirmations, plan-mode confirms, and open-ended multiple-choice questions are all caught. Detection MUST survive interleaved color/escape sequences and cursor-positioning codes that produce a visible gap without any literal space byte.
+
+#### Scenario: Permission prompt with a numbered selection
+
+- **WHEN** the recent output ends with a selection cursor followed by a numbered list of options
+- **THEN** the system reports the agent is waiting for input
+
+#### Scenario: Open-ended question with a numbered selection but no fixed phrasing
+
+- **WHEN** the selection widget appears without any "Do you want to" phrasing
+- **THEN** the system reports the agent is waiting for input
+
+#### Scenario: Selection markup split by color escapes
+
+- **WHEN** the cursor and the first option are separated only by color escape sequences and a literal space
+- **THEN** the system reports the agent is waiting for input
+
+#### Scenario: Selection markup with cursor-positioning instead of a space
+
+- **WHEN** the cursor and the first option are separated by a cursor-positioning escape and no literal space byte exists between them
+- **THEN** the system reports the agent is waiting for input
+
+#### Scenario: A bare selection cursor without a numbered option does not fire
+
+- **WHEN** the output contains the selection cursor glyph but it is not followed by a numbered option
+- **THEN** the system reports the agent is not waiting for input
+
+#### Scenario: A plain numbered list without the selection cursor does not fire
+
+- **WHEN** the output contains a numbered list with no selection cursor preceding the first item
+- **THEN** the system reports the agent is not waiting for input
+
+### Requirement: Trailing-question detection is anchored to the input prompt box
+
+The system SHALL treat the agent as waiting for input when the last non-blank line of the transcript above the rendered input prompt box ends with a question mark (ASCII `?` or full-width `？`). The search MUST be anchored to the prompt-box opener so that hint lines rendered below the box are excluded. Blank lines between the transcript and the prompt box MUST be skipped. When no prompt box is present in the recent output, the trailing-question signal SHALL NOT fire.
+
+#### Scenario: Question above the prompt box fires
+
+- **WHEN** the last content line above the input prompt box ends with a question mark
+- **THEN** the system reports the agent is waiting for input
+
+#### Scenario: Statement above the prompt box does not fire
+
+- **WHEN** the last content line above the input prompt box does not end with a question mark
+- **THEN** the system reports the agent is not waiting for input
+
+#### Scenario: Full-width question mark fires
+
+- **WHEN** the last content line above the prompt box ends with a full-width question mark
+- **THEN** the system reports the agent is waiting for input
+
+#### Scenario: Hint lines below the prompt box are ignored
+
+- **WHEN** a statement sits above the prompt box and only a hint line containing a question mark sits below it
+- **THEN** the system reports the agent is not waiting for input
+
+#### Scenario: Trailing whitespace after the question mark still fires
+
+- **WHEN** the last content line ends with a question mark followed by trailing whitespace
+- **THEN** the system reports the agent is waiting for input
+
+#### Scenario: Blank lines between transcript and prompt box are skipped
+
+- **WHEN** multiple blank lines separate the trailing question from the prompt box
+- **THEN** the system reports the agent is waiting for input
+
+#### Scenario: No prompt box present skips the question heuristic
+
+- **WHEN** the output contains a trailing question but no rendered input prompt box
+- **THEN** the system reports the agent is not waiting for input
+
+### Requirement: Detection scans only a bounded recent tail
+
+The system SHALL only inspect a bounded window at the end of the output buffer. Signals appearing only in output older than this window SHALL NOT be detected, while a signal landing at the very end of the buffer MUST be detected even when far more older output precedes it.
+
+#### Scenario: Signal at the end of a large buffer is detected
+
+- **WHEN** the selection prompt appears at the very end of a buffer larger than the scan window
+- **THEN** the system reports the agent is waiting for input
+
+#### Scenario: Signal older than the scan window is not detected
+
+- **WHEN** the selection prompt appears only at the start of a buffer and is followed by more output than the scan window
+- **THEN** the system reports the agent is not waiting for input
+
+### Requirement: Session-level blocked check over the live output ring
+
+The system SHALL expose a session-level check that reports whether a given session is blocked on a user prompt by applying needs-input detection to that session's recent output tail. A nil session SHALL never be reported as blocked. This check is intended to be paired with an idle check by the caller, because a prompt the agent is still streaming past is not blocking.
+
+#### Scenario: Nil session is not blocked
+
+- **WHEN** the blocked check is given no session
+- **THEN** the system reports the session is not blocked
+
+#### Scenario: Session with plain output is not blocked
+
+- **WHEN** a session's recent output contains only ordinary work output
+- **THEN** the system reports the session is not blocked
+
+#### Scenario: Session showing a selection overlay is blocked
+
+- **WHEN** a session's recent output shows the numbered-selection prompt UI
+- **THEN** the system reports the session is blocked
+
+### Requirement: Rerender kick is gated on idle and needs-input state
+
+The system SHALL decide whether to stop-and-resume a session to re-render its scrollback at a new terminal width based on, in order: whether a kick is possible at all, whether the width change is large enough to matter, whether the agent is idle, and whether the agent is blocked on a user prompt. A kick SHALL be skipped entirely when there is no session to resume or a kick is already in flight. A kick SHALL be skipped when the width change is below the configured margin. When the change is large enough but the agent is not idle, the decision SHALL be to defer because the agent is busy. When the change is large enough and the agent is idle but blocked on a user prompt, the decision SHALL be to defer because of the prompt, so that resuming the session does not silently dismiss the pending question. Only when all gates pass SHALL the decision be to kick.
+
+#### Scenario: No session to resume skips the kick
+
+- **WHEN** there is no session to resume (or a kick is already pending)
+- **THEN** the decision is to skip
+
+#### Scenario: Below-margin width change skips the kick
+
+- **WHEN** the difference between the panel width and the session's initial width is smaller than the margin
+- **THEN** the decision is to skip
+
+#### Scenario: Busy agent defers the kick
+
+- **WHEN** the width change exceeds the margin but the agent is not idle
+- **THEN** the decision is to defer because the agent is busy
+
+#### Scenario: Idle agent blocked on a prompt defers the kick
+
+- **WHEN** the width change exceeds the margin and the agent is idle but is blocked on a user prompt
+- **THEN** the decision is to defer because of the prompt
+
+#### Scenario: All gates pass triggers the kick
+
+- **WHEN** the width change exceeds the margin, the agent is idle, and it is not blocked on a prompt
+- **THEN** the decision is to stop and resume the session
+
+### Requirement: Width-margin threshold treats unknown initial width as sane
+
+The system SHALL compute whether a width change is large enough to justify a kick from the absolute difference between the panel width and the session's recorded initial width, using a fixed minimum margin. An unknown initial width (reported as zero or less) SHALL be treated as already sane so that it never triggers a surprise restart.
+
+#### Scenario: Unknown initial width never exceeds the threshold
+
+- **WHEN** the session's initial width is unknown
+- **THEN** the system reports the margin threshold is not exceeded
+
+#### Scenario: Width difference at or above the margin exceeds the threshold
+
+- **WHEN** the absolute difference between panel width and initial width is at least the margin
+- **THEN** the system reports the margin threshold is exceeded

--- a/openspec/specs/knowledge-base/spec.md
+++ b/openspec/specs/knowledge-base/spec.md
@@ -1,0 +1,227 @@
+# Knowledge Base
+
+## Purpose
+
+The knowledge base provides a searchable, full-text index over a vault of Obsidian-style markdown documents. It parses each markdown file's YAML frontmatter and body into a structured document, keeps the index continuously synchronized with the files on disk, and exposes search, list, ingest, and status operations so users and agents can find and retrieve stored knowledge.
+
+## Requirements
+
+### Requirement: Markdown document parsing
+
+The system SHALL parse a markdown file into a document with a title, tag list, body, word count, and tier. The title SHALL be resolved by precedence: YAML frontmatter `title`, then the first H1 heading in the body, then the filename stem (without the `.md` extension). The body SHALL exclude any frontmatter block. Newly parsed documents SHALL be assigned the tier `hot`.
+
+#### Scenario: Title from frontmatter
+
+- **WHEN** a document contains YAML frontmatter with a `title` field
+- **THEN** the parsed document's title is taken from that field and the body excludes the frontmatter block
+
+#### Scenario: Title falls back to first H1
+
+- **WHEN** a document has no frontmatter title but the body contains an H1 heading
+- **THEN** the parsed document's title is the text of that H1 heading
+
+#### Scenario: Title falls back to filename stem
+
+- **WHEN** a document has neither a frontmatter title nor an H1 heading
+- **THEN** the parsed document's title is the filename with the `.md` extension stripped
+
+#### Scenario: Default tier and word count
+
+- **WHEN** a document is parsed
+- **THEN** its tier is `hot` and its word count reflects the number of words in the body
+
+### Requirement: YAML frontmatter extraction
+
+The system SHALL extract `title` and `tags` from a leading YAML frontmatter block delimited by `---` lines, supporting both LF and CRLF line endings. Tags MAY be expressed inline as a bracketed or comma-separated list. When the opening `---` has no matching closing `---`, the system SHALL treat the file as having no frontmatter and return the original content as the body.
+
+#### Scenario: Inline tag list
+
+- **WHEN** frontmatter contains `tags: [alpha, beta]`
+- **THEN** the parsed tags are `alpha` and `beta`
+
+#### Scenario: No frontmatter present
+
+- **WHEN** a document does not begin with a `---` delimiter
+- **THEN** no title or tags are extracted and the body is the full content unchanged
+
+#### Scenario: Malformed frontmatter with no closing delimiter
+
+- **WHEN** a document opens with `---` but never closes the block
+- **THEN** no title or tags are extracted and the body is returned as the full original content unchanged
+
+#### Scenario: CRLF line endings
+
+- **WHEN** the frontmatter block uses `\r\n` line endings
+- **THEN** the title and body are still extracted correctly
+
+### Requirement: Markdown rendering round-trip
+
+The system SHALL render a document back into markdown with a YAML frontmatter block containing the title and, when present, the tags. Titles containing double quotes SHALL be escaped, and tags containing YAML-special characters (comma, closing bracket, quote, backslash) SHALL be quoted. The rendered output SHALL end with a trailing newline. A render followed by a parse SHALL preserve the title, tag count, and body content.
+
+#### Scenario: Render with tags
+
+- **WHEN** a document with a title and tags is rendered
+- **THEN** the output contains the title and tags in the frontmatter and ends with a newline
+
+#### Scenario: Render without tags
+
+- **WHEN** a document has no tags
+- **THEN** the rendered frontmatter contains no `tags` line
+
+#### Scenario: Special characters are escaped
+
+- **WHEN** the title contains a double quote or a tag contains a comma or quote
+- **THEN** the rendered frontmatter escapes the quote in the title and quotes the affected tags
+
+#### Scenario: Round-trip preserves content
+
+- **WHEN** a document is rendered to markdown and that markdown is parsed back
+- **THEN** the parsed title, tag count, and body content match the original document
+
+### Requirement: File ingestion into the index
+
+The system SHALL ingest a markdown file by reading its contents, parsing it into a document, and upserting it into the store keyed by its vault-relative path. The stored path SHALL be the file's path relative to the configured vault root; if a relative path cannot be computed, the original (absolute) path SHALL be used as a fallback. Ingestion SHALL record an ingestion timestamp and a modification timestamp.
+
+#### Scenario: Ingest a file under the vault
+
+- **WHEN** a markdown file inside the vault is ingested
+- **THEN** the store contains a document keyed by the file's vault-relative path with the parsed title, tags, and body
+
+#### Scenario: Missing file fails ingestion
+
+- **WHEN** ingestion targets a path that does not exist on disk
+- **THEN** ingestion returns an error and no document is stored
+
+#### Scenario: Relative-path fallback
+
+- **WHEN** the vault-relative path cannot be computed for an ingested file
+- **THEN** the document is stored under its original path
+
+### Requirement: Full scan of the vault
+
+The system SHALL walk the entire vault and ingest every markdown file. It SHALL only process files whose name ends in `.md` (case-insensitive), and SHALL skip hidden directories (those whose name begins with `.`, such as `.obsidian`, `.git`, `.trash`) and their contents. If the vault root itself is inaccessible, the scan SHALL return an error; errors reading individual sub-paths SHALL be skipped without failing the scan.
+
+#### Scenario: Only markdown files in non-hidden directories are indexed
+
+- **WHEN** a full scan runs over a vault containing markdown files, a non-markdown file, a nested markdown file, and a markdown file inside a hidden directory
+- **THEN** the markdown files in non-hidden directories (including nested ones) are indexed and the non-markdown file and the hidden-directory file are not
+
+#### Scenario: Inaccessible vault root errors
+
+- **WHEN** a full scan targets a vault path that does not exist
+- **THEN** the scan returns an error
+
+### Requirement: Incremental synchronization
+
+The system SHALL synchronize the index against the vault given a map of indexed paths to their stored modification times. For each markdown file on disk, the system SHALL re-ingest it only if it is new or its modification time differs from the stored value, and SHALL skip files whose modification time is unchanged. For each stored path no longer present on disk, the system SHALL delete it from the index; a delete failure SHALL be logged and SHALL NOT abort the synchronization.
+
+#### Scenario: Unchanged file is skipped
+
+- **WHEN** an incremental scan encounters a file whose disk modification time equals the stored modification time
+- **THEN** the file is not re-ingested and its stored document is left untouched
+
+#### Scenario: Modified file is re-ingested
+
+- **WHEN** an incremental scan encounters a file whose disk modification time differs from the stored value
+- **THEN** the file is re-ingested with its updated content
+
+#### Scenario: New file is ingested
+
+- **WHEN** an incremental scan encounters a markdown file not present in the stored metadata
+- **THEN** the file is ingested into the index
+
+#### Scenario: Removed file is deleted
+
+- **WHEN** a stored path is absent from the vault on disk during an incremental scan
+- **THEN** that path is deleted from the index
+
+### Requirement: Continuous file watching
+
+After an initial scan, the system SHALL watch the vault recursively for file changes and keep the index synchronized. Creating or writing an eligible markdown file SHALL ingest it after a debounce delay; removing or renaming an eligible markdown file SHALL delete it from the index. Newly created subdirectories SHALL be added to the watch (excluding hidden directories). Files that are hidden, end in `.icloud`, end in `.tmp`, or are not `.md` SHALL NOT be ingested.
+
+#### Scenario: New file is picked up
+
+- **WHEN** a markdown file is created in the watched vault after the watcher is ready
+- **THEN** the file is ingested into the index after the debounce delay
+
+#### Scenario: Deleted file is removed
+
+- **WHEN** a watched markdown file is removed from disk
+- **THEN** the corresponding document is deleted from the index
+
+#### Scenario: New subdirectory is watched
+
+- **WHEN** a new non-hidden subdirectory is created and a markdown file is added inside it
+- **THEN** the nested file is ingested into the index
+
+#### Scenario: Ineligible files are ignored
+
+- **WHEN** a non-markdown file (or a `.icloud`, `.tmp`, or hidden file) is created in the vault
+- **THEN** it is not ingested into the index
+
+### Requirement: Startup scan strategy
+
+On start, the system SHALL choose a scan strategy based on whether the index already holds documents. If the index is non-empty, it SHALL run a synchronous incremental scan against the existing metadata. If the index is empty, it SHALL run a full scan in the background so startup is not blocked, exposing a flag that reports whether the background scan is still in progress. If no vault path is configured, start SHALL be a no-op that immediately signals readiness. The system SHALL support being stopped, and stopping SHALL be idempotent.
+
+#### Scenario: Empty index triggers background full scan
+
+- **WHEN** start runs against an empty index with a populated vault
+- **THEN** a background full scan runs, the scanning flag is set while it runs, and the vault's documents are present once it completes
+
+#### Scenario: Non-empty index triggers synchronous incremental scan
+
+- **WHEN** start runs against an index that already contains documents
+- **THEN** an incremental scan runs synchronously and the scanning flag is not set
+
+#### Scenario: No configured vault path
+
+- **WHEN** start runs with an empty vault path
+- **THEN** it returns without error and immediately signals readiness
+
+#### Scenario: Metadata lookup failure aborts start
+
+- **WHEN** start cannot read the index metadata map
+- **THEN** start returns an error
+
+#### Scenario: Stop is idempotent
+
+- **WHEN** stop is called more than once
+- **THEN** subsequent calls are no-ops and do not error
+
+### Requirement: Search query sanitization
+
+The system SHALL sanitize search queries before they reach the full-text index by replacing FTS5 special characters (`"`, `*`, `(`, `)`, `:`, `^`, `{`, `}`, `-`, `+`) with spaces and trimming surrounding whitespace, so that user-supplied punctuation cannot break the query.
+
+#### Scenario: Special characters are neutralized
+
+- **WHEN** a query contains FTS5 special characters such as `:`, `*`, `^`, or parentheses
+- **THEN** those characters are replaced with spaces in the sanitized query
+
+#### Scenario: Surrounding whitespace is trimmed
+
+- **WHEN** a query has leading or trailing whitespace
+- **THEN** the sanitized query has that whitespace removed
+
+### Requirement: Command-line access to the knowledge base
+
+The system SHALL provide a command-line interface to search, list, ingest, and report status of the knowledge base, communicating with the running daemon. Search SHALL accept a query and an optional result limit (default 10) and print each result's tier, title, path, and snippet, or report when no results are found. List SHALL accept an optional path prefix and limit (default 100) and print each document's path, tier, and word count, or report when none are found. Ingest SHALL read a file from disk and submit its content. Status SHALL report the indexed document count, the vault path, and the MCP port, indicating when the vault or port is not configured.
+
+#### Scenario: Search prints results
+
+- **WHEN** the user runs a search that returns matches
+- **THEN** each match is printed with its tier, title, path, and snippet
+
+#### Scenario: Search with no matches
+
+- **WHEN** a search returns no results
+- **THEN** the command reports that no results were found
+
+#### Scenario: Ingest a missing file
+
+- **WHEN** the user runs ingest against a file path that cannot be read
+- **THEN** the command reports a read error and exits non-zero
+
+#### Scenario: Status reports unconfigured vault and port
+
+- **WHEN** status runs and no vault path or MCP port is configured
+- **THEN** the output indicates the vault is not configured and the port is not running

--- a/openspec/specs/llm-backends/spec.md
+++ b/openspec/specs/llm-backends/spec.md
@@ -1,0 +1,140 @@
+# LLM Backends
+
+## Purpose
+
+Argus runs coding tasks through command-template LLM backends (Claude Code, Codex, custom CLIs). Some backends depend on a local inference daemon being warm before the agent's first request, and Argus also uses a cheap LLM call to auto-name tasks. This capability covers the local-ollama prelaunch path (ensure the daemon is up and the target model is loaded) and the non-interactive task-name generator that shells out to the local `claude` CLI. Both paths are best-effort utilities that must fail predictably so the surrounding task workflow can proceed or fall back cleanly.
+
+## Requirements
+
+### Requirement: Ollama daemon liveness probe
+
+The system SHALL determine whether the local ollama daemon is reachable by issuing a single short-timeout liveness probe to its tags endpoint. The probe SHALL report "running" only when the daemon answers with an HTTP 200 within the timeout, and SHALL report "not running" for any network failure, non-200 status, or cancelled/expired context.
+
+#### Scenario: Daemon answers 200
+
+- **WHEN** the ollama endpoint responds 200 to the tags probe within the timeout
+- **THEN** the probe reports the daemon as running
+
+#### Scenario: Daemon unreachable
+
+- **WHEN** the ollama endpoint cannot be connected to
+- **THEN** the probe reports the daemon as not running
+
+#### Scenario: Daemon returns an error status
+
+- **WHEN** the ollama endpoint responds with a non-200 status (e.g. 500)
+- **THEN** the probe reports the daemon as not running
+
+#### Scenario: Probe context already cancelled
+
+- **WHEN** the caller's context is cancelled or the probe exceeds its timeout
+- **THEN** the probe reports the daemon as not running rather than raising an error
+
+### Requirement: Starting the ollama daemon
+
+The system SHALL bring up a downed ollama daemon by running a configured start command and then polling the liveness probe until the daemon answers or a bounded start timeout elapses. A successful return of the start command alone SHALL NOT be treated as the daemon being ready; readiness is confirmed only by a successful liveness probe. If the start command itself fails, the system SHALL return an error that includes the command and its captured output.
+
+#### Scenario: Daemon becomes ready after start
+
+- **WHEN** the start command succeeds and the liveness probe begins answering 200 within the start timeout
+- **THEN** start succeeds with no error
+
+#### Scenario: Start command fails
+
+- **WHEN** the configured start command exits non-zero
+- **THEN** start returns an error containing the command name and its captured output
+
+#### Scenario: Daemon never becomes ready
+
+- **WHEN** the start command succeeds but the liveness probe never returns 200 before the start timeout elapses
+- **THEN** start returns a timeout error indicating the daemon was not ready
+
+### Requirement: Preloading a model into the daemon
+
+The system SHALL preload a named model into the running daemon by requesting a generation with a keep-alive hint, so the model is resident and the agent's first real inference is fast. When the requested model is not installed, the system SHALL return a clear error that names the model and tells the user how to install it. Any other non-success response SHALL be returned as an error including the status.
+
+#### Scenario: Model loads successfully
+
+- **WHEN** a preload is requested for an installed model and the daemon responds 200
+- **THEN** preload succeeds and the request carries a keep-alive hint so the model stays resident
+
+#### Scenario: Model not installed
+
+- **WHEN** the daemon responds 404 because the model is not installed
+- **THEN** preload returns an error naming the model and instructing the user to pull it
+
+#### Scenario: Daemon error during preload
+
+- **WHEN** the daemon responds with a server error status
+- **THEN** preload returns an error including the HTTP status
+
+### Requirement: Ensuring a backend's model is warm
+
+The system SHALL provide a single entry point that probes the daemon, starts it only if it is down, and then preloads the requested model. This orchestration SHALL be serialized so that concurrent task launches requiring the same daemon do not each shell out to start it; later callers SHALL observe the daemon already up and complete via a fast preload. If starting the daemon fails, the orchestration SHALL return an error indicating the start failure.
+
+#### Scenario: Daemon already running
+
+- **WHEN** the ensure entry point runs while the daemon is already up
+- **THEN** the start command is not invoked and the model is preloaded
+
+#### Scenario: Daemon down then ensured
+
+- **WHEN** the ensure entry point runs while the daemon is down
+- **THEN** the daemon is started and the model is preloaded
+
+#### Scenario: Concurrent ensure callers
+
+- **WHEN** multiple callers invoke the ensure entry point concurrently for a downed daemon
+- **THEN** the start command runs exactly once and every caller completes without error
+
+#### Scenario: Daemon fails to start
+
+- **WHEN** the ensure entry point runs while the daemon is down and the start command fails
+- **THEN** the ensure entry point returns an error indicating the daemon failed to start
+
+### Requirement: Generating a task name from a description
+
+The system SHALL generate a short kebab-case task name by summarizing a task description through the local `claude` CLI pinned to a fast, low-cost model with all context sources disabled. The generated name SHALL consist of lowercase alphanumeric segments joined by single hyphens with no leading or trailing hyphen, and SHALL NOT exceed the maximum name length.
+
+#### Scenario: Valid name produced
+
+- **WHEN** a non-empty task description is summarized and the model returns a valid kebab-case candidate
+- **THEN** the system returns that name
+
+#### Scenario: Description framed as data not a question
+
+- **WHEN** a task description is sent for naming
+- **THEN** it is conveyed as a task description to summarize, with framing instructing the model not to answer or engage with its content
+
+### Requirement: Name generation skip and failure semantics
+
+The system SHALL fail open so that callers can keep their fallback name. It SHALL return a distinct "empty prompt" signal when the description is empty or whitespace, a distinct "unavailable" signal when the `claude` CLI is not installed, and a generic error when the CLI ran but produced output that is not a valid name. A name candidate that is not valid kebab-case SHALL be rejected rather than returned.
+
+#### Scenario: Empty description
+
+- **WHEN** the description is empty or only whitespace
+- **THEN** the system returns the empty-prompt signal without invoking the CLI
+
+#### Scenario: CLI not installed
+
+- **WHEN** the `claude` CLI is not found on PATH
+- **THEN** the system returns the unavailable signal so the caller treats it as a clean skip
+
+#### Scenario: Model returns unusable output
+
+- **WHEN** the CLI runs but returns prose or other output that is not valid kebab-case
+- **THEN** the system returns a generic error and no name
+
+### Requirement: Sanitizing model output
+
+The system SHALL sanitize a raw model response before validating it: trim surrounding whitespace, strip wrapping quotes, single quotes, and backtick fences, lowercase the result, and drop trailing sentence punctuation. After sanitizing, a candidate SHALL be accepted only if it is non-empty, within the maximum length, and matches strict kebab-case; otherwise it SHALL be rejected.
+
+#### Scenario: Wrapped or decorated candidate
+
+- **WHEN** the model returns a candidate wrapped in quotes, backticks, a code fence, or with trailing punctuation or mixed case
+- **THEN** the wrappers and punctuation are stripped and the lowercased kebab-case core is accepted
+
+#### Scenario: Non-kebab candidate rejected
+
+- **WHEN** the sanitized candidate contains underscores, spaces, slashes, a leading or trailing hyphen, doubled hyphens, or exceeds the maximum length
+- **THEN** the candidate is rejected and no name is returned

--- a/openspec/specs/mcp-injection/spec.md
+++ b/openspec/specs/mcp-injection/spec.md
@@ -1,0 +1,113 @@
+# MCP Config Injection
+
+## Purpose
+
+This capability registers the Argus MCP server into the agent backends' own config files so that any Claude Code or Codex session launched on the machine can reach Argus's MCP tools (knowledge base and task tools). Injection edits the user's global backend config — Claude Code's `~/.claude.json` (`mcpServers.argus`) and Codex's `~/.codex/config.toml` (`[mcp_servers.argus]`) — and is idempotent so it can run on every Argus startup without churning the files or disturbing unrelated configuration. It also suppresses Claude Code's first-use project-MCP approval prompt.
+
+## Requirements
+
+### Requirement: Idempotent Claude MCP server registration
+
+Argus SHALL register itself as an HTTP MCP server in Claude Code's config under `mcpServers.argus`, pointing at a localhost URL on the configured port with transport type `http`. Registration SHALL be idempotent: the file SHALL be rewritten only when the entry is absent, its URL points at a different port, or it lacks the `http` transport type. All config keys other than `mcpServers.argus` SHALL be preserved verbatim. A config file that exists but is not valid JSON SHALL NOT be modified, and that condition SHALL surface as an error. A missing config file SHALL be created. `InjectGlobal` SHALL resolve the config path as `~/.claude.json`.
+
+#### Scenario: Entry added with HTTP transport on configured port
+
+- **WHEN** injection runs against a Claude config that has no `argus` entry
+- **THEN** an `mcpServers.argus` entry is written with type `http` and a localhost URL on the configured port
+
+#### Scenario: Old format without transport is upgraded
+
+- **WHEN** an existing `argus` entry has a URL but no `type` field
+- **THEN** the entry is rewritten to include the `http` transport type
+
+#### Scenario: No rewrite when already correct
+
+- **WHEN** injection runs twice with the same port and the entry is already correct
+- **THEN** the second run does not rewrite the file (its modification time is unchanged)
+
+#### Scenario: Rewrite on port change
+
+- **WHEN** injection runs with a different port than the existing entry
+- **THEN** the entry's URL is updated to the new port
+
+#### Scenario: Unrelated keys preserved
+
+- **WHEN** the config contains other MCP server entries alongside the `argus` entry
+- **THEN** those unrelated entries are preserved after injection
+
+#### Scenario: Malformed config left untouched
+
+- **WHEN** the Claude config file exists but is not valid JSON
+- **THEN** injection returns an error and does not overwrite the file
+
+#### Scenario: Missing config file created
+
+- **WHEN** the Claude config file does not exist
+- **THEN** injection creates it containing the `argus` MCP entry
+
+### Requirement: Idempotent Codex MCP server registration
+
+Argus SHALL register itself as an MCP server in Codex's `~/.codex/config.toml` under a `[mcp_servers.argus]` section whose `url` points at a localhost URL on the configured port, and SHALL ensure `experimental_use_rmcp_client = true` exists at the TOML top level (before the first section header). Registration SHALL be idempotent: the file SHALL be rewritten only when the section is absent or its URL points at a different port. Unrelated top-level keys and sections SHALL be preserved. The `~/.codex` directory and the config file SHALL be created if missing. `InjectGlobal` SHALL resolve the config path as `~/.codex/config.toml`.
+
+#### Scenario: Section created with url and top-level rmcp flag
+
+- **WHEN** injection runs against a Codex config that has no `argus` section
+- **THEN** a `[mcp_servers.argus]` section is written with a localhost url on the configured port, and `experimental_use_rmcp_client = true` is present at the TOML top level
+
+#### Scenario: Idempotent on repeat with same port
+
+- **WHEN** injection runs twice with the same port
+- **THEN** the file content is identical after the second run
+
+#### Scenario: Port change replaces the old url
+
+- **WHEN** injection runs with a different port than the existing section
+- **THEN** the section's url uses the new port and the old port no longer appears in the file
+
+#### Scenario: Existing content preserved
+
+- **WHEN** the config already contains unrelated top-level settings and other sections
+- **THEN** those settings and sections remain after the `argus` section is added
+
+#### Scenario: rmcp flag kept at top level, never inside a section
+
+- **WHEN** the config ends with a section header and the rmcp flag must be added
+- **THEN** `experimental_use_rmcp_client` is placed before the first section header, not inside any section
+
+#### Scenario: Misplaced rmcp flag migrated without duplication
+
+- **WHEN** an existing config has `experimental_use_rmcp_client` inside a section
+- **THEN** the flag is moved to the top level and appears exactly once
+
+### Requirement: Legacy argus-kb entry migration
+
+Both backends SHALL remove the pre-rename `argus-kb` entry on the next injection, replacing it with the current `argus` entry, while preserving all unrelated entries. This migrates configs written by older Argus builds where the MCP server was named `argus-kb`.
+
+#### Scenario: Legacy Claude key migrated, others preserved
+
+- **WHEN** the Claude config contains a legacy `mcpServers.argus-kb` entry alongside an unrelated MCP entry
+- **THEN** the legacy entry is removed, the `argus` entry is added, and the unrelated entry is preserved
+
+#### Scenario: Legacy Codex section migrated, others preserved
+
+- **WHEN** the Codex config contains a legacy `[mcp_servers.argus-kb]` section alongside an unrelated section
+- **THEN** the legacy section is removed, the `[mcp_servers.argus]` section is added, and the unrelated section is preserved
+
+### Requirement: Claude project MCP trust suppression
+
+Argus SHALL write `enableAllProjectMcpServers: true` to `~/.claude/settings.json` so Claude Code does not show its first-use project-MCP approval prompt for the injected Argus server. The operation SHALL be idempotent (no rewrite when the flag is already set) and SHALL preserve all existing keys in the settings file, creating the `~/.claude` directory and the file if absent.
+
+#### Scenario: Flag created when absent
+
+- **WHEN** the settings file has no `enableAllProjectMcpServers` flag
+- **THEN** the flag is written as `true`
+
+#### Scenario: Idempotent when already set
+
+- **WHEN** the flag is already set to true
+- **THEN** a subsequent run does not rewrite the file (its modification time is unchanged)
+
+#### Scenario: Existing settings preserved
+
+- **WHEN** the settings file already contains unrelated keys
+- **THEN** those keys are preserved and the trust flag is added alongside them

--- a/openspec/specs/mcp-server/spec.md
+++ b/openspec/specs/mcp-server/spec.md
@@ -1,0 +1,317 @@
+# MCP Server
+
+## Purpose
+
+The MCP server exposes Argus capabilities to LLM agents over the Model Context Protocol (Streamable HTTP transport). It surfaces a knowledge-base tool set and, when the daemon wires them in, tools for task lifecycle management, dependency linking, inter-task messaging, recurring schedules, clipboard staging, and viewable artifacts. The server lets an agent (or an orchestrator agent) drive Argus programmatically without going through the TUI or web UI.
+
+## Requirements
+
+### Requirement: JSON-RPC over Streamable HTTP transport
+
+The server SHALL serve a single MCP endpoint that follows the MCP Streamable HTTP transport: POST carries client-to-server JSON-RPC, GET is a long-lived server-to-client SSE channel, and DELETE acknowledges session termination. JSON-RPC requests (those carrying an `id`) MUST receive a JSON response; pure notifications (no `id`) MUST receive HTTP 202 Accepted with an empty body. Malformed JSON MUST yield a JSON-RPC parse error (code -32700). Unknown methods MUST yield a method-not-found error (code -32601). The request body SHALL be capped (4 MiB) to bound memory.
+
+#### Scenario: Request with id returns a JSON-RPC response
+
+- **WHEN** a POST carries a JSON-RPC request with an `id`
+- **THEN** the server returns HTTP 200 with a JSON-RPC response object carrying the same `id`
+
+#### Scenario: Notification returns 202 with empty body
+
+- **WHEN** a POST carries a JSON-RPC message with no `id` (e.g. `notifications/initialized`)
+- **THEN** the server returns HTTP 202 Accepted with an empty body and no JSON-RPC response
+
+#### Scenario: Unparseable body is a parse error
+
+- **WHEN** a POST body is not valid JSON
+- **THEN** the server returns a JSON-RPC error with code -32700
+
+#### Scenario: Unknown method is method-not-found
+
+- **WHEN** a request names a method the server does not implement
+- **THEN** the server returns a JSON-RPC error with code -32601
+
+#### Scenario: GET stream stays open until disconnect or shutdown
+
+- **WHEN** a client opens the GET SSE stream
+- **THEN** the connection stays open, emitting periodic keepalive comment frames, and returns only when the client disconnects or the server shuts down
+
+### Requirement: Initialize handshake advertises tool capability
+
+On `initialize` the server SHALL return its server info (name `argus`), advertise the tools capability, include the knowledge-base usage instructions, and echo back the client's requested protocol version (falling back to a default when the client omits it).
+
+#### Scenario: Protocol version is echoed
+
+- **WHEN** a client sends `initialize` with a `protocolVersion`
+- **THEN** the response's `protocolVersion` equals the value the client sent
+
+#### Scenario: Missing protocol version falls back to default
+
+- **WHEN** a client sends `initialize` with no `protocolVersion`
+- **THEN** the response carries a default protocol version
+
+### Requirement: Tool surface is gated on wired capabilities
+
+`tools/list` SHALL always include the knowledge-base tools. Task tools (and dependency-linking tools) SHALL appear only when task management is wired; clipboard, messaging, and artifact tools SHALL appear only when their dependency AND task management are both wired; schedule tools SHALL appear only when both schedule store and runner are wired. Plugin-registered tools SHALL be unioned in additively, and a registry failure MUST NOT break the listing of built-in tools. Calling a tool whose capability is not wired MUST return a tool error stating the capability is not configured.
+
+#### Scenario: KB tools always listed
+
+- **WHEN** `tools/list` is called on a server with no managers wired
+- **THEN** the knowledge-base tools are present in the result
+
+#### Scenario: Task tools appear only when wired
+
+- **WHEN** task management has been wired and `tools/list` is called
+- **THEN** the task tools (including the linking tools) appear in the result
+
+#### Scenario: Calling an unwired task tool errors
+
+- **WHEN** a task tool is called on a server where task management is not wired
+- **THEN** the response is a tool error indicating task management is not configured
+
+### Requirement: Knowledge-base tools
+
+The server SHALL expose tools to search, read, list, ingest, and delete knowledge-base documents. Search input SHALL be sanitized and an empty post-sanitization query MUST return a no-results message rather than an error. Ingest and delete paths MUST be vault-relative with no escaping (`..` components or absolute paths rejected, and resolved paths that escape the configured vault directory rejected). Ingest MUST require both a non-empty path and content. When a vault path is configured, ingest SHALL write the document back to the vault and delete SHALL remove the vault file.
+
+#### Scenario: Empty query after sanitization
+
+- **WHEN** `kb_search` is called with a query that sanitizes to empty
+- **THEN** the result reports no results and is not flagged as an error
+
+#### Scenario: Path traversal rejected on ingest and delete
+
+- **WHEN** `kb_ingest` or `kb_delete` is called with a path containing `..` or an absolute path
+- **THEN** the response is a tool error reporting an invalid path
+
+#### Scenario: Ingest requires path and content
+
+- **WHEN** `kb_ingest` is called without a path or without content
+- **THEN** the response is a tool error reporting path and content are required
+
+### Requirement: Task creation with worktree and orchestration fields
+
+`task_create` SHALL require a project and a prompt, derive the name from the prompt when omitted, create a worktree, start the agent session, and return a summary including the task ID, name, status, and project. It MUST cap concurrent creations and reject when the limit is exceeded. When `name` is supplied, it SHALL be idempotent on the `(name, project)` pair: an existing non-archived match errors unless `upsert: true` is passed, in which case the existing task is returned unchanged. `depends_on` entries MUST reference real, non-archived tasks, MUST be capped in count, and MUST be rejected when they would form a cycle in the persisted dependency graph or when the graph is too large to verify acyclic.
+
+#### Scenario: Missing required fields
+
+- **WHEN** `task_create` is called without a project or without a prompt
+- **THEN** the response is a tool error naming the missing field
+
+#### Scenario: Duplicate name without upsert errors
+
+- **WHEN** `task_create` is called with a `name` matching an existing non-archived task in the same project and `upsert` is not set
+- **THEN** the response is a tool error reporting the task already exists and suggesting `upsert: true`
+
+#### Scenario: Duplicate name with upsert returns the existing task
+
+- **WHEN** `task_create` is called with a duplicate `(name, project)` and `upsert: true`
+- **THEN** the existing task is returned unchanged with a summary indicating it already exists
+
+#### Scenario: Dependency on unknown or archived task rejected
+
+- **WHEN** `task_create` declares a `depends_on` entry that does not exist or is archived
+- **THEN** the response is a tool error identifying the offending dependency
+
+#### Scenario: Concurrent-create limit enforced
+
+- **WHEN** more than the allowed number of `task_create` calls are in flight at once
+- **THEN** further calls return a tool error reporting too many concurrent task creations
+
+### Requirement: Task read and listing
+
+`task_list` SHALL list non-archived tasks, optionally filtered by status, project, and plan_slug, and report a no-tasks message when none match. `task_get` SHALL require an `id`, error when the task is not found, and render the task's details including its dependency state, surfacing the subset of dependencies that have not yet reached complete (or are missing) as the blocking set.
+
+#### Scenario: List filters by status
+
+- **WHEN** `task_list` is called with a `status` filter
+- **THEN** only non-archived tasks whose status matches are returned
+
+#### Scenario: Get unknown task errors
+
+- **WHEN** `task_get` is called with an `id` that does not exist
+- **THEN** the response is a tool error reporting the task was not found
+
+#### Scenario: Get surfaces unresolved dependencies as blocking
+
+- **WHEN** `task_get` is called on a task with dependencies that have not all reached complete
+- **THEN** the rendered details include the unresolved dependencies as the blocked-by set
+
+### Requirement: Caller identity resolved by id or cwd
+
+Tools invoked by an agent that does not know its own task ID (archive, rename, complete, set-result, clipboard, messaging, artifacts) SHALL resolve the task from an explicit `id` or, failing that, from a `cwd` matched against task worktree paths using longest-prefix-wins with separator guarding so sibling worktrees do not collide. When neither an `id` nor a matching `cwd` is provided, the tool MUST return a tool error.
+
+#### Scenario: Resolve by exact worktree cwd
+
+- **WHEN** a tool is called with a `cwd` equal to or nested inside a task's worktree
+- **THEN** the operation targets that task
+
+#### Scenario: Sibling worktree with shared prefix does not match
+
+- **WHEN** a `cwd` shares a string prefix with a worktree but is not that worktree or a child of it
+- **THEN** that task is not selected
+
+#### Scenario: Neither id nor matching cwd
+
+- **WHEN** a tool is called with no `id` and a `cwd` that matches no worktree
+- **THEN** the response is a tool error
+
+### Requirement: Task lifecycle transitions
+
+`task_stop` SHALL send a stop signal (reporting an eventual transition to in_review) and require an `id`. `task_complete` SHALL set status to complete (stamping the end time) and be a no-op when already complete; it does not stop a running session. `task_archive` SHALL set or toggle the archived flag, report a no-op when the requested state already holds, and on archive best-effort clear queued messages for the task. `task_rename` SHALL require a non-empty, length-capped name, update only the display name, and report a no-op when the name is unchanged.
+
+#### Scenario: Stop requires id
+
+- **WHEN** `task_stop` is called without an `id`
+- **THEN** the response is a tool error reporting id is required
+
+#### Scenario: Complete is a no-op when already complete
+
+- **WHEN** `task_complete` resolves a task already in complete status
+- **THEN** the task is unchanged and the result reports it is already complete
+
+#### Scenario: Archive toggles when no explicit state given
+
+- **WHEN** `task_archive` resolves a task and no `archived` value is supplied
+- **THEN** the archived flag is flipped to its opposite value
+
+#### Scenario: Rename rejects empty name
+
+- **WHEN** `task_rename` is called with a name that is empty after trimming
+- **THEN** the response is a tool error reporting name is required
+
+### Requirement: Structured task result storage
+
+`task_set_result` SHALL require a `result` that is a JSON object (arrays, scalars, and bare strings rejected), re-encode it canonically before storing, enforce a serialized-size cap, and persist it as last-write-wins. The daemon SHALL NOT interpret the payload.
+
+#### Scenario: Non-object result rejected
+
+- **WHEN** `task_set_result` is called with a `result` that is not a JSON object
+- **THEN** the response is a tool error reporting the result must be a JSON object
+
+#### Scenario: Oversized result rejected
+
+- **WHEN** the canonically-serialized result exceeds the size cap
+- **THEN** the response is a tool error reporting the size limit
+
+### Requirement: Dependency linking and cascade control
+
+`task_link` SHALL add a dependency edge (child depends on parent), be idempotent for an existing edge, and reject any edge that would close a cycle, returning the offending path. `task_unlink` SHALL remove an edge and be a no-op when the edge is absent. `task_deps` SHALL return the one-hop upstream and downstream neighbours. `task_halt_downstream` SHALL stop running descendants and archive still-pending descendants of a seed task (without halting the seed itself), and return a per-row summary of stopped, archived, and not-found IDs. `task_set_plan_slug` SHALL stamp (or, with an empty string, clear) the orchestrator grouping label.
+
+#### Scenario: Cycle-forming link rejected
+
+- **WHEN** `task_link` would create a dependency cycle
+- **THEN** the response is a tool error reporting the cycle and its path
+
+#### Scenario: Deps returns upstream and downstream
+
+- **WHEN** `task_deps` is called for a task
+- **THEN** the result lists the task's direct dependencies (upstream) and the tasks depending on it (downstream)
+
+#### Scenario: Halt cascade summarizes outcomes
+
+- **WHEN** `task_halt_downstream` is called for a seed task with descendants
+- **THEN** running descendants are stopped, pending descendants are archived, and the result summarizes which IDs were stopped, archived, or not found
+
+### Requirement: Inter-task messaging
+
+`task_message_send` SHALL require a recipient `to` and a `body`, resolve the sender by id/cwd, reject when the recipient does not exist, default the kind to note, and persist a durable message; it MUST translate body-too-large, self-send, inbox-full, and rate-limit failures into clear tool errors, and when a nudger is wired best-effort write a notification line to a live recipient's session. `task_inbox` SHALL return messages addressed to the caller oldest-first (defaulting to unread-only) without auto-acking them, supporting sender and since filters and a capped limit. `task_message_ack` SHALL require a non-empty, capped list of message IDs and mark the caller's matching messages read, silently ignoring IDs not belonging to the caller. `task_ask` SHALL send a question and, when given a positive timeout within the cap, block for a reply, otherwise return immediately with the question ID.
+
+#### Scenario: Send requires recipient and body
+
+- **WHEN** `task_message_send` is called without `to` or without `body`
+- **THEN** the response is a tool error naming the missing field
+
+#### Scenario: Send to unknown recipient rejected
+
+- **WHEN** `task_message_send` targets a `to` that does not resolve to a task
+- **THEN** the response is a tool error reporting the recipient was not found
+
+#### Scenario: Inbox defaults to unread only
+
+- **WHEN** `task_inbox` is called without `unread_only`
+- **THEN** only unread messages addressed to the caller are returned, oldest first, and not marked read
+
+#### Scenario: Ask with zero timeout returns immediately
+
+- **WHEN** `task_ask` is called with `timeout_seconds` of 0
+- **THEN** the question is sent and the result returns the question ID for polling without blocking
+
+#### Scenario: Ask timeout over the cap rejected
+
+- **WHEN** `task_ask` is called with `timeout_seconds` above the maximum
+- **THEN** the response is a tool error reporting the timeout cap
+
+### Requirement: Schedule management
+
+The server SHALL expose tools to list, create, update, delete, and run-now scheduled tasks. `schedule_create` SHALL require name, project, and prompt, accept exactly one of a cron `schedule` or a future RFC3339 `run_once_at`, reject a past one-shot timestamp, default to enabled, validate the schedule, and precompute the next run time. `schedule_update` SHALL apply only the supplied fields, reject supplying both a non-empty cron schedule and a non-empty one-shot timestamp in the same call, auto-clear the opposing cadence field when one is set, and recompute the next run time when the cadence changes. `schedule_run_now` SHALL fire the schedule out of cycle and report the created task.
+
+#### Scenario: Create requires a future one-shot timestamp
+
+- **WHEN** `schedule_create` is given a `run_once_at` that is not in the future
+- **THEN** the response is a tool error reporting the timestamp must be in the future
+
+#### Scenario: Update rejects both cadences at once
+
+- **WHEN** `schedule_update` is given both a non-empty `schedule` and a non-empty `run_once_at`
+- **THEN** the response is a tool error reporting that only one cadence may be specified
+
+#### Scenario: Run-now creates a task
+
+- **WHEN** `schedule_run_now` is called with a valid schedule id
+- **THEN** a fresh task is created from the schedule and the result reports its id and name
+
+### Requirement: Clipboard staging
+
+`argus_clipboard_set` SHALL require non-empty text, resolve the target task by id/cwd, and stage the text for the user to copy via a single gesture (it does not write to the OS clipboard directly). It MUST report a tool error when the clipboard capability is not wired.
+
+#### Scenario: Empty text rejected
+
+- **WHEN** `argus_clipboard_set` is called with empty text
+- **THEN** the response is a tool error reporting text is required
+
+#### Scenario: Staged text reported
+
+- **WHEN** `argus_clipboard_set` is called with text for a resolvable task
+- **THEN** the text is staged and the result confirms how many bytes were staged for the task
+
+### Requirement: Viewable artifact registration
+
+`artifact_register` SHALL require a source `path`, resolve the owning task by id/cwd, sanitize the destination basename (rejecting path separators and `..`), determine the artifact type from an explicit valid value or infer it from the extension, copy the source file into durable per-task storage under a size cap, and persist a manifest row (last-write-wins per filename). When the manifest write fails after the copy, the copied bytes MUST be removed so no unreferenced file is left behind.
+
+#### Scenario: Path required
+
+- **WHEN** `artifact_register` is called without a `path`
+- **THEN** the response is a tool error reporting path is required
+
+#### Scenario: Invalid explicit type rejected
+
+- **WHEN** `artifact_register` is called with a `type` that is not a recognized artifact type
+- **THEN** the response is a tool error listing the valid types
+
+#### Scenario: Oversized artifact rejected
+
+- **WHEN** the source file exceeds the artifact size cap
+- **THEN** the response is a tool error reporting the cap and no manifest row is created
+
+### Requirement: Plugin tool registry and proxying
+
+Plugin-registered tools SHALL be name-scoped (a tool name MUST start with its scope prefix and contain only an allowlisted character set), validated against size caps and a per-scope tool count limit, and persisted with a last-seen heartbeat. Registering an existing name from a different scope MUST be rejected. A `tools/call` for a registered plugin name SHALL be proxied as an HTTP POST to the plugin's callback URL, returning the plugin's MCP-native result; a non-2xx plugin response or decode failure MUST surface as a tool error. Idle tools (no heartbeat within the idle window) SHALL be sweepable, and a successful invocation MUST refresh the heartbeat.
+
+#### Scenario: Name must carry the scope prefix
+
+- **WHEN** a plugin registers a tool whose name does not start with `<scope>_`
+- **THEN** the registration is rejected with a scope-prefix error
+
+#### Scenario: Cross-scope name collision rejected
+
+- **WHEN** a scope tries to register a tool name already owned by a different scope
+- **THEN** the registration is rejected
+
+#### Scenario: Plugin call proxied to callback
+
+- **WHEN** `tools/call` names a registered plugin tool
+- **THEN** the server POSTs the input to the plugin's callback URL and returns the plugin's tool result
+
+#### Scenario: Plugin error surfaced as tool error
+
+- **WHEN** the plugin callback returns a non-2xx status or an undecodable body
+- **THEN** the response is a tool error describing the plugin failure

--- a/openspec/specs/mobile-pwa/spec.md
+++ b/openspec/specs/mobile-pwa/spec.md
@@ -1,0 +1,177 @@
+# Mobile PWA
+
+## Purpose
+
+The mobile PWA is the installable, offline-aware web client that lets a user manage Argus agent sessions from a phone. It ships as a single-page app shell (HTML, vendored xterm.js, manifest, icons) served by the REST API and cached by a service worker, an on-screen virtual key bar for keys iOS soft keyboards omit, a full-screen offline view when the daemon is unreachable, and OS integration via web share target and push-notification deep links.
+
+## Requirements
+
+### Requirement: Installable web app manifest
+
+The app SHALL provide a web app manifest declaring a standalone, installable PWA with an app name, theme/background colors, and icon set so the OS can add it to the home screen and launch it chromeless.
+
+#### Scenario: Manifest declares standalone display
+
+- **WHEN** the OS reads `/manifest.webmanifest`
+- **THEN** `display` is `standalone`, `start_url` is `/`, and both `theme_color` and `background_color` are set
+
+#### Scenario: Icon set covers required sizes and purposes
+
+- **WHEN** the OS selects an app icon
+- **THEN** 192x192 and 512x512 PNG icons are available, including a `maskable` 512x512 variant
+
+### Requirement: Service worker caches the app shell
+
+The service worker SHALL cache the app shell (root document, manifest, vendored xterm.js/CSS, fit addon, icons) cache-first, serving cached assets immediately and refreshing them from the network in the background, so the SPA boots without a live connection.
+
+#### Scenario: Shell asset served from cache
+
+- **WHEN** a GET request targets a cached same-origin shell asset
+- **THEN** the cached response is returned immediately and a background fetch refreshes the cache entry when the network response is OK
+
+#### Scenario: Uncached GET falls back to network
+
+- **WHEN** a GET request for a same-origin, non-`/api/` asset is not in the cache
+- **THEN** the service worker fetches it from the network and caches a basic, OK response
+
+#### Scenario: Cross-origin requests are not intercepted
+
+- **WHEN** a request targets a different origin
+- **THEN** the service worker does not intercept it and the browser handles it normally
+
+### Requirement: API requests bypass the cache
+
+The service worker SHALL treat `/api/*` requests as network-only and never cache them, because they carry authentication and dynamic data.
+
+#### Scenario: API path is not cached
+
+- **WHEN** a request path starts with `/api/`
+- **THEN** the service worker does not intercept or cache the request and lets the browser fetch it from the network
+
+### Requirement: Cache versioning busts stale shells
+
+The service worker SHALL key its cache by a version string (`SW_VERSION`) and, on activation, delete every cache whose key differs from the current version, so bumping the version after any shell asset change replaces the stale cached shell on every installed device.
+
+#### Scenario: Old cache versions purged on activation
+
+- **WHEN** the service worker activates with a new `SW_VERSION`
+- **THEN** all caches keyed by a different version are deleted and the worker claims existing clients
+
+#### Scenario: New worker takes control immediately
+
+- **WHEN** the service worker installs
+- **THEN** it precaches the shell asset list and skips waiting so the updated worker activates without requiring all tabs to close
+
+### Requirement: Offline view on repeated connection failure
+
+The SPA SHALL show a full-screen offline view when the daemon becomes unreachable, requiring two consecutive `/api` poll failures before flipping (so a single transient hiccup does not eject the user), while the browser `offline` event flips immediately.
+
+#### Scenario: Two consecutive failures trigger offline view
+
+- **WHEN** two consecutive `/api` connection attempts fail
+- **THEN** the offline screen is shown and the terminal stream, detail view, and open modals are torn down
+
+#### Scenario: Browser offline event flips immediately
+
+- **WHEN** the browser fires an `offline` event and a token is present
+- **THEN** the offline screen is shown without waiting for the failure threshold
+
+#### Scenario: Successful connection hides the offline view
+
+- **WHEN** a connection attempt succeeds
+- **THEN** the failure counter resets, the offline screen is hidden, and the user is returned to the main app (or the auth screen when no token is present)
+
+#### Scenario: Retry from offline view
+
+- **WHEN** the user taps Retry on the offline view with a saved token
+- **THEN** the SPA re-attempts the connection and, on success, hides the offline view
+
+### Requirement: Reconnect on browser online event
+
+When the browser regains connectivity, the SPA SHALL re-attempt the connection if offline, and otherwise refresh the task list and re-attach the terminal stream for an in-progress task.
+
+#### Scenario: Online event while offline view shown
+
+- **WHEN** the browser fires an `online` event and the offline view is shown
+- **THEN** the SPA retries the connection
+
+#### Scenario: Online event re-attaches in-progress terminal
+
+- **WHEN** the browser fires an `online` event while the main app is visible, a token is present, and the open task is in progress with no active stream
+- **THEN** the SPA refreshes and re-attaches the terminal so disk-log replay runs on reconnect
+
+### Requirement: Virtual key bar for missing soft-keyboard keys
+
+The SPA SHALL provide a toggleable on-screen key bar that sends raw escape sequences for keys iOS soft keyboards omit (Esc, Tab, Shift+Tab, Enter, arrows) to the PTY, with its visibility preference persisted and the bar mounted only while the compose bar is visible.
+
+#### Scenario: Key bar sends raw byte sequences
+
+- **WHEN** the user taps a virtual key (e.g. Esc, Tab, an arrow)
+- **THEN** the corresponding raw escape sequence is sent to the PTY over the same input path as typed text
+
+#### Scenario: Visibility preference persists
+
+- **WHEN** the user toggles the key bar
+- **THEN** the preference is saved to local storage and restored on the next load
+
+#### Scenario: Bar only mounts with the compose bar
+
+- **WHEN** the key bar is enabled but the compose bar is not visible
+- **THEN** the key bar is not displayed
+
+### Requirement: Web share target prefills a new task
+
+The SPA SHALL register a web share target at `/share`; when content is shared to the app it SHALL capture the shared fields, switch to the create-task view, and prefill the prompt with the combined content. The service worker SHALL serve the cached app shell for `/share` so the SPA boots even offline.
+
+#### Scenario: Shared content prefills the create prompt
+
+- **WHEN** the app is opened via a share to `/share` carrying title/text/url params
+- **THEN** the SPA switches to the create tab and prefills the prompt with the non-empty shared fields combined
+
+#### Scenario: Share fields are length-capped
+
+- **WHEN** a shared field exceeds the per-field maximum
+- **THEN** the field is truncated before being stored
+
+#### Scenario: Share URL is stripped after capture
+
+- **WHEN** the share landing is captured
+- **THEN** the URL is rewritten to `/` so a refresh does not re-fire the share and the token does not linger in history
+
+#### Scenario: Share target served offline
+
+- **WHEN** a GET request hits `/share`
+- **THEN** the service worker responds with the cached app shell
+
+### Requirement: Push notification click deep-links to a task
+
+A push notification carrying a task id SHALL, on click, focus an existing app window and open the deep-linked task without a reload when one exists, and otherwise open a fresh window deep-linked to the task; the SPA SHALL open the task once tasks have loaded.
+
+#### Scenario: Existing window opens task without reload
+
+- **WHEN** a notification with a task id is clicked and a same-origin window already exists
+- **THEN** the service worker focuses that window and posts a message instructing the SPA to open the task, without navigating or reloading
+
+#### Scenario: No existing window opens deep link
+
+- **WHEN** a notification with a task id is clicked and no app window exists
+- **THEN** the service worker opens a new window at `/?task=<id>`
+
+#### Scenario: SPA opens deep-linked task
+
+- **WHEN** the SPA receives the open-task message or boots with a `?task=` parameter
+- **THEN** it opens the matching task, refreshing and falling back to the archived filter to locate it, and silently no-ops if the task no longer exists
+
+### Requirement: Push notification rendering
+
+On a push event the service worker SHALL display a notification using the payload title and body (with safe defaults when the payload is missing or malformed), tagged by task id so notifications for the same task collapse.
+
+#### Scenario: Push displays notification with defaults
+
+- **WHEN** a push event arrives with no data or unparseable data
+- **THEN** a notification is shown with a default title and body
+
+#### Scenario: Push notification tagged by task
+
+- **WHEN** a push event carries a task id
+- **THEN** the notification is tagged by that task id so repeat notifications replace rather than stack

--- a/openspec/specs/os-integration/spec.md
+++ b/openspec/specs/os-integration/spec.md
@@ -1,0 +1,222 @@
+# OS Integration
+
+## Purpose
+
+This capability provides macOS-specific operating-system integration for Argus: managing the launchd LaunchAgent that auto-starts the argus daemon at user login, and discovering installed macOS applications (including their AppleScript scriptability) so the user can pick CFBundleIdentifiers for the per-project AppleEvents allowlist. On non-macOS platforms LaunchAgent management is unavailable and degrades to safe no-ops.
+
+## Requirements
+
+### Requirement: Platform availability gating
+
+LaunchAgent management SHALL be reported as available only on macOS (darwin). On every non-darwin platform, availability SHALL be reported as false and the operations SHALL degrade to safe no-ops or unsupported errors rather than attempting launchd operations.
+
+#### Scenario: macOS reports available
+
+- **WHEN** availability is queried on darwin
+- **THEN** it SHALL report true
+
+#### Scenario: Non-darwin reports unavailable
+
+- **WHEN** availability is queried on a non-darwin platform
+- **THEN** it SHALL report false
+
+#### Scenario: Operations are unsupported off darwin
+
+- **WHEN** install, uninstall, plist-path resolution, or daemon-exe resolution is invoked on a non-darwin platform
+- **THEN** each SHALL return an error that matches the sentinel unsupported error (identifiable via errors.Is), and no operation SHALL panic
+
+#### Scenario: Status carries an explanatory reason off darwin
+
+- **WHEN** the LaunchAgent status is queried on a non-darwin platform
+- **THEN** the status SHALL report not-installed and not-loaded, an empty plist path, and a non-empty reason explaining the platform restriction
+
+### Requirement: LaunchAgent plist location
+
+On macOS, the LaunchAgent plist SHALL live at a fixed, user-scoped path derived from the user's home directory, using the canonical job label as its filename.
+
+#### Scenario: Plist path under the user LaunchAgents directory
+
+- **WHEN** the plist path is resolved on macOS
+- **THEN** it SHALL be `<home>/Library/LaunchAgents/com.drn.argus.daemon.plist`
+
+### Requirement: Daemon executable resolution and symlink stability
+
+On macOS, resolving the daemon executable for the plist SHALL produce a stable `~/.argus/argusd` symlink that points at the running binary, so that the daemon appears with a friendly process name. The symlink creation SHALL be idempotent and SHALL never fail the caller: if the symlink cannot be created, the resolved binary path SHALL be returned unchanged.
+
+#### Scenario: Resolve returns the stable symlink path
+
+- **WHEN** the daemon executable is resolved on macOS
+- **THEN** the returned path SHALL be the `~/.argus/argusd` symlink and that symlink SHALL resolve to a reachable target
+
+#### Scenario: Symlink creation is idempotent
+
+- **WHEN** the daemon symlink is ensured twice for the same target executable
+- **THEN** the second call SHALL return the same symlink path and SHALL NOT recreate the existing correct symlink
+
+#### Scenario: Symlink failure falls back to the binary path
+
+- **WHEN** the daemon symlink cannot be created
+- **THEN** the original executable path SHALL be returned unchanged so a working plist can still be written
+
+#### Scenario: Symlink passthrough off darwin
+
+- **WHEN** the daemon symlink is ensured on a non-darwin platform
+- **THEN** the input path SHALL be returned unchanged
+
+### Requirement: Plist content contract
+
+The rendered LaunchAgent plist SHALL be well-formed XML that instructs launchd to run the daemon at load, restart it only on unclean exit, and execute it with a PATH that includes user-specific install locations. All path and user-supplied values SHALL be XML-escaped so special characters cannot produce a malformed plist.
+
+#### Scenario: Plist declares the daemon launch program
+
+- **WHEN** the plist is rendered for a given daemon executable path
+- **THEN** it SHALL declare the canonical job label and program arguments that invoke the executable with `daemon` and `start`
+
+#### Scenario: Plist enables run-at-load and crash-only restart
+
+- **WHEN** the plist is rendered
+- **THEN** it SHALL set run-at-load to true and configure keep-alive to restart only on unsuccessful exit (so a clean daemon stop is honored)
+
+#### Scenario: PATH bakes in user install locations in priority order
+
+- **WHEN** the plist is rendered for home `/Users/me`
+- **THEN** the PATH environment value SHALL be exactly `/Users/me/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` so user-installed tools are found before system directories
+
+#### Scenario: Special characters are XML-escaped
+
+- **WHEN** the plist is rendered with paths or home values containing `<`, `>`, `&`, or `"`
+- **THEN** those characters SHALL appear escaped and the resulting document SHALL parse as well-formed XML
+
+### Requirement: LaunchAgent status reporting
+
+On macOS, status reporting SHALL determine whether the plist file exists on disk and whether launchd recognizes the job as loaded. The loaded check is best-effort and SHALL report not-loaded when the launchd query fails.
+
+#### Scenario: Not installed and not loaded
+
+- **WHEN** the plist file does not exist and launchd reports the label is not loaded
+- **THEN** status SHALL report not-installed and not-loaded, with a plist path still populated
+
+#### Scenario: Installed and loaded
+
+- **WHEN** the plist file exists on disk and launchd reports the label is loaded
+- **THEN** status SHALL report installed and loaded
+
+### Requirement: LaunchAgent installation
+
+On macOS, installation SHALL require a non-empty daemon executable path, create the required directories, write the rendered plist, and bootstrap the job into the user's launchd domain. If the job is already loaded, it SHALL be booted out first so the new plist takes effect. Failures from launchd SHALL be surfaced as errors that include the launchd output.
+
+#### Scenario: Empty executable path is rejected
+
+- **WHEN** installation is invoked with an empty daemon executable path
+- **THEN** it SHALL return an error and SHALL NOT write a plist
+
+#### Scenario: Fresh install writes plist and bootstraps
+
+- **WHEN** installation runs and the job is not currently loaded
+- **THEN** the plist file SHALL be written containing the daemon path and label, no boot-out SHALL be performed, and exactly one bootstrap into the user's launchd domain SHALL be performed referencing the plist path
+
+#### Scenario: Reinstall boots out the existing job first
+
+- **WHEN** installation runs and the job is already loaded
+- **THEN** exactly one boot-out SHALL be performed before exactly one bootstrap
+
+#### Scenario: Bootstrap failure surfaces an error
+
+- **WHEN** the launchd bootstrap step exits non-zero
+- **THEN** installation SHALL return an error mentioning the bootstrap failure
+
+### Requirement: LaunchAgent uninstallation
+
+On macOS, uninstallation SHALL boot the job out of launchd if it is currently loaded and remove the plist file. Both steps are best-effort: a missing plist SHALL NOT be treated as an error, and no boot-out SHALL be attempted when the job is not loaded.
+
+#### Scenario: Loaded agent is booted out and plist removed
+
+- **WHEN** uninstallation runs and the job is loaded with a plist present
+- **THEN** exactly one boot-out SHALL be performed and the plist file SHALL be removed
+
+#### Scenario: Not-installed uninstall is a no-op
+
+- **WHEN** uninstallation runs and the job is not loaded
+- **THEN** it SHALL return no error and SHALL NOT perform a boot-out
+
+### Requirement: Application discovery
+
+Scanning SHALL walk the given application directories (defaulting to the standard macOS app roots when none are supplied), parse each `.app` bundle's Info.plist, and return the apps it can identify. Results SHALL be sorted by lowercase display name, deduplicated by bundle identifier with the first-scanned bundle winning, and SHALL never be nil. Unreadable directories and unparseable or unidentified bundles SHALL be skipped silently so one bad bundle cannot break discovery.
+
+#### Scenario: Bundles parsed and identified
+
+- **WHEN** scanning a directory containing valid `.app` bundles
+- **THEN** each parsed bundle SHALL be returned with its display name and bundle identifier, sorted by lowercase name
+
+#### Scenario: Display name fallback order
+
+- **WHEN** a bundle has no display name and no bundle name in its Info.plist
+- **THEN** its name SHALL fall back to the `.app` directory basename without the extension
+
+#### Scenario: Bundles without an identifier are skipped
+
+- **WHEN** a bundle's Info.plist has no bundle identifier
+- **THEN** that bundle SHALL be omitted from the results
+
+#### Scenario: Duplicate identifiers are deduplicated first-wins
+
+- **WHEN** the same bundle identifier appears in two scanned directories
+- **THEN** only the first-scanned bundle SHALL be returned
+
+#### Scenario: Unreadable directories and invalid plists are skipped
+
+- **WHEN** a scan target directory does not exist or a bundle has an unparseable Info.plist
+- **THEN** those SHALL be skipped silently and a non-nil result SHALL be returned
+
+### Requirement: Scriptability detection
+
+A scanned app SHALL be flagged scriptable when it declares AppleScript support by any of three independent signals: an `NSAppleScriptEnabled` value that is boolean true or a string of "true"/"yes" (case-insensitive), a non-empty `OSAScriptingDefinition` key, or the presence of any `.sdef` file in the bundle's `Contents/Resources`. The scriptable-only convenience scan SHALL return only apps flagged scriptable.
+
+#### Scenario: Boolean NSAppleScriptEnabled flags scriptable
+
+- **WHEN** a bundle declares `NSAppleScriptEnabled` true (boolean or "true"/"yes" string)
+- **THEN** the app SHALL be flagged scriptable
+
+#### Scenario: OSAScriptingDefinition flags scriptable
+
+- **WHEN** a bundle declares a non-empty `OSAScriptingDefinition` key
+- **THEN** the app SHALL be flagged scriptable
+
+#### Scenario: A .sdef file flags scriptable
+
+- **WHEN** a bundle has a `.sdef` file in `Contents/Resources` even without a scripting Info.plist key
+- **THEN** the app SHALL be flagged scriptable
+
+#### Scenario: No scripting signals means not scriptable
+
+- **WHEN** a bundle declares none of the scripting signals
+- **THEN** the app SHALL NOT be flagged scriptable
+
+#### Scenario: Scriptable-only scan filters out non-scriptable apps
+
+- **WHEN** the scriptable-only scan runs over a mix of scriptable and non-scriptable apps
+- **THEN** only the scriptable apps SHALL be returned
+
+### Requirement: Bundle identifier validation and filtering helpers
+
+The package SHALL provide helpers for picker UIs: a bundle-identifier validator that accepts only identifiers beginning with an alphanumeric and containing only alphanumerics, dots, and hyphens; a case-insensitive substring filter over app name and bundle identifier; and a stable display format. These let a picker accept manually typed legacy-alias identifiers that no installed app exposes.
+
+#### Scenario: Valid identifiers are accepted
+
+- **WHEN** validating an identifier that starts with an alphanumeric and contains only alphanumerics, dots, and hyphens (e.g. `com.apple.iChat`)
+- **THEN** it SHALL be accepted
+
+#### Scenario: Invalid identifiers are rejected
+
+- **WHEN** validating an empty string, an identifier with a leading dot or hyphen, or one containing spaces, quotes, parentheses, slashes, or underscores
+- **THEN** it SHALL be rejected
+
+#### Scenario: Text filter matches name or bundle id case-insensitively
+
+- **WHEN** filtering apps by a non-empty query
+- **THEN** only apps whose name or bundle identifier contains the query (case-insensitive) SHALL be returned; an empty or whitespace-only query SHALL return the input unchanged
+
+#### Scenario: App display format
+
+- **WHEN** an app with a name and bundle identifier is formatted
+- **THEN** the result SHALL be "Name — bundle.id"

--- a/openspec/specs/project-detection/spec.md
+++ b/openspec/specs/project-detection/spec.md
@@ -1,0 +1,152 @@
+# Project Detection & Skills
+
+## Purpose
+
+This capability gives the UI two pieces of contextual metadata about a working directory and the user's tooling. First, it inspects a project directory for well-known build-system marker files and reports a Nerd Font icon plus a language name so the task list and project views can label projects at a glance. Second, it discovers the Claude Code skills and slash commands available on the machine — from project-scoped directories, the user's `~/.claude/skills`, and installed plugins — so the new-task form can offer them for autocomplete.
+
+## Requirements
+
+### Requirement: Detect project language from marker files
+
+The capability SHALL inspect a directory for a fixed set of well-known build-system marker files and return the language name associated with the first matching marker. When no marker is found it SHALL return an empty language name.
+
+#### Scenario: Recognised marker present
+
+- **WHEN** a directory contains a recognised marker file (for example `go.mod`, `Cargo.toml`, `package.json`, `tsconfig.json`, `Gemfile`, `requirements.txt`, `setup.py`, `pyproject.toml`, `pom.xml`, `build.gradle`, or `mix.exs`)
+- **THEN** the detected language is the name mapped to that marker (`go`, `rust`, `node`, `typescript`, `ruby`, `python`, `python`, `python`, `java`, `java`, `elixir` respectively)
+
+#### Scenario: No recognised marker present
+
+- **WHEN** a directory contains none of the recognised marker files
+- **THEN** the detected language is the empty string
+
+### Requirement: Detect project icon from marker files
+
+The capability SHALL return a Nerd Font icon for a directory based on the first matching marker file, and SHALL return a generic folder icon when no marker matches. Some markers (such as `Makefile` and `.git`) map to an icon but carry no language name.
+
+#### Scenario: Language marker yields its icon
+
+- **WHEN** a directory contains a recognised language marker such as `go.mod`
+- **THEN** the returned icon is the marker's mapped icon, not the generic folder fallback
+
+#### Scenario: Git directory yields a non-fallback icon
+
+- **WHEN** a directory contains a `.git` directory and no higher-priority marker
+- **THEN** the returned icon is the git icon, not the generic folder fallback
+
+#### Scenario: No marker yields the folder fallback
+
+- **WHEN** a directory contains none of the recognised marker files
+- **THEN** the returned icon is the generic folder fallback icon
+
+### Requirement: First-match marker priority
+
+When a directory contains more than one recognised marker file, the capability SHALL resolve detection to the first marker in a fixed priority order, so detection is deterministic and independent of filesystem listing order.
+
+#### Scenario: Higher-priority marker wins
+
+- **WHEN** a directory contains both `go.mod` and `package.json`
+- **THEN** the detected language is `go`, because `go.mod` precedes `package.json` in the priority order
+
+### Requirement: Discover skills from project and user directories
+
+The capability SHALL discover skills by scanning each supplied project-scoped directory and then the user's `~/.claude/skills` directory, treating each immediate sub-directory that contains a `SKILL.md` manifest as one skill whose name is the sub-directory name. Non-directory entries SHALL be ignored, and a directory that cannot be read SHALL contribute no skills rather than causing an error.
+
+#### Scenario: User skill is discovered
+
+- **WHEN** `~/.claude/skills/<name>/SKILL.md` exists
+- **THEN** the discovered skill list includes an item named `<name>`
+
+#### Scenario: Missing skills directory is tolerated
+
+- **WHEN** a scanned skills directory does not exist or cannot be read
+- **THEN** no skills are contributed from that directory and no error is surfaced
+
+### Requirement: Discover plugin commands and skills
+
+The capability SHALL read `~/.claude/plugins/installed_plugins.json` and, for each installed plugin that has an install path, expose its `commands/*.md` files and any `SKILL.md` found recursively under `skills/` as items named `<plugin>:<name>`. Command names SHALL be the file base name without the `.md` extension; plugin-skill names SHALL be the manifest `name` field, falling back to the skill's directory name when that field is absent. Non-`.md` files in the commands directory SHALL be ignored. When the manifest is missing or cannot be parsed, plugin discovery SHALL contribute nothing while other sources still load.
+
+#### Scenario: Plugin command and skill are namespaced
+
+- **WHEN** an installed plugin `cortex` ships `commands/review.md` and a `skills/.../SKILL.md` whose frontmatter `name` is `font-licensing`
+- **THEN** the discovered list includes `cortex:review` and `cortex:font-licensing`
+
+#### Scenario: Non-markdown command files are ignored
+
+- **WHEN** a plugin's `commands` directory contains a non-`.md` file alongside `.md` command files
+- **THEN** only the `.md` command files become items
+
+#### Scenario: Missing plugin manifest does not block user skills
+
+- **WHEN** `installed_plugins.json` is absent but a user skill exists under `~/.claude/skills`
+- **THEN** the discovered list still contains the user skill and contains no plugin items
+
+#### Scenario: Plugin skills directory is a symlink
+
+- **WHEN** a plugin's `skills/` entry is a symlink to a real directory containing a `SKILL.md`
+- **THEN** the symlink is followed and the contained skill is discovered
+
+#### Scenario: Dangling plugin skills symlink is skipped
+
+- **WHEN** a plugin's `skills/` entry is a symlink whose target does not exist, but its `commands/` directory is valid
+- **THEN** no skill is discovered from the dangling symlink and the plugin's commands are still discovered
+
+### Requirement: Reject unsafe plugin names
+
+The capability SHALL skip any plugin whose name is empty or contains control characters or ANSI escape sequences (null, ESC, newline, carriage return, or tab), so that malicious manifest entries cannot inject characters into rendered names.
+
+#### Scenario: Plugin name with control characters is rejected
+
+- **WHEN** the manifest declares a plugin whose name contains an ANSI escape and a newline
+- **THEN** that plugin contributes no items to the discovered list
+
+### Requirement: Name-collision precedence
+
+The capability SHALL keep the first item seen for any given name and drop later duplicates, scanning project directories first, then the user skills directory, then plugins, so project-scoped skills win over user skills with the same name.
+
+#### Scenario: Project skill overrides user skill
+
+- **WHEN** both a project-scoped directory and `~/.claude/skills` define a skill named `review` with different descriptions
+- **THEN** the discovered list contains a single `review` item whose description is the project-scoped one
+
+### Requirement: Deterministic sorted output
+
+The capability SHALL return discovered skills sorted by name, so the same set of inputs always yields the same ordering.
+
+#### Scenario: Mixed sources are returned sorted
+
+- **WHEN** user skills and plugin items are discovered together
+- **THEN** the returned list is ordered ascending by name
+
+### Requirement: Read description from manifest frontmatter
+
+The capability SHALL read each item's description from a single top-level field in the YAML-style frontmatter block fenced by `---` lines at the start of the manifest, stripping surrounding quotes. It SHALL return an empty value when the file cannot be opened, the field is absent, or a frontmatter line exceeds the maximum line size, rather than returning a truncated or garbled value.
+
+#### Scenario: Description is parsed and unquoted
+
+- **WHEN** a manifest frontmatter contains `description: "User commit skill"`
+- **THEN** the item's description is `User commit skill` without the surrounding quotes
+
+#### Scenario: Over-long frontmatter line yields empty description
+
+- **WHEN** a manifest's description value exceeds the maximum frontmatter line size
+- **THEN** the parsed description is the empty string
+
+### Requirement: Filter skills by case-insensitive substring
+
+The capability SHALL filter a list of skills to those whose name contains a given filter string as a case-insensitive substring, matching anywhere in the name. An empty filter SHALL return the full list unchanged.
+
+#### Scenario: Substring matches user and plugin names
+
+- **WHEN** the list contains `review` and `cortex:review` and the filter is `re`
+- **THEN** both `review` and `cortex:review` are returned
+
+#### Scenario: Empty filter returns all
+
+- **WHEN** the filter string is empty
+- **THEN** every item in the input list is returned
+
+#### Scenario: Filter is case-insensitive
+
+- **WHEN** the filter is `CO` and the list contains `commit` and `cortex:review`
+- **THEN** both `commit` and `cortex:review` are returned

--- a/openspec/specs/remote-tui/spec.md
+++ b/openspec/specs/remote-tui/spec.md
@@ -1,0 +1,214 @@
+# Remote TUI Mode
+
+## Purpose
+
+Remote TUI mode lets the Argus terminal UI drive a daemon running on another
+host entirely over the REST API instead of a local SQLite database and Unix
+socket. It is launched with `--remote URL --token TOKEN` and is intended for
+controlling a home/work daemon over a private network such as Tailscale. All
+persistence and agent-session control routes through HTTP and Server-Sent
+Events, so the daemon remains the single owner of the database and the running
+agent processes.
+
+## Requirements
+
+### Requirement: Remote launch authentication and preflight
+
+The remote TUI SHALL require a bearer token and SHALL verify connectivity to
+the remote host before taking over the terminal, failing loudly with a
+distinct exit code or message for each failure class so a misconfigured host
+or token never produces a silent or corrupted alt-screen.
+
+#### Scenario: Missing token
+
+- **WHEN** `--remote` is launched with an empty token (neither `--token` nor `ARGUS_TOKEN` provided)
+- **THEN** the process SHALL print an error instructing the user to supply a token and exit with a non-zero status without starting the UI
+
+#### Scenario: Token rejected by remote
+
+- **WHEN** the initial status request to the remote host returns 401 Unauthorized
+- **THEN** the process SHALL print an error indicating the token was rejected and exit without starting the UI
+
+#### Scenario: Remote unreachable
+
+- **WHEN** the initial status request fails for any non-401 reason (host down, network error)
+- **THEN** the process SHALL print an error naming the unreachable base URL and exit without starting the UI
+
+#### Scenario: Token passed on the command line
+
+- **WHEN** the token is supplied via `--token` rather than the `ARGUS_TOKEN` environment variable
+- **THEN** the process SHALL emit a warning that the token is visible in process listings before the UI starts
+
+### Requirement: Authenticated REST transport
+
+The HTTP client SHALL attach the bearer token to every API request, normalise
+the base URL, and translate non-2xx responses into typed errors that callers
+can classify without string matching.
+
+#### Scenario: Authorization header on requests
+
+- **WHEN** any `/api/*` request is issued with a non-empty token
+- **THEN** the request SHALL carry an `Authorization: Bearer <token>` header
+
+#### Scenario: Base URL normalisation
+
+- **WHEN** a client is constructed with a base URL that has a trailing slash
+- **THEN** the trailing slash SHALL be stripped before requests are built
+
+#### Scenario: Not-found classification
+
+- **WHEN** a request returns HTTP 404 with an `{"error":"..."}` body
+- **THEN** the returned error SHALL be classifiable as not-found and expose the status code and server message
+
+#### Scenario: Unauthorized classification
+
+- **WHEN** a request returns HTTP 401
+- **THEN** the returned error SHALL be classifiable as unauthorized
+
+### Requirement: Persistence proxied over REST
+
+The remote store SHALL satisfy the same persistence interface as the local
+database, proxying each task, project, backend, schedule, and config operation
+to the corresponding REST endpoint, and SHALL translate remote not-found
+responses back into the local sentinel errors callers expect.
+
+#### Scenario: Listing and fetching tasks
+
+- **WHEN** the store lists or fetches tasks
+- **THEN** it SHALL return full task records sourced from the raw task endpoints, preserving fields such as dependencies
+
+#### Scenario: Not-found translated to local sentinel
+
+- **WHEN** fetching a task or schedule by ID returns a remote 404
+- **THEN** the store SHALL return the local not-found sentinel error (`db.ErrTaskNotFound` / `db.ErrScheduleNotFound`) rather than the raw HTTP error
+
+#### Scenario: Mutating a task
+
+- **WHEN** the store updates, renames, archives, or deletes a task
+- **THEN** it SHALL invoke the matching REST endpoint and the server SHALL own the resulting worktree, branch, and message/artifact cleanup
+
+### Requirement: Project and backend upsert semantics
+
+The store SHALL upsert projects and backends by attempting a create first and
+falling back to an update ONLY when the create fails specifically because the
+record already exists, so that genuine validation errors are surfaced rather
+than masked by a second attempt.
+
+#### Scenario: Create succeeds
+
+- **WHEN** a project or backend is set and the create request succeeds
+- **THEN** the store SHALL NOT issue an update request
+
+#### Scenario: Conflict falls back to update
+
+- **WHEN** the create request fails with HTTP 409 conflict
+- **THEN** the store SHALL retry the operation as an update with the same body
+
+#### Scenario: Other failures are surfaced
+
+- **WHEN** the create request fails with a non-409 status (other 4xx, 5xx) or a transport error
+- **THEN** the store SHALL return that error without attempting an update
+
+### Requirement: Config snapshot caching with periodic refresh
+
+The store SHALL serve config reads from a cached snapshot rather than a
+per-call HTTP request, and the remote mode SHALL refresh that snapshot
+periodically in the background so settings changed on the daemon become
+visible without a request on every UI frame.
+
+#### Scenario: Config served from cache
+
+- **WHEN** the cached config has been populated via a refresh and config is read repeatedly
+- **THEN** each read SHALL return the cached snapshot without issuing a new HTTP request
+
+#### Scenario: Refresh failure preserves prior snapshot
+
+- **WHEN** a config refresh request fails
+- **THEN** the previously cached snapshot SHALL be returned unchanged and the error reported to the caller
+
+#### Scenario: Periodic background refresh
+
+- **WHEN** remote mode is running
+- **THEN** the config snapshot SHALL be refreshed on a recurring interval until shutdown cancels the refresher
+
+### Requirement: Config value updates restricted to mapped keys
+
+The store SHALL update only the configuration keys that map to a known typed
+settings endpoint, and SHALL reject any unmapped key with an error rather than
+silently dropping the write.
+
+#### Scenario: Mapped key is forwarded
+
+- **WHEN** a recognised config key (e.g. a sandbox, KB, API, or defaults key) is set
+- **THEN** the store SHALL translate it to the typed settings update body and POST it to the settings endpoint
+
+#### Scenario: Unmapped key rejected
+
+- **WHEN** an unrecognised config key is set
+- **THEN** the store SHALL return an error indicating no remote handler exists for that key
+
+### Requirement: Agent sessions over HTTP and SSE
+
+The session provider SHALL satisfy the same session-provider interface as the
+in-process runner, fronting each task with a session whose terminal output is
+streamed over SSE into a local ring buffer while input, resize, stop, and
+status queries are issued as REST calls.
+
+#### Scenario: Starting a session attaches the stream
+
+- **WHEN** a session is started for a task
+- **THEN** the provider SHALL resume the task on the server, return a session handle, and begin streaming output for that task
+
+#### Scenario: Streamed output reaches the ring buffer
+
+- **WHEN** the SSE stream emits a base64-encoded `data:` output event
+- **THEN** the decoded bytes SHALL be appended to the session's local ring buffer and become readable via the recent-output accessors
+
+#### Scenario: Writing input updates last-input time
+
+- **WHEN** input is written to a session
+- **THEN** the bytes SHALL be POSTed to the input endpoint and the session's last-input timestamp SHALL advance
+
+#### Scenario: Session liveness queried from the server
+
+- **WHEN** running, idle, or has-session state is requested
+- **THEN** the provider SHALL derive the answer from the server's session-state endpoint, returning empty/false when that request fails
+
+### Requirement: Stream termination and reconnection
+
+A session's SSE reader SHALL distinguish a server-reported process exit from a
+transient connection drop, attempting a bounded number of reconnects on
+transient drops and reporting the appropriate exit reason when the session
+ultimately ends.
+
+#### Scenario: Server reports process exit
+
+- **WHEN** the stream emits an `event: exit` or the stream endpoint returns 404 (no session for the task)
+- **THEN** the session SHALL be marked done, removed from the provider, and the registered exit callback SHALL fire
+
+#### Scenario: Transient drop is retried
+
+- **WHEN** the stream connection drops without an exit event
+- **THEN** the reader SHALL attempt to reconnect up to a bounded retry limit before giving up
+
+#### Scenario: Retries exhausted
+
+- **WHEN** reconnection attempts are exhausted without recovering the stream
+- **THEN** the session SHALL be marked done and removed with a stream-lost exit reason
+
+### Requirement: Master-only operations and daemon-admin no-ops
+
+Operations the remote process cannot meaningfully perform SHALL surface a clear
+error rather than silently succeed: master-only server operations rejected for
+device tokens SHALL propagate the rejection, and persistence operations with no
+remote endpoint SHALL return an explanatory error.
+
+#### Scenario: Master-only endpoint rejected for a device token
+
+- **WHEN** a master-only operation (e.g. stop-all, prune-completed, raw task writes) is invoked with a device token and the server returns 403
+- **THEN** the error SHALL propagate to the caller rather than be treated as success
+
+#### Scenario: No remote endpoint for an operation
+
+- **WHEN** a store operation has no corresponding REST endpoint (e.g. purging task messages or artifacts directly)
+- **THEN** the store SHALL return an explanatory error noting the daemon performs that cleanup on task deletion instead

--- a/openspec/specs/rest-api/spec.md
+++ b/openspec/specs/rest-api/spec.md
@@ -1,0 +1,305 @@
+# REST API
+
+## Purpose
+
+The REST API exposes the Argus daemon's tasks, terminal sessions, configuration, git status, and uploads over HTTP so mobile devices and external scripts can drive the daemon remotely. It is designed for single-user remote control over Tailscale: it refuses to listen on untrusted LANs, authenticates every API request with a bearer token, and reserves destructive or configuration-mutating operations for the master token while allowing per-device tokens to perform per-task operations.
+
+## Requirements
+
+### Requirement: Network binding refuses untrusted networks
+
+The server SHALL bind to the loopback address (`127.0.0.1`) and, when a Tailscale CGNAT address is detected, additionally bind to that address. It SHALL NEVER bind to `0.0.0.0`. Loopback binding is mandatory; if it cannot bind within the retry window the server SHALL return an error. Tailscale binding is best-effort: failure to detect or bind the Tailscale address SHALL leave the server running on loopback only rather than aborting startup.
+
+#### Scenario: Loopback bind succeeds on the requested port
+
+- **WHEN** the requested port is free
+- **THEN** the server binds `127.0.0.1` on that port and reports the port it bound
+
+#### Scenario: Requested port in use advances to the next port
+
+- **WHEN** the requested port is already in use but a subsequent port within the retry window is free
+- **THEN** the server binds the next free port and reports that actual port
+
+#### Scenario: All candidate ports occupied
+
+- **WHEN** every port in the retry window is occupied
+- **THEN** the server returns an error explaining the bind failure that unwraps to the underlying syscall error
+
+#### Scenario: Tailscale address resolves only legitimate CGNAT addresses
+
+- **WHEN** Tailscale address discovery returns a non-CGNAT address such as `0.0.0.0`
+- **THEN** the discovery result is rejected and treated as "no Tailscale address" so the server binds loopback only
+
+### Requirement: Authenticated API access via bearer token or query param
+
+Every `/api/*` route SHALL require authentication. The server SHALL accept either an `Authorization: Bearer <token>` header or a `?token=<token>` query parameter, with the header taking precedence. A request with no recognized token SHALL be rejected with 401. A small set of routes that the browser must fetch before login (the dashboard, the share target, vendored static assets, the PWA manifest, the service worker, and icons) SHALL be served without authentication.
+
+#### Scenario: Valid master token accepted
+
+- **WHEN** a request presents `Authorization: Bearer <master-token>`
+- **THEN** the request is authenticated and tagged with `X-Argus-Auth: master`
+
+#### Scenario: Missing or wrong token rejected
+
+- **WHEN** a request to an `/api/*` route presents no token or an unrecognized token
+- **THEN** the server responds 401 Unauthorized
+
+#### Scenario: Query-param token accepted for EventSource
+
+- **WHEN** a request presents a valid token only via the `?token=` query parameter and no Bearer header
+- **THEN** the request is authenticated
+
+#### Scenario: Bearer header wins over query param
+
+- **WHEN** a request presents a valid Bearer header and a wrong `?token=` query parameter
+- **THEN** the request is authenticated using the Bearer header
+
+#### Scenario: Unauthenticated dashboard load
+
+- **WHEN** a request hits the dashboard route or a vendored static asset without a token
+- **THEN** the asset is served without requiring authentication
+
+### Requirement: Per-device and plugin-scoped tokens
+
+The server SHALL accept non-revoked per-device tokens persisted as SHA-256 hashes in addition to the master token. A device token (empty scope) SHALL be tagged `X-Argus-Auth: device`; a token bound to a non-empty scope SHALL be tagged `X-Argus-Auth: scope:<name>`. Revoked tokens SHALL be rejected. The plaintext token SHALL be returned only at mint time.
+
+#### Scenario: Device token authenticates and is tagged device
+
+- **WHEN** a request presents a valid, non-revoked device token
+- **THEN** the request is authenticated and tagged `X-Argus-Auth: device`
+
+#### Scenario: Plugin-scoped token tagged with its scope
+
+- **WHEN** a request presents a valid token minted with scope `ludwig`
+- **THEN** the request is authenticated and tagged `X-Argus-Auth: scope:ludwig`
+
+#### Scenario: Revoked token rejected
+
+- **WHEN** a request presents a token that has been revoked
+- **THEN** the server responds 401 Unauthorized
+
+### Requirement: Master-only gating for destructive and configuration endpoints
+
+Endpoints that mutate shared configuration or act across all tasks SHALL require the master token: project CRUD, backend CRUD, config and settings reads/writes, token minting/listing/revocation, stop-all sessions, and prune-completed. A request authenticated with a device token or a plugin-scoped token SHALL be rejected with 403 for these endpoints. Per-task operations (stop, delete, archive, rename, set-status, write input) SHALL remain available to any authenticated token.
+
+#### Scenario: Device token rejected from a master-only endpoint
+
+- **WHEN** a request authenticated as `device` calls a master-only endpoint such as stop-all, token minting, or project/backend CRUD
+- **THEN** the server responds 403 Forbidden
+
+#### Scenario: Master token permitted
+
+- **WHEN** a request authenticated as `master` calls a master-only endpoint
+- **THEN** the endpoint executes and returns its normal success status
+
+#### Scenario: Plugin scope token does not satisfy master
+
+- **WHEN** a request authenticated as `scope:<plugin>` calls a master-only endpoint
+- **THEN** the server responds 403 Forbidden
+
+#### Scenario: Device token allowed for per-task operations
+
+- **WHEN** a request authenticated as `device` calls a per-task operation such as stop or delete
+- **THEN** the operation executes (subject to task existence)
+
+### Requirement: Task creation
+
+The server SHALL create a task from a JSON body containing `prompt`, `project`, and optional `name` and `backend` fields. `project` SHALL be required. At least one of `name` or `prompt` SHALL be required. When `name` is empty it SHALL be synthesized from the prompt (first 40 characters, newlines/tabs replaced with spaces) and an asynchronous rename may follow. A `backend` that is not configured SHALL be rejected before any worktree is created. On success the server SHALL respond 201 with the new task id, name, and status. Requests with a `multipart/form-data` body SHALL additionally accept file attachments.
+
+#### Scenario: Creates a task
+
+- **WHEN** a valid create request with name, prompt, and project is submitted
+- **THEN** the server responds 201 with the task id and name
+
+#### Scenario: Missing project rejected
+
+- **WHEN** a create request omits `project`
+- **THEN** the server responds 400 Bad Request
+
+#### Scenario: Missing name and prompt rejected
+
+- **WHEN** a create request supplies neither `name` nor `prompt`
+- **THEN** the server responds 400 Bad Request
+
+#### Scenario: Unknown backend rejected
+
+- **WHEN** a create request names a backend that is not configured
+- **THEN** the server responds 400 Bad Request
+
+#### Scenario: Backend override persists to the task
+
+- **WHEN** a create request names a configured backend
+- **THEN** the created task records that backend
+
+### Requirement: Task listing and retrieval with runtime idle state
+
+The server SHALL list tasks and SHALL support optional filtering by `status`, `project`, and `archived` (`0`/default excludes archived, `1` returns only archived, `all` returns both). For each task the server SHALL derive a runtime `idle` flag that is true only when the task is `in_progress` and either has no live session or its session is waiting for input; non-`in_progress` tasks SHALL never be reported idle. Retrieving a task that does not exist SHALL return 404.
+
+#### Scenario: Lists all non-archived tasks
+
+- **WHEN** a list request omits the archived filter
+- **THEN** the server returns the non-archived tasks
+
+#### Scenario: In-progress task without a live session reports idle
+
+- **WHEN** a task is `in_progress` but has no live session
+- **THEN** its listed entry reports `idle: true`
+
+#### Scenario: Non-in-progress task never idle
+
+- **WHEN** a task is `pending`
+- **THEN** its listed entry reports idle false
+
+#### Scenario: Filter by status and project
+
+- **WHEN** a list request supplies `status` and/or `project` filters
+- **THEN** only tasks matching the filters are returned
+
+#### Scenario: Get a missing task
+
+- **WHEN** a get request names a task id that does not exist
+- **THEN** the server responds 404 Not Found
+
+### Requirement: Task lifecycle transitions
+
+Stopping a task SHALL stop its session (if any) and set its status to `in_review`. Resuming a task SHALL start or reattach a session and set status to `in_progress`, except that an actively-working (non-idle, live-session) `in_progress` task SHALL be refused with 409; idle or ghost `in_progress` tasks SHALL be resumed (healed) rather than refused. Setting status SHALL accept only `pending`, `in_progress`, `in_review`, `complete` and reject any other value. Renaming SHALL require a non-empty name. Deleting SHALL remove the task, its session, logs, and worktree/branch. Forking SHALL create a new task inheriting the source's prompt/project/backend when not overridden. All of these SHALL return 404 when the target task does not exist.
+
+#### Scenario: Stop flips status to in_review
+
+- **WHEN** a stop request targets an existing `in_progress` task
+- **THEN** the session is stopped and the task status becomes `in_review`
+
+#### Scenario: Resume refuses an actively-running task
+
+- **WHEN** a resume request targets an `in_progress` task with a live, non-idle session
+- **THEN** the server responds 409 Conflict
+
+#### Scenario: Resume heals a desynced live session
+
+- **WHEN** a resume request targets a task whose DB row drifted off `in_progress` while a live session still exists
+- **THEN** the server reattaches, re-syncs the row to `in_progress`, and reports the resume as healed
+
+#### Scenario: Set status rejects unknown value
+
+- **WHEN** a set-status request supplies a status outside the allowed set
+- **THEN** the server responds 400 Bad Request
+
+#### Scenario: Rename rejects empty name
+
+- **WHEN** a rename request supplies a blank name
+- **THEN** the server responds 400 Bad Request
+
+#### Scenario: Delete removes the worktree and branch
+
+- **WHEN** a delete request targets a task with a worktree and branch
+- **THEN** the task is removed and its worktree directory and branch are cleaned up
+
+#### Scenario: Fork requires a project
+
+- **WHEN** a fork request omits a project and the source task has none
+- **THEN** the server responds 400 Bad Request
+
+#### Scenario: Lifecycle action on a missing task
+
+- **WHEN** a stop, resume, rename, set-status, archive, or delete request names a task id that does not exist
+- **THEN** the server responds 404 Not Found
+
+### Requirement: Terminal output, input, and resize
+
+The server SHALL return a task's terminal output, preferring the on-disk session log and falling back to the live ring buffer, advertising a resume cursor (`X-Output-Total`) and source (`X-Source`) so a client can resume a stream without gap or overlap. A task with neither a log nor a live session SHALL return 404 for output. Writing input and reading/setting PTY size SHALL require a live session and return 404 otherwise. Resize SHALL reject zero dimensions and dimensions out of range (greater than 1000).
+
+#### Scenario: Output served from the on-disk log with resume cursor
+
+- **WHEN** an output request targets a task that has a session log on disk
+- **THEN** the server returns the log tail, sets `X-Source: log`, and sets `X-Output-Total` to the full log size
+
+#### Scenario: Tail bound does not change the resume cursor
+
+- **WHEN** an output request asks for a tail smaller than the full log
+- **THEN** the body is the requested tail but `X-Output-Total` still advertises the full file size
+
+#### Scenario: No log and no session
+
+- **WHEN** an output request targets a task with no log file and no live session
+- **THEN** the server responds 404 Not Found
+
+#### Scenario: Input or size without a live session
+
+- **WHEN** a write-input, get-size, or resize request targets a task with no live session
+- **THEN** the server responds 404 Not Found
+
+#### Scenario: Resize rejects invalid dimensions
+
+- **WHEN** a resize request supplies zero or out-of-range dimensions on a live session
+- **THEN** the server responds 400 Bad Request
+
+### Requirement: Configuration CRUD for projects and backends
+
+The server SHALL expose master-only CRUD for projects and backends. Creating a project SHALL require non-empty name and path; creating a backend SHALL require non-empty name and command; updating a backend SHALL require a non-empty command. The full configuration snapshot SHALL be retrievable (master-only) and SHALL include defaults, backends, and projects.
+
+#### Scenario: Create a backend
+
+- **WHEN** a master request creates a backend with name and command
+- **THEN** the backend is persisted and the server responds 201
+
+#### Scenario: Create backend rejects empty name
+
+- **WHEN** a master request creates a backend with an empty name
+- **THEN** the server responds 400 Bad Request
+
+#### Scenario: Config snapshot includes core sections
+
+- **WHEN** a master request reads the configuration snapshot
+- **THEN** the response contains defaults, backends, and projects
+
+### Requirement: Git status and diff are path-traversal safe
+
+The server SHALL return git status, file diff, and file-tree listings scoped to a task's worktree. These SHALL return 404 when the task or its worktree is unknown. Diff and file-tree path parameters SHALL reject absolute paths and any path containing `..` with 400, so the diff cannot be coerced into reading files outside the worktree.
+
+#### Scenario: Diff rejects absolute or dotdot paths
+
+- **WHEN** a git-diff request supplies an absolute path or a path containing `..`
+- **THEN** the server responds 400 Bad Request
+
+#### Scenario: Git status for an unknown worktree
+
+- **WHEN** a git-status request targets a task with no worktree
+- **THEN** the server responds 404 Not Found
+
+### Requirement: File uploads enforce size and count caps
+
+The server SHALL accept multipart file uploads (per task and at task creation) and SHALL enforce a per-file cap of 10 MB, a per-request total cap of 50 MB, and a maximum of 20 files. Uploaded filenames SHALL be sanitized (directory components, control characters, bidi overrides, and leading dashes removed) and written into the worktree without clobbering existing files (auto-suffixed). Oversize or too-many uploads SHALL return 413; empty or invalid-name parts SHALL return 400.
+
+#### Scenario: Oversize attachment rejected
+
+- **WHEN** an upload contains a file exceeding the per-file or per-request size cap, or exceeds the file count cap
+- **THEN** the server responds 413 Request Entity Too Large
+
+#### Scenario: Empty or invalid attachment name rejected
+
+- **WHEN** an upload contains an empty file part or a part whose name sanitizes to nothing
+- **THEN** the server responds 400 Bad Request
+
+#### Scenario: Filename collision auto-suffixed
+
+- **WHEN** an uploaded file's sanitized name already exists in the destination directory
+- **THEN** the saved file is given a numeric suffix so the existing file is not overwritten
+
+### Requirement: Settings partial update is master-only
+
+The server SHALL return a curated settings view (sandbox, KB, API, defaults) and SHALL apply partial updates where each absent section means "leave unchanged". Settings updates SHALL require the master token. Apple-event bundle IDs SHALL be filtered through validation before persistence so invalid entries are dropped. Log retrieval SHALL be limited to the whitelisted log names and SHALL return an empty body rather than 404 when a log file does not yet exist.
+
+#### Scenario: Settings update requires master
+
+- **WHEN** a settings update is requested without the master token
+- **THEN** the server responds 403 Forbidden
+
+#### Scenario: Missing log file returns empty body
+
+- **WHEN** a log read targets a whitelisted log that does not yet exist on disk
+- **THEN** the server responds 200 with an empty body
+
+#### Scenario: Unknown log name rejected
+
+- **WHEN** a log read targets a name that is not whitelisted
+- **THEN** the server responds 400 Bad Request

--- a/openspec/specs/rest-api/spec.md
+++ b/openspec/specs/rest-api/spec.md
@@ -80,7 +80,7 @@ The server SHALL accept non-revoked per-device tokens persisted as SHA-256 hashe
 
 ### Requirement: Master-only gating for destructive and configuration endpoints
 
-Endpoints that mutate shared configuration or act across all tasks SHALL require the master token: project CRUD, backend CRUD, config and settings reads/writes, token minting/listing/revocation, stop-all sessions, and prune-completed. A request authenticated with a device token or a plugin-scoped token SHALL be rejected with 403 for these endpoints. Per-task operations (stop, delete, archive, rename, set-status, write input) SHALL remain available to any authenticated token.
+Endpoints that mutate shared configuration or act across all tasks SHALL require the master token: project CRUD, backend CRUD, the config snapshot read (`GET /api/config`), settings writes (`PUT /api/settings`), token minting/listing/revocation, stop-all sessions, and prune-completed. A request authenticated with a device token or a plugin-scoped token SHALL be rejected with 403 for these endpoints. The curated settings read (`GET /api/settings`) SHALL remain available to any authenticated token, including device tokens. Per-task operations (stop, delete, archive, rename, set-status, write input) SHALL remain available to any authenticated token.
 
 #### Scenario: Device token rejected from a master-only endpoint
 
@@ -101,6 +101,11 @@ Endpoints that mutate shared configuration or act across all tasks SHALL require
 
 - **WHEN** a request authenticated as `device` calls a per-task operation such as stop or delete
 - **THEN** the operation executes (subject to task existence)
+
+#### Scenario: Settings read available to a device token
+
+- **WHEN** a request authenticated as `device` calls `GET /api/settings`
+- **THEN** the server returns the curated settings view (the read is not master-gated)
 
 ### Requirement: Task creation
 

--- a/openspec/specs/sandbox-execution/spec.md
+++ b/openspec/specs/sandbox-execution/spec.md
@@ -1,0 +1,196 @@
+# Sandbox Execution
+
+## Purpose
+
+Argus runs agent processes inside a macOS `sandbox-exec` confinement so an autonomous agent can do real work (edit its worktree, push over SSH, store auth tokens, drive a browser) without being able to write outside its task's worktree or read sensitive credential stores. This capability generates a deny-by-default SBPL profile per task, grants the minimal set of write and read paths the supported agent backends actually need, and wraps the agent command in the `sandbox-exec` invocation.
+
+## Requirements
+
+### Requirement: Sandbox availability detection
+
+The system SHALL report whether `sandbox-exec` is available on the host, preferring the canonical macOS path and falling back to `PATH` lookup. The result SHALL be cached after the first probe and SHALL be safe to query concurrently.
+
+#### Scenario: sandbox-exec present at canonical path
+
+- **WHEN** the host has an executable at the canonical `/usr/bin/sandbox-exec` path
+- **THEN** the availability check reports that the sandbox is available
+
+#### Scenario: cache reset re-probes
+
+- **WHEN** the cached availability is reset and the availability check is queried again
+- **THEN** the probe runs again and the cached value reflects the fresh result
+
+#### Scenario: concurrent queries are safe
+
+- **WHEN** many callers query availability simultaneously
+- **THEN** the probe runs once and all callers observe a consistent result without a data race
+
+### Requirement: Deny-by-default profile with worktree write access
+
+The generated SBPL profile SHALL deny all operations by default and SHALL grant write access only to the task's worktree and a fixed set of system temp locations. Writes inside the worktree SHALL succeed and writes to arbitrary paths outside the allowed set SHALL be denied.
+
+#### Scenario: write inside the worktree is allowed
+
+- **WHEN** a sandboxed command writes a file under the task's worktree path
+- **THEN** the write succeeds and the file exists
+
+#### Scenario: write outside the allowed set is denied
+
+- **WHEN** a sandboxed command writes a file to a path not covered by any allow rule
+- **THEN** the write fails and the file is not created
+
+#### Scenario: write to system temp is allowed
+
+- **WHEN** a sandboxed command creates a temp file under `/tmp`
+- **THEN** the write succeeds
+
+### Requirement: Generated profile parameterized by HOME and WORKTREE
+
+The system SHALL emit the profile with `HOME` and `WORKTREE` referenced as SBPL params, and SHALL return a params list binding those names to the resolved home directory and the resolved worktree path. All emitted paths SHALL be resolved through symlink resolution because the macOS kernel resolves symlinks before matching sandbox rules, so unresolved paths silently fail to match.
+
+#### Scenario: profile references the params
+
+- **WHEN** a profile is generated for a worktree
+- **THEN** the profile text references both the `HOME` and `WORKTREE` params, and the returned params list contains a `HOME=` entry and a `WORKTREE=` entry bound to the worktree path
+
+#### Scenario: symlink resolution falls back to the original path
+
+- **WHEN** a path cannot be symlink-resolved (for example it does not yet exist)
+- **THEN** the original path is used unchanged rather than failing generation
+
+### Requirement: Credential read protection
+
+The generated profile SHALL deny read access to known credential directories (`~/.gnupg`, `~/.aws`, `~/.kube`, `~/.config/gcloud`) while leaving `~/.ssh` readable so that git push and fetch over SSH continue to work.
+
+#### Scenario: credential dir reads are denied
+
+- **WHEN** a sandboxed command tries to read a protected credential directory such as `~/.aws`, `~/.gnupg`, or `~/.kube`
+- **THEN** the read is blocked
+
+#### Scenario: SSH directory remains readable
+
+- **WHEN** a sandboxed command reads `~/.ssh`
+- **THEN** the read is allowed, since SSH keys are required for git over SSH
+
+#### Scenario: custom deny-read path is honored
+
+- **WHEN** the sandbox config specifies an additional deny-read path and a sandboxed command tries to read a file under it
+- **THEN** the read is blocked
+
+### Requirement: Backend auth and session persistence writes
+
+The generated profile SHALL grant the narrow write paths each supported agent backend needs to persist auth tokens and session state, without broadening to all of `$HOME`. This covers `~/.claude.json` (including atomic-write sibling files), `~/.claude/`, `~/.codex/`, and `~/.pi/`. Unrelated `$HOME`-rooted paths SHALL remain denied.
+
+#### Scenario: Claude auth file and atomic-write siblings are writable
+
+- **WHEN** a sandboxed command writes `~/.claude.json` or an atomic-write sibling such as `~/.claude.json.tmp.NNN`, `~/.claude.json.backup`, or `~/.claude.json.lock`
+- **THEN** each write succeeds, preserving OAuth token persistence
+
+#### Scenario: Codex and Pi session state are writable
+
+- **WHEN** a sandboxed command writes Codex state under `~/.codex/` (auth, session DB, sessions) or Pi session files under `~/.pi/`
+- **THEN** the writes succeed so the backends can persist auth and resume sessions
+
+#### Scenario: unrelated HOME path stays denied
+
+- **WHEN** a sandboxed command writes an unrelated `$HOME`-rooted path such as `~/.not-claude-related`
+- **THEN** the write is denied, confirming the backend rules are not over-broad
+
+### Requirement: Narrow SSH known_hosts write access
+
+The generated profile SHALL allow writes to `~/.ssh/known_hosts` (prefix-scoped to cover OpenSSH's atomic mkstemp-then-rename update) while keeping private keys, `authorized_keys`, and the SSH `config` file write-protected.
+
+#### Scenario: known_hosts append and atomic tempfile are allowed
+
+- **WHEN** a sandboxed command appends to `~/.ssh/known_hosts` or writes an OpenSSH atomic-update tempfile like `~/.ssh/known_hosts.XXXXXX`
+- **THEN** the writes succeed so new host keys can be accepted without an interactive prompt
+
+#### Scenario: sensitive SSH files remain write-protected
+
+- **WHEN** a sandboxed command tries to write `~/.ssh/id_ed25519`, `~/.ssh/authorized_keys`, or `~/.ssh/config`
+- **THEN** each write is denied
+
+### Requirement: Scoped tool, cache, and browser write access
+
+The generated profile SHALL grant scoped write access to the GitHub CLI config (`~/.config/gh`), build-tool caches, the macOS Keychains directory, and the Google Chrome support directory, without broadening to their parent directories. In particular the gh allow rule SHALL NOT undo the gcloud deny-read, and the Chrome allow rule SHALL NOT broaden to all of Application Support.
+
+#### Scenario: gh config is writable but gcloud read stays denied
+
+- **WHEN** a sandboxed command writes a file under `~/.config/gh` and separately tries to read `~/.config/gcloud`
+- **THEN** the gh write succeeds and the gcloud read remains blocked
+
+#### Scenario: Chrome crashpad support file is writable
+
+- **WHEN** a sandboxed command writes the Chrome crashpad `settings.dat` under `~/Library/Application Support/Google/Chrome`
+- **THEN** the write succeeds, allowing Chrome to launch for browser automation
+
+#### Scenario: sibling Application Support directories stay denied
+
+- **WHEN** a sandboxed command writes to an unrelated `~/Library/Application Support/OtherApp` path
+- **THEN** the write is denied, confirming the Chrome rule is not over-broad
+
+#### Scenario: Keychains directory is writable
+
+- **WHEN** a sandboxed command writes a file under `~/Library/Keychains`
+- **THEN** the write succeeds so the agent can store API keys via the macOS Keychain
+
+### Requirement: Worktree git-dir write access
+
+When the worktree is a git worktree (its `.git` is a file pointing at a main repo's `.git/worktrees/<name>` directory), the generated profile SHALL grant write access to that main repo's `.git` directory so git metadata operations succeed. A plain repository or a non-git directory SHALL NOT add such a rule.
+
+#### Scenario: worktree git metadata is writable
+
+- **WHEN** the worktree's `.git` file points at a main repo's `.git/worktrees/<name>` and a sandboxed command writes a lock file under that git dir
+- **THEN** the write succeeds and the profile contains the corresponding git-dir write rule
+
+#### Scenario: non-worktree directory adds no git-dir rule
+
+- **WHEN** the path has a real `.git` directory or no `.git` at all
+- **THEN** no main-repo git-dir write rule is added to the profile
+
+### Requirement: Custom extra write paths
+
+The generated profile SHALL append a write-allow rule for each configured extra write path, expanding a leading `~/` to the home directory and trimming surrounding whitespace before resolving symlinks.
+
+#### Scenario: configured extra write path is granted
+
+- **WHEN** the sandbox config lists an extra write path and a sandboxed command writes a file under it
+- **THEN** the write succeeds
+
+### Requirement: AppleEvent destination allow rules with bundle-ID validation
+
+The system SHALL emit one `appleevent-send` allow rule per configured AppleEvent destination, but only for entries that pass syntactic CFBundleIdentifier validation; entries that are empty, whitespace-only, or fail validation SHALL be silently skipped so a single bad entry cannot make `sandbox-exec` reject the whole profile.
+
+#### Scenario: valid bundle IDs emit rules
+
+- **WHEN** the config lists valid bundle identifiers
+- **THEN** the profile contains one `appleevent-send` allow rule per identifier
+
+#### Scenario: invalid or injection entries are skipped
+
+- **WHEN** the config mixes a valid identifier with blank, whitespace-only, and SBPL injection-attempt entries
+- **THEN** only the valid identifier produces a rule and no injected content appears in the profile
+
+#### Scenario: bundle-ID validation accepts and rejects per charset
+
+- **WHEN** validating a candidate bundle identifier
+- **THEN** identifiers matching the allowed letters/digits/dot/hyphen charset (not starting with dot or hyphen) are accepted, and empty strings or those containing spaces, quotes, parentheses, semicolons, or slashes are rejected
+
+### Requirement: Profile lifecycle and command wrapping
+
+The system SHALL write the generated profile to a temporary file and return a cleanup function that removes it; after cleanup the file SHALL no longer exist. The system SHALL wrap an agent command in a `sandbox-exec` invocation that passes each param via `-D`, the profile via `-f`, and runs the command through `sh -c`, with all arguments shell-quoted. When the sandbox is disabled, the command SHALL NOT be wrapped and no cleanup function SHALL be returned.
+
+#### Scenario: cleanup removes the profile file
+
+- **WHEN** a profile is generated and its cleanup function is then called
+- **THEN** the temporary profile file exists before cleanup and is removed afterward
+
+#### Scenario: wrapped command carries params, profile, and shell invocation
+
+- **WHEN** a command is wrapped with the sandbox using a profile path and params
+- **THEN** the result begins with the sandbox-exec path, contains a `-D` flag for each param, a `-f` flag with the profile path, and runs the original command via `sh -c`
+
+#### Scenario: sandbox disabled skips wrapping
+
+- **WHEN** an agent command is built with the sandbox disabled
+- **THEN** the resulting command is not wrapped in `sandbox-exec` and no cleanup function is returned

--- a/openspec/specs/scheduling/spec.md
+++ b/openspec/specs/scheduling/spec.md
@@ -1,0 +1,163 @@
+# Task Scheduling
+
+## Purpose
+
+Lets an operator register prompts that spawn argus tasks automatically — either on a recurring cron cadence or once at a specific future time. A daemon-resident scheduler fires due schedules by creating tasks through the standard headless task-creation flow, and a master-only REST surface lets operators list, create, update, delete, and manually run schedules.
+
+## Requirements
+
+### Requirement: Cadence validation
+
+A schedule MUST specify exactly one cadence: either a cron expression (`schedule`) or a one-shot fire time (`run_once_at`), never both and never neither. A schedule MUST also have a non-empty name, project, and prompt. Cron expressions accept standard 5-field syntax, descriptors (`@hourly`, `@daily`, etc.), and intervals (`@every 30m`). A one-shot fire time MUST be RFC3339-formatted and in the future. A request specifying both cadences in one call MUST be rejected.
+
+#### Scenario: Missing required field is rejected
+- **WHEN** a create request omits name, project, prompt, or any cadence
+- **THEN** the request is rejected with a 400 Bad Request and no schedule is persisted
+
+#### Scenario: Malformed cron expression is rejected
+- **WHEN** a create request supplies a cron expression that does not parse
+- **THEN** the request is rejected with a 400 Bad Request
+
+#### Scenario: Past or malformed run_once_at is rejected
+- **WHEN** a create request supplies a `run_once_at` that is in the past or not RFC3339
+- **THEN** the request is rejected with a 400 Bad Request
+
+#### Scenario: Both cadences in one request is rejected
+- **WHEN** a request supplies both a non-empty cron expression and a non-empty `run_once_at`
+- **THEN** the request is rejected with a 400 Bad Request and an error indicating exactly one cadence must be chosen
+
+### Requirement: Schedule lifecycle over REST
+
+The API MUST support creating, listing, updating, and deleting schedules. New schedules default to enabled and MUST have their next-run time pre-populated so the UI can preview it before the first tick. Updates MUST support partial field changes (e.g. toggling enabled without resending the prompt). Updating or deleting a non-existent schedule MUST return 404 Not Found.
+
+#### Scenario: Create returns the persisted schedule
+- **WHEN** a valid create request is submitted
+- **THEN** the schedule is persisted with a generated ID, defaults to enabled, has a populated next-run time, and is returned with 201 Created
+
+#### Scenario: Partial update toggles a single field
+- **WHEN** an update request sets only `enabled` to false
+- **THEN** the schedule's enabled flag is updated and all other fields are preserved, returned with 200 OK
+
+#### Scenario: Delete removes the schedule
+- **WHEN** a delete request targets an existing schedule
+- **THEN** the schedule is removed and returns 204 No Content, and a subsequent list no longer contains it
+
+#### Scenario: Operating on a missing schedule
+- **WHEN** an update or delete targets an ID that does not exist
+- **THEN** the response is 404 Not Found
+
+### Requirement: Cadence switching clears the prior anchor
+
+When an update changes the cadence, the previously-set cadence anchor MUST be cleared automatically so a row is never simultaneously recurring and one-shot. Switching to a one-shot clears the cron expression; switching to a cron expression clears the one-shot time. Whenever the cadence changes, the next-run time MUST be recomputed.
+
+#### Scenario: Recurring switched to one-shot
+- **WHEN** a recurring schedule is updated with a future `run_once_at`
+- **THEN** the cron expression is cleared and the schedule becomes a one-shot
+
+#### Scenario: One-shot switched to recurring
+- **WHEN** a one-shot schedule is updated with a cron expression
+- **THEN** the one-shot fire time is cleared and the schedule becomes recurring
+
+#### Scenario: Editing a never-run schedule anchors next-run on now
+- **WHEN** the cron expression of a schedule that has never fired is updated
+- **THEN** the recomputed next-run time is a real future time anchored on the present, not a year-0001 date that would fire on the next tick
+
+### Requirement: Master-only access
+
+All schedule endpoints (list, create, update, delete, run-now) MUST require master authorization. Per-device tokens MUST be denied because schedule prompts can carry sensitive operational context.
+
+#### Scenario: Device token is forbidden
+- **WHEN** any schedule endpoint is called with a per-device token rather than the master token
+- **THEN** the response is 403 Forbidden
+
+### Requirement: First fire is deferred, not immediate
+
+A recurring schedule MUST NOT fire on the first scheduler tick after creation. The first tick only computes and persists the next-run time; the schedule fires only on a later tick once its next-run time has passed. Disabled schedules MUST still have their next-run time populated for UI preview, but MUST NOT fire.
+
+#### Scenario: No fire on the initial tick
+- **WHEN** the scheduler ticks for the first time after a recurring schedule is created
+- **THEN** no task is created and the schedule's next-run time is populated
+
+#### Scenario: Fire once the next-run time passes
+- **WHEN** a later tick observes that an enabled schedule's next-run time has passed
+- **THEN** the scheduler creates exactly one task and recomputes the next-run time to a future instant
+
+#### Scenario: Disabled schedule never fires
+- **WHEN** the scheduler ticks for a disabled schedule whose next-run time has passed
+- **THEN** no task is created but the next-run time is still populated for display
+
+### Requirement: Firing creates a task and records bookkeeping
+
+When a schedule fires, the scheduler MUST create a task using the schedule's name, prompt, project, and backend override. The fired task name MUST be made unique per fire by appending the fire timestamp so concurrent worktrees cannot collide. On success the schedule MUST record the last-run time, the created task ID, and clear any prior error. The backend override MUST reach task creation at fire time so the launched agent runs on the overriding backend.
+
+#### Scenario: Fire creates a task with the schedule's fields
+- **WHEN** a due schedule fires
+- **THEN** a task is created carrying the schedule's project and prompt, and the schedule records last-run time and the new task ID
+
+#### Scenario: Backend override is passed at fire time
+- **WHEN** a schedule with a non-empty backend override fires (via tick or run-now)
+- **THEN** the created task is launched with that backend
+
+### Requirement: Fire failures are surfaced without losing the row
+
+If task creation fails when a schedule fires, the scheduler MUST persist the error for display and MUST NOT drop the schedule. For recurring rows the next-run time advances normally; for one-shot rows the schedule stays enabled so it (or the user) can retry, and its fire time remains visible.
+
+#### Scenario: Recurring fire failure records the error
+- **WHEN** task creation fails on a recurring schedule fire
+- **THEN** the schedule's last error is populated and no task is reported created
+
+#### Scenario: One-shot fire failure keeps the row enabled
+- **WHEN** task creation fails on a due one-shot schedule
+- **THEN** the schedule's last error is populated, it remains enabled, and its next-run time stays populated
+
+### Requirement: One-shot fires exactly once then auto-disables
+
+A one-shot schedule MUST fire once when its fire time has passed and it is enabled, then auto-disable and clear its next-run time so it cannot fire again. Until it fires, its next-run time mirrors its fire time. Once it has fired (last-run time set), it MUST never fire again — even if the user re-enables it.
+
+#### Scenario: Fires once and disables
+- **WHEN** an enabled one-shot schedule's fire time passes and the scheduler ticks
+- **THEN** exactly one task is created, the schedule auto-disables, its next-run time is cleared, and later ticks create no further tasks
+
+#### Scenario: Re-enabling a fired one-shot does not refire
+- **WHEN** a one-shot schedule that already fired is manually re-enabled
+- **THEN** subsequent ticks create no new task and the next-run time stays cleared
+
+#### Scenario: Disabled one-shot with a past time never fires
+- **WHEN** a disabled one-shot schedule whose fire time is in the past is ticked
+- **THEN** no task is created
+
+### Requirement: Run-now fires out of cycle without double-firing
+
+The run-now action MUST fire a schedule immediately regardless of its next-run time, updating bookkeeping so the regular tick will not fire the same schedule again right after. A one-shot run via run-now MUST also auto-disable the row. Running a non-existent schedule MUST return 404. Run-now on a recurring schedule with a malformed cron expression MUST persist the parse error and not fire.
+
+#### Scenario: Run-now fires immediately and advances bookkeeping
+- **WHEN** an operator triggers run-now on a recurring schedule
+- **THEN** exactly one task is created, the last-run time is recorded, and a concurrent or following tick does not produce a duplicate task
+
+#### Scenario: Run-now on a one-shot auto-disables
+- **WHEN** an operator triggers run-now on a future-dated one-shot schedule
+- **THEN** a task is created and the schedule auto-disables even though its fire time had not yet arrived
+
+#### Scenario: Run-now on a missing schedule
+- **WHEN** run-now targets an ID that does not exist
+- **THEN** the response is 404 Not Found
+
+#### Scenario: Run-now is unavailable without a running scheduler
+- **WHEN** run-now is called but no scheduler is wired into the API
+- **THEN** the response is 503 Service Unavailable
+
+### Requirement: Manual fires suppress automatic notifications
+
+The scheduler MAY notify on a fire via a callback. The callback MUST be invoked only for automatic (tick-driven) fires that succeed; it MUST NOT be invoked for manual run-now fires (which are explicit user actions) nor when a fire fails.
+
+#### Scenario: Notification on a successful tick fire
+- **WHEN** an automatic tick fire successfully creates a task and a fire callback is registered
+- **THEN** the callback is invoked once with the created task
+
+#### Scenario: No notification for run-now
+- **WHEN** a schedule is fired via run-now
+- **THEN** the fire callback is not invoked
+
+#### Scenario: No notification when a fire fails
+- **WHEN** an automatic tick fire fails to create a task
+- **THEN** the fire callback is not invoked

--- a/openspec/specs/self-update/spec.md
+++ b/openspec/specs/self-update/spec.md
@@ -1,0 +1,115 @@
+# Self-Update
+
+## Purpose
+
+Self-update lets the operator replace the running Argus binary in place with a freshly built one, sourced from a configured local Argus source clone. The capability rebuilds the binary by syncing the clone to the latest published source and running `go install`, then triggers a daemon respawn so the new binary takes over. It is an operator-only control surface, gated behind the master credential.
+
+## Requirements
+
+### Requirement: Configured source path
+
+The capability SHALL operate against a source directory configured as the master-only `argus.source_path` setting. The configured path SHALL be readable and writable through the control surface, and SHALL be persisted across calls.
+
+#### Scenario: Reading the configured source path
+
+- **WHEN** the master credential requests the configured source path
+- **THEN** the currently persisted `argus.source_path` value is returned
+
+#### Scenario: Persisting a new source path
+
+- **WHEN** the master credential submits a new source path
+- **THEN** the value is persisted as `argus.source_path` and the persisted value is returned
+
+#### Scenario: Whitespace is trimmed
+
+- **WHEN** a source path is submitted with leading or trailing whitespace
+- **THEN** the persisted value has the surrounding whitespace removed
+
+### Requirement: Master-only access
+
+All self-update operations (reading the source path, setting the source path, and triggering an update) SHALL require the master credential. Device-scoped credentials SHALL be rejected.
+
+#### Scenario: Device token cannot read the source path
+
+- **WHEN** a request authenticated with a device token asks for the source path
+- **THEN** the request is rejected with a forbidden status
+
+#### Scenario: Device token cannot trigger an update
+
+- **WHEN** a request authenticated with a device token triggers an update
+- **THEN** the request is rejected with a forbidden status
+
+### Requirement: Source path validation
+
+An update run SHALL validate the configured source path before building. An empty path, a path that is not an existing directory, or a directory that is not a Go module (no `go.mod`) SHALL cause the run to fail without attempting a build.
+
+#### Scenario: Empty source path
+
+- **WHEN** an update is triggered with no source path configured
+- **THEN** the run fails with an error indicating the source path is not set and no build is attempted
+
+#### Scenario: Nonexistent source directory
+
+- **WHEN** the configured source path does not point at an existing directory
+- **THEN** the run fails with an error indicating the path is not a directory
+
+#### Scenario: Source path is not a Go module
+
+- **WHEN** the configured source directory contains no `go.mod`
+- **THEN** the run fails with an error indicating the path is not a Go module
+
+### Requirement: Sync source clone to origin/master
+
+When the source directory is a git clone (contains a `.git` directory), an update run SHALL fetch `origin master` and hard-reset the working tree to `origin/master` before building, so that whatever is on `origin/master` is exactly what gets installed. The sync SHALL be best-effort: a fetch or reset failure SHALL be recorded in the output log but SHALL NOT abort the run, and the build SHALL proceed against whatever the clone then contains.
+
+#### Scenario: Clone is reset to origin/master before building
+
+- **WHEN** an update runs against a git clone whose working tree has diverged from `origin/master`
+- **THEN** the working tree is hard-reset to match `origin/master` and the build runs against that content
+
+#### Scenario: Fetch failure does not abort the run
+
+- **WHEN** the fetch of `origin master` fails (for example, the operator is offline or the remote has no `master` branch)
+- **THEN** the failure is recorded in the output log and the build proceeds against the existing clone contents
+
+#### Scenario: Non-git source directory skips sync
+
+- **WHEN** the source directory is a Go module without a `.git` directory
+- **THEN** no fetch or reset is attempted and the build runs directly
+
+### Requirement: Build via go install
+
+An update run SHALL build and install the binary by running `go install ./...` from the source directory. The combined stdout and stderr of every step SHALL be accumulated into an output log that is returned to the caller regardless of success or failure. A `go install` failure SHALL fail the run.
+
+#### Scenario: Successful build
+
+- **WHEN** `go install ./...` succeeds against a valid source module
+- **THEN** the run succeeds and the output log includes a success marker indicating the daemon should be restarted to pick up the new binary
+
+#### Scenario: Build failure surfaces the log
+
+- **WHEN** `go install ./...` fails (for example, the source does not compile)
+- **THEN** the run fails and the returned output log includes the build step output so the operator can see the cause
+
+### Requirement: Respawn on successful update
+
+When an update build succeeds, the control surface SHALL report success to the caller before triggering a daemon respawn, and SHALL signal that a restart will occur. The success response SHALL be flushed to the client before the successor daemon is spawned, because the successor terminates the current daemon as it starts. On a failed update, the control surface SHALL report failure and SHALL signal that no restart will occur.
+
+#### Scenario: Success response precedes respawn
+
+- **WHEN** an update build succeeds
+- **THEN** a success response carrying the build output and a restart-will-occur signal is flushed to the caller, and only afterward is a successor daemon spawned
+
+#### Scenario: Failure reports no restart
+
+- **WHEN** an update build fails
+- **THEN** the caller receives a failure response carrying the build output and a signal that no restart will occur
+
+### Requirement: Respawn refused under test binary
+
+The successor-daemon spawn SHALL be refused when the process is running as a Go test binary, to avoid re-invoking the test binary as a daemon (which would re-run the entire test suite as a fork bomb).
+
+#### Scenario: Spawn refused from a test binary
+
+- **WHEN** a successor daemon spawn is attempted from a process identified as a Go test binary
+- **THEN** the spawn is refused with an error and the current process is left running

--- a/openspec/specs/session-artifacts/spec.md
+++ b/openspec/specs/session-artifacts/spec.md
@@ -1,0 +1,105 @@
+# Session Artifacts
+
+## Purpose
+
+Session artifacts are files (HTML reports, PDFs, images, markdown, text) that an agent produces during a task and registers in a per-task manifest. This capability exposes those artifacts over the REST API so the remote SPA can list and view them, while enforcing that only registered files are served, that no file outside the task's artifact directory can be reached, and that embedded artifacts can be safely iframed without leaking the caller's auth token.
+
+## Requirements
+
+### Requirement: List task artifacts
+
+The API SHALL return the registered-artifact manifest for an existing task as a JSON object. When a task has no artifacts the response SHALL contain an empty array rather than a null value. Requests for a non-existent task SHALL be rejected.
+
+#### Scenario: Task with registered artifacts
+
+- **WHEN** a client requests the artifact list for a task that has registered artifacts
+- **THEN** the response is HTTP 200 with a JSON `artifacts` array containing each registered artifact's metadata
+
+#### Scenario: Task with no artifacts
+
+- **WHEN** a client requests the artifact list for an existing task that has no registered artifacts
+- **THEN** the response is HTTP 200 and the `artifacts` field is an empty array (`[]`), never null
+
+#### Scenario: Unknown task
+
+- **WHEN** a client requests the artifact list for a task ID that does not exist
+- **THEN** the response is HTTP 404
+
+### Requirement: Serve registered artifact bytes
+
+The API SHALL serve the raw bytes of a single artifact selected by its on-disk filename, with the Content-Type that matches the artifact's recorded type. Range requests and HEAD handling SHALL be supported for the served content.
+
+#### Scenario: Serve by artifact type
+
+- **WHEN** a client requests a registered artifact whose type is HTML, markdown, PDF, image, or text
+- **THEN** the response is HTTP 200, the body is the exact stored bytes, and the Content-Type matches the artifact type (for example `text/html; charset=utf-8` for HTML, `application/pdf` for PDF, `image/png` for a PNG image)
+
+### Requirement: Manifest-scoped serving
+
+A filename SHALL only be served when a manifest row exists for that (task, filename) pair. The presence of a file on disk without a corresponding manifest row SHALL NOT make it servable. A manifest row whose backing bytes are missing SHALL produce a not-found response rather than an error.
+
+#### Scenario: Unregistered file on disk
+
+- **WHEN** a file physically exists in the task's artifact directory but has no manifest row, and a client requests it
+- **THEN** the response is HTTP 404 and the bytes are not served
+
+#### Scenario: Registered row with missing bytes
+
+- **WHEN** a manifest row exists but its backing file was never written or has been deleted
+- **THEN** the response is HTTP 404
+
+### Requirement: Path-escape defense
+
+The API SHALL ensure a served file resolves to a location directly inside the task's artifact directory. Filenames that traverse outside the directory, name a nested subpath, or resolve through a symlink to a target outside the directory SHALL be refused, even when a manifest row would otherwise select them.
+
+#### Scenario: Path traversal
+
+- **WHEN** the resolved artifact filename attempts to traverse above the artifact directory (for example `../../../etc/passwd`)
+- **THEN** the path is refused and the bytes are not served
+
+#### Scenario: Nested subpath
+
+- **WHEN** the resolved artifact filename names a path inside a subdirectory rather than a direct child of the artifact directory
+- **THEN** the path is refused
+
+#### Scenario: Symlink escape
+
+- **WHEN** a file inside the artifact directory is a symlink pointing to a target outside that directory
+- **THEN** the path is refused and the symlink target is not served
+
+#### Scenario: Legitimate basename
+
+- **WHEN** the filename is a direct child of the artifact directory and its real (symlink-resolved) path is still inside that directory
+- **THEN** the resolved real path is accepted and its bytes are served
+
+### Requirement: Framing and caching headers
+
+When serving an artifact, the API SHALL relax the global frame-deny policy to permit same-origin embedding, set an equivalent content-security-policy that restricts frame ancestors to the same origin, and instruct intermediaries not to cache the response so a regenerated artifact under the same name is never served stale.
+
+#### Scenario: Headers on a served artifact
+
+- **WHEN** a registered artifact is served successfully
+- **THEN** the response sets `X-Frame-Options: SAMEORIGIN`, `Content-Security-Policy: frame-ancestors 'self'`, and `Cache-Control: no-store`
+
+### Requirement: Authenticated access
+
+Both the artifact list endpoint and the raw artifact endpoint SHALL require authentication; neither is in the auth-skip allowlist. Read-only access via a device token SHALL be sufficient.
+
+#### Scenario: Missing token
+
+- **WHEN** a client requests either the artifact list or a raw artifact without a valid token
+- **THEN** the response is HTTP 401
+
+#### Scenario: Valid token
+
+- **WHEN** a client requests a raw artifact with a valid bearer token
+- **THEN** the response is HTTP 200
+
+### Requirement: Artifact cleanup on task deletion
+
+Deleting a task SHALL remove both its artifact manifest rows and its on-disk artifact directory.
+
+#### Scenario: Delete task with artifacts
+
+- **WHEN** a task that has registered artifacts is deleted
+- **THEN** the manifest rows for that task are removed and the task's on-disk artifact directory no longer exists

--- a/openspec/specs/settings-view/spec.md
+++ b/openspec/specs/settings-view/spec.md
@@ -1,0 +1,297 @@
+# Settings View
+
+## Purpose
+
+The Settings View is the configuration tab of the argus TUI. It presents a two-panel layout — a left rail of categories and a right pane that renders the selected category's rows and per-row detail. It lets the user inspect and change system, sandbox, project, backend, schedule, knowledge-base, remote-API, appearance, and logging configuration, and renders plugin-registered settings sections (forms and live streams) alongside the built-in categories.
+
+## Requirements
+
+### Requirement: Category rail navigation
+
+The view SHALL present a fixed set of built-in categories (System, Sandbox, Projects, Backends, Schedules, Knowledge Base, Remote API, Appearance, Logs) in a left rail and let the user move focus between the rail and the right pane. Selecting a category SHALL load that category's rows into the pane and reset the row cursor to the top.
+
+#### Scenario: Default focus and category on open
+
+- **WHEN** the Settings View is created
+- **THEN** the active category is System and input focus is on the right pane
+
+#### Scenario: Moving focus to the rail and back
+
+- **WHEN** focus is on the pane and the user presses Left (or `h`)
+- **THEN** focus moves to the rail
+- **WHEN** focus is on the rail and the user presses Right (or `l`) or Enter
+- **THEN** focus moves back to the pane
+
+#### Scenario: Selecting a different category
+
+- **WHEN** focus is on the rail and the user moves the rail cursor to another category
+- **THEN** the active category changes, the pane renders that category's rows, and the row cursor resets to the first row
+
+#### Scenario: Vim aliases for navigation
+
+- **WHEN** the user presses `j` or `k`
+- **THEN** the cursor moves down or up respectively, in either the rail (when rail-focused) or the row list (when pane-focused)
+
+### Requirement: Boolean configuration toggles persist
+
+Pressing Enter on the Sandbox, Knowledge Base, or Remote API status row SHALL flip the corresponding boolean and persist the new value to the configuration store.
+
+#### Scenario: Toggling the sandbox
+
+- **WHEN** the cursor is on the Sandbox status row and the user presses Enter
+- **THEN** the sandbox-enabled state inverts and the new value is written to config key `sandbox.enabled`
+
+#### Scenario: Toggling the knowledge base
+
+- **WHEN** the cursor is on the Knowledge Base status row and the user presses Enter
+- **THEN** the KB-enabled state inverts and the new value is written to config key `kb.enabled`
+
+#### Scenario: Toggling the remote API
+
+- **WHEN** the cursor is on the Remote API status row and the user presses Enter
+- **THEN** the API-enabled state inverts and the new value is written to config key `api.enabled`
+
+### Requirement: Restart-required indication for boot-sensitive settings
+
+For settings that only take effect when the daemon restarts (Metis vault path and Remote API enabled state), the view SHALL capture the value in effect at boot on first refresh and SHALL append a "restart required" indication while the current value differs from the boot value.
+
+#### Scenario: Vault path changed after boot
+
+- **WHEN** the Metis vault path has been changed to a value different from the value recorded at the first refresh
+- **THEN** the vault path row is annotated with "(restart required)"
+
+#### Scenario: API enabled state changed after boot
+
+- **WHEN** the Remote API enabled state differs from the value recorded at the first refresh
+- **THEN** the Remote API row and detail show "(restart required)"
+
+### Requirement: Project and schedule management actions delegate to callbacks
+
+In the Projects category, the view SHALL fire new/edit/delete/quick-add/apple-events callbacks for the selected project. In the Schedules category, the view SHALL fire new/edit/delete/toggle/run callbacks for the selected schedule. Action keys SHALL be ignored when focus is on the rail or the category does not apply.
+
+#### Scenario: Editing the selected project
+
+- **WHEN** the cursor is on a project row and the user presses `e`
+- **THEN** the edit-project callback fires with the selected project's name and config
+
+#### Scenario: Deleting the selected project
+
+- **WHEN** the cursor is on a project row and the user presses `d`
+- **THEN** the delete-project callback fires with the selected project's name
+
+#### Scenario: Apple-events key only applies to a project row
+
+- **WHEN** the user presses `a` while focus is on the rail or the active category is not Projects
+- **THEN** no callback fires and the key is not consumed
+
+#### Scenario: Toggling a schedule persists its enabled state
+
+- **WHEN** the cursor is on a schedule row and the user presses `t`
+- **THEN** the schedule's enabled flag inverts and the change is persisted to the store
+
+#### Scenario: Running a schedule now
+
+- **WHEN** the cursor is on a schedule row and the user presses `r`
+- **THEN** the run-schedule callback fires with the schedule's ID
+
+### Requirement: Default backend selection persists
+
+Pressing `d` on a non-default backend row SHALL mark that backend as the default and persist it; pressing `d` on the already-default backend SHALL be a no-op.
+
+#### Scenario: Setting a new default backend
+
+- **WHEN** the cursor is on a backend that is not the current default and the user presses `d`
+- **THEN** the default backend becomes that backend and `default_backend` is written to config
+
+#### Scenario: Pressing default on the current default
+
+- **WHEN** the cursor is on the backend already marked default and the user presses `d`
+- **THEN** nothing changes
+
+### Requirement: Empty categories show a guiding placeholder
+
+When the Projects, Backends, or Schedules category has no entries, the view SHALL render a single placeholder row directing the user how to add one rather than an empty list.
+
+#### Scenario: No projects
+
+- **WHEN** the Projects category is active and no projects exist
+- **THEN** a placeholder row prompting the user to press `n` to add is shown
+
+### Requirement: Inline path editing commits or cancels
+
+The Metis vault path and Argus source path rows SHALL support inline text editing. Pressing Enter SHALL commit the edited buffer and persist it; pressing Escape SHALL abort without persisting. While editing, navigation keys SHALL be consumed so the cursor and tab do not change.
+
+#### Scenario: Committing a vault path edit
+
+- **WHEN** the user edits the Metis vault path and presses Enter
+- **THEN** the vault path updates to the edited value and is written to config key `kb.metis_vault_path`
+
+#### Scenario: Cancelling a source path edit
+
+- **WHEN** the user is editing the Argus source path and presses Escape
+- **THEN** editing ends and the source path retains its prior value
+
+#### Scenario: Navigation keys are inert while editing
+
+- **WHEN** an inline editor is active and the user presses an arrow key
+- **THEN** the keypress is consumed and neither the row cursor nor the active tab changes
+
+### Requirement: Cycling settings via arrow keys
+
+The Appearance spinner row SHALL cycle through spinner styles on Left/Right (and Enter advances forward), persisting the choice. The vault path row SHALL cycle through discovered iCloud vaults on Left/Right; with no discovered vaults the cycle SHALL be a no-op.
+
+#### Scenario: Cycling the spinner style
+
+- **WHEN** the cursor is on the spinner row and the user presses Right
+- **THEN** the spinner style advances to the next style and is written to config key `ui.spinner`
+
+#### Scenario: Cycling vault path with no discovered vaults
+
+- **WHEN** the cursor is on the vault path row, no iCloud vaults were discovered, and the user presses Left or Right
+- **THEN** the vault path does not change
+
+### Requirement: Logs category renders and scrolls log content
+
+The Logs category SHALL offer a UX Log and a Daemon Log row, render the selected log's lines in the detail pane, scroll on mouse wheel, and reset scroll state when the cursor moves off the log row or switches to a different log.
+
+#### Scenario: Scrolling a log with the wheel
+
+- **WHEN** a log row is selected and the user scrolls the wheel up or down
+- **THEN** the log scroll offset decreases or increases (never below zero)
+
+#### Scenario: Switching logs resets scroll
+
+- **WHEN** the cursor moves off the current log row or to a different log
+- **THEN** the cached log lines and scroll offset are reset
+
+### Requirement: Daemon-dependent and platform-dependent rows are conditional
+
+System-category rows for daemon restart, Argus source path, and Update Argus SHALL appear only when the daemon is connected. The auto-start-at-login row SHALL appear only on platforms where the launch agent is available, and its label SHALL reflect installed/loaded/busy state. While the daemon is not connected, the view SHALL surface an in-process-mode warning.
+
+#### Scenario: Daemon disconnected hides restart actions and warns
+
+- **WHEN** the daemon connection state is set to disconnected
+- **THEN** the System category shows an in-process-mode warning and omits the daemon-restart, source-path, and update rows
+
+#### Scenario: Auto-start row reflects status
+
+- **WHEN** the launch agent is available and installed and loaded
+- **THEN** the auto-start row indicates it is enabled
+
+### Requirement: Long-running daemon actions show in-flight state
+
+Triggering Restart Daemon, Update Argus, or the auto-start toggle SHALL mark the action busy, dispatch the work via the corresponding callback, and reflect a busy label until a result is reported back; a second activation while busy SHALL be ignored.
+
+#### Scenario: Updating Argus dispatches once
+
+- **WHEN** the cursor is on the Update Argus row, the daemon is connected, and the user presses Enter
+- **THEN** the update callback fires once, the row shows an updating label, and pressing Enter again while updating does not fire the callback a second time
+
+#### Scenario: Result clears busy state
+
+- **WHEN** a self-update result is reported back to the view
+- **THEN** the updating flag clears and the reported status and output are shown in the detail pane
+
+### Requirement: Plugin sections render after built-in categories
+
+Plugin-registered settings sections SHALL be hidden entirely when none are registered, and when present SHALL render below a separator and a "Plugins" header, sorted alphabetically by title with ties broken by scope. Neither the separator nor the header SHALL be selectable; rail navigation and rail clicks SHALL skip them.
+
+#### Scenario: No plugins registered
+
+- **WHEN** there are no registered plugin sections
+- **THEN** no "Plugins" header, separator, or plugin entries appear in the rail
+
+#### Scenario: Plugins shown and ordered
+
+- **WHEN** plugin sections are registered
+- **THEN** they appear after the built-in categories under a "Plugins" header, ordered alphabetically by title
+
+#### Scenario: Navigation skips non-selectable rail rows
+
+- **WHEN** the rail cursor moves across the separator and "Plugins" header
+- **THEN** the cursor lands on a selectable category or plugin entry, never on the separator or header
+
+### Requirement: Plugin form fields are editable and submittable
+
+A selected form-type plugin section SHALL render one row per declared field plus a Save row. Bool fields toggle on Enter or Left/Right; enum fields cycle on Enter or Left/Right; string and int fields open an inline editor on Enter. Int edits SHALL reject non-numeric input (keeping the editor open) and clamp committed values to any declared min/max. Pressing Save SHALL gather every field's current draft value (falling back to its default when untouched) and dispatch them to the section's submit hook, recording the result status.
+
+#### Scenario: Toggling a bool field
+
+- **WHEN** the cursor is on a bool field row and the user presses Enter
+- **THEN** the field's draft value inverts
+
+#### Scenario: Cycling an enum field
+
+- **WHEN** the cursor is on an enum field row and the user presses Right (or Left)
+- **THEN** the draft value advances (or retreats) to the adjacent option, wrapping around the option list
+
+#### Scenario: Int edit clamps to max
+
+- **WHEN** the user edits an int field with a declared max and commits a value above the max
+- **THEN** the stored draft value is clamped to the max
+
+#### Scenario: Int edit rejects non-numeric input
+
+- **WHEN** the user commits a non-numeric value in an int field editor
+- **THEN** the value is not committed and the editor stays open
+
+#### Scenario: Saving submits all field values
+
+- **WHEN** the user presses Enter on the Save row
+- **THEN** the submit hook receives a value for every field (untouched fields contribute their defaults) and the resulting status (success or failure) is recorded for display
+
+#### Scenario: Save with no submitter wired
+
+- **WHEN** the Save row is activated and no submit hook is configured
+- **THEN** a "saved (no submitter)" status is recorded and no error is raised
+
+### Requirement: Plugin stream sections render a live pane and signal focus transitions
+
+A stream-type plugin section SHALL contribute no field rows; instead the right pane SHALL be devoted to a live stream pane. The view SHALL fire a focus signal when a stream section gains focus and a blur signal when it loses focus (category change, focus to rail, or the section being unregistered), and SHALL preserve the stream pane's received content across focus toggles.
+
+#### Scenario: Focusing and blurring a stream section
+
+- **WHEN** a stream section gains focus and then the active section changes away from it
+- **THEN** the stream-focus signal fires on entry and the stream-blur signal fires on exit
+
+#### Scenario: Content preserved across re-entry
+
+- **WHEN** the user leaves a stream section and returns to it
+- **THEN** the same stream pane (with its previously received content) is reused rather than recreated
+
+#### Scenario: Unregistering the focused stream blurs it
+
+- **WHEN** a stream section currently holding focus is unregistered on refresh
+- **THEN** its stream pane is closed and the stream-blur signal fires
+
+### Requirement: Stale plugin state is pruned and recovered
+
+On refresh, the view SHALL drop draft values and submit statuses for plugin sections that are no longer registered. If the active category is a plugin section that has been unregistered, rail navigation SHALL recover by resetting the active category to System.
+
+#### Scenario: Drafts pruned for unregistered plugin
+
+- **WHEN** a refresh occurs and a previously registered plugin section is gone
+- **THEN** that section's draft values and submit status are removed
+
+#### Scenario: Navigation recovers from a stale active plugin
+
+- **WHEN** the active category points at a plugin section no longer present and the user attempts to move the rail cursor
+- **THEN** the active category resets to System
+
+### Requirement: Inline edits accept pasted text
+
+While an inline editor is active (vault path, source path, or plugin string/int field), pasted text SHALL be appended to the corresponding edit buffer.
+
+#### Scenario: Pasting into a plugin field editor
+
+- **WHEN** a plugin string field editor is active and text is pasted
+- **THEN** the pasted text is appended to that field's edit buffer
+
+### Requirement: Settings data degrades gracefully on load errors
+
+Refreshing settings data SHALL tolerate failures loading projects, tasks, schedules, or plugin sections by treating the failed dataset as empty rather than crashing.
+
+#### Scenario: Projects fail to load
+
+- **WHEN** the projects datastore returns an error during refresh
+- **THEN** the Projects category renders as an empty list (its placeholder row) instead of failing

--- a/openspec/specs/task-lifecycle/spec.md
+++ b/openspec/specs/task-lifecycle/spec.md
@@ -1,0 +1,168 @@
+# Task Lifecycle
+
+## Purpose
+
+A task is a unit of work an LLM agent performs. Each task carries a status that moves through a fixed workflow (pending, in progress, in review, complete) and timestamps that record when it started and ended. This capability defines the status state machine, its string/JSON serialization, and the timestamp and elapsed-time semantics that downstream UI, persistence, and orchestration layers rely on.
+
+## Requirements
+
+### Requirement: Status workflow ordering
+
+The task status SHALL be one of four ordered states: pending, in progress, in review, complete. Advancing the status SHALL move to the next state in order and SHALL NOT advance past complete. Reversing the status SHALL move to the previous state and SHALL NOT regress below pending.
+
+#### Scenario: Advance from an intermediate state
+
+- **WHEN** advancing a task that is pending or in progress
+- **THEN** the status moves to the next state in order (pending to in progress, in progress to in review)
+
+#### Scenario: Advance is clamped at complete
+
+- **WHEN** advancing a task that is already complete
+- **THEN** the status remains complete
+
+#### Scenario: Reverse from an intermediate state
+
+- **WHEN** reversing a task that is in review or complete
+- **THEN** the status moves to the previous state in order (complete to in review)
+
+#### Scenario: Reverse is clamped at pending
+
+- **WHEN** reversing a task that is already pending
+- **THEN** the status remains pending
+
+### Requirement: Status string representation
+
+Each known status SHALL have a stable lowercase identifier: `pending`, `in_progress`, `in_review`, `complete`. An unrecognized status value SHALL render as `unknown(N)` where N is the underlying numeric value.
+
+#### Scenario: Known status names
+
+- **WHEN** rendering the string form of each known status
+- **THEN** the result is the corresponding identifier (`pending`, `in_progress`, `in_review`, or `complete`)
+
+#### Scenario: Out-of-range status
+
+- **WHEN** rendering the string form of a status value outside the known range
+- **THEN** the result is `unknown(N)` using the numeric value
+
+### Requirement: Status parsing
+
+Parsing SHALL convert a known status identifier into its status value. Parsing an unknown or empty identifier SHALL return an error and default to the pending status value.
+
+#### Scenario: Parse a known identifier
+
+- **WHEN** parsing one of `pending`, `in_progress`, `in_review`, or `complete`
+- **THEN** the corresponding status value is returned with no error
+
+#### Scenario: Parse an invalid identifier
+
+- **WHEN** parsing an empty string or any unrecognized identifier
+- **THEN** an error is returned and the resulting status defaults to pending
+
+### Requirement: Status text and JSON serialization
+
+A status SHALL serialize to its lowercase string identifier as text, and SHALL serialize as a JSON string (not an integer) when embedded in a JSON document. Deserializing a status from its text identifier SHALL recover the original status, and deserializing an invalid identifier SHALL return an error.
+
+#### Scenario: Text round-trip
+
+- **WHEN** a known status is marshaled to text and then unmarshaled back
+- **THEN** the recovered status equals the original
+
+#### Scenario: JSON encodes as a string
+
+- **WHEN** a task status is encoded as part of a JSON document
+- **THEN** the status appears as its string identifier (for example `"in_review"`), not a number
+
+#### Scenario: Unmarshaling invalid text fails
+
+- **WHEN** unmarshaling a status from an unrecognized text value
+- **THEN** an error is returned
+
+### Requirement: Status transition timestamps
+
+Setting a task's status SHALL record lifecycle timestamps automatically. Entering the in-progress state SHALL set the start time only if it has not already been set, preserving any earlier start time. Entering the complete state SHALL set the end time. Setting any other status SHALL leave both timestamps unchanged.
+
+#### Scenario: Entering in progress sets the start time
+
+- **WHEN** a task with no start time is set to in progress
+- **THEN** the start time is set and the end time remains unset
+
+#### Scenario: Entering in progress preserves an existing start time
+
+- **WHEN** a task that already has a start time is set to in progress
+- **THEN** the original start time is preserved
+
+#### Scenario: Entering complete sets the end time
+
+- **WHEN** a task is set to complete
+- **THEN** the end time is set
+
+#### Scenario: Pending leaves timestamps unset
+
+- **WHEN** a task with no timestamps is set to pending
+- **THEN** both the start time and the end time remain unset
+
+### Requirement: Elapsed time computation
+
+A task SHALL report elapsed time as zero when it has not started. While running (started but not ended) it SHALL report the time since the start. Once ended it SHALL report the fixed duration between start and end.
+
+#### Scenario: Not started
+
+- **WHEN** a task has no start time
+- **THEN** its elapsed time is zero
+
+#### Scenario: Running
+
+- **WHEN** a task has a start time but no end time
+- **THEN** its elapsed time is the duration from the start time to now
+
+#### Scenario: Completed
+
+- **WHEN** a task has both a start time and an end time
+- **THEN** its elapsed time is the fixed duration between start and end
+
+### Requirement: Human-readable elapsed string
+
+A task SHALL format its elapsed time as a compact, unit-suffixed string: empty when not started, seconds (`s`) under one minute, minutes (`m`) under one hour, hours (`h`) under one day, and days (`d`) beyond that.
+
+#### Scenario: Not started yields empty string
+
+- **WHEN** a task has not started
+- **THEN** its elapsed string is empty
+
+#### Scenario: Sub-minute uses seconds
+
+- **WHEN** the elapsed time is less than one minute
+- **THEN** the string is the whole number of seconds suffixed with `s`
+
+#### Scenario: Sub-hour uses minutes
+
+- **WHEN** the elapsed time is at least one minute but less than one hour
+- **THEN** the string is the whole number of minutes suffixed with `m`
+
+#### Scenario: Multi-day uses days
+
+- **WHEN** the elapsed time is at least one day
+- **THEN** the string is the whole number of days suffixed with `d`
+
+### Requirement: Pinned and archived mutual exclusivity
+
+A task SHALL never be both pinned and archived at the same time. Setting pinned to true SHALL clear archived, and setting archived to true SHALL clear pinned. Clearing either flag SHALL leave the other unchanged.
+
+#### Scenario: Pinning clears archived
+
+- **WHEN** a task is set to pinned
+- **THEN** its archived flag is cleared
+
+#### Scenario: Archiving clears pinned
+
+- **WHEN** a task is set to archived
+- **THEN** its pinned flag is cleared
+
+### Requirement: Session ID generation
+
+The system SHALL generate a session identifier as a UUID version 4 string in canonical hyphenated form, suitable for pinning an agent conversation.
+
+#### Scenario: Generated identifier is a v4 UUID
+
+- **WHEN** a new session identifier is generated
+- **THEN** it is a canonical hyphenated UUID with the version 4 and variant bits set

--- a/openspec/specs/task-linking/spec.md
+++ b/openspec/specs/task-linking/spec.md
@@ -1,0 +1,142 @@
+# Task Linking
+
+## Purpose
+
+This capability owns two user-facing surfaces and explicitly does NOT own the dependency-graph engine (that is `task-orchestration`).
+
+First, it owns the **REST/HTTP contract** for managing task-to-task dependency links: creating a link, removing a link, and inspecting a task's immediate dependencies. It specifies the contract as it is observable over HTTP — request/response shapes, status codes (including the cycle→409 rejection), and the guarantee that dependency state is left unchanged when an operation fails. It deliberately does not restate the graph algorithm (cycle detection, neighbour computation, unlink semantics); those engine invariants live in `task-orchestration`. The HTTP surface is reachable from both the master token and per-device tokens so the mobile client can manage dependencies.
+
+Second, it owns the **terminal-output URL feature**: extracting followable URLs from agent terminal output, rejecting malformed ones, opening only http/https schemes, and the link-picker selection UI. The URL picker is a terminal-side affordance for following links an agent has printed.
+
+## Requirements
+
+### Requirement: Create a dependency link between two tasks
+
+The system SHALL attach a parent task to a child task via the child's dependency list. On success it SHALL persist the parent's id in the child's `DependsOn` set and report success. The endpoint SHALL be reachable without master privileges (same tier as archive/rename) so device tokens can manage dependencies.
+
+#### Scenario: Linking a child to an existing parent
+
+- **WHEN** a request supplies a valid parent id for an existing child task
+- **THEN** the parent id is added to the child's `DependsOn` list and the response reports a linked status
+
+#### Scenario: Linking to a non-existent parent
+
+- **WHEN** the supplied parent id does not correspond to any task
+- **THEN** the request is rejected as not found and the child's dependency list is unchanged
+
+#### Scenario: Malformed link request body
+
+- **WHEN** the request body is not valid JSON
+- **THEN** the request is rejected as a bad request and no dependency is created
+
+### Requirement: Reject cycle-forming links over HTTP with a 409
+
+When the orchestration engine reports that a link would form a cycle, the HTTP endpoint SHALL translate that into a conflict response whose body carries the cycle path the engine reported, so the client can render the offending chain inline. The endpoint SHALL leave the response indicating that no dependency state changed. (The graph-level definition of "cycle" and the path-ordering semantics are owned by `task-orchestration`; this requirement only fixes how that outcome is surfaced over HTTP.)
+
+#### Scenario: Linking would close a cycle
+
+- **WHEN** a link request is one the engine rejects as cycle-forming
+- **THEN** the request is answered with a conflict status and a response body containing a non-empty cycle path field, and the response indicates no dependency was added
+
+### Requirement: Remove a dependency link over HTTP
+
+The unlink endpoint SHALL identify both the child and the parent from the request path so it works with no request body (browser-friendly DELETE). On a successful unlink it SHALL report an unlinked status. The endpoint SHALL be reachable without master privileges. (The graph effect of removal — and its no-op-when-absent behaviour — is owned by `task-orchestration`.)
+
+#### Scenario: Unlinking via a no-body DELETE
+
+- **WHEN** a DELETE request names a child and a parent entirely in its path with no body
+- **THEN** the request succeeds and the response reports an unlinked status
+
+### Requirement: Expose a task's immediate dependencies over HTTP
+
+The dependency-inspection endpoint SHALL return, in its response body, the one-hop upstream and downstream neighbours the engine computes for a task. This read SHALL be available to device tokens so the dependency view can render on mobile. (The definition of "one-hop neighbour" is owned by `task-orchestration`; this requirement only fixes that the read is exposed over HTTP and reachable by device tokens.)
+
+#### Scenario: Reading neighbours over HTTP
+
+- **WHEN** a device-token request inspects a task that two others declare as a parent and that itself has no parents
+- **THEN** the response succeeds and its body reports zero upstream neighbours and two downstream neighbours
+
+### Requirement: Map dependency and graph errors to HTTP statuses
+
+The system SHALL translate dependency operation failures to stable HTTP statuses: an empty/invalid task id SHALL be a bad request, an unknown task SHALL be not found, a cycle SHALL be a conflict, and any unrecognised failure SHALL be an internal server error so unexpected conditions surface rather than masquerading as client errors.
+
+#### Scenario: Operation references an unknown task
+
+- **WHEN** a dependency operation targets a task id that does not exist
+- **THEN** the request is rejected as not found
+
+#### Scenario: Unexpected backend failure
+
+- **WHEN** a dependency operation fails for a reason that is neither a missing task, an empty id, nor a cycle
+- **THEN** the request is rejected as an internal server error
+
+### Requirement: Extract followable URLs from terminal output
+
+The system SHALL extract unique http and https URLs from raw terminal output that may contain ANSI escape sequences, markdown links, or OSC 8 hyperlinks. Markdown links SHALL contribute their display text as the label; bare URLs SHALL use the URL itself as the label. The extractor SHALL strip terminal formatting before matching, deduplicate identical URLs, and present the distinct schemes and forms uniformly.
+
+#### Scenario: Markdown link and bare URL together
+
+- **WHEN** output contains a markdown link and a separate bare URL
+- **THEN** both are returned, the markdown link uses its display text as its label, and the bare URL uses itself as its label
+
+#### Scenario: Same URL appears as both a markdown link and a bare URL
+
+- **WHEN** the same URL appears once in markdown form and once bare
+- **THEN** only one link is returned, keeping the markdown display text as its label
+
+#### Scenario: ANSI formatting embedded in or around a URL
+
+- **WHEN** color codes appear in the middle of a URL and cursor-movement sequences follow it
+- **THEN** the color codes are removed so the URL stays intact, and the cursor movement prevents unrelated trailing text from merging into the URL
+
+#### Scenario: OSC 8 hyperlink with separate display text
+
+- **WHEN** output contains an OSC 8 hyperlink whose target URL differs from its visible display text
+- **THEN** the embedded target URL is extracted and the display text is not spliced into it
+
+### Requirement: Reject incomplete or malformed extracted URLs
+
+The system SHALL exclude URLs that are still being typed or are otherwise not safely openable: truncated URLs, URLs with no host, URLs whose host has no valid top-level domain, and hosts with a leading or trailing dot. The system SHALL accept IPv4 literals, the literal `localhost`, multi-label TLDs, and IDN punycode TLDs. Trailing punctuation that is not part of the URL SHALL be stripped.
+
+#### Scenario: Truncated URL is excluded
+
+- **WHEN** a URL ends in an ellipsis (unicode `…` or a trailing `...`)
+- **THEN** that URL is not returned, while other complete URLs in the same content still are
+
+#### Scenario: Host without a valid TLD is excluded
+
+- **WHEN** a URL has no dot in its host, a one-character TLD, a numeric-only TLD, or no host at all
+- **THEN** that URL is not returned
+
+#### Scenario: Special hosts and trailing punctuation
+
+- **WHEN** content contains a `localhost` URL, an IPv4-literal URL, or a URL followed by trailing punctuation
+- **THEN** the localhost and IPv4 URLs are returned and the trailing punctuation is stripped from the returned URL
+
+### Requirement: Open only http and https URLs from the link UI
+
+The system SHALL open a chosen URL in the user's browser only when its scheme is http or https, and SHALL silently refuse any other scheme (such as file, javascript, or empty input) without launching anything.
+
+#### Scenario: Non-http scheme is refused
+
+- **WHEN** the user attempts to open a URL whose scheme is not http or https, or an empty string
+- **THEN** no browser is launched and the attempt is logged as rejected
+
+### Requirement: Choose among multiple extracted links
+
+The system SHALL present a selection modal when multiple links are available, supporting cursor navigation with arrow keys and j/k, confirmation, and cancellation. Navigation SHALL clamp at the first and last entries. The modal SHALL report whether the user selected a link or cancelled, and SHALL expose the currently highlighted link.
+
+#### Scenario: Navigating and selecting a link
+
+- **WHEN** the user moves the cursor down and confirms
+- **THEN** the modal reports that a link was selected and exposes the highlighted link as the chosen one
+
+#### Scenario: Cancelling the picker
+
+- **WHEN** the user dismisses the modal with escape or the detach key
+- **THEN** the modal reports that it was cancelled and reports that no link was selected
+
+#### Scenario: Navigation clamps at the ends
+
+- **WHEN** the user presses up while at the first entry or down while at the last entry
+- **THEN** the highlighted entry does not move past that boundary

--- a/openspec/specs/task-list-view/spec.md
+++ b/openspec/specs/task-list-view/spec.md
@@ -1,0 +1,225 @@
+# Task List View
+
+## Purpose
+
+The task list view is the primary navigation surface for browsing all tasks, grouped by project into collapsible folders. It provides keyboard-driven cursor navigation, a substring filter, pinned and archive sections, per-task and per-project status indicators, and an accompanying detail and live-output preview pane for the selected task. It exists so a user can scan the state of every task at a glance and drill into one without leaving the keyboard.
+
+## Requirements
+
+### Requirement: Project grouping and section ordering
+
+Tasks SHALL be grouped by project name (alphabetically), and partitioned into three sections rendered top-to-bottom: Pinned, Active, and Archive. A task's section SHALL be chosen by precedence where pinned wins over archived, and archived wins over active. Tasks with no project name SHALL be grouped under "(no project)".
+
+#### Scenario: Pinned task surfaces above active and archive
+
+- **WHEN** a task is both pinned and archived
+- **THEN** it appears in the Pinned section, not the Archive section
+
+#### Scenario: Empty project name is grouped under a placeholder
+
+- **WHEN** a task has an empty project name
+- **THEN** it is grouped under the project label "(no project)"
+
+#### Scenario: Pinned section renders above active
+
+- **WHEN** there are both pinned and active tasks
+- **THEN** the Pinned section header and its tasks render above the active project groups
+
+### Requirement: One active project expanded at a time
+
+Within the Active section, exactly one project SHALL be expanded at a time, showing its task rows; all other active project folders SHALL be collapsed to their header. When no project is expanded and active projects exist, the first project SHALL auto-expand. The Pinned section SHALL always be fully expanded and SHALL never auto-collapse.
+
+#### Scenario: First active project auto-expands
+
+- **WHEN** tasks are loaded and no project is currently expanded
+- **THEN** the first active project (alphabetically) becomes expanded and its task rows are visible
+
+#### Scenario: Moving the cursor into another project switches expansion
+
+- **WHEN** the cursor moves into a different active project
+- **THEN** that project expands and the previously expanded project collapses
+
+#### Scenario: Pinned section stays expanded when cursor leaves
+
+- **WHEN** the cursor leaves the Pinned section into another section
+- **THEN** the Pinned section remains fully expanded
+
+### Requirement: Cursor navigation skips non-task rows
+
+Cursor movement (up/down via arrow keys or j/k) SHALL always land the cursor on a task row, skipping project headers, section headers, and separators. When moving up past a project header, the cursor SHALL land on the last task of the previous expanded project. The cursor change callback SHALL fire only when the cursor actually moves to a different position.
+
+#### Scenario: Cursor never rests on a header
+
+- **WHEN** the cursor moves in either direction across a project or section header
+- **THEN** it lands on a task row, never on the header or a separator
+
+#### Scenario: Moving up past a header lands on the previous group's last task
+
+- **WHEN** the cursor is on the first task of a project and the user moves up
+- **THEN** the cursor lands on the last task of the previous expanded project
+
+#### Scenario: No movement fires no cursor-change notification
+
+- **WHEN** the cursor is at a boundary and a move attempt does not change its position
+- **THEN** the cursor-change callback does not fire
+
+### Requirement: Archive section auto-expand on cursor entry
+
+The Archive section SHALL auto-expand when the cursor enters it and auto-collapse when the cursor leaves it. Within the expanded archive, exactly one archived project SHALL be expanded at a time, tracked independently from the active-section expansion.
+
+#### Scenario: Archive expands when cursor enters
+
+- **WHEN** the cursor navigates into the Archive section
+- **THEN** the archive expands to reveal its archived project groups
+
+#### Scenario: Archive collapses when cursor leaves
+
+- **WHEN** the cursor navigates out of the Archive section
+- **THEN** the archive collapses back to its header
+
+### Requirement: Substring filter narrows visible tasks
+
+Pressing `/` SHALL activate a filter input mode. Typed text SHALL filter tasks by case-insensitive substring; whitespace splits the text into terms, and every term MUST match either the task name or its project name for the task to remain visible. While a filter is active, all matching projects and sections SHALL be shown expanded regardless of normal collapse state. Escape SHALL clear the filter; Enter SHALL confirm the filter (keeping the text but exiting input mode).
+
+#### Scenario: Filter matches name or project per term
+
+- **WHEN** the filter text is "forge download" and a task named "Download-this-video" lives in project "forge"
+- **THEN** the task remains visible because each term matches the name or project
+
+#### Scenario: Filter is case-insensitive
+
+- **WHEN** the filter text differs only in letter case from a task name or project
+- **THEN** the task still matches
+
+#### Scenario: Escape clears an active filter
+
+- **WHEN** the filter input is active and the user presses Escape
+- **THEN** the filter text is cleared and filter input mode exits
+
+#### Scenario: Enter confirms the filter
+
+- **WHEN** the filter input is active with text and the user presses Enter
+- **THEN** the filter text is retained and filter input mode exits
+
+#### Scenario: Filtered view expands all groups
+
+- **WHEN** a filter is active
+- **THEN** every project group containing a match is shown expanded, including archived groups
+
+### Requirement: Task selection and status actions
+
+Pressing Enter on a non-complete task SHALL fire the select callback; Enter on a complete task SHALL do nothing. Keyboard actions on the selected task SHALL cycle status forward (`s`) and backward (`S`), toggle archive (`a`), toggle pinned (`P`), rename (`r`), and copy the prompt (`c`, only when the prompt is non-empty). Each action SHALL fire its corresponding callback.
+
+#### Scenario: Enter ignores completed tasks
+
+- **WHEN** the cursor is on a task with complete status and the user presses Enter
+- **THEN** the select callback does not fire
+
+#### Scenario: Enter selects an in-progress task
+
+- **WHEN** the cursor is on a non-complete task and the user presses Enter
+- **THEN** the select callback fires with that task
+
+#### Scenario: Status cycle keys advance and reverse status
+
+- **WHEN** the user presses `s` (or `S`) on the selected task
+- **THEN** the task status advances to its next (or previous) value and the status-change callback fires
+
+#### Scenario: Copy prompt requires a non-empty prompt
+
+- **WHEN** the user presses `c` on a task whose prompt is empty
+- **THEN** the copy-prompt callback does not fire
+
+### Requirement: Per-task status indicator
+
+Each task row SHALL display a status glyph reflecting its state. For an in-progress task the glyph SHALL reflect, in priority order: needs-input (agent blocked on a prompt), idle-but-unvisited, idle/session-absent, and actively-running (animated spinner). Pending tasks, in-review tasks, and complete tasks SHALL each render their own distinct glyph.
+
+#### Scenario: Needs-input outranks other in-progress states
+
+- **WHEN** an in-progress task is flagged as needing user input
+- **THEN** its row shows the needs-input glyph even if it is also actively running or idle-unvisited
+
+#### Scenario: Actively-running task shows a spinner
+
+- **WHEN** an in-progress task has a live session and is not idle or needs-input
+- **THEN** its row shows the animated spinner glyph
+
+### Requirement: Per-project aggregated status indicator
+
+Each project header SHALL display a single aggregated status glyph computed from the statuses of that project's tasks within that header's section. The aggregation priority SHALL be: any needs-input, then any actively-running, then any in-review, then idle in-progress, then all-complete, then mixed complete-and-pending, then all-pending.
+
+#### Scenario: One blocked task surfaces at the project level
+
+- **WHEN** any task in a busy project is blocked on user input
+- **THEN** the project header shows the needs-input glyph even though other tasks are actively running
+
+#### Scenario: Aggregation is scoped to the header's section
+
+- **WHEN** a project name exists in more than one section
+- **THEN** the header's aggregated glyph reflects only the tasks in that header's own section
+
+### Requirement: Task detail panel
+
+The detail panel SHALL display metadata for the selected task: name, status (annotated "(running)" or "(idle)" for in-progress), and any present fields among project, branch, backend, sandbox flag, worktree (truncated to fit), created date, elapsed time, and prompt. When no task is selected, it SHALL display "No task selected" and SHALL not error.
+
+#### Scenario: No task selected shows placeholder
+
+- **WHEN** the detail panel has no task set
+- **THEN** it renders "No task selected"
+
+#### Scenario: In-progress status annotates running vs idle
+
+- **WHEN** the selected task is in-progress and its session is running
+- **THEN** the status line reads "(running)", and reads "(idle)" when the session is not running
+
+#### Scenario: Absent fields are omitted
+
+- **WHEN** the selected task has an empty branch, backend, or worktree
+- **THEN** that field's row is not rendered
+
+### Requirement: Task output preview panel
+
+The preview panel SHALL render a terminal snapshot of the selected task's most recent agent output, showing the latest visible lines (newest output at the bottom) clipped to the panel viewport. It SHALL show placeholder text — "No task selected", "Loading...", "Waiting for output...", or "Preview unavailable" — when there is no task, no output yet, or output cannot be rendered. Switching the previewed task SHALL clear the cached snapshot. Drawing SHALL never block or panic, including at zero dimensions.
+
+#### Scenario: Latest output lines are shown
+
+- **WHEN** the agent output has more lines than the preview viewport height
+- **THEN** the newest lines are shown at the bottom and the oldest top-of-buffer lines are dropped
+
+#### Scenario: Empty output shows a waiting placeholder
+
+- **WHEN** the previewed task has produced no output
+- **THEN** the panel shows "Waiting for output..."
+
+#### Scenario: Switching task clears the snapshot
+
+- **WHEN** the previewed task id changes
+- **THEN** the cached cells are cleared and the panel shows "Loading..." until new output arrives
+
+#### Scenario: Unrenderable output degrades gracefully
+
+- **WHEN** output cannot be rendered by the terminal emulator
+- **THEN** the panel shows "Preview unavailable" rather than crashing
+
+### Requirement: Empty-state banner
+
+When there are no tasks at all, the task page SHALL display a centered banner with the hint "Press [n] to create your first task" instead of the three-panel layout. When tasks exist, the three-panel layout SHALL be shown and the hint SHALL not appear.
+
+#### Scenario: Banner shown with no tasks
+
+- **WHEN** the task page is drawn and there are no tasks
+- **THEN** the empty-state hint text is rendered
+
+#### Scenario: Layout shown with tasks present
+
+- **WHEN** the task page is drawn and at least one task exists
+- **THEN** the three-panel layout is rendered and the empty-state hint is absent
+
+### Requirement: Cursor preservation across data refresh
+
+When the task list is refreshed with a new task set, the cursor SHALL be restored to the same task (or project) within the same section when it still exists; otherwise the cursor SHALL be clamped to a valid task row.
+
+#### Scenario: Cursor follows the same task after refresh
+
+- **WHEN** the task set is replaced and the previously selected task still exists in the same section
+- **THEN** the cursor is restored onto that same task

--- a/openspec/specs/task-messaging/spec.md
+++ b/openspec/specs/task-messaging/spec.md
@@ -1,0 +1,145 @@
+# Task Messaging
+
+## Purpose
+
+Task Messaging lets one task send durable messages to another task and lets a task read and acknowledge its inbox. It exposes this over the REST API (mirroring the equivalent MCP tool surface) so the mobile PWA inbox view and admin clients can list, send, and mark messages read. Messages persist independently of agent process lifecycle and carry caps to protect recipients from overload.
+
+## Requirements
+
+### Requirement: Listing a task inbox
+
+The system SHALL return the inbox for a path-bound task, including the messages and the task's current unread count. Listing SHALL default to unread-only and accept filters for read state, sender, a `since` timestamp, and a result limit. A request for a task that does not exist SHALL fail with a not-found error.
+
+#### Scenario: Empty inbox
+
+- **WHEN** a client lists the inbox for an existing task that has no messages
+- **THEN** the response succeeds with an empty message list and an unread count of zero
+
+#### Scenario: Inbox reflects a received message
+
+- **WHEN** a message has been sent to a task and the client lists that task's inbox
+- **THEN** the response includes that message and reports an unread count of one
+
+#### Scenario: Unread-only toggle synonyms
+
+- **WHEN** a client passes `unread_only` as `false`, `0`, or `no`
+- **THEN** the request succeeds and already-acknowledged messages are included
+
+#### Scenario: Sender, since, and limit filters
+
+- **WHEN** a client lists an inbox with a sender filter, a valid `since` timestamp, and a limit
+- **THEN** the request succeeds and returns only matching messages
+
+#### Scenario: Unknown task
+
+- **WHEN** a client lists the inbox for a task ID that does not exist
+- **THEN** the request fails with a not-found error
+
+### Requirement: Validating inbox filter parameters
+
+The system SHALL reject malformed inbox filter parameters with a bad-request error rather than silently ignoring them. The `since` parameter SHALL be accepted in RFC3339 form (with or without sub-second precision) and rejected otherwise; the `limit` parameter SHALL be a non-negative integer.
+
+#### Scenario: Invalid since timestamp
+
+- **WHEN** a client supplies a `since` value that is not a valid RFC3339 timestamp
+- **THEN** the request fails with a bad-request error identifying the invalid `since`
+
+#### Scenario: Invalid limit
+
+- **WHEN** a client supplies a `limit` value that is not a non-negative integer
+- **THEN** the request fails with a bad-request error identifying the invalid limit
+
+### Requirement: Sending a message between tasks
+
+The system SHALL stage a durable message from the path-bound sender task to a named recipient task. The request SHALL require both a recipient and a non-empty body, default the message kind to a note when omitted, and accept only the recognized kinds (note, question, answer). On success the system SHALL return the new message identifier and its creation timestamp. The sender task and the recipient task SHALL both exist.
+
+#### Scenario: Successful send
+
+- **WHEN** an authorized client sends a message with a recipient and body to an existing recipient task
+- **THEN** the message is created and the new message identifier and creation timestamp are returned
+
+#### Scenario: Missing recipient or body
+
+- **WHEN** a send request omits the recipient or omits the body
+- **THEN** the request fails with a bad-request error
+
+#### Scenario: Sender task does not exist
+
+- **WHEN** the path-bound sender task ID does not resolve
+- **THEN** the request fails with a not-found error
+
+#### Scenario: Recipient task does not exist
+
+- **WHEN** the named recipient task does not exist
+- **THEN** the request fails with a not-found error identifying the missing recipient
+
+#### Scenario: Unknown message kind
+
+- **WHEN** a send request supplies a message kind that is not note, question, or answer
+- **THEN** the request fails with a bad-request error naming the invalid kind
+
+#### Scenario: Malformed request body
+
+- **WHEN** a send request body is not valid JSON
+- **THEN** the request fails with a bad-request error
+
+### Requirement: Sending is master-only over REST
+
+The system SHALL restrict the REST send endpoint to master-tier authentication. Device-tier tokens SHALL be rejected, because the mobile inbox view is read-only and outbound sends mutate shared state across tasks.
+
+#### Scenario: Device token rejected
+
+- **WHEN** a client authenticated with a device token attempts to send a message
+- **THEN** the request fails with a forbidden error and no message is created
+
+### Requirement: Message caps
+
+The system SHALL reject messages that violate protective caps and surface each cap rejection as a bad-request error with the reason preserved. The caps SHALL cover an oversized body, a self-send (sender equals recipient), a full recipient inbox, and exceeding the send rate limit.
+
+#### Scenario: Self-send rejected
+
+- **WHEN** a client sends a message whose recipient is the same as the sender task
+- **THEN** the request fails with a bad-request error indicating a self-send
+
+#### Scenario: Oversized body rejected
+
+- **WHEN** a client sends a message whose body exceeds the maximum body size
+- **THEN** the request fails with a client error rather than a server error
+
+### Requirement: Acknowledging inbox messages
+
+The system SHALL mark the supplied message identifiers read for the path-bound task and return the count of messages actually flipped. The path-bound task SHALL exist, at least one identifier SHALL be supplied, and the number of identifiers per call SHALL not exceed the maximum. Identifiers not belonging to the path-bound task SHALL be silently ignored and excluded from the returned count.
+
+#### Scenario: Acknowledge an unread message
+
+- **WHEN** a client acknowledges the identifier of an unread message addressed to the task
+- **THEN** the response reports one message acknowledged and the task's unread count drops to zero
+
+#### Scenario: Acknowledge for unknown task
+
+- **WHEN** a client acknowledges messages for a task ID that does not exist
+- **THEN** the request fails with a not-found error
+
+#### Scenario: Empty identifier list rejected
+
+- **WHEN** an acknowledge request supplies no identifiers
+- **THEN** the request fails with a bad-request error
+
+#### Scenario: Too many identifiers rejected
+
+- **WHEN** an acknowledge request supplies more identifiers than the per-call maximum
+- **THEN** the request fails with a bad-request error stating the maximum
+
+### Requirement: Message cleanup on task lifecycle
+
+The system SHALL remove a task's messages when the task leaves active use, so a recipient never remains pinned at its unread cap by messages bound to a departed task. Archiving a task SHALL clear its unread messages, and deleting a task SHALL remove all messages referencing it on both the sending and receiving side.
+
+#### Scenario: Archive clears unread messages
+
+- **WHEN** a task with unread messages is archived
+- **THEN** that task's unread count becomes zero
+
+#### Scenario: Delete cascades both message legs
+
+- **WHEN** a task that has both sent and received messages is deleted
+- **THEN** no surviving message references the deleted task on either side

--- a/openspec/specs/task-orchestration/spec.md
+++ b/openspec/specs/task-orchestration/spec.md
@@ -1,0 +1,209 @@
+# Task Orchestration (DAG)
+
+## Purpose
+
+Argus lets an orchestrator agent build a directed acyclic graph of tasks where each task can declare upstream dependencies (`depends_on`). This capability owns the **dependency-graph engine and its views** — the layer beneath any transport. It resolves that graph: it auto-starts blocked tasks once their dependencies complete, cascades a halt across downstream tasks when a milestone fails, and lays out the graph visually so users can inspect a stack at a glance. It also owns the underlying **graph primitives** — the link/unlink mutations, cycle detection (including the cycle-path ordering it reports), and one-hop neighbour computation — expressed here as graph semantics and engine invariants, independent of how any caller is wired in. Dependency status — not the agent-supplied result payload — is the only gate the daemon enforces; interpreting failure is the orchestrator's job.
+
+The REST/HTTP surface that drives these primitives (status codes, request/response shapes, the cycle→409 mapping, device-token reach) is owned by `task-linking`; this spec deliberately states engine behaviour without restating HTTP status codes.
+
+## Requirements
+
+### Requirement: Auto-start of blocked tasks when dependencies complete
+
+The dependency watcher SHALL periodically scan all tasks and start any task that is pending, unarchived, and has a non-empty `depends_on` list whose every referenced dependency has reached the complete status. Tasks with no dependencies SHALL NOT be started by the watcher. The watcher SHALL gate solely on dependency status and SHALL NOT inspect the dependency's result payload.
+
+#### Scenario: All dependencies complete
+
+- **WHEN** a pending unarchived task's only dependency has reached the complete status
+- **THEN** the watcher starts the task's agent session and transitions the task to in-progress
+
+#### Scenario: A dependency is not yet complete
+
+- **WHEN** a pending task depends on two tasks and one of them is still in progress
+- **THEN** the watcher leaves the task pending and starts no session
+
+#### Scenario: Task has no dependencies
+
+- **WHEN** a pending task has an empty `depends_on` list
+- **THEN** the watcher takes no action on that task
+
+#### Scenario: A failed dependency still unblocks downstream
+
+- **WHEN** a dependency reached the complete status carrying a result payload indicating failure (e.g. `{"failed":true}`)
+- **THEN** the watcher still treats the dependency as resolved and starts the dependent task, leaving the failure interpretation to the orchestrator
+
+### Requirement: Blocked tasks with broken or archived dependencies remain blocked
+
+The watcher SHALL treat a dependency referenced by an ID that is absent from the database as unresolved and SHALL refuse to start the dependent task. The watcher SHALL never start an archived task even when its dependencies are complete.
+
+#### Scenario: Dependency ID missing from the database
+
+- **WHEN** a pending task depends on an ID that no longer exists in the database
+- **THEN** the watcher leaves the task pending and starts no session
+
+#### Scenario: Archived blocked task
+
+- **WHEN** a pending but archived task's dependency is complete
+- **THEN** the watcher does not start the task
+
+### Requirement: Race-safe and self-healing start
+
+The watcher SHALL re-read each candidate task immediately before starting it and SHALL skip starting if the task is no longer pending or has become archived in the interim. A transient start failure SHALL leave the task pending so a subsequent scan can retry. The watcher SHALL run a scan immediately on startup so tasks unblocked while the daemon was down are caught up without waiting a full interval.
+
+#### Scenario: Task advanced between scan and start
+
+- **WHEN** a task observed as pending during the scan has been flipped to in-progress before the watcher re-reads it
+- **THEN** the watcher skips it and starts no second session, leaving the newer status intact
+
+#### Scenario: Task archived between scan and start
+
+- **WHEN** a task observed as pending during the scan has been archived before the watcher re-reads it
+- **THEN** the watcher skips it and starts no session
+
+#### Scenario: Transient start failure then retry
+
+- **WHEN** a start attempt fails and a later scan finds the task still pending with dependencies complete
+- **THEN** the task remains pending after the failure and is started successfully on the retry
+
+#### Scenario: Existing session present from a prior partial start
+
+- **WHEN** a task is pending but a live agent session already exists for it (a prior start succeeded but the status write did not)
+- **THEN** the watcher synchronises the task to in-progress without spawning a second process
+
+### Requirement: Cycle detection on dependency links
+
+The system SHALL reject any dependency link that would close a cycle, leaving the dependency state unchanged, and SHALL report the offending node sequence in dependency order (first and last element being the node that closes the cycle) so the cause is actionable. A self-link (a task depending on itself) SHALL be rejected as a cycle. Adding a dependency that already exists SHALL be a no-op.
+
+#### Scenario: Link closes a cycle
+
+- **WHEN** linking would create a cycle among existing dependencies
+- **THEN** the operation is rejected with a cycle error whose path lists the nodes in the cycle, and no dependency is added
+
+#### Scenario: Self-link
+
+- **WHEN** a task is linked to depend on itself
+- **THEN** the operation is rejected as a cycle
+
+#### Scenario: Duplicate link
+
+- **WHEN** a dependency that already exists is added again
+- **THEN** the dependency list is unchanged and no error is returned
+
+#### Scenario: Valid new link
+
+- **WHEN** a non-cyclic dependency from child to parent is added
+- **THEN** the parent ID is appended to the child's dependency list
+
+### Requirement: Unlinking dependencies
+
+The system SHALL remove a parent from a child's dependency list when requested, and SHALL treat removal of a non-existent dependency as a no-op. Empty task IDs SHALL be rejected.
+
+#### Scenario: Remove an existing dependency
+
+- **WHEN** an existing parent dependency is removed from a child
+- **THEN** the child's dependency list no longer contains that parent
+
+#### Scenario: Remove a dependency that is not present
+
+- **WHEN** a removal targets a parent the child does not depend on
+- **THEN** the dependency list is unchanged and no error is returned
+
+### Requirement: One-hop dependency neighbours
+
+The system SHALL report, for a given task, its direct upstream dependencies and the set of tasks that directly depend on it.
+
+#### Scenario: Task with downstream dependents
+
+- **WHEN** querying neighbours of a task that two other tasks depend on and that itself depends on nothing
+- **THEN** the result lists no upstream entries and two downstream entries
+
+#### Scenario: Task with an upstream dependency
+
+- **WHEN** querying neighbours of a task that depends on one parent and has no dependents
+- **THEN** the result lists that parent upstream and no downstream entries
+
+### Requirement: Halt-downstream cascade
+
+The system SHALL cascade a halt to all transitive descendants of a seed task without halting the seed itself. For each descendant the action SHALL depend on its current, freshly re-read status: in-progress descendants SHALL have their running session stopped; pending and in-review descendants SHALL be archived rather than stopped; complete descendants SHALL be left untouched. A stop that reports the session already exited SHALL NOT be counted as a stopped task. The operation SHALL return a report of which descendants were stopped, archived, or could not be found.
+
+#### Scenario: Mixed-status descendants
+
+- **WHEN** halting downstream from a seed whose descendants include a pending task, an in-progress task, and a complete task
+- **THEN** the pending task is archived, the in-progress task's session is stopped, the complete task is left untouched, and the seed itself is neither stopped nor archived
+
+#### Scenario: In-review descendant has no live session
+
+- **WHEN** a descendant is in review (its agent already exited)
+- **THEN** it is archived rather than stopped, and it does not appear in the stopped report
+
+#### Scenario: Session already exited before stop
+
+- **WHEN** stopping an in-progress descendant returns a session-not-found result
+- **THEN** that descendant is not counted in the stopped report
+
+### Requirement: DAG snapshot and plan-slug grouping
+
+The system SHALL produce a filterable snapshot of DAG nodes, each projecting the task's id, name, status, archived flag, plan slug, result, and dependency list, with edges implied by the dependency list. Filters SHALL scope by project and plan slug, and archived nodes SHALL be excluded unless archived inclusion is explicitly requested. The plan slug SHALL be a freely-settable opaque grouping label that the daemon does not interpret.
+
+#### Scenario: Archived nodes excluded by default
+
+- **WHEN** listing the DAG without requesting archived inclusion
+- **THEN** archived tasks are omitted from the snapshot
+
+#### Scenario: Archived nodes included on request
+
+- **WHEN** listing the DAG with archived inclusion enabled
+- **THEN** archived tasks appear in the snapshot
+
+#### Scenario: Project filter
+
+- **WHEN** listing the DAG scoped to a single project
+- **THEN** only nodes belonging to that project are returned
+
+#### Scenario: Set and clear a plan slug
+
+- **WHEN** a plan slug is set on a task and later cleared
+- **THEN** the task carries the slug after the set and an empty slug after the clear
+
+### Requirement: Deterministic layered DAG layout
+
+The system SHALL lay out the DAG with each node assigned a layer equal to the longest dependency path from a source (sources at layer 0), order nodes within a layer to reduce edge crossings, and produce a deterministic ordering for identical input. Dependency references to nodes not present in the snapshot SHALL be silently dropped from the edge list rather than causing a failure, and a defective cyclic input SHALL degrade to a bounded layout rather than looping forever.
+
+#### Scenario: Layer assignment by longest path
+
+- **WHEN** laying out a chain or diamond of dependencies
+- **THEN** each node is placed one layer deeper than its deepest parent, with parentless nodes at layer 0
+
+#### Scenario: Stale dependency reference
+
+- **WHEN** a node depends on an ID absent from the laid-out set
+- **THEN** the layout renders the partial graph and omits the dangling edge
+
+#### Scenario: Identical input
+
+- **WHEN** the same node set is laid out twice
+- **THEN** both layouts produce identical node ordering
+
+### Requirement: DAG view node filtering
+
+The DAG view SHALL exclude archived tasks and pure-orphan tasks — those with no live (non-archived, present) parent and not referenced as a parent by any surviving task — while retaining any task that participates in the linked graph, including a task whose only listed parents are stale but which still has a live child.
+
+#### Scenario: Pure orphan dropped
+
+- **WHEN** projecting a task set containing a linked parent-child pair and an unconnected standalone task
+- **THEN** the standalone task is dropped and the linked pair is retained
+
+#### Scenario: Archived task dropped
+
+- **WHEN** the task set contains an archived task
+- **THEN** the archived task is excluded from the projection
+
+#### Scenario: Stale parent reference but referenced by a live child
+
+- **WHEN** a task lists only a deleted parent ID yet a live child depends on it
+- **THEN** the task is retained as a source node
+
+#### Scenario: Node fields preserved through the projection
+
+- **WHEN** a task with a name, status, result payload, and dependency list is projected
+- **THEN** those fields are carried through and the dependency list is an independent copy

--- a/openspec/specs/terminal-rendering/spec.md
+++ b/openspec/specs/terminal-rendering/spec.md
@@ -1,0 +1,277 @@
+# Terminal Rendering
+
+## Purpose
+
+Argus renders raw PTY output from an agent session directly onto the terminal screen without an ANSI-string intermediary. Inbound bytes are parsed by a VT emulator into a cell grid, and each cell is painted to the screen with its glyph and styling. This capability covers live follow-tail rendering, scrollback browsing, finished-session replay, diff display, the byte-stream filters that protect the emulator from upstream parser bugs, and the helpers that strip terminal noise to plain text. Updates rely on per-cell diffing (synchronized output) for atomic, flash-free repaints — there is no screen-wide clear-and-redraw in the steady state.
+
+## Requirements
+
+### Requirement: Live PTY rendering
+
+The terminal pane SHALL feed inbound PTY bytes through a VT emulator and paint the resulting cell grid directly to the screen, mapping emulator cell glyphs and styles to screen cells without an intermediate ANSI string. In live follow-tail mode it SHALL feed only the bytes that have arrived since the last paint, rather than re-feeding the full stream on every frame.
+
+#### Scenario: New PTY bytes arrive
+
+- **WHEN** a live session has written more bytes than were last fed to the emulator
+- **THEN** only the new (delta) bytes SHALL be fed to the emulator and the updated cell grid SHALL be painted to the screen
+
+#### Scenario: Redraw with no new bytes
+
+- **WHEN** a redraw is triggered (keystroke or timer tick) but no new PTY bytes have arrived and the viewport is unchanged
+- **THEN** the emulator SHALL NOT be re-fed and the previous frame's painted cells SHALL be replayed unchanged
+
+#### Scenario: Cell styling is preserved
+
+- **WHEN** an emulator cell carries foreground/background color, bold, faint, italic, blink, reverse, strikethrough, or underline (single/double/curly/dotted/dashed) styling
+- **THEN** the painted screen cell SHALL carry the equivalent style
+
+### Requirement: Cursor visibility
+
+The terminal pane SHALL render the cursor only when the emulator reports the cursor as visible, and SHALL default the cursor to hidden when an emulator is created or rebuilt until an explicit show-cursor sequence is processed.
+
+#### Scenario: Hidden cursor not painted
+
+- **WHEN** the emulator reports the cursor as hidden
+- **THEN** no cursor cell SHALL be painted and a hidden cursor below the last content row SHALL NOT extend the rendered content region
+
+#### Scenario: Visible cursor painted with high contrast
+
+- **WHEN** the emulator reports the cursor as visible and it lies within the main screen area
+- **THEN** the cell at the cursor position SHALL be painted with a fixed high-contrast color independent of the active theme
+
+#### Scenario: Freshly built emulator defaults to hidden cursor
+
+- **WHEN** an emulator is created or rebuilt and no show-cursor sequence has yet been processed
+- **THEN** the cursor SHALL be treated as hidden
+
+### Requirement: Scrollback browsing
+
+The terminal pane SHALL support scrolling up into session history and back down to the live tail. While scrolled, it SHALL keep the viewed content pinned as new output arrives (anchor-lock), and SHALL clamp the scroll offset to the available scrollback. Returning to the bottom SHALL resume live follow-tail.
+
+#### Scenario: Scroll up enters history
+
+- **WHEN** the user scrolls up from the live tail
+- **THEN** the pane SHALL display earlier content from the scrollback buffer and show a scroll indicator
+
+#### Scenario: Anchor-lock on new output
+
+- **WHEN** the user is scrolled up and new output arrives that grows the total line count
+- **THEN** the scroll offset SHALL be increased by the growth so the viewed content stays pinned in place
+
+#### Scenario: Scroll back to bottom resumes live
+
+- **WHEN** the user scrolls down such that the offset reaches zero
+- **THEN** the pane SHALL resume live follow-tail rendering
+
+#### Scenario: Scroll offset clamped to available history
+
+- **WHEN** the requested scroll offset exceeds the available scrollback
+- **THEN** the offset SHALL be clamped to the maximum available scroll
+
+### Requirement: Keyboard scroll acceleration
+
+The terminal pane SHALL accelerate keyboard scroll steps when scroll events repeat in rapid succession, and SHALL reset to a single-line step when scrolls are spaced apart.
+
+#### Scenario: Rapid repeats accelerate
+
+- **WHEN** consecutive scroll events arrive within the acceleration window
+- **THEN** the per-event step SHALL increase up to a capped maximum
+
+#### Scenario: Spaced scrolls reset acceleration
+
+- **WHEN** a scroll event arrives after the acceleration window has elapsed
+- **THEN** the step SHALL reset to a single line
+
+### Requirement: Finished-session replay
+
+When no live session is attached but a finished session has logged output, the terminal pane SHALL reconstruct the session's content from its log for display and scrollback. The replay path SHALL run heavy log reads and emulation on a background goroutine so the rendering thread is not blocked, painting a placeholder or a best-available fallback frame while the reconstruction is in flight.
+
+#### Scenario: Replay reconstructed from log
+
+- **WHEN** the pane is attached to a task with logged output and no live session
+- **THEN** the content SHALL be reconstructed from the session log and rendered
+
+#### Scenario: Reconstruction in flight
+
+- **WHEN** a replay reconstruction has been kicked off and is not yet complete
+- **THEN** the pane SHALL paint the best available emulator (a stale replay or the live emulator) or a waiting placeholder rather than blocking
+
+#### Scenario: No content available
+
+- **WHEN** there is no live session and no logged or buffered output for the task
+- **THEN** the pane SHALL display an informational message (e.g. that the session is not running or no session is active)
+
+### Requirement: Empty and pending states
+
+The terminal pane SHALL display contextual placeholder messaging when there is nothing to render, distinguishing a task whose worktree is still being prepared from a selected task with no running session.
+
+#### Scenario: Pending task
+
+- **WHEN** a task is pending (worktree being created) and no session has started
+- **THEN** the pane SHALL display a launch banner instead of the no-session message
+
+#### Scenario: Selected task not running
+
+- **WHEN** a task is selected, has no live session, and has no content
+- **THEN** the pane SHALL display a message indicating the session is not running and can be started
+
+### Requirement: PTY size tracking
+
+The terminal pane SHALL keep the PTY size aligned with the visible content area. When the content area dimensions change for a live session, it SHALL request a matching PTY resize. For dead or replay sessions it SHALL render at the current content-area dimensions so content reflows with the window.
+
+#### Scenario: Panel resized for a live session
+
+- **WHEN** the rendered content area dimensions differ from the tracked PTY size and the session is alive
+- **THEN** a PTY resize to the new dimensions SHALL be requested
+
+#### Scenario: Forced resync
+
+- **WHEN** a one-shot forced resync is armed and a live session is drawn
+- **THEN** a PTY resize SHALL be reposted even if the tracked dimensions appear unchanged, and the flag SHALL be cleared only after a live session consumes it
+
+#### Scenario: Dead session reflows to window
+
+- **WHEN** the session is dead or absent and the content area dimensions change
+- **THEN** the replayed content SHALL be rendered at the current content-area dimensions rather than a stale PTY size
+
+### Requirement: Paste forwarding
+
+When focused on a live session, the terminal pane SHALL forward pasted text to the PTY as a single write wrapped in bracketed-paste sequences, rather than sending it character-by-character.
+
+#### Scenario: Paste into a live session
+
+- **WHEN** text is pasted while a live, alive session is attached
+- **THEN** the text SHALL be written to the PTY once, wrapped in bracketed-paste start/end sequences
+
+#### Scenario: Paste with no live session
+
+- **WHEN** text is pasted while no live or alive session is attached
+- **THEN** no PTY write SHALL occur
+
+### Requirement: Diff display mode
+
+The terminal pane SHALL support a diff display mode that replaces terminal rendering with a parsed unified or side-by-side diff for a named file, with independent scrolling, and SHALL restore terminal rendering on exit.
+
+#### Scenario: Enter diff mode
+
+- **WHEN** diff mode is entered with a diff and file name
+- **THEN** the pane SHALL render the parsed diff with a header instead of terminal output
+
+#### Scenario: Toggle split view
+
+- **WHEN** the split toggle is invoked in diff mode
+- **THEN** the view SHALL switch between unified and side-by-side rendering and reset diff scroll
+
+#### Scenario: Exit diff mode
+
+- **WHEN** diff mode is exited
+- **THEN** the pane SHALL return to terminal rendering
+
+### Requirement: OSC sequence filtering
+
+Before bytes reach the live emulator, the terminal pane SHALL strip OSC sequences (`ESC ] … terminator`) from the PTY stream, treating only BEL or 7-bit ST as terminators and explicitly NOT treating a `0x9C` byte as a terminator (working around an upstream parser bug that leaks UTF-8 window titles onto the screen). The filter SHALL be stateful so a sequence split across incremental feeds is fully removed, SHALL preserve non-OSC bytes, and SHALL stop dropping after a bounded maximum so a never-terminated OSC cannot consume the stream unboundedly.
+
+#### Scenario: OSC sequence removed
+
+- **WHEN** an OSC sequence appears in the byte stream
+- **THEN** the OSC bytes SHALL be removed and surrounding non-OSC bytes SHALL pass through unchanged
+
+#### Scenario: OSC split across feeds
+
+- **WHEN** an OSC sequence begins in one incremental feed and ends in a later one
+- **THEN** the entire sequence SHALL still be stripped across the feed boundary
+
+#### Scenario: 0x9C is not a terminator
+
+- **WHEN** a `0x9C` byte (e.g. a UTF-8 continuation byte) appears inside an OSC payload
+- **THEN** it SHALL NOT end the OSC and the payload SHALL continue to be dropped until a real terminator
+
+#### Scenario: Runaway OSC is bounded
+
+- **WHEN** an OSC payload exceeds the maximum drop budget without a recognized terminator
+- **THEN** the filter SHALL stop dropping and resume passing bytes through so it can never hang
+
+### Requirement: Escape-boundary alignment for tail feeds
+
+When feeding a byte slice that may begin in the middle of an escape sequence (a log tail or ring-buffer tail) into a fresh emulator, the terminal pane SHALL skip to the first escape byte so the parser sees complete sequences and does not render orphan parameter bytes as text.
+
+#### Scenario: Tail starts mid-sequence
+
+- **WHEN** a tail slice begins partway through a CSI sequence (no leading ESC) and contains an ESC later
+- **THEN** the slice SHALL be advanced to the first ESC before being fed to the emulator
+
+#### Scenario: Already aligned or no escape
+
+- **WHEN** the slice already starts with ESC, or contains no ESC at all
+- **THEN** the slice SHALL be fed unchanged
+
+### Requirement: Emulator panic and query-response safety
+
+The terminal pane SHALL protect against emulator hangs and crashes: every emulator SHALL have its query-response pipe continuously drained so query sequences (DA1/DA2/DSR, etc.) do not block writes, and emulator writes SHALL recover from upstream panics rather than crashing the renderer.
+
+#### Scenario: Query sequence does not hang
+
+- **WHEN** input containing a terminal query sequence is written to the emulator
+- **THEN** the write SHALL complete without blocking because the response pipe is drained
+
+#### Scenario: Emulator write panics
+
+- **WHEN** an emulator write triggers an upstream panic
+- **THEN** the panic SHALL be recovered, logged, and surfaced as an error rather than crashing the rendering thread
+
+### Requirement: Focus-regain screen repair
+
+The screen wrapper SHALL invoke a screen-repair callback when the terminal pane regains focus (e.g. after a multiplexer window switch), to recover from any backing-store drift, while passing the focus event through unchanged. Screen-wide synchronization SHALL NOT be used for ordinary content updates.
+
+#### Scenario: Focus regained
+
+- **WHEN** a focus-gained event is observed
+- **THEN** the configured screen-repair callback SHALL be invoked and the event SHALL still be returned for normal handling
+
+#### Scenario: Focus lost or other event
+
+- **WHEN** a focus-lost event or any non-focus event is observed
+- **THEN** the screen-repair callback SHALL NOT be invoked
+
+### Requirement: PTY output sanitization to plain text
+
+The capability SHALL provide a sanitizer that converts raw PTY output into clean, human-readable plain text by stripping ANSI escape sequences, normalizing line endings and non-breaking spaces, collapsing consecutive blank lines, and removing terminal rendering noise (spinners, status bars, partial repaint frames, transient hints).
+
+#### Scenario: ANSI sequences stripped
+
+- **WHEN** text containing ANSI escape sequences (CSI, OSC, charset, keypad, DEC line attributes) is sanitized
+- **THEN** the escape sequences SHALL be removed leaving the underlying text
+
+#### Scenario: Noise lines removed
+
+- **WHEN** the output contains terminal rendering noise lines (spinner frames, status bars, separators, transient timing/keybinding hints)
+- **THEN** those lines SHALL be omitted from the cleaned output
+
+#### Scenario: Whitespace normalized
+
+- **WHEN** the output contains CRLF/CR line endings, non-breaking spaces, or runs of blank lines
+- **THEN** line endings SHALL be normalized to LF, non-breaking spaces SHALL become regular spaces, consecutive blank lines SHALL collapse, and trailing blank lines SHALL be trimmed
+
+### Requirement: Plugin-view terminal surface
+
+The plugin-view terminal surface SHALL feed an ANSI byte stream from a channel through a VT emulator and paint the main-screen cell grid to a bordered panel, auto-sizing the emulator to the panel's inner rect each frame and forwarding focused keystrokes and pastes to a configured input channel without blocking.
+
+#### Scenario: Stream chunk rendered
+
+- **WHEN** a non-empty chunk arrives on the source channel
+- **THEN** the chunk SHALL be fed to the emulator, the touched counter SHALL increment, and a redraw SHALL be requested if a redraw callback is set
+
+#### Scenario: Panel resized
+
+- **WHEN** the panel's inner rect changes between draws
+- **THEN** the emulator SHALL be resized to the new inner dimensions
+
+#### Scenario: Focused input forwarded
+
+- **WHEN** the pane is focused, has an input-back channel configured, and receives a keystroke or paste
+- **THEN** the encoded bytes SHALL be sent to the input channel, dropping silently if the channel is full
+
+#### Scenario: No input channel configured
+
+- **WHEN** no input-back channel is configured
+- **THEN** the pane SHALL be read-only and forward no input

--- a/openspec/specs/tui-shell/spec.md
+++ b/openspec/specs/tui-shell/spec.md
@@ -1,0 +1,204 @@
+# TUI Shell
+
+## Purpose
+
+The TUI Shell is the top-level terminal application frame for Argus. It owns the persistent layout (header tab bar, body, status bar), routes every global keystroke to the correct destination, switches between top-level tabs and full-screen views, surrenders the keyboard to plugin-registered views, and provides the cross-cutting visual primitives (theme palette, status icons) and configurable spinner animation. It also exposes the persistence interface (Store) that the rest of the TUI consumes without knowing whether it is backed by local SQLite or a remote HTTP API.
+
+## Requirements
+
+### Requirement: Top-level layout
+
+The shell SHALL present a fixed vertical layout: a single-row header (tab bar) at the top, a body region that swaps between views, and a single-row status bar at the bottom. The body region SHALL display exactly one view at a time.
+
+#### Scenario: Persistent frame around the active view
+
+- **WHEN** the application is running and any view is active
+- **THEN** the header occupies the top row, the status bar occupies the bottom row, and the currently selected view fills the region between them
+
+#### Scenario: Header restored on return to a root view
+
+- **WHEN** the user leaves the agent view and returns to the task list
+- **THEN** the header row is restored to one row high and reflects the Tasks tab as active
+
+### Requirement: Top-level tab navigation
+
+The shell SHALL expose three top-level tabs in order — Tasks, DAG, Settings — and SHALL switch among them in response to global keys. Tab switching SHALL update both the header's active tab and the status bar's tab context, and SHALL move focus to the newly activated view.
+
+#### Scenario: Numeric keys select tabs by position
+
+- **WHEN** the user presses `1`, `2`, or `3` while not in the agent view
+- **THEN** the active tab becomes Tasks, DAG, or Settings respectively and that view is shown with focus
+
+#### Scenario: Arrow keys step between adjacent tabs
+
+- **WHEN** the user presses Left or Right while not in the agent view and the active view does not itself consume the key
+- **THEN** the active tab moves to the previous or next adjacent tab, clamped at the Tasks and Settings ends
+
+#### Scenario: Switching to a tab refreshes its content
+
+- **WHEN** the user switches to the DAG tab or the Settings tab
+- **THEN** the shell refreshes that view's content before showing it
+
+### Requirement: Application quit
+
+The shell SHALL provide global keys to terminate the application from the top-level views.
+
+#### Scenario: Quit from the task list
+
+- **WHEN** the user presses `q` while on the task list and not filtering or editing
+- **THEN** the application event loop stops and the program exits
+
+#### Scenario: Ctrl+C quits outside the agent view
+
+- **WHEN** the user presses Ctrl+C while not in the agent view
+- **THEN** the application event loop stops
+
+#### Scenario: Ctrl+C is forwarded to the agent inside the agent view
+
+- **WHEN** the user presses Ctrl+C while in the agent view and a live session is attached
+- **THEN** the keystroke is sent to the agent process as an interrupt rather than quitting the application
+
+### Requirement: Help overlay
+
+The shell SHALL open a help overlay on demand from the top-level views and SHALL not open it from within the agent view.
+
+#### Scenario: Open help from a top-level view
+
+- **WHEN** the user presses `?` while not in the agent view and not filtering or editing
+- **THEN** a help overlay is shown over the current view
+
+### Requirement: Manual screen refresh
+
+The shell SHALL repair screen damage on explicit user request without otherwise re-emitting the full screen during normal updates.
+
+#### Scenario: Ctrl+L forces a full repaint outside the agent view
+
+- **WHEN** the user presses Ctrl+L while not in the agent view
+- **THEN** the shell performs a full screen re-emit to clear any stale cells
+
+### Requirement: Agent view entry and exit routing
+
+The shell SHALL treat the agent view as a distinct mode in which global tab/quit/help keys are suppressed in favor of agent-specific handling, and SHALL reset shell state when the agent view is exited.
+
+#### Scenario: Returning to Tasks tab while in the agent view exits it
+
+- **WHEN** the active tab is switched to Tasks while the agent view is active
+- **THEN** the shell exits the agent view, resets the active tab to Tasks, shows the task list, and moves focus to it
+
+#### Scenario: Exiting the agent view resets the active tab
+
+- **WHEN** the user exits the agent view
+- **THEN** the active tab is reset to Tasks regardless of which tab was active when the agent view was entered, and the agent session is detached
+
+### Requirement: Plugin-view keyboard surrender
+
+When a plugin-registered full-screen view is active, the shell SHALL forward all keystrokes to the plugin and reserve no key for its own navigation, except a double-Ctrl+Q failsafe and a single-key dismissal of a plugin-triggered help overlay.
+
+#### Scenario: All keys forwarded while a plugin holds the keyboard
+
+- **WHEN** a plugin view is active and the user presses any key other than the failsafe sequence
+- **THEN** the keystroke is forwarded to the plugin and the shell takes no navigation action
+
+#### Scenario: Double Ctrl+Q failsafe returns control to the shell
+
+- **WHEN** a plugin view is active and the user presses Ctrl+Q twice within the failsafe window
+- **THEN** the shell deactivates the plugin view and reclaims the keyboard instead of forwarding the second Ctrl+Q
+
+#### Scenario: Plugin help overlay consumes the next key to dismiss
+
+- **WHEN** a plugin-triggered help overlay is visible and the user presses any key
+- **THEN** the shell consumes that single key to dismiss the overlay and returns control to the plugin
+
+### Requirement: Plugin-view hotkey activation
+
+The shell SHALL activate a plugin-registered view when its registered hotkey is pressed from the task list. Hotkeys SHALL be recognized in the `ctrl+<letter>` form, case-insensitively.
+
+#### Scenario: Registered hotkey opens its plugin view
+
+- **WHEN** the user presses a non-rune key that matches a registered plugin hotkey while on the task list
+- **THEN** the corresponding plugin view is activated
+
+#### Scenario: Hotkey string parsing
+
+- **WHEN** a hotkey string such as `ctrl+l` or `CTRL+L` is parsed
+- **THEN** it resolves to the matching control-letter key, while malformed forms (empty, multi-letter, non-letter, or non-`ctrl+` prefixes) are rejected
+
+### Requirement: Plugin top-level view registry
+
+The shell SHALL persist plugin-registered top-level views keyed by (scope, title) and SHALL enforce that each registration has a non-empty title and callback URL and is unique per (scope, title) pair.
+
+#### Scenario: Registration rejects missing title or callback URL
+
+- **WHEN** a view is registered with an empty/whitespace title or an empty callback URL
+- **THEN** the registration is rejected with the corresponding error and nothing is persisted
+
+#### Scenario: Duplicate (scope, title) rejected
+
+- **WHEN** a view is registered for a (scope, title) pair that already exists
+- **THEN** the registration is rejected as already-registered
+
+#### Scenario: Same title under different scopes allowed
+
+- **WHEN** two views share a title but belong to different scopes
+- **THEN** both registrations succeed and both appear in the registry listing
+
+#### Scenario: Scope revocation cascades
+
+- **WHEN** a scope is revoked
+- **THEN** every view owned by that scope is removed and views owned by other scopes are retained
+
+### Requirement: Configurable spinner animation
+
+The shell SHALL provide a set of named spinner styles, each with an ordered frame sequence and a per-frame tick interval, and SHALL select frames by animation tick with wraparound. The active style SHALL be set from configuration at startup and SHALL be cyclable at runtime in both directions with wraparound.
+
+#### Scenario: Frame selection wraps around the sequence
+
+- **WHEN** a tick index greater than or equal to the frame count is requested for a spinner
+- **THEN** the returned frame is the one at the tick index modulo the frame count
+
+#### Scenario: Unknown style falls back to the default
+
+- **WHEN** a spinner is requested for an unknown style name
+- **THEN** the default (Progress) spinner is returned
+
+#### Scenario: Cycling styles wraps in both directions
+
+- **WHEN** the next style after the last is requested, or the previous style before the first
+- **THEN** the cycle wraps to the first or last style respectively, and an unrecognized current style yields the default
+
+### Requirement: Spinner animation only while work is active
+
+The shell SHALL drive spinner repaints only while at least one task is actively running and not idle, and SHALL suppress periodic spinner repaints when all tasks are idle.
+
+#### Scenario: No spinner repaints when all tasks are idle
+
+- **WHEN** there are no running tasks, or every running task is idle
+- **THEN** the shell does not enqueue spinner-driven redraws
+
+#### Scenario: Spinner repaints while a task is actively running
+
+- **WHEN** at least one running task is not idle
+- **THEN** the shell enqueues periodic redraws to animate the spinner
+
+### Requirement: Persistence interface abstraction
+
+The shell SHALL consume persistence exclusively through a Store interface so that local (direct database) and remote (HTTP-backed) backends are interchangeable without changes to the rest of the TUI.
+
+#### Scenario: Local backend satisfies the Store interface
+
+- **WHEN** the application is built
+- **THEN** the local database type satisfies the Store interface, enforced as a compile-time assertion
+
+### Requirement: Theme palette and status icons
+
+The shell SHALL define a single shared palette of colors, text styles, and status icons used across the TUI, including distinct colors and styles for each task status and a distinct color and icon for the "agent blocked on user prompt" state.
+
+#### Scenario: Distinct styling per task status
+
+- **WHEN** a task status (pending, in-progress, in-review, complete) is rendered
+- **THEN** it is drawn with the status-specific color defined by the shared theme
+
+#### Scenario: Needs-input state is visually distinct
+
+- **WHEN** an idle task is blocked on a user prompt
+- **THEN** it is rendered with the dedicated needs-input color and icon

--- a/openspec/specs/uxlog/spec.md
+++ b/openspec/specs/uxlog/spec.md
@@ -1,0 +1,91 @@
+# UX Logging
+
+## Purpose
+
+UX logging provides a dedicated debug log for the Argus TUI layer, written to a file (`~/.argus/ux.log`) that is separate from the daemon's logs. It exists to diagnose hard-to-see TUI failures (tasks failing to start, unexpected auto-completion) and, critically, to give the TUI process a safe sink for `slog`/stdlib-`log` output so those writes never reach the user's live terminal and corrupt the rendered screen.
+
+## Requirements
+
+### Requirement: Timestamped log writes
+
+The system SHALL write each log entry as a single line prefixed with a millisecond-precision timestamp and terminated by a newline, formatting the message from a format string and arguments.
+
+#### Scenario: Writing a formatted entry after initialization
+
+- **WHEN** the log has been initialized and a caller logs with a format string and arguments
+- **THEN** the resulting file content contains the fully formatted message on its own line, prefixed by a timestamp
+
+#### Scenario: Multiple entries each occupy one line
+
+- **WHEN** two separate log calls are made
+- **THEN** the file contains exactly two lines, each carrying its own timestamp prefix
+
+### Requirement: Logging is a no-op when uninitialized
+
+The system SHALL silently discard log writes when the log file has not been opened, and SHALL NOT panic or error.
+
+#### Scenario: Logging before initialization
+
+- **WHEN** a caller logs while the log file is not open
+- **THEN** the call returns without panicking and produces no output
+
+### Requirement: Initialization opens the log file and is idempotent
+
+The system SHALL open the log file for appending (creating it if absent) on first initialization, and SHALL treat any subsequent initialization as a no-op that returns no error while leaving the already-open file in place.
+
+#### Scenario: First initialization succeeds
+
+- **WHEN** initialization is requested with a writable path
+- **THEN** the log file is opened and subsequent log calls are written to it
+
+#### Scenario: Repeated initialization is a no-op
+
+- **WHEN** initialization is requested a second time after the file is already open
+- **THEN** the call returns no error and does not replace the open file
+
+#### Scenario: Existing log content is preserved
+
+- **WHEN** initialization opens a path that already contains data
+- **THEN** new entries are appended rather than overwriting existing content
+
+### Requirement: Default log path derivation
+
+The system SHALL derive the default UX log path by appending the log file name to the supplied data directory.
+
+#### Scenario: Deriving a path from a data directory
+
+- **WHEN** a data directory is supplied for path derivation
+- **THEN** the returned path is that directory followed by `/ux.log`
+
+### Requirement: Safe writer accessor for logger redirection
+
+The system SHALL expose a non-nil `io.Writer` for the underlying log file so callers (notably the TUI redirecting the default `slog` and stdlib `log` handlers) can route output into the same file. When the log is not initialized, the system SHALL return a discarding writer rather than nil.
+
+#### Scenario: Writer before initialization returns a safe discard sink
+
+- **WHEN** the writer is requested while the log file is not open
+- **THEN** a non-nil discarding writer is returned and writing to it succeeds without error
+
+#### Scenario: Writer after initialization targets the log file
+
+- **WHEN** the writer is requested after the log file is open
+- **THEN** a non-discarding writer is returned and bytes written through it appear in the log file
+
+#### Scenario: Redirected logger output stays out of the terminal
+
+- **WHEN** the default `slog` and stdlib `log` handlers are pointed at the writer and emit messages
+- **THEN** none of that output reaches the process's standard error, and every message is captured in the log file
+
+### Requirement: Closing releases the log file and is idempotent
+
+The system SHALL close and release the open log file, after which logging reverts to its uninitialized no-op behavior, and SHALL tolerate being closed when no file is open.
+
+#### Scenario: Closing an open log
+
+- **WHEN** the log is closed after being initialized
+- **THEN** the file is released and later log calls are discarded until re-initialization
+
+#### Scenario: Closing when nothing is open
+
+- **WHEN** close is invoked while no log file is open
+- **THEN** the call completes without error or panic

--- a/openspec/specs/web-push/spec.md
+++ b/openspec/specs/web-push/spec.md
@@ -1,0 +1,188 @@
+# Web Push Notifications
+
+## Purpose
+
+Argus delivers Web Push notifications to registered PWA devices so the user can be alerted when an agent session needs attention without keeping the UI open. This capability owns VAPID key lifecycle, device-subscription registration, the fan-out that sends notifications, expired-subscription pruning, and the idle-watcher gating that decides when a busy→idle agent transition is worth a push.
+
+## Requirements
+
+### Requirement: VAPID key lifecycle
+
+The system SHALL persist a single VAPID keypair across restarts, generating one on first use and reusing the stored keys thereafter. The public key SHALL be retrievable for the PWA to register subscriptions.
+
+#### Scenario: Generate keypair on first run
+
+- **WHEN** the push manager initializes and no VAPID public or private key is stored
+- **THEN** a new VAPID keypair is generated, persisted, and the public key is non-empty
+
+#### Scenario: Reuse stored keypair across restarts
+
+- **WHEN** the push manager re-initializes over a store that already holds a VAPID keypair
+- **THEN** the previously stored public key is returned verbatim and no new keypair is generated
+
+#### Scenario: Public key endpoint unavailable without manager
+
+- **WHEN** a client requests the VAPID public key and no push manager is configured
+- **THEN** the request is rejected with HTTP 503
+
+### Requirement: VAPID subject management
+
+The system SHALL track the VAPID JWT subject claim, which MUST be a routable mailto: or https:// URL, persist changes, and clear a known-bad legacy default so push services do not keep rejecting deliveries.
+
+#### Scenario: Set and persist a subject
+
+- **WHEN** a valid https subject is supplied
+- **THEN** the subject is stored, persisted, and returned on subsequent reads
+
+#### Scenario: Empty or unchanged subject is a no-op
+
+- **WHEN** an empty subject, or a subject equal to the current one, is supplied
+- **THEN** the stored subject is left unchanged and no persistence write occurs
+
+#### Scenario: Legacy bad default cleared on init
+
+- **WHEN** the push manager initializes and the stored subject equals the known-bad legacy default
+- **THEN** the stored subject is cleared to empty
+
+### Requirement: Subscription registration
+
+The system SHALL register a device push subscription from a W3C PushSubscription payload, requiring an endpoint and both encryption keys, and SHALL reject malformed or incomplete requests.
+
+#### Scenario: Valid subscription is created
+
+- **WHEN** a subscribe request supplies an endpoint, p256dh key, and auth key
+- **THEN** the subscription is stored and HTTP 201 is returned with its new id
+
+#### Scenario: Missing endpoint or keys rejected
+
+- **WHEN** a subscribe request omits the endpoint, the p256dh key, or the auth key
+- **THEN** the request is rejected with HTTP 400
+
+#### Scenario: Invalid JSON rejected
+
+- **WHEN** a subscribe request body is not valid JSON
+- **THEN** the request is rejected with HTTP 400
+
+### Requirement: Subscription listing and removal
+
+The system SHALL list registered subscriptions with their endpoints masked, and SHALL allow removal of a subscription by id.
+
+#### Scenario: List masks long endpoints
+
+- **WHEN** subscriptions are listed and an endpoint exceeds the masking threshold
+- **THEN** each returned endpoint is truncated to a masked form rather than exposed in full
+
+#### Scenario: Delete by id
+
+- **WHEN** an unsubscribe request supplies a valid subscription id
+- **THEN** that subscription is removed and the deleted id is returned
+
+#### Scenario: Invalid id rejected
+
+- **WHEN** an unsubscribe request supplies a non-numeric id
+- **THEN** the request is rejected with HTTP 400
+
+### Requirement: Notification fan-out
+
+The system SHALL send a notification carrying title, body, and an optional task id to every registered subscription, and SHALL skip the send entirely when no subscriptions are registered. A nil manager SHALL be safe to call.
+
+#### Scenario: Fan-out to all subscriptions
+
+- **WHEN** a notification is sent and at least one subscription is registered and a VAPID subject is set
+- **THEN** a push request is delivered to each subscription's endpoint
+
+#### Scenario: No subscriptions skips send
+
+- **WHEN** a notification is sent and no subscriptions are registered
+- **THEN** no push request is made
+
+#### Scenario: Send skipped when subject unset
+
+- **WHEN** a notification is sent and no VAPID subject has been established
+- **THEN** no push request is delivered and the subscription is preserved
+
+### Requirement: Per-key throttling
+
+The system SHALL throttle repeated notifications sharing a non-empty throttle key to at most one send per throttle window, SHALL disable throttling when the key is empty, and SHALL NOT record a throttle entry when there are no subscriptions.
+
+#### Scenario: Repeat within window suppressed
+
+- **WHEN** a second notification with the same non-empty throttle key is sent within the throttle window
+- **THEN** the second send is suppressed and the recorded send time is unchanged
+
+#### Scenario: Empty key disables throttling
+
+- **WHEN** notifications are sent with an empty throttle key
+- **THEN** no throttle entry is recorded and sends are not suppressed
+
+#### Scenario: No-subscription state does not poison throttle
+
+- **WHEN** a notification with a non-empty throttle key is sent while no subscriptions exist
+- **THEN** no throttle entry is recorded, so a later send after the user subscribes is not suppressed
+
+### Requirement: Expired-subscription pruning
+
+The system SHALL drop a subscription when the push service reports it as permanently gone (HTTP 410 or 404), and SHALL preserve the subscription on transient or other non-success responses and on send errors.
+
+#### Scenario: Drop on Gone or Not Found
+
+- **WHEN** a push delivery to a subscription returns HTTP 410 or HTTP 404
+- **THEN** that subscription is removed from the store
+
+#### Scenario: Keep on other failures
+
+- **WHEN** a push delivery returns another non-success status (e.g. HTTP 500) or the send errors out
+- **THEN** the subscription is preserved
+
+#### Scenario: Keep on success
+
+- **WHEN** a push delivery returns a success status
+- **THEN** the subscription is preserved
+
+### Requirement: Test notification endpoint
+
+The system SHALL expose a master-only endpoint that sends a verification notification to all registered devices, rejecting non-master callers, so a device holder cannot spam every registered device.
+
+#### Scenario: Master triggers test push
+
+- **WHEN** a master-authenticated caller invokes the test-push endpoint with a push manager configured
+- **THEN** a test notification is fanned out to all subscriptions and success is reported
+
+#### Scenario: Non-master rejected
+
+- **WHEN** a non-master caller invokes the test-push endpoint
+- **THEN** the request is rejected and no notification is sent
+
+### Requirement: Idle-watcher push gating
+
+The system SHALL fire at most one idle push per agent work cycle, only on a busy→idle transition, only after the session has received user input, and SHALL re-arm only when fresh input arrives after the last push. The first observation of a session SHALL never fire, and per-task state SHALL be independent.
+
+#### Scenario: Busy to idle fires once
+
+- **WHEN** a session previously observed busy transitions to idle and has received user input since startup
+- **THEN** exactly one idle push fires for that transition
+
+#### Scenario: First observation suppressed
+
+- **WHEN** a session is observed for the first time, whether idle or busy
+- **THEN** no push fires
+
+#### Scenario: No user input ever suppresses
+
+- **WHEN** a session goes idle but has never received any user input
+- **THEN** no push fires
+
+#### Scenario: Idle blips after a push stay silent
+
+- **WHEN** a session that has already pushed flips busy then idle again with no new user input in between
+- **THEN** no further push fires
+
+#### Scenario: Fresh input re-arms
+
+- **WHEN** user input arrives strictly after the last push and the agent then goes idle again
+- **THEN** a new idle push fires
+
+#### Scenario: Per-task independence
+
+- **WHEN** multiple sessions are watched concurrently
+- **THEN** each session's fire decision is tracked independently by task id

--- a/openspec/specs/worktree-management/spec.md
+++ b/openspec/specs/worktree-management/spec.md
@@ -1,0 +1,224 @@
+# Worktree Management
+
+## Purpose
+
+Argus isolates every task in its own git worktree and branch so concurrent agent sessions never collide in a shared working tree. This capability owns the deterministic worktree path layout, branch naming, name-conflict resolution, transactional task creation (with full rollback on any failure), and the removal/pruning of worktrees and branches when tasks finish or go orphaned.
+
+## Requirements
+
+### Requirement: Deterministic worktree path layout
+
+The system SHALL place each task's worktree at a deterministic path under the Argus data directory, namespaced by project and task name, so the same project/task pair always resolves to the same location.
+
+#### Scenario: Path is composed from project and task name
+
+- **WHEN** a worktree path is requested for project "myproject" and task "fix-bug"
+- **THEN** the path is `<data-dir>/worktrees/myproject/fix-bug`, ending in `<project>/<task>` under the `.argus/worktrees` directory
+
+### Requirement: Worktree creation with argus branch
+
+The system SHALL create a git worktree at the deterministic path on a new branch named `argus/<task-name>`, basing it on the requested start point (defaulting to `HEAD` when no base branch is given). On success it SHALL return the worktree path, the final task name, and the branch name.
+
+#### Scenario: Fresh worktree created on a new branch
+
+- **WHEN** a worktree is created for a task named "fix-bug" with no explicit base branch
+- **THEN** the returned branch name is `argus/fix-bug`, the returned final name is "fix-bug", a `.git` entry exists inside the worktree directory, and the `argus/fix-bug` branch exists in the repository
+
+#### Scenario: Worktree based on a custom start point
+
+- **WHEN** a worktree is created with an explicit base branch that resolves to a valid commit
+- **THEN** the worktree HEAD matches the commit of that base branch
+
+### Requirement: Base branch resolution against remotes
+
+When the requested base branch is not `HEAD`, the system SHALL fetch remotes before resolving the start point, and SHALL fall back to remote-tracking branches (`origin/<ref>` or `upstream/<ref>`) when no matching local ref exists, so a worktree can be based on a branch the local repo has not yet seen.
+
+#### Scenario: Local branch missing, remote-tracking branch used
+
+- **WHEN** a worktree is requested on a base branch that exists only as `origin/<branch>` after the local default branch was deleted
+- **THEN** the worktree is created successfully based on the remote-tracking branch
+
+#### Scenario: Unfetched remote branch is fetched first
+
+- **WHEN** a worktree is requested on a branch that was pushed to the remote after the local clone and is not yet known locally
+- **THEN** the system fetches the remote and creates the worktree whose HEAD matches the upstream branch's commit
+
+### Requirement: Task name sanitization
+
+The system SHALL sanitize task names before using them as branch names or directory components, replacing characters that are invalid in git refs or hostile to shell navigation (including slashes, control characters, quotes, and shell metacharacters) with hyphens, collapsing repeated hyphens, trimming leading/trailing hyphens and dots, and capping length. A name that sanitizes to empty SHALL fall back to "task".
+
+#### Scenario: Invalid and shell-hostile characters replaced
+
+- **WHEN** a task name contains characters such as spaces, `?`, `~`, `:`, brackets, quotes, or shell metacharacters
+- **THEN** those characters are replaced with single hyphens (e.g. "hello world" becomes "hello-world", "a:b:c" becomes "a-b-c")
+
+#### Scenario: Slashes are stripped
+
+- **WHEN** a task name contains `/` (e.g. "a/b/c")
+- **THEN** the slashes are replaced with hyphens so the safe name introduces no extra directory depth (e.g. "a-b-c")
+
+#### Scenario: Entirely-invalid name falls back
+
+- **WHEN** a task name is empty or consists only of invalid characters (e.g. "???")
+- **THEN** the sanitized name is "task"
+
+#### Scenario: Overlong name is truncated
+
+- **WHEN** a sanitized task name exceeds the length cap
+- **THEN** it is truncated, preferring a hyphen boundary, with no trailing hyphen or dot
+
+### Requirement: Name-conflict suffixing
+
+When the deterministic worktree path already exists for a different worktree, the system SHALL append a numeric suffix (`-1`, `-2`, …) to the task name and branch until a free slot is found, returning the suffixed final name. If no free slot is found after exhausting the suffix range, it SHALL return an error.
+
+#### Scenario: Duplicate name gets a numeric suffix
+
+- **WHEN** a worktree is created for "fix-bug" when a worktree at that path already exists
+- **THEN** the returned final name is "fix-bug-1" and the branch is `argus/fix-bug-1`
+
+### Requirement: Resilient worktree creation
+
+The system SHALL tolerate stale worktree references and partial git failures during creation: it SHALL prune stale worktree references before creating; SHALL treat a non-zero git exit as success when a valid worktree directory was nonetheless produced (e.g. a failing post-checkout hook); and SHALL retry attaching to an already-existing branch when the initial branch-creating add fails.
+
+#### Scenario: Stale reference is pruned
+
+- **WHEN** a previous worktree directory was deleted without `git worktree remove`, leaving the branch locked to a stale entry, and a new worktree is requested at the same name
+- **THEN** the stale reference is pruned and the worktree is created successfully
+
+#### Scenario: Post-checkout hook fails but worktree is valid
+
+- **WHEN** `git worktree add` exits non-zero due to a failing post-checkout hook but a valid worktree (with a `.git` entry) was created
+- **THEN** creation is treated as successful and returns the worktree path, final name, and branch
+
+#### Scenario: Branch already exists
+
+- **WHEN** the `argus/<name>` branch already exists but no worktree occupies the path
+- **THEN** the system attaches a worktree to the existing branch and succeeds
+
+### Requirement: Transactional task creation with LIFO rollback
+
+The system SHALL create and start a task as a single transaction: resolve project config, create the worktree, write attachments, run an optional post-worktree hook, persist the task row, reserve a session ID, and start the agent session. Each side-effecting step SHALL register a compensating cleanup that runs in last-in-first-out order if any later step fails, leaving no orphan worktree, branch, or database row. On success the task SHALL have status InProgress, a recorded start timestamp, and the agent PID populated.
+
+#### Scenario: Successful creation starts the session
+
+- **WHEN** a task is created for a configured project and the session starts successfully
+- **THEN** the returned task has status InProgress, a populated agent PID, an absolute worktree path, branch `argus/<name>`, a matching persisted DB row, and a worktree on disk
+
+#### Scenario: Session-start failure unwinds everything
+
+- **WHEN** task creation reaches session start but `runner.Start` returns an error
+- **THEN** the call returns an error with a nil task and session, no DB row remains, the worktree directory is removed, and the `argus/<name>` branch is deleted
+
+#### Scenario: Post-worktree hook failure unwinds the worktree
+
+- **WHEN** the optional post-worktree hook returns an error
+- **THEN** the session is never started, no DB row remains, and the worktree is removed
+
+#### Scenario: Missing project rejected before side effects
+
+- **WHEN** task creation references a project not present in config, or a project with no configured path
+- **THEN** the call returns an error before any worktree, DB, or session side effect occurs
+
+### Requirement: Attachment handling during creation
+
+The system SHALL write user-supplied attachments into the `.context` directory inside the worktree before the session starts, de-duplicating same-named files within a batch by suffixing, rejecting path-traversal names, and appending the resulting worktree-relative paths to the task prompt. When the prompt is otherwise empty it SHALL still produce an "Attached files:" listing.
+
+#### Scenario: Attachments written and listed in prompt
+
+- **WHEN** a task is created with attachments
+- **THEN** each attachment is written under `<worktree>/.context/`, the user's prompt text is preserved, and each attachment's `./.context/<name>` path is appended to the prompt
+
+#### Scenario: Duplicate names de-duplicated within a batch
+
+- **WHEN** two attachments share the same name in one batch
+- **THEN** the second is written with a numeric suffix (e.g. "shot.png" and "shot-1.png"), both files persist with their distinct contents, and both paths appear in the prompt
+
+#### Scenario: Path-traversal name rejected
+
+- **WHEN** an attachment name attempts path traversal (e.g. "..")
+- **THEN** task creation returns an error
+
+### Requirement: Session ID reservation by backend type
+
+The system SHALL reserve and persist a generated session ID for backends that support session pinning (Claude-style), and SHALL skip reservation for backends whose IDs are captured after the process exits (Codex, pi).
+
+#### Scenario: Session ID generated for Claude-style backend
+
+- **WHEN** a task is created with a Claude-style backend
+- **THEN** the task is assigned a generated session ID that is also persisted to its DB row
+
+### Requirement: Worktree and branch removal
+
+The system SHALL remove a task's worktree (forcing removal and deleting any leftover directory contents) and delete both its local and remote branch on a best-effort basis, never failing the caller. It SHALL only act on paths recognized as worktree subdirectories, skip cleanly when the path is missing or not a worktree, and skip branch deletion when no branch is supplied. When the stored branch is not an `argus/*` branch, it SHALL infer the worktree branch from the directory name.
+
+#### Scenario: Worktree and branch removed
+
+- **WHEN** removal is requested for an existing worktree and its `argus/<name>` branch
+- **THEN** the worktree directory is removed and the branch is deleted locally and on the remote
+
+#### Scenario: Leftover untracked files cleaned
+
+- **WHEN** removal targets a worktree containing untracked files that `git worktree remove` leaves behind
+- **THEN** the directory is fully removed including the leftover files
+
+#### Scenario: Branch inferred when stored branch is a base branch
+
+- **WHEN** the stored branch is a base branch such as "origin/master" rather than an `argus/*` branch
+- **THEN** the system infers `argus/<dir-name>` from the worktree directory and deletes that branch
+
+#### Scenario: Empty branch skips branch cleanup
+
+- **WHEN** removal is requested with an empty branch name
+- **THEN** the worktree is removed but no branch is deleted
+
+#### Scenario: Non-worktree or missing path is a no-op
+
+- **WHEN** removal targets a path that is not a recognized worktree subdirectory, or a path that does not exist
+- **THEN** nothing is removed and the path is left intact
+
+### Requirement: Orphaned worktree sweeping
+
+The system SHALL identify worktree directories under the worktree root that are not tracked in the database, count them, and optionally remove them along with their inferred `argus/<task>` branches. It SHALL skip any directory that is an ancestor of a tracked worktree path so it never destroys a live worktree nested deeper than the standard `<project>/<task>` layout, and SHALL remove emptied project directories after sweeping.
+
+#### Scenario: Untracked worktrees counted and swept
+
+- **WHEN** a sweep runs over a worktree root containing directories not present in the known-paths set
+- **THEN** those directories are counted as orphans and, when a projects map is supplied, removed along with their branches, and emptied project directories are removed
+
+#### Scenario: Ancestor of a tracked worktree is preserved
+
+- **WHEN** an orphan candidate directory is an ancestor of a tracked (known) worktree path
+- **THEN** it is not counted as an orphan and is not removed, leaving the live worktree intact
+
+### Requirement: Pruning completed tasks
+
+The system SHALL prune completed tasks in two phases: a synchronous phase that removes completed rows from the database, stops their sessions, removes their session logs, and computes the remaining worktree and orphan cleanup counts; and a slow phase that removes each task's worktree and branch in parallel and runs the orphan sweep. The slow phase SHALL execute at most once per plan; subsequent invocations SHALL be no-ops.
+
+#### Scenario: Completed tasks pruned, active tasks retained
+
+- **WHEN** a prune runs with one completed task (with a worktree on disk), one active task, and one orphan directory under the worktree root
+- **THEN** only the completed task is removed from the database, its worktree and the orphan directory are both removed, and the active task and its row remain
+
+#### Scenario: Nothing to prune
+
+- **WHEN** a prune runs with no completed tasks
+- **THEN** the plan reports zero pruned tasks and zero worktree cleanup work and performs no removal
+
+#### Scenario: Slow phase runs at most once
+
+- **WHEN** the slow prune phase is invoked a second time on the same plan
+- **THEN** the second invocation is a no-op and fires no progress callbacks
+
+### Requirement: Test-environment write guard
+
+The system SHALL refuse worktree removal operations that target the real Argus data directory while running inside a test binary, while still permitting operations on paths under the OS temporary directory so tests using a redirected HOME can clean up their synthetic data dirs.
+
+#### Scenario: Real data dir blocked during tests
+
+- **WHEN** a removal targets a path under the real `~/.argus/` directory during a test run
+- **THEN** the operation is blocked and no removal occurs
+
+#### Scenario: Temp-dir path allowed during tests
+
+- **WHEN** a removal targets a path under the OS temporary directory during a test run
+- **THEN** the operation is permitted


### PR DESCRIPTION
## Why

Argus had no real OpenSpec coverage — only the single `plugin-views` capability from an archived change. This is a **one-time reverse-engineering bootstrap**: derive OpenSpec base specs for the entire application from the existing Go codebase, so future change work has a contract to diff against.

This deliberately overrides the usual "never derive specs from code" rule. A code-derived baseline is better than no specs, and these are local docs — **nothing in CI depends on them**.

## What changed

- **`openspec/project.md`** — project context (stack, gates, the load-bearing note that specs here are local docs).
- **37 new `openspec/specs/<capability>/spec.md`** — covering domain, agent, daemon, API/PWA, TUI, orchestration, and infra capabilities. With the existing `plugin-views`, that's **38 capabilities / 362 requirements / 1014 scenarios**.
- All pass `openspec validate --all --strict`.

## How it was built

- A **36-agent fan-out** (one spec-author per capability) read each package + its tests and wrote that capability's spec — behavior, not implementation.
- **Deduped afterward:** `mcp-injection` split out of `fork-create` (it's MCP-config registration, not fork-context injection); the `task-linking` (HTTP/URL layer) vs `task-orchestration` (engine/DAG layer) boundary made non-redundant.

## Review

- **Strict validation:** 38/38 specs pass.
- **Contradiction-only spot-check** on the four security/correctness-critical specs (`sandbox-execution`, `agent-execution`, `data-persistence`, `rest-api`). Three were clean against code + tests. The check caught one real spec error in `rest-api` — the master-only-gating requirement wrongly asserted that settings *reads* require the master token, when `GET /api/settings` is intentionally device-readable (pinned by `TestHandleSettings_GetIsAvailableToDevice`). Corrected the spec to match the real auth contract.

## Notes

- **Docs-only:** zero `.go` files changed, so CI build/vet/lint/test/coverage are unaffected.
- `govulncheck` locally flags two pre-existing Go stdlib advisories fixed in go1.26.4; CI's floating `go-version: '1.26'` pin resolves to the patched toolchain. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
