### PR TITLE
Add POST /api/tasks/{id}/restart (resume task session) for hera reattach

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -434,6 +434,73 @@ func (s *Server) handleStopTask(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "stopped"})
 }
 
+// --- Restart Task ---
+
+// handleRestartTask re-spawns a finished agent session via
+// POST /api/tasks/{id}/restart. It is the argus side of hera's agent-reattach
+// feature: hera calls this endpoint when the user presses Enter on a dead
+// session row so the prior conversation is resumed in the same worktree.
+//
+// Behaviour:
+//   - 404 if the task does not exist.
+//   - 409 if a non-idle session is already running (agent is live — no restart
+//     needed).
+//   - 200 + {"status":"restarted","pid":<n>} on success. The new PTY session
+//     streams through the same ring-buffer / SSE path that consumers (hera's
+//     proxy subscription, the SPA terminal) already listen on, so they pick up
+//     the resumed output automatically without re-subscribing.
+//
+// The session is always started with resume=true so BuildCmd appends
+// --resume <last-session-id> for Claude/pi backends when task.SessionID is
+// non-empty. If the task has no prior session ID (first-start path), BuildCmd
+// omits the flag and starts fresh.
+func (s *Server) handleRestartTask(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	task, err := s.db.Get(id)
+	if err != nil || task == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		return
+	}
+
+	// 409 only when the agent is actively working. Idle in_progress tasks
+	// (no live session, or session.IsIdle()) are exactly what this endpoint
+	// targets — they should be restarted, not rejected.
+	if sess := s.runner.Get(task.ID); sess != nil && !sess.IsIdle() {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "task already running"})
+		return
+	}
+
+	cfg := s.db.Config()
+	// Always resume so BuildCmd appends --resume <session-id> when the task
+	// has a prior session (the normal post-exit case). If SessionID is empty,
+	// BuildCmd starts fresh — same graceful degradation as /resume.
+	sess, reattached, err := s.runner.StartOrReattach(task, cfg, 24, 80, true)
+	if err != nil {
+		uxlog.Log("[api] restart: start failed task=%s err=%v", id, err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	task.SetStatus(model.StatusInProgress)
+	task.AgentPID = sess.PID()
+	s.db.Update(task) //nolint:errcheck
+
+	if reattached {
+		uxlog.Log("[api] restart: healed task=%s pid=%d", id, task.AgentPID)
+	} else {
+		uxlog.Log("[api] restart: started task=%s pid=%d resume=%t", id, task.AgentPID, task.SessionID != "")
+	}
+
+	resp := map[string]any{
+		"status": "restarted",
+		"pid":    task.AgentPID,
+	}
+	if reattached {
+		resp["healed"] = true
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // --- Resume Task ---
 
 func (s *Server) handleResumeTask(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -409,6 +409,98 @@ func TestHandleResumeTask(t *testing.T) {
 	})
 }
 
+// TestHandleRestartTask covers POST /api/tasks/{id}/restart: the endpoint
+// hera calls to re-spawn a dead agent session via --resume <last-session-id>.
+func TestHandleRestartTask(t *testing.T) {
+	t.Run("404 when task missing", func(t *testing.T) {
+		srv, _ := testServer(t)
+		mux := srv.routes()
+		req := authedReq("POST", "/api/tasks/missing/restart", "")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		testutil.Equal(t, w.Code, http.StatusNotFound)
+	})
+
+	t.Run("409 when task has a live non-idle session", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("starts a real PTY-backed sleep; skipped in -short")
+		}
+		srv, d := testServer(t)
+		mux := srv.routes()
+
+		testutil.NoError(t, d.SetBackend("sh-sleep", config.Backend{Command: "sleep 30"}))
+		task := &model.Task{
+			Name:     "running",
+			Status:   model.StatusInProgress,
+			Backend:  "sh-sleep",
+			Worktree: t.TempDir(),
+		}
+		testutil.NoError(t, d.Add(task))
+		sess, err := srv.runner.Start(task, d.Config(), 24, 80, false)
+		testutil.NoError(t, err)
+		t.Cleanup(func() {
+			_ = srv.runner.Stop(task.ID)
+			<-sess.Done()
+		})
+
+		req := authedReq("POST", "/api/tasks/"+task.ID+"/restart", "")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		testutil.Equal(t, w.Code, http.StatusConflict)
+	})
+
+	t.Run("restarts a dead task", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("starts a real PTY-backed sleep; skipped in -short")
+		}
+		srv, d := testServer(t)
+		mux := srv.routes()
+
+		testutil.NoError(t, d.SetBackend("sh-sleep", config.Backend{Command: "sleep 30"}))
+		task := &model.Task{
+			Name:     "dead",
+			Status:   model.StatusInReview,
+			Backend:  "sh-sleep",
+			Worktree: t.TempDir(),
+		}
+		testutil.NoError(t, d.Add(task))
+
+		req := authedReq("POST", "/api/tasks/"+task.ID+"/restart", "")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		testutil.Equal(t, w.Code, http.StatusOK)
+		t.Cleanup(func() {
+			if sess := srv.runner.Get(task.ID); sess != nil {
+				_ = srv.runner.Stop(task.ID)
+				<-sess.Done()
+			}
+		})
+
+		var resp map[string]any
+		testutil.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		testutil.Equal(t, resp["status"], "restarted")
+		pid, _ := resp["pid"].(float64)
+		testutil.True(t, pid > 0)
+
+		// DB row must be flipped to in_progress.
+		got, err := d.Get(task.ID)
+		testutil.NoError(t, err)
+		testutil.Equal(t, got.Status, model.StatusInProgress)
+	})
+
+	t.Run("500 when start fails (no backend)", func(t *testing.T) {
+		srv, d := testServer(t)
+		mux := srv.routes()
+
+		task := &model.Task{Name: "no-backend", Status: model.StatusInReview}
+		testutil.NoError(t, d.Add(task))
+
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, authedReq("POST", "/api/tasks/"+task.ID+"/restart", ""))
+		testutil.Equal(t, w.Code, http.StatusInternalServerError)
+	})
+}
+
 func TestHandleDeleteTask(t *testing.T) {
 	srv, d := testServer(t)
 	mux := srv.routes()

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -40,6 +40,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/skills", s.handleListSkills)
 	mux.HandleFunc("GET /api/tasks/{id}", s.handleGetTask)
 	mux.HandleFunc("POST /api/tasks/{id}/stop", s.handleStopTask)
+	mux.HandleFunc("POST /api/tasks/{id}/restart", s.handleRestartTask)
 	mux.HandleFunc("POST /api/tasks/{id}/resume", s.handleResumeTask)
 	mux.HandleFunc("DELETE /api/tasks/{id}", s.handleDeleteTask)
 	mux.HandleFunc("GET /api/tasks/{id}/output", s.handleGetOutput)


### PR DESCRIPTION
## Summary

- Adds `POST /api/tasks/{id}/restart` — the argus-side endpoint that unblocks hera's BUG-033 agent-reattach feature
- On press of Enter on a dead-session row, hera calls this endpoint; argus re-spawns the agent with `--resume <last-session-id>` and routes output through the existing task stream so hera's proxy subscription picks up the revived session automatically
- Session ID tracking was already in place (`task.SessionID`, `captureSessionIDPostExit`); no new DB schema needed

## Endpoint behaviour

- **404** — task not found
- **409** — a non-idle session is already running (agent is live, no restart needed)
- **500** — session start failed (missing worktree, backend misconfigured, etc.)
- **200** — `{"status":"restarted","pid":<n>}` (+ `"healed":true` when StartOrReattach detected an existing runner session that the DB had drifted away from)

## Session-ID / PTY routing

`task.SessionID` is populated by `captureSessionIDPostExit` (daemon `onFinish`) on every Claude session exit. When this endpoint fires, `BuildCmd(task, cfg, resume=true)` sees the stored UUID and appends `--resume <uuid>` — exactly `claude --resume <last-session-id>`. The new PTY session writes into the same ring-buffer / SSE path (`GET /api/tasks/{id}/stream`) that hera and the SPA already subscribe to; no re-subscription needed.

## Hera contract satisfied

Matches `argus.Client.RestartTask` in hera (`POST /api/tasks/{id}/restart`, no request body, 404/405 → `ErrNoTaskRestart`, other non-2xx → `*HTTPError`).

## Tests

4 subtests in `TestHandleRestartTask`: 404 on unknown task, 409 on live session, 200 with status/pid/DB flip, 500 on start failure.

## CI

- `go build ./...` ✓
- `go vet ./...` ✓
- `goimports -l` ✓ (no unformatted files)
- `golangci-lint --new-from-rev=origin/master` ✓ (0 issues)
- `go test -race ./internal/api/` ✓
- Coverage 89.5% (above 88% floor) ✓
- `govulncheck` failures (GO-2026-5037/5039) are pre-existing stdlib issues present on master before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>