### PR TITLE
fix(tui): rebind file-panel hotkeys to f/o/t, drop editor action

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ The sections below are the dense usage docs — keybindings, REST endpoints, con
 | ------- | ------------------------- |
 | `Enter` | Open diff                 |
 | `s`     | Toggle split/unified diff |
-| `o`     | Reveal in Finder          |
-| `e`     | Open in editor            |
+| `f`     | Reveal in Finder          |
+| `o`     | Open file (default app)   |
 | `t`     | Open terminal in worktree |
 
 #### Modals & Forms

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2247,11 +2247,11 @@ func (a *App) handleFilePanelKey(event *tcell.EventKey) *tcell.EventKey {
 				go a.fetchDirChildren(dir)
 			}
 			return nil
-		case 'o':
+		case 'f':
 			a.openInFinder()
 			return nil
-		case 'e':
-			a.openInEditor()
+		case 'o':
+			a.openFile()
 			return nil
 		case 't':
 			a.openTerminal()
@@ -2360,18 +2360,35 @@ func (a *App) openFileDiff() {
 	}()
 }
 
+// systemOpener is the package-level seam for the macOS `open` command. Tests
+// stub this out so they don't actually launch Finder or a default app. `open`
+// with `-R` reveals a path in Finder; without `-R` it opens the path with its
+// default system handler.
+var systemOpener = func(args ...string) error {
+	return exec.Command("open", args...).Start()
+}
+
+// openInFinder reveals the selected file in Finder (bound to `f`).
 func (a *App) openInFinder() {
 	f := a.filePanel.SelectedFile()
 	if f == nil || a.worktreeDir == "" {
 		return
 	}
-	exec.Command("open", "-R", a.worktreeDir+"/"+f.Path).Start() //nolint:errcheck
+	if err := systemOpener("-R", a.worktreeDir+"/"+f.Path); err != nil {
+		uxlog.Log("[tui] reveal in Finder failed: %v", err)
+	}
 }
 
-// editorOpener is the package-level seam for "open file in tmux + nvim".
-// Tests stub this out so they don't actually spawn a tmux window.
-var editorOpener = func(worktreeDir, path string) error {
-	return exec.Command("tmux", "new-window", "nvim", worktreeDir+"/"+path).Start()
+// openFile opens the selected file with its default system handler (bound to
+// `o`).
+func (a *App) openFile() {
+	f := a.filePanel.SelectedFile()
+	if f == nil || a.worktreeDir == "" {
+		return
+	}
+	if err := systemOpener(a.worktreeDir + "/" + f.Path); err != nil {
+		uxlog.Log("[tui] open file failed: %v", err)
+	}
 }
 
 // terminalOpener is the package-level seam for "open shell in worktree dir
@@ -2398,16 +2415,6 @@ var repoOpener = func(dir string) error {
 	cmd := exec.Command("gh", "repo", "view", "--web")
 	cmd.Dir = dir
 	return cmd.Start()
-}
-
-func (a *App) openInEditor() {
-	f := a.filePanel.SelectedFile()
-	if f == nil || a.worktreeDir == "" {
-		return
-	}
-	if err := editorOpener(a.worktreeDir, f.Path); err != nil {
-		uxlog.Log("[tui] open in editor failed: %v", err)
-	}
 }
 
 func (a *App) openTerminal() {

--- a/internal/tui/forms_render_test.go
+++ b/internal/tui/forms_render_test.go
@@ -35,9 +35,9 @@ func TestDirAC_Draw_Closed(t *testing.T) {
 	testutil.Equal(t, rows, 0)
 }
 
-// --- handleFilePanelKey: 'o', 'e', 't' branches ---
+// --- handleFilePanelKey: 'f', 'o', 't' branches ---
 
-func TestApp_HandleFilePanelKey_OEAndT(t *testing.T) {
+func TestApp_HandleFilePanelKey_FOAndT(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
 	app := New(d, runner, false)
@@ -48,17 +48,36 @@ func TestApp_HandleFilePanelKey_OEAndT(t *testing.T) {
 	app.filePanel.SetFiles([]gitutil.ChangedFile{{Status: "M", Path: "a.go"}})
 	app.worktreeDir = t.TempDir()
 
-	// 'o' calls openInFinder.
-	got := app.handleFilePanelKey(tcell.NewEventKey(tcell.KeyRune, 'o', 0))
-	testutil.Nil(t, got)
+	var systemArgs [][]string
+	var termHits int
+	oldSystem := systemOpener
+	oldTerm := terminalOpener
+	t.Cleanup(func() { systemOpener = oldSystem; terminalOpener = oldTerm })
+	systemOpener = func(args ...string) error { systemArgs = append(systemArgs, args); return nil }
+	terminalOpener = func(string) error { termHits++; return nil }
 
-	// 'e' calls openInEditor.
-	got = app.handleFilePanelKey(tcell.NewEventKey(tcell.KeyRune, 'e', 0))
-	testutil.Nil(t, got)
+	wantFile := app.worktreeDir + "/a.go"
 
-	// 't' calls openTerminal.
+	// 'f' reveals the selected file in Finder (`open -R <path>`).
+	got := app.handleFilePanelKey(tcell.NewEventKey(tcell.KeyRune, 'f', 0))
+	testutil.Nil(t, got)
+	testutil.DeepEqual(t, systemArgs[len(systemArgs)-1], []string{"-R", wantFile})
+
+	// 'o' opens the selected file with its default handler (`open <path>`).
+	got = app.handleFilePanelKey(tcell.NewEventKey(tcell.KeyRune, 'o', 0))
+	testutil.Nil(t, got)
+	testutil.DeepEqual(t, systemArgs[len(systemArgs)-1], []string{wantFile})
+
+	// 't' opens a terminal in the worktree.
 	got = app.handleFilePanelKey(tcell.NewEventKey(tcell.KeyRune, 't', 0))
 	testutil.Nil(t, got)
+	testutil.Equal(t, termHits, 1)
+
+	// 'e' is no longer bound — the event falls through unconsumed.
+	got = app.handleFilePanelKey(tcell.NewEventKey(tcell.KeyRune, 'e', 0))
+	if got == nil {
+		t.Error("'e' should no longer be handled by the file panel")
+	}
 
 	// 'j' navigates down.
 	got = app.handleFilePanelKey(tcell.NewEventKey(tcell.KeyRune, 'j', 0))

--- a/internal/tui/main_test.go
+++ b/internal/tui/main_test.go
@@ -11,11 +11,11 @@ import (
 // inside the test (with t.Cleanup to restore).
 //
 // Without these defaults, running `go test ./internal/tui/` in any
-// developer terminal would shell out to tmux/open/gh whenever an exercised
-// path reaches openInEditor / openTerminal / openURL / openPR.
+// developer terminal would shell out to open/tmux/gh whenever an exercised
+// path reaches openInFinder / openFile / openTerminal / openURL / openPR.
 func TestMain(m *testing.M) {
 	browserOpener = func(string) error { return nil }
-	editorOpener = func(string, string) error { return nil }
+	systemOpener = func(...string) error { return nil }
 	terminalOpener = func(string) error { return nil }
 	prOpener = func(string) error { return nil }
 	os.Exit(m.Run())

--- a/internal/tui/modal/help.go
+++ b/internal/tui/modal/help.go
@@ -84,8 +84,8 @@ var HelpSections = []HelpSection{
 		Bindings: []HelpBinding{
 			{"Enter", "open diff"},
 			{"s", "toggle split/unified"},
-			{"o", "reveal in Finder"},
-			{"e", "open in editor"},
+			{"f", "reveal in Finder"},
+			{"o", "open file"},
 			{"t", "open terminal in worktree"},
 		},
 	},

--- a/internal/tui/settings_render_test.go
+++ b/internal/tui/settings_render_test.go
@@ -660,11 +660,11 @@ func TestApp_OpenInFinder_NoFile(t *testing.T) {
 	app.openInFinder()
 }
 
-func TestApp_OpenInEditor_NoFile(t *testing.T) {
+func TestApp_OpenFile_NoFile(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)
 	app := New(d, runner, false)
-	app.openInEditor()
+	app.openFile()
 }
 
 func TestApp_OpenTerminal_NoWorktree(t *testing.T) {


### PR DESCRIPTION
Rebind the agent file-panel hotkeys to match intent: f=reveal in Finder, o=open file with the default system app, t=open terminal. Remove the editor (e) action. Add a systemOpener seam wrapping macOS `open`, update the help overlay and README keybinding table, and update tests to assert each opener fires with the right args and that e now falls through unconsumed.

Co-Authored-By: Claude <noreply@anthropic.com>