### PR TITLE
test(views): fix flaky TestConnector_OnCloseFiresOnRemoteDisconnect

### DIFF
--- a/internal/tui/views/connector_test.go
+++ b/internal/tui/views/connector_test.go
@@ -29,11 +29,24 @@ type pluginEcho struct {
 	done        chan struct{}
 	closeOnce   sync.Once
 	serverConn  *websocket.Conn // captured server-side conn, for forced drops
+	connected   chan struct{}   // closed once serverConn is captured by the handler
+	connectOnce sync.Once       // guards the connected close against repeat Accepts
 }
 
 // dropServerConn force-closes the server-side WebSocket, simulating a plugin
 // daemon dying mid-session. The client read pump errors and fires onClose.
+//
+// The client's Dial returns the instant it reads the 101 handshake response,
+// which races the server handler storing serverConn. Without waiting for that
+// store, a fast caller can observe a nil serverConn, no-op the drop, and leave
+// the client read pump blocked forever (the bug behind a flaky onClose test
+// under GOMAXPROCS=2 + CPU contention). Block on connected so the drop always
+// targets a live conn.
 func (p *pluginEcho) dropServerConn() {
+	select {
+	case <-p.connected:
+	case <-time.After(5 * time.Second):
+	}
 	p.mu.Lock()
 	conn := p.serverConn
 	p.mu.Unlock()
@@ -47,6 +60,7 @@ func newPluginEcho() *pluginEcho {
 		bytesToSend: make(chan []byte, 16),
 		textToSend:  make(chan string, 16),
 		done:        make(chan struct{}),
+		connected:   make(chan struct{}),
 	}
 }
 
@@ -63,6 +77,7 @@ func (p *pluginEcho) handler() http.Handler {
 		p.mu.Lock()
 		p.serverConn = c
 		p.mu.Unlock()
+		p.connectOnce.Do(func() { close(p.connected) })
 		defer func() { _ = c.Close(websocket.StatusNormalClosure, "") }()
 		// Pump pending ANSI bytes asynchronously.
 		go func() {
@@ -467,9 +482,11 @@ func TestConnector_OnCloseFiresOnRemoteDisconnect(t *testing.T) {
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Kill the server side — the client read pump errors and must fire onClose.
+	// dropServerConn waits for the handler to capture the server conn first, so
+	// the drop always lands on a live socket (see dropServerConn for the race).
 	plugin.dropServerConn()
 
-	waitFor(t, time.Second, func() bool {
+	waitFor(t, 2*time.Second, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return fired >= 1


### PR DESCRIPTION
## Summary
- Fixes the flaky `TestConnector_OnCloseFiresOnRemoteDisconnect` in `internal/tui/views/connector_test.go` that failed [CI run 27439616496](https://github.com/drn/argus/actions/runs/27439616496/job/81110182522).
- The flake was a **test-only race in the `pluginEcho` harness**, not a `Connector` bug.

## Root cause
The test's `pluginEcho.handler()` stored the server-side WebSocket in `p.serverConn` only *after* `websocket.Accept` returned. But the client's `Connector.Dial` returns the instant it reads the 101 handshake response — concurrently with the server handler goroutine. Under `GOMAXPROCS=2` + CPU contention (a 2-core GitHub runner under load), the test could call `dropServerConn()` *before* the handler had stored `serverConn`. `dropServerConn` then observed `nil`, no-op'd the close, and the client read pump's `conn.Read` blocked forever — so `onClose` never fired and the 1s `waitFor` failed.

This was a **missed close, not slow scheduling**. Latency instrumentation under heavy load showed `onClose` fires in ~2µs on the happy path but **never within 60s** on the failing path — confirming a hang, so simply raising the timeout would not have fixed it.

## Fix
- Added a `connected` channel to `pluginEcho`, closed (once, `sync.Once`-guarded against repeat `Accept`s) as soon as the handler captures `serverConn`.
- `dropServerConn` now waits on `connected` (with a 5s safety bound) before closing, so the forced drop always lands on a live socket.

## Test plan
- `go test -race ./internal/tui/views/` — green.
- Reproduced the flake reliably pre-fix: **3/400** failures under `GOMAXPROCS=2` + 12 CPU spinners.
- Post-fix: **400/400 pass** under that exact load (previously produced multi-second-to-never hangs).
- Full CI mirror green locally: build, vet, fmt-check, lint-pr pass; `test-cover-gate` at **89.6% ≥ 88% floor** with the full `-race` suite green. (`make vuln` reports only stdlib/toolchain CVEs `go1.26.1`→`go1.26.2`, which CI treats as `continue-on-error`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
