### PR TITLE
fix(BUG-058): handleResize skips KickRerender when ?skip_kick=1 is set

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1126,7 +1126,15 @@ func (s *Server) handleResize(w http.ResponseWriter, r *http.Request) {
 	// The kick stops the session; the runner's exit goroutine restarts it
 	// at the new dimensions via --session-id so the agent re-emits the
 	// entire conversation. Best-effort: never let this fail the resize.
-	rerendered := s.maybeKickRerender(id, req.Rows, req.Cols)
+	//
+	// ?skip_kick=1 suppresses the kill+resume step while still delivering
+	// SIGWINCH. Callers that manage their own resize lifecycle (e.g. hera's
+	// pinnedTerminalPane) pass this flag to avoid oscillation loops where
+	// repeated geometry changes would otherwise trigger repeated restarts.
+	rerendered := false
+	if r.URL.Query().Get("skip_kick") != "1" {
+		rerendered = s.maybeKickRerender(id, req.Rows, req.Cols)
+	}
 
 	writeJSON(w, http.StatusOK, struct {
 		Cols       int  `json:"cols"`

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2551,6 +2551,36 @@ func TestHandleResize_LiveSession(t *testing.T) {
 		mux.ServeHTTP(w, authedReq("POST", "/api/tasks/"+task.ID+"/resize", `{"cols":100,"rows":40}`))
 		testutil.Equal(t, w.Code, http.StatusOK)
 	})
+
+	t.Run("skip_kick=1 suppresses rerender even with large delta", func(t *testing.T) {
+		// Give the task a SessionID so maybeKickRerender clears all early-exit
+		// gates. With ?skip_kick=1 the handler must skip the call entirely and
+		// always return rerendered:false, regardless of delta or idle state.
+		task.SessionID = "fake-session-skip-kick-test"
+		testutil.NoError(t, d.Update(task))
+		srv.invalidateColsCache(task.ID) // ensure cols-cache doesn't short-circuit
+
+		req := httptest.NewRequest(
+			"POST",
+			"/api/tasks/"+task.ID+"/resize?skip_kick=1",
+			strings.NewReader(`{"cols":200,"rows":24}`),
+		)
+		req.Header.Set("Authorization", "Bearer test-token")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		testutil.Equal(t, w.Code, http.StatusOK)
+
+		var resp struct {
+			Cols       int  `json:"cols"`
+			Rows       int  `json:"rows"`
+			Rerendered bool `json:"rerendered"`
+		}
+		testutil.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		testutil.Equal(t, resp.Rerendered, false)
+		testutil.Equal(t, resp.Cols, 200)
+		testutil.Equal(t, resp.Rows, 24)
+	})
 }
 
 func TestHandleGetSize_LiveSession(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `?skip_kick=1` query parameter support to `POST /api/tasks/{id}/resize`
- When the flag is set, the PTY resize (SIGWINCH) fires normally but the `maybeKickRerender` stop+restart is suppressed
- Callers that manage their own resize lifecycle (e.g. hera's `pinnedTerminalPane`) pass this flag to avoid oscillation loops where repeated geometry changes would otherwise trigger repeated agent restarts
- Adds test coverage verifying `rerendered:false` is returned with the flag even when the session has a SessionID and the column delta exceeds `RerenderMargin`

## Test plan

- [ ] `go test ./internal/api/... -race` passes (new subtest: `TestHandleResize_LiveSession/skip_kick=1_suppresses_rerender_even_with_large_delta`)
- [ ] Hera PR #84 (`?skip_kick=1` on all `ResizeTask` calls) can rely on server-side support