### PR TITLE
docs(help): document ctrl+k task switcher in agent-view help overlay

### DIFF
--- a/internal/tui/modal/help.go
+++ b/internal/tui/modal/help.go
@@ -73,6 +73,7 @@ var HelpSections = []HelpSection{
 			{"Cmd+↑ / Cmd+↓", "navigate tasks"},
 			{"Shift+↑ / Shift+↓", "scroll terminal"},
 			{"ctrl+z", "toggle single-pane (zoom)"},
+			{"ctrl+k", "task switcher"},
 			{"ctrl+l", "link picker"},
 			{"ctrl+r", "switch Claude session"},
 			{"ctrl+p", "open PR"},

--- a/internal/tui/modal/help_test.go
+++ b/internal/tui/modal/help_test.go
@@ -57,6 +57,7 @@ func TestHelpModal_Draw(t *testing.T) {
 	// Sample a few bindings to catch regressions in the section list.
 	testutil.Contains(t, body, "new task")
 	testutil.Contains(t, body, "fork task")
+	testutil.Contains(t, body, "task switcher")
 }
 
 func TestHelpModal_DrawZeroSizeNoOp(t *testing.T) {


### PR DESCRIPTION
The Ctrl+K → task switcher binding shipped in 097e681 but was never listed in the help overlay's Agent View section. Adds the entry plus a matching test assertion in help_test.go.

Co-Authored-By: Claude <noreply@anthropic.com>