### PR TITLE
fix(BUG-007): raise maxPluginBarHints from 8 to 20

### DIFF
--- a/internal/tui/widget/statusbar.go
+++ b/internal/tui/widget/statusbar.go
@@ -38,7 +38,7 @@ type StatusBar struct {
 // maxPluginBarHints caps how many plugin hints the bar will attempt to render
 // so a misbehaving plugin can't flood the bar. The reserved exit hint is
 // always rendered regardless of this cap.
-const maxPluginBarHints = 8
+const maxPluginBarHints = 20
 
 // pluginExitHintKey / pluginExitHintLabel are the reserved "return to argus"
 // affordance. Esc is surrendered to the plugin, so the only advertised exit is


### PR DESCRIPTION
## Summary

- Raises `maxPluginBarHints` in `internal/tui/widget/statusbar.go` from 8 → 20 so plugins with more than 8 hints can render their full key bar without truncation.

## Changes

- `internal/tui/widget/statusbar.go`: `maxPluginBarHints = 8` → `maxPluginBarHints = 20`

## Test plan

- [ ] Build passes (`make build`)
- [ ] Plugin with >8 hints renders all hints without truncation
- [ ] Reserved exit hint still renders regardless of count