### PR TITLE
fix(notify): deliver CR as separate WriteInput after text

### DIFF
--- a/internal/api/notify.go
+++ b/internal/api/notify.go
@@ -99,11 +99,11 @@ func (s *Server) handleNotify(w http.ResponseWriter, r *http.Request) {
 	// idle-watcher tick.
 	s.notifier.Reconcile(time.Now())
 
+	// DeliveryState returns StateSubmitted when the delivery was genuinely
+	// submitted, StatePending when it is still queued, or "" when it was
+	// removed without submission (deadline expiry, write failure, cancel).
+	// Never assume "" means submitted — that would misreport failed removals.
 	state := s.notifier.DeliveryState(taskID, req.DeliveryID)
-	if state == "" {
-		// Delivery is gone from pending — it was submitted by the inline Reconcile.
-		state = notify.StateSubmitted
-	}
 	uxlog.Log("[api] notify registered task=%s delivery_id=%s state=%s", taskID, req.DeliveryID, state)
 	writeJSON(w, http.StatusAccepted, notifyResp{DeliveryID: req.DeliveryID, State: string(state)})
 }

--- a/internal/api/notify.go
+++ b/internal/api/notify.go
@@ -103,7 +103,11 @@ func (s *Server) handleNotify(w http.ResponseWriter, r *http.Request) {
 	// submitted, StatePending when it is still queued, or "" when it was
 	// removed without submission (deadline expiry, write failure, cancel).
 	// Never assume "" means submitted — that would misreport failed removals.
+	// Map "" to pending to keep the API response in the documented set.
 	state := s.notifier.DeliveryState(taskID, req.DeliveryID)
+	if state == "" {
+		state = notify.StatePending
+	}
 	uxlog.Log("[api] notify registered task=%s delivery_id=%s state=%s", taskID, req.DeliveryID, state)
 	writeJSON(w, http.StatusAccepted, notifyResp{DeliveryID: req.DeliveryID, State: string(state)})
 }

--- a/internal/notify/service.go
+++ b/internal/notify/service.go
@@ -197,11 +197,11 @@ func (n *Notifier) processOne(taskID string, d *delivery, now time.Time) {
 	}
 
 	// All gates passed: submit.
-	// Three separate writes mirror how a human presses Enter:
-	//   1. Ctrl+U  – kill any stale partial input
-	//   2. text    – prime the input buffer (no trailing CR)
-	//   3. delay   – brief pause so CR is processed as a distinct keypress
-	//   4. \r      – submit; must be its own WriteInput, not appended to text
+	// Three separate WriteInput calls, with a brief pause before the third:
+	//   1. Ctrl+U – kill any stale partial input
+	//   2. text   – prime the input buffer (no trailing CR)
+	//      (submitCRDelay pause here — ensures CR arrives as a distinct keypress)
+	//   3. \r     – submit; must be its own call, never appended to text
 	// The glued ctrl+u+text+CR sequence leaves the line un-submitted in some
 	// shell/agent configurations; the separated form is empirically reliable.
 	if _, err := sess.WriteInput([]byte("\x15")); err != nil {

--- a/internal/notify/service.go
+++ b/internal/notify/service.go
@@ -197,13 +197,27 @@ func (n *Notifier) processOne(taskID string, d *delivery, now time.Time) {
 	}
 
 	// All gates passed: submit.
-	// Ctrl+U clears any stale partial input, then text+CR submits.
+	// Three separate writes mirror how a human presses Enter:
+	//   1. Ctrl+U  – kill any stale partial input
+	//   2. text    – prime the input buffer (no trailing CR)
+	//   3. delay   – brief pause so CR is processed as a distinct keypress
+	//   4. \r      – submit; must be its own WriteInput, not appended to text
+	// The glued ctrl+u+text+CR sequence leaves the line un-submitted in some
+	// shell/agent configurations; the separated form is empirically reliable.
 	if _, err := sess.WriteInput([]byte("\x15")); err != nil {
 		uxlog.Log("[notify] delivery ctrl+u failed task=%s id=%s err=%v", taskID, d.deliveryID, err)
 		return
 	}
-	if _, err := sess.WriteInput([]byte(d.text + "\r")); err != nil {
-		uxlog.Log("[notify] delivery write failed task=%s id=%s err=%v", taskID, d.deliveryID, err)
+	if _, err := sess.WriteInput([]byte(d.text)); err != nil {
+		uxlog.Log("[notify] delivery text write failed task=%s id=%s err=%v", taskID, d.deliveryID, err)
+		return
+	}
+	// processOne runs without n.mu held; this sleep is safe.
+	time.Sleep(submitCRDelay)
+	if _, err := sess.WriteInput([]byte("\r")); err != nil {
+		uxlog.Log("[notify] delivery enter write failed task=%s id=%s err=%v", taskID, d.deliveryID, err)
+		// Text is now in the buffer without a CR. The next Reconcile will
+		// ctrl+U (clearing the stale text) then retry the full sequence.
 		return
 	}
 

--- a/internal/notify/service_test.go
+++ b/internal/notify/service_test.go
@@ -104,9 +104,10 @@ func TestNotifier_ImmediateSubmit(t *testing.T) {
 	n.Reconcile(time.Now())
 
 	writes := sess.allWrites()
-	testutil.Equal(t, len(writes), 2)
+	testutil.Equal(t, len(writes), 3)
 	testutil.Equal(t, string(writes[0]), "\x15")
-	testutil.Equal(t, string(writes[1]), "hello\r")
+	testutil.Equal(t, string(writes[1]), "hello")
+	testutil.Equal(t, string(writes[2]), "\r")
 }
 
 func TestNotifier_DeferredWhenBusy(t *testing.T) {
@@ -125,7 +126,7 @@ func TestNotifier_DeferredWhenBusy(t *testing.T) {
 	sess.idle = true
 	sess.mu.Unlock()
 	n.Reconcile(time.Now())
-	testutil.Equal(t, len(sess.allWrites()), 2)
+	testutil.Equal(t, len(sess.allWrites()), 3)
 }
 
 func TestNotifier_DeferredWhenFocused(t *testing.T) {
@@ -192,7 +193,7 @@ func TestNotifier_DeduplicatePending_SharedCancel(t *testing.T) {
 	sess.idle = true
 	sess.mu.Unlock()
 	n.Reconcile(time.Now())
-	testutil.Equal(t, len(sess.allWrites()), 2)
+	testutil.Equal(t, len(sess.allWrites()), 3)
 }
 
 func TestNotifier_DeduplicateSubmitted(t *testing.T) {
@@ -203,14 +204,14 @@ func TestNotifier_DeduplicateSubmitted(t *testing.T) {
 	cancel1 := n.ReliableNotify("t1", "hello", "d1", NotifyOpts{})
 	defer cancel1()
 	n.Reconcile(time.Now())
-	testutil.Equal(t, len(sess.allWrites()), 2)
+	testutil.Equal(t, len(sess.allWrites()), 3)
 
 	// Re-post the same deliveryID.
 	cancel2 := n.ReliableNotify("t1", "hello", "d1", NotifyOpts{})
 	defer cancel2()
 	n.Reconcile(time.Now())
-	// Still only 2 writes (no second submission).
-	testutil.Equal(t, len(sess.allWrites()), 2)
+	// Still only 3 writes (no second submission).
+	testutil.Equal(t, len(sess.allWrites()), 3)
 }
 
 func TestNotifier_NoSession_DeferDelivery(t *testing.T) {
@@ -257,14 +258,15 @@ func TestNotifier_SerializeConcurrentDeliveries(t *testing.T) {
 	// First reconcile submits d1.
 	n.Reconcile(time.Now())
 	writes1 := sess.allWrites()
-	testutil.Equal(t, len(writes1), 2) // ctrl+u + "first\r"
+	testutil.Equal(t, len(writes1), 3) // ctrl+u + "first" + CR
 
 	// Second reconcile submits d2.
 	n.Reconcile(time.Now())
 	writes2 := sess.allWrites()
-	testutil.Equal(t, len(writes2), 4) // two more writes for "second"
-	testutil.Equal(t, string(writes2[2]), "\x15")
-	testutil.Equal(t, string(writes2[3]), "second\r")
+	testutil.Equal(t, len(writes2), 6) // three more writes for "second"
+	testutil.Equal(t, string(writes2[3]), "\x15")
+	testutil.Equal(t, string(writes2[4]), "second")
+	testutil.Equal(t, string(writes2[5]), "\r")
 }
 
 func TestNotifier_SessionExists(t *testing.T) {
@@ -308,9 +310,37 @@ func TestNotifier_PreClear_WritesCtrlU(t *testing.T) {
 	n.Reconcile(time.Now())
 
 	writes := sess.allWrites()
-	testutil.Equal(t, len(writes), 2)
+	testutil.Equal(t, len(writes), 3)
 	testutil.Equal(t, writes[0][0], byte(0x15)) // Ctrl+U
-	testutil.Equal(t, string(writes[1]), "text\r")
+	testutil.Equal(t, string(writes[1]), "text")
+	testutil.Equal(t, string(writes[2]), "\r")
+}
+
+// TestNotifier_SubmitThreeOrderedWrites verifies that submit issues exactly three
+// WriteInput calls in order: Ctrl+U (0x15), then the text WITHOUT a trailing CR,
+// then a standalone CR (0x0D). The gap between writes 2 and 3 exists in production
+// but is not observable here because fakeSession.WriteInput is synchronous.
+//
+// NOTE: whether the CR is interpreted as "Enter" vs "paste continuation" depends
+// on the target shell/agent's line-discipline and cannot be verified with this
+// byte-level fake. Real-TUI submit correctness must be verified empirically after
+// deploy by confirming the message appears in the agent's conversation.
+func TestNotifier_SubmitThreeOrderedWrites(t *testing.T) {
+	r := newFakeRunner()
+	sess := r.addSession("t1", true) // idle
+	n := newTestNotifier(r, fakeNoFocus{})
+
+	n.ReliableNotify("t1", "the message", "d1", NotifyOpts{})
+	n.Reconcile(time.Now())
+
+	writes := sess.allWrites()
+	testutil.Equal(t, len(writes), 3)
+	// Write 1: Ctrl+U line-kill.
+	testutil.Equal(t, string(writes[0]), "\x15")
+	// Write 2: text without trailing CR.
+	testutil.Equal(t, string(writes[1]), "the message")
+	// Write 3: standalone CR — not appended to write 2.
+	testutil.Equal(t, string(writes[2]), "\r")
 }
 
 func TestNotifier_FocusLifts_PendingDeliverySubmits(t *testing.T) {
@@ -326,7 +356,7 @@ func TestNotifier_FocusLifts_PendingDeliverySubmits(t *testing.T) {
 
 	ft.SetFocused("t1", false) // human leaves
 	n.Reconcile(time.Now())
-	testutil.Equal(t, len(sess.allWrites()), 2) // ctrl+u + text\r
+	testutil.Equal(t, len(sess.allWrites()), 3) // ctrl+u + text + CR
 }
 
 func TestNotifier_WriteInputCtrlUFailure_DeliveryRemainesPending(t *testing.T) {
@@ -363,8 +393,9 @@ func TestNotifier_CancelActiveDelivery_PromotesQueued(t *testing.T) {
 	sess.idle = true
 	sess.mu.Unlock()
 	n.Reconcile(time.Now())
-	testutil.Equal(t, len(sess.allWrites()), 2)
-	testutil.Equal(t, string(sess.allWrites()[1]), "second\r")
+	testutil.Equal(t, len(sess.allWrites()), 3)
+	testutil.Equal(t, string(sess.allWrites()[1]), "second")
+	testutil.Equal(t, string(sess.allWrites()[2]), "\r")
 }
 
 func TestNotifier_CancelQueuedDelivery(t *testing.T) {

--- a/internal/notify/types.go
+++ b/internal/notify/types.go
@@ -15,6 +15,12 @@ const defaultDeadlineMS = 5 * 60 * 1000
 // evicted ID would re-inject; in practice a task never accumulates this many.
 const maxSubmittedPerTask = 1000
 
+// submitCRDelay is the pause between writing the delivery text and sending the
+// final CR. The gap ensures CR is processed as a distinct keypress rather than
+// as part of a single paste sequence, which is necessary for reliable submission
+// in some shell/agent configurations.
+const submitCRDelay = 50 * time.Millisecond
+
 // NotifyOpts controls optional parameters for ReliableNotify.
 type NotifyOpts struct {
 	// DeadlineMS is the maximum milliseconds to wait for a safe submit window.

--- a/openspec/changes/add-reliable-pane-delivery/specs/reliable-pane-delivery/spec.md
+++ b/openspec/changes/add-reliable-pane-delivery/specs/reliable-pane-delivery/spec.md
@@ -47,7 +47,7 @@ The system SHALL ensure that re-posting the same deliveryID for the same task is
 
 ### Requirement: Pre-clear before inject
 
-The system SHALL emit a Ctrl+U (line-kill) signal before injecting the delivery text so that any stale partial input in the shell's line buffer is discarded. If the shell's input line is empty, Ctrl+U SHALL be a no-op at the shell level. The sequence is: Ctrl+U, then text+CR.
+The system SHALL emit a Ctrl+U (line-kill) signal before injecting the delivery text so that any stale partial input in the shell's line buffer is discarded. If the shell's input line is empty, Ctrl+U SHALL be a no-op at the shell level. The submit sequence is three separate PTY writes: (1) Ctrl+U, (2) the delivery text without any trailing CR, (3) a brief pause (~50 ms), then (4) a standalone CR as its own write. The CR MUST be delivered as a separate `WriteInput` call after the text write — not appended to the text — so that the target shell/agent processes it as a distinct keypress (Enter) rather than as part of a paste sequence.
 
 #### Scenario: Clean input line yields normal submission
 
@@ -58,6 +58,11 @@ The system SHALL emit a Ctrl+U (line-kill) signal before injecting the delivery 
 
 - **WHEN** the PTY's shell input line contains partial text at the moment of submit
 - **THEN** the Ctrl+U clears the partial text before the delivery text and CR are written
+
+#### Scenario: CR delivered as separate write
+
+- **WHEN** the notifier submits a delivery
+- **THEN** the PTY receives three ordered writes: Ctrl+U (0x15), then the text without a trailing CR, then a standalone CR (0x0D) as its own write — never glued to the text write
 
 ### Requirement: Deadline backstop
 


### PR DESCRIPTION
## Problem

The reliable-notify submit sequence glued `ctrl+U + text + CR` into a single `WriteInput` call (`text+"\r"`). In some shell/agent configurations this was processed as a single paste sequence, leaving the line sitting in the input buffer without submitting it. A real delivery sat ~13 min un-submitted in production until a human pressed Enter manually.

## Changes

### `internal/notify/service.go` — three-write submit sequence

Split `processOne`'s submit from 2 writes into 3 ordered writes with a 50 ms pause:

1. `\x15` (Ctrl+U) – kill any stale partial input
2. `text` – prime the input buffer (no trailing CR)
3. *(50 ms pause — `submitCRDelay` const)*
4. `\r` – submit as its own `WriteInput` call, never appended to text

The pause ensures CR arrives as a distinct keypress rather than part of a paste batch.

### `internal/api/notify.go` — tighten state reporting

`handleNotify` was treating `DeliveryState==""` (delivery gone from the pending map) as `"submitted"`. This is wrong: `DeliveryState` already returns `StateSubmitted` explicitly when the delivery was genuinely submitted. The `""` case means "removed without submission" (deadline expiry, write failure, concurrent cancel). Fixed to:

- Drop the `if state == ""` → `StateSubmitted` override
- Add `if state == ""` → `StatePending` fallback so the API always returns a documented value (`"submitted"` or `"pending"`)

### Tests

- Updated all write-count assertions from 2→3 and content assertions from `"text\r"` to `"text"` + `"\r"` separately
- Added `TestNotifier_SubmitThreeOrderedWrites` — pins the three-ordered-writes contract with a clear NOTE that real-TUI submit correctness requires empirical post-deploy verification

### Spec

Updated `openspec/changes/add-reliable-pane-delivery/specs/reliable-pane-delivery/spec.md`:
- Rewrote the "Pre-clear before inject" requirement to specify the separate CR write
- Added new scenario: "CR delivered as separate write"

## Verification

- `make build` ✓
- `make vet` ✓
- `make fmt-check` ✓
- `make lint-pr` — 0 issues ✓
- `make test-cover-gate` — 89.4% ≥ 88% ✓
- `govulncheck` — 2 pre-existing stdlib vulns (go1.26.3→go1.26.4), not introduced by this change

**NOT deployed** — awaits user merge + argus bounce + live re-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>