### PR TITLE
feat(mcp): native hera_* tool surface + dup-tool guard (M3)

### DIFF
--- a/context/knowledge/gotchas/orchestration.md
+++ b/context/knowledge/gotchas/orchestration.md
@@ -46,6 +46,15 @@ Stacked-PR / depends_on flow — invariants that caused bugs when violated.
 - **Role+binding creation is transactional in one tx** (`CreateHeraRoleWithBinding`), fixing Hera's deferred debt where it was two non-transactional execs. If the binding insert violates a live-uniqueness index, the role insert rolls back too — no orphan role. Born-bound spawn (M4) builds on this.
 - **The partial unique indexes are the race backstop, not just the app-level pre-checks.** `CreateHeraOrchestrator`/`CreateHeraRole` pre-check for an existing active row, but two concurrent creates resolve deterministically at the index (INSERT fails) rather than corrupting state.
 
+## Hera MCP tools (M3)
+
+- **`heraEnabled()` requires both heraSvc AND taskMgmtEnabled()** — caller resolution (cwd → task → binding) goes through `resolveTask`, which dereferences `s.taskDB` without a nil check. A server with `heraSvc` wired but no `taskDB` would panic. Always call both `SetHeraService` and `SetTaskManager` before starting the server.
+- **dup-tool guard is scope-based, not name-based.** When `heraEnabled()`, all plugin registry entries with `Scope == "hera"` are filtered from `tools/list`. This suppresses the external Hera daemon's registered tools during the native cutover. Non-hera scopes (iris, plannotator, …) pass through regardless of name.
+- **`hera_inbox` marks messages as read via an explicit `MarkRead` call after `Inbox`.** `Service.Inbox` only fetches unread messages and cancels deliveries — it does NOT stamp `read_at`. `toolHeraInbox` calls `MarkRead` immediately after to match the tool description's "marks messages as read" contract. `toolHeraJoin` (claim mode) deliberately calls only `HeraStore.HeraInbox` (not `Service.Inbox`) so join reporting doesn't consume the inbox.
+- **`SetHeraService` must be called before `ListenAndServe`** — `heraSvc` and `heraStore` are read at request time without a mutex, following the `SetMessageManager` precedent. All `Set*` calls must precede server start.
+- **`SetMeta` calls are best-effort soft-fail.** Any failure in `SetMeta` (task_meta mirror) logs a warning but never returns an error to the caller and never undoes the primary DB write. This is structural, not an oversight — meta is a display aid, not authoritative state.
+- **`resolveCallerRole` with `orchestratorName=""` returns `ErrHeraAmbiguous` when 2+ live bindings match the task.** Callers get a human-readable list of orchestrator names. Supply `orchestrator=<name>` to disambiguate. This mirrors the `HeraLiveBindingByTask` M1 rule.
+
 ## Linking + DAG
 
 - **orch.Link stages the hypothetical edge on a child *copy*, not the snapshot's pointer.** A `Store` implementation that shares pointers between `Get()` and `Tasks()` (e.g. the MCP test mock) would otherwise see the parent appended twice — once via the snapshot mutation, once via the post-cycle-check `Update`. Production `*db.DB` returns fresh scanned objects so this never bites in real code, but the defensive copy keeps tests using a sharing mock from emitting duplicate edges.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 	"github.com/drn/argus/internal/depswatcher"
 	"github.com/drn/argus/internal/events"
 	"github.com/drn/argus/internal/gitutil"
+	"github.com/drn/argus/internal/hera"
 	"github.com/drn/argus/internal/inject"
 	injectcodex "github.com/drn/argus/internal/inject/codex"
 	"github.com/drn/argus/internal/kb"
@@ -619,6 +620,8 @@ func (d *Daemon) Serve(sockPath string) error {
 		mcpSrv.SetClipboard(d.clipboard)
 		mcpSrv.SetScheduleManager(d.db, sch)
 		mcpSrv.SetMessageManager(d.db, runnerNudger{notifier: d.notifier})
+		// M8: gate on cfg.Hera.Enabled once the Settings toggle lands (Milestone 8).
+		mcpSrv.SetHeraService(hera.New(d.db, d.notifier), d.db)
 		mcpSrv.SetArtifactManager(d.db)
 		mcpSrv.SetPluginRegistry(pluginRegistry)
 		d.mcpServer = mcpSrv

--- a/internal/mcp/hera.go
+++ b/internal/mcp/hera.go
@@ -1,0 +1,761 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/drn/argus/internal/db"
+	"github.com/drn/argus/internal/hera"
+	"github.com/drn/argus/internal/model"
+)
+
+// HeraStore is the subset of *db.DB used by the native hera_* MCP tools.
+// Defined as an interface so tests can inject a fake without spinning up SQLite.
+type HeraStore interface {
+	// Orchestrators
+	CreateHeraOrchestrator(name string) (*db.HeraOrchestrator, error)
+	HeraOrchestrator(id int64) (*db.HeraOrchestrator, error)
+	HeraOrchestratorByName(name string) (*db.HeraOrchestrator, error)
+	// Roles
+	HeraRole(id int64) (*db.HeraRole, error)
+	HeraRoleByName(orchID int64, name string) (*db.HeraRole, error)
+	ListHeraRolesByKind(orchID int64, kind db.HeraRoleKind) ([]*db.HeraRole, error)
+	CreateHeraRoleWithBinding(roleIn db.CreateHeraRoleInput, taskID, worktreePath string) (*db.HeraRole, *db.HeraBinding, error)
+	// Bindings
+	HeraLiveBindingByTask(taskID string) (*db.HeraBinding, error)
+	HeraLiveBindingByTaskAndOrchestrator(taskID string, orchID int64) (*db.HeraBinding, error)
+	ListHeraLiveBindingsByTask(taskID string) ([]*db.HeraBinding, error)
+	// Role status
+	UpsertHeraRoleStatus(roleID int64, status db.HeraRoleStatusValue) error
+	// Inbox count for hera_join claim response (does NOT cancel deliveries).
+	HeraInbox(roleID int64) ([]*db.HeraMessage, error)
+	// Task meta mirror (best-effort soft-fail).
+	SetMeta(taskID, namespace, key, value string) error
+}
+
+// heraToolDefs contains the 9 hera_* tool schemas, ported verbatim from
+// Hera's daemon.toolDefinitions() — same param names, descriptions, and
+// required lists as the external Hera daemon so agents have an identical
+// surface when running natively.
+var heraToolDefs = []Tool{
+	{
+		Name:        "hera_new_orchestrator",
+		Description: "Bootstrap a new Hera orchestrator and claim the coordinator role for the calling task. Call this once to start a multi-agent coordination session. The coordinator is automatically bound to the calling task's argus worktree.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"cwd":                   map[string]interface{}{"type": "string", "description": "Caller's worktree path (use $PWD)"},
+				"name":                  map[string]interface{}{"type": "string", "description": "Orchestrator name (e.g., the project / feature being coordinated)"},
+				"coordinator_role_name": map[string]interface{}{"type": "string", "description": "Name for the coordinator role under the new orchestrator (e.g., 'coord' or 'foo-coordinator')"},
+				"prompt":                map[string]interface{}{"type": "string", "description": "(optional) Coordinator's prompt, free-form prose"},
+			},
+			"required": []string{"cwd", "name", "coordinator_role_name"},
+		},
+	},
+	{
+		Name:        "hera_join",
+		Description: "Claim an existing hera role already bound to this task (claim mode, role_name omitted), or attach as a new worker/freelance role (attach mode, role_name + kind supplied). Use hera_new_orchestrator to become a coordinator.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"cwd":          map[string]interface{}{"type": "string", "description": "Caller's worktree path (use $PWD)"},
+				"orchestrator": map[string]interface{}{"type": "string", "description": "(optional in claim mode for tasks with exactly one binding; required for tasks with 2+ bindings or for attach mode) The orchestrator to claim from or attach to."},
+				"role_name":    map[string]interface{}{"type": "string", "description": "(attach mode only) Self-chosen role name"},
+				"kind":         map[string]interface{}{"type": "string", "enum": []string{"worker", "freelance"}, "description": "(attach mode only) Role kind. coordinator is not accepted here — use hera_new_orchestrator."},
+				"prompt":       map[string]interface{}{"type": "string", "description": "(optional, attach mode) Role prompt, free-form prose"},
+				"status":       map[string]interface{}{"type": "string", "enum": []string{"idle", "working", "blocked", "done"}, "description": "(optional, attach mode) Initial role status"},
+			},
+			"required": []string{"cwd"},
+		},
+	},
+	{
+		Name:        "hera_send",
+		Description: "Send a message to another role in the same orchestrator. Workers/freelancers default to the coordinator when 'to' is omitted. Coordinators must supply an explicit 'to'.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"cwd":          map[string]interface{}{"type": "string", "description": "Caller's worktree path (use $PWD)"},
+				"body":         map[string]interface{}{"type": "string", "description": "Message body"},
+				"tldr":         map[string]interface{}{"type": "string", "description": "One-line summary of the message (≤120 chars, required)"},
+				"to":           map[string]interface{}{"type": "string", "description": "(optional for worker/freelance, required for coordinator) Recipient role name within the same orchestrator"},
+				"in_reply_to":  map[string]interface{}{"type": "integer", "description": "(optional) Message id this is a reply to"},
+				"orchestrator": map[string]interface{}{"type": "string", "description": "(required when the caller's argus task holds 2+ live bindings; optional when it holds exactly one) The orchestrator whose binding identifies the sender role for this call. The recipient is resolved within the same orchestrator."},
+			},
+			"required": []string{"cwd", "body", "tldr"},
+		},
+	},
+	{
+		Name:        "hera_inbox",
+		Description: "Read unread messages addressed to the caller's hera role. Marks messages as read (cancels pending doorbell deliveries). Returns oldest first.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"cwd":          map[string]interface{}{"type": "string", "description": "Caller's worktree path (use $PWD)"},
+				"orchestrator": map[string]interface{}{"type": "string", "description": "(required when the caller's argus task holds 2+ live bindings; optional when it holds exactly one) The orchestrator whose binding identifies the calling role."},
+			},
+			"required": []string{"cwd"},
+		},
+	},
+	{
+		Name:        "hera_mark_read",
+		Description: "Mark specific hera messages as read and cancel their pending doorbell deliveries.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"cwd":          map[string]interface{}{"type": "string", "description": "Caller's worktree path (use $PWD)"},
+				"message_ids":  map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "integer"}, "description": "Inbox message ids returned by hera_inbox"},
+				"orchestrator": map[string]interface{}{"type": "string", "description": "(required when the caller's argus task holds 2+ live bindings; optional when it holds exactly one) The orchestrator whose binding identifies the calling role."},
+			},
+			"required": []string{"cwd", "message_ids"},
+		},
+	},
+	{
+		Name:        "hera_status",
+		Description: "Update the calling role's status within its orchestrator. Also mirrors the status to the argus task_meta sidecar (best-effort).",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"cwd":          map[string]interface{}{"type": "string", "description": "Caller's worktree path (use $PWD)"},
+				"status":       map[string]interface{}{"type": "string", "enum": []string{"idle", "working", "blocked", "done"}, "description": "New role status"},
+				"orchestrator": map[string]interface{}{"type": "string", "description": "(required when the caller's argus task holds 2+ live bindings; optional when it holds exactly one) The orchestrator whose binding identifies the calling role."},
+			},
+			"required": []string{"cwd", "status"},
+		},
+	},
+	{
+		Name:        "hera_spawn_worker",
+		Description: "Spawn a new born-bound worker task for this orchestrator. (M4 stub — not yet implemented natively.)",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"cwd":          map[string]interface{}{"type": "string", "description": "Coordinator's worktree path (use $PWD)"},
+				"orchestrator": map[string]interface{}{"type": "string", "description": "(optional) Disambiguates when the calling task holds multiple live coordinator bindings"},
+				"role_name":    map[string]interface{}{"type": "string", "description": "(optional) Worker role name. Derived from prompt slug if omitted; made unique within the orchestrator automatically"},
+				"prompt":       map[string]interface{}{"type": "string", "description": "Full task prompt delivered to the new worker session. An orientation prefix naming the coordinator is prepended automatically. The verbatim prompt is also stored on the role row"},
+				"project":      map[string]interface{}{"type": "string", "description": "(optional) Override the argus project. Defaults to the coordinator's own project"},
+				"branch":       map[string]interface{}{"type": "string", "description": "(optional) Branch passed to argus CreateTask. Defaults to project default"},
+				"backend":      map[string]interface{}{"type": "string", "description": "(optional) Backend passed to argus CreateTask. Defaults to project default"},
+			},
+			"required": []string{"cwd", "prompt"},
+		},
+	},
+	{
+		Name:        "hera_tree_updates",
+		Description: "Retrieve a rolled-up view of the orchestrator subtree since a message cursor. (M5 stub — not yet implemented natively.)",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"cwd":          map[string]interface{}{"type": "string", "description": "Absolute path of the calling agent's working directory"},
+				"orchestrator": map[string]interface{}{"type": "string", "description": "Orchestrator name (optional if the task has one live binding)"},
+				"since":        map[string]interface{}{"type": "integer", "description": "Message ID cursor; omit to use stored cursor"},
+			},
+			"required": []string{"cwd"},
+		},
+	},
+	{
+		Name:        "hera_get_messages",
+		Description: "Fetch full message bodies for specific message IDs. Access is restricted to messages within the caller's orchestrator (M3; full subtree in M5).",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"cwd":          map[string]interface{}{"type": "string", "description": "Absolute path of the calling agent's working directory"},
+				"orchestrator": map[string]interface{}{"type": "string", "description": "Orchestrator name (optional if the task has one live binding)"},
+				"ids":          map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "integer"}, "description": "Message IDs to fetch"},
+			},
+			"required": []string{"cwd", "ids"},
+		},
+	},
+}
+
+// callerRoleResult holds the resolved context for the calling agent's hera
+// role. Returned by resolveCallerRole; consumed by every hera tool that
+// requires the caller to already be bound to a role.
+type callerRoleResult struct {
+	task    *model.Task
+	binding *db.HeraBinding
+	role    *db.HeraRole
+	orch    *db.HeraOrchestrator
+}
+
+// SetHeraService wires the native hera_* MCP tools. Must be called before
+// ListenAndServe. Mirrors the SetMessageManager precedent: fields are read at
+// request time without a mutex, so all Set* calls must precede server start.
+func (s *Server) SetHeraService(svc *hera.Service, store HeraStore) {
+	s.heraSvc = svc
+	s.heraStore = store
+}
+
+// heraEnabled returns true when the hera service is wired AND task management
+// is also enabled — caller resolution via cwd requires task management.
+func (s *Server) heraEnabled() bool {
+	return s.heraSvc != nil && s.taskMgmtEnabled()
+}
+
+// resolveCallerRole maps cwd to an argus task, then to the caller's live hera
+// binding+role. orchestratorName disambiguates when the task holds multiple
+// live bindings. On ErrHeraAmbiguous the returned error lists the caller's
+// orchestrator options.
+func (s *Server) resolveCallerRole(cwd, orchestratorName string) (*callerRoleResult, error) {
+	task, err := s.resolveTask("", cwd)
+	if err != nil {
+		return nil, err
+	}
+
+	if orchestratorName != "" {
+		orch, err := s.heraStore.HeraOrchestratorByName(orchestratorName)
+		if errors.Is(err, db.ErrHeraNotFound) {
+			return nil, fmt.Errorf("unknown orchestrator %q", orchestratorName)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("resolve orchestrator: %w", err)
+		}
+		binding, err := s.heraStore.HeraLiveBindingByTaskAndOrchestrator(task.ID, orch.ID)
+		if errors.Is(err, db.ErrHeraNotFound) {
+			return nil, fmt.Errorf("task has no live hera binding under orchestrator %q; call hera_join first", orchestratorName)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("resolve binding: %w", err)
+		}
+		role, err := s.heraStore.HeraRole(binding.RoleID)
+		if err != nil {
+			return nil, fmt.Errorf("resolve role: %w", err)
+		}
+		return &callerRoleResult{task: task, binding: binding, role: role, orch: orch}, nil
+	}
+
+	binding, err := s.heraStore.HeraLiveBindingByTask(task.ID)
+	if errors.Is(err, db.ErrHeraNotFound) {
+		return nil, fmt.Errorf("this argus task is not bound to any hera role; call hera_join with orchestrator+role_name+kind to attach, or hera_new_orchestrator to create one")
+	}
+	if errors.Is(err, db.ErrHeraAmbiguous) {
+		return nil, s.buildHeraAmbiguousError(task.ID)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("resolve binding: %w", err)
+	}
+
+	role, err := s.heraStore.HeraRole(binding.RoleID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve role: %w", err)
+	}
+	orch, err := s.heraStore.HeraOrchestrator(binding.OrchestratorID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve orchestrator: %w", err)
+	}
+	return &callerRoleResult{task: task, binding: binding, role: role, orch: orch}, nil
+}
+
+// buildHeraAmbiguousError returns a disambiguation error listing the
+// orchestrator names bound to taskID.
+func (s *Server) buildHeraAmbiguousError(taskID string) error {
+	bindings, listErr := s.heraStore.ListHeraLiveBindingsByTask(taskID)
+	if listErr != nil {
+		return fmt.Errorf("task holds multiple hera bindings; re-call with orchestrator=<name> to disambiguate (list unavailable: %w)", listErr)
+	}
+	names := make([]string, 0, len(bindings))
+	for _, b := range bindings {
+		o, oErr := s.heraStore.HeraOrchestrator(b.OrchestratorID)
+		if oErr == nil {
+			names = append(names, o.Name)
+		} else {
+			names = append(names, fmt.Sprintf("id:%d", b.OrchestratorID))
+		}
+	}
+	return fmt.Errorf("task holds live bindings in multiple orchestrators (%s); re-call with orchestrator=<name> to disambiguate", strings.Join(names, ", "))
+}
+
+func (s *Server) toolHeraNewOrchestrator(id interface{}, args json.RawMessage) *Response {
+	if !s.heraEnabled() {
+		return toolError(id, "hera not configured")
+	}
+	var p struct {
+		Cwd                 string `json:"cwd"`
+		Name                string `json:"name"`
+		CoordinatorRoleName string `json:"coordinator_role_name"`
+		Prompt              string `json:"prompt"`
+	}
+	json.Unmarshal(args, &p) //nolint:errcheck
+
+	if p.Cwd == "" {
+		return toolError(id, "cwd is required")
+	}
+	if p.Name == "" {
+		return toolError(id, "name is required")
+	}
+	if p.CoordinatorRoleName == "" {
+		return toolError(id, "coordinator_role_name is required")
+	}
+
+	task, err := s.resolveTask("", p.Cwd)
+	if err != nil {
+		return toolError(id, err.Error())
+	}
+
+	// Create (or fetch existing) orchestrator — CreateHeraOrchestrator is idempotent.
+	orch, err := s.heraStore.CreateHeraOrchestrator(p.Name)
+	if err != nil {
+		return toolError(id, fmt.Sprintf("create orchestrator: %v", err))
+	}
+
+	// Reject if this task already holds a live binding under the target orchestrator.
+	existing, checkErr := s.heraStore.HeraLiveBindingByTaskAndOrchestrator(task.ID, orch.ID)
+	if checkErr == nil && existing != nil {
+		return toolError(id, fmt.Sprintf(
+			"task already has a live binding under orchestrator %q (binding_id=%d); use hera_join to retrieve your current role",
+			p.Name, existing.ID))
+	}
+
+	role, binding, err := s.heraStore.CreateHeraRoleWithBinding(db.CreateHeraRoleInput{
+		OrchestratorID: orch.ID,
+		Name:           p.CoordinatorRoleName,
+		Kind:           db.HeraKindCoordinator,
+		Prompt:         p.Prompt,
+	}, task.ID, task.Worktree)
+	if err != nil {
+		return toolError(id, fmt.Sprintf("create coordinator role: %v", err))
+	}
+
+	// Mirror to task_meta best-effort — failure must never undo local state.
+	if metaErr := s.heraStore.SetMeta(task.ID, "hera", "role", string(db.HeraKindCoordinator)); metaErr != nil {
+		slog.Warn("[hera] meta mirror failed", "tool", "hera_new_orchestrator", "task_id", task.ID, "err", metaErr)
+	}
+
+	slog.Info("[hera] new_orchestrator ok", "orch", orch.Name, "role", role.Name, "binding_id", binding.ID, "task_id", task.ID)
+	var b strings.Builder
+	fmt.Fprintf(&b, "Orchestrator created.\n\n")
+	fmt.Fprintf(&b, "- **orchestrator**: %s\n", orch.Name)
+	fmt.Fprintf(&b, "- **role_name**: %s\n", role.Name)
+	fmt.Fprintf(&b, "- **kind**: coordinator\n")
+	fmt.Fprintf(&b, "- **binding_id**: %d\n", binding.ID)
+	fmt.Fprintf(&b, "- **argus_task_id**: %s\n", task.ID)
+	return toolResult(id, b.String())
+}
+
+func (s *Server) toolHeraJoin(id interface{}, args json.RawMessage) *Response {
+	if !s.heraEnabled() {
+		return toolError(id, "hera not configured")
+	}
+	var p struct {
+		Cwd          string `json:"cwd"`
+		Orchestrator string `json:"orchestrator"`
+		RoleName     string `json:"role_name"`
+		Kind         string `json:"kind"`
+		Prompt       string `json:"prompt"`
+		Status       string `json:"status"`
+	}
+	json.Unmarshal(args, &p) //nolint:errcheck
+
+	if p.Cwd == "" {
+		return toolError(id, "cwd is required")
+	}
+
+	if p.RoleName == "" {
+		// Claim mode: retrieve the existing binding + unread count.
+		caller, err := s.resolveCallerRole(p.Cwd, p.Orchestrator)
+		if err != nil {
+			return toolError(id, err.Error())
+		}
+		// HeraInbox does NOT cancel deliveries — that is intentional for claim mode.
+		msgs, _ := s.heraStore.HeraInbox(caller.role.ID)
+		unread := len(msgs)
+
+		var b strings.Builder
+		fmt.Fprintf(&b, "Joined (claim mode).\n\n")
+		fmt.Fprintf(&b, "- **orchestrator**: %s\n", caller.orch.Name)
+		fmt.Fprintf(&b, "- **role_name**: %s\n", caller.role.Name)
+		fmt.Fprintf(&b, "- **kind**: %s\n", caller.role.Kind)
+		fmt.Fprintf(&b, "- **binding_id**: %d\n", caller.binding.ID)
+		fmt.Fprintf(&b, "- **unread_message_count**: %d\n", unread)
+		return toolResult(id, b.String())
+	}
+
+	// Attach mode: create a new role+binding.
+	if p.Kind == string(db.HeraKindCoordinator) {
+		return toolError(id, "coordinator kind is not accepted here; use hera_new_orchestrator to bootstrap a new orchestrator")
+	}
+	if p.Kind != string(db.HeraKindWorker) && p.Kind != string(db.HeraKindFreelance) {
+		return toolError(id, "kind must be 'worker' or 'freelance'")
+	}
+	if p.Orchestrator == "" {
+		return toolError(id, "orchestrator is required in attach mode")
+	}
+
+	task, err := s.resolveTask("", p.Cwd)
+	if err != nil {
+		return toolError(id, err.Error())
+	}
+
+	orch, err := s.heraStore.HeraOrchestratorByName(p.Orchestrator)
+	if errors.Is(err, db.ErrHeraNotFound) {
+		return toolError(id, fmt.Sprintf("unknown orchestrator %q", p.Orchestrator))
+	}
+	if err != nil {
+		return toolError(id, fmt.Sprintf("resolve orchestrator: %v", err))
+	}
+
+	// Reject if already bound to this orchestrator.
+	existing, checkErr := s.heraStore.HeraLiveBindingByTaskAndOrchestrator(task.ID, orch.ID)
+	if checkErr == nil && existing != nil {
+		return toolError(id, fmt.Sprintf("task already has a live binding under orchestrator %q; call hera_join(cwd) without role_name to retrieve your current role", p.Orchestrator))
+	}
+
+	role, binding, err := s.heraStore.CreateHeraRoleWithBinding(db.CreateHeraRoleInput{
+		OrchestratorID: orch.ID,
+		Name:           p.RoleName,
+		Kind:           db.HeraRoleKind(p.Kind),
+		Prompt:         p.Prompt,
+	}, task.ID, task.Worktree)
+	if err != nil {
+		return toolError(id, fmt.Sprintf("create role: %v", err))
+	}
+
+	// Optional initial status.
+	if p.Status != "" {
+		sv := db.HeraRoleStatusValue(p.Status)
+		if uErr := s.heraStore.UpsertHeraRoleStatus(role.ID, sv); uErr != nil {
+			slog.Warn("[hera] upsert initial status failed", "role_id", role.ID, "err", uErr)
+		}
+	}
+
+	// Mirror to task_meta best-effort.
+	if metaErr := s.heraStore.SetMeta(task.ID, "hera", "role", string(role.Kind)); metaErr != nil {
+		slog.Warn("[hera] meta mirror failed", "tool", "hera_join", "task_id", task.ID, "err", metaErr)
+	}
+
+	slog.Info("[hera] join (attach) ok", "orch", orch.Name, "role", role.Name, "kind", role.Kind, "binding_id", binding.ID, "task_id", task.ID)
+	var b strings.Builder
+	fmt.Fprintf(&b, "Joined (attach mode).\n\n")
+	fmt.Fprintf(&b, "- **orchestrator**: %s\n", orch.Name)
+	fmt.Fprintf(&b, "- **role_name**: %s\n", role.Name)
+	fmt.Fprintf(&b, "- **kind**: %s\n", role.Kind)
+	fmt.Fprintf(&b, "- **binding_id**: %d\n", binding.ID)
+	fmt.Fprintf(&b, "- **argus_task_id**: %s\n", task.ID)
+	return toolResult(id, b.String())
+}
+
+func (s *Server) toolHeraSend(id interface{}, args json.RawMessage) *Response {
+	if !s.heraEnabled() {
+		return toolError(id, "hera not configured")
+	}
+	var p struct {
+		Cwd          string `json:"cwd"`
+		Body         string `json:"body"`
+		Tldr         string `json:"tldr"`
+		To           string `json:"to"`
+		InReplyTo    *int64 `json:"in_reply_to"`
+		Orchestrator string `json:"orchestrator"`
+	}
+	json.Unmarshal(args, &p) //nolint:errcheck
+
+	if p.Cwd == "" {
+		return toolError(id, "cwd is required")
+	}
+	if p.Body == "" {
+		return toolError(id, "body is required")
+	}
+	if p.Tldr == "" {
+		return toolError(id, "tldr is required")
+	}
+
+	caller, err := s.resolveCallerRole(p.Cwd, p.Orchestrator)
+	if err != nil {
+		return toolError(id, err.Error())
+	}
+
+	// Resolve recipient.
+	var toRole *db.HeraRole
+	if p.To != "" {
+		toRole, err = s.heraStore.HeraRoleByName(caller.orch.ID, p.To)
+		if errors.Is(err, db.ErrHeraNotFound) {
+			return toolError(id, fmt.Sprintf("recipient role %q not found in orchestrator %q", p.To, caller.orch.Name))
+		}
+		if err != nil {
+			return toolError(id, fmt.Sprintf("resolve recipient: %v", err))
+		}
+	} else {
+		switch caller.role.Kind {
+		case db.HeraKindWorker, db.HeraKindFreelance:
+			// Default to the active coordinator.
+			coordinators, listErr := s.heraStore.ListHeraRolesByKind(caller.orch.ID, db.HeraKindCoordinator)
+			if listErr != nil {
+				return toolError(id, fmt.Sprintf("list coordinators: %v", listErr))
+			}
+			if len(coordinators) == 0 {
+				return toolError(id, "no active coordinator found in orchestrator; supply an explicit 'to' recipient")
+			}
+			toRole = coordinators[0]
+		case db.HeraKindCoordinator:
+			return toolError(id, "coordinator senders must supply an explicit 'to' recipient")
+		default:
+			return toolError(id, "cannot determine default recipient for unknown role kind; supply an explicit 'to'")
+		}
+	}
+
+	msg, err := s.heraSvc.Send(caller.role.ID, toRole.ID, p.Body, p.Tldr, p.InReplyTo)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrHeraMessageBodyTooLarge):
+			return toolError(id, "body exceeds 64 KiB")
+		case errors.Is(err, db.ErrHeraMessageSelfSend):
+			return toolError(id, "cannot send a message to self")
+		case errors.Is(err, db.ErrHeraMessageInboxFull):
+			return toolError(id, "recipient inbox is full (500 unread cap)")
+		case errors.Is(err, db.ErrHeraMessageRateLimited):
+			return toolError(id, "sender rate limit exceeded (50/min)")
+		case errors.Is(err, db.ErrHeraMessageTldrRequired):
+			return toolError(id, "tldr is required")
+		case errors.Is(err, db.ErrHeraMessageTldrTooLong):
+			return toolError(id, "tldr exceeds 120 characters")
+		case errors.Is(err, db.ErrHeraMessageRecipientInvalid):
+			return toolError(id, "recipient role is missing or archived")
+		default:
+			slog.Warn("[hera] send failed", "from_role_id", caller.role.ID, "to_role_id", toRole.ID, "err", err)
+			return toolError(id, fmt.Sprintf("send failed: %v", err))
+		}
+	}
+
+	slog.Info("[hera] send ok", "msg_id", msg.ID, "from_role", caller.role.Name, "to_role", toRole.Name)
+	var b strings.Builder
+	fmt.Fprintf(&b, "Message sent.\n\n")
+	fmt.Fprintf(&b, "- **message_id**: %d\n", msg.ID)
+	fmt.Fprintf(&b, "- **to**: %s\n", toRole.Name)
+	fmt.Fprintf(&b, "- **delivery_mode**: %s\n", msg.DeliveryMode)
+	return toolResult(id, b.String())
+}
+
+func (s *Server) toolHeraInbox(id interface{}, args json.RawMessage) *Response {
+	if !s.heraEnabled() {
+		return toolError(id, "hera not configured")
+	}
+	var p struct {
+		Cwd          string `json:"cwd"`
+		Orchestrator string `json:"orchestrator"`
+	}
+	json.Unmarshal(args, &p) //nolint:errcheck
+
+	if p.Cwd == "" {
+		return toolError(id, "cwd is required")
+	}
+
+	caller, err := s.resolveCallerRole(p.Cwd, p.Orchestrator)
+	if err != nil {
+		return toolError(id, err.Error())
+	}
+
+	// Service.Inbox fetches unread messages and cancels pending doorbell deliveries.
+	msgs, err := s.heraSvc.Inbox(caller.role.ID)
+	if err != nil {
+		return toolError(id, fmt.Sprintf("inbox query failed: %v", err))
+	}
+
+	// Mark all returned messages as read (matches tool description: "Marks messages
+	// as read"). Inbox cancels deliveries; MarkRead stamps read_at.
+	if len(msgs) > 0 {
+		ids := make([]int64, len(msgs))
+		for i, m := range msgs {
+			ids[i] = m.ID
+		}
+		if _, markErr := s.heraSvc.MarkRead(caller.role.ID, ids); markErr != nil {
+			slog.Warn("[hera] inbox: mark-read failed", "role_id", caller.role.ID, "err", markErr)
+		}
+	}
+
+	if len(msgs) == 0 {
+		return toolResult(id, fmt.Sprintf("Inbox empty for role %q.", caller.role.Name))
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Inbox for role %q (%d message%s):\n", caller.role.Name, len(msgs), plural(len(msgs)))
+	for _, m := range msgs {
+		fromName := fmt.Sprintf("role:%d", m.FromRoleID)
+		if fromRole, rErr := s.heraStore.HeraRole(m.FromRoleID); rErr == nil {
+			fromName = fromRole.Name
+		}
+		fmt.Fprintf(&b, "\n--- %d ---\n", m.ID)
+		fmt.Fprintf(&b, "from: %s\n", fromName)
+		if m.InReplyTo != nil {
+			fmt.Fprintf(&b, "in_reply_to: %d\n", *m.InReplyTo)
+		}
+		fmt.Fprintf(&b, "sent_at: %s\n", m.SentAt.Format(time.RFC3339))
+		fmt.Fprintf(&b, "tldr: %s\n", m.Tldr)
+		fmt.Fprintf(&b, "body:\n%s\n", m.Body)
+	}
+	return toolResult(id, b.String())
+}
+
+func (s *Server) toolHeraMarkRead(id interface{}, args json.RawMessage) *Response {
+	if !s.heraEnabled() {
+		return toolError(id, "hera not configured")
+	}
+	var p struct {
+		Cwd          string  `json:"cwd"`
+		MessageIDs   []int64 `json:"message_ids"`
+		Orchestrator string  `json:"orchestrator"`
+	}
+	json.Unmarshal(args, &p) //nolint:errcheck
+
+	if p.Cwd == "" {
+		return toolError(id, "cwd is required")
+	}
+	if len(p.MessageIDs) == 0 {
+		return toolError(id, "message_ids is required (non-empty list)")
+	}
+
+	caller, err := s.resolveCallerRole(p.Cwd, p.Orchestrator)
+	if err != nil {
+		return toolError(id, err.Error())
+	}
+
+	n, err := s.heraSvc.MarkRead(caller.role.ID, p.MessageIDs)
+	if err != nil {
+		return toolError(id, fmt.Sprintf("mark read failed: %v", err))
+	}
+
+	return toolResult(id, fmt.Sprintf("Marked %d of %d message ID%s as read.", n, len(p.MessageIDs), plural(len(p.MessageIDs))))
+}
+
+func (s *Server) toolHeraStatus(id interface{}, args json.RawMessage) *Response {
+	if !s.heraEnabled() {
+		return toolError(id, "hera not configured")
+	}
+	var p struct {
+		Cwd          string `json:"cwd"`
+		Status       string `json:"status"`
+		Orchestrator string `json:"orchestrator"`
+	}
+	json.Unmarshal(args, &p) //nolint:errcheck
+
+	if p.Cwd == "" {
+		return toolError(id, "cwd is required")
+	}
+	if p.Status == "" {
+		return toolError(id, "status is required")
+	}
+
+	sv := db.HeraRoleStatusValue(p.Status)
+	switch sv {
+	case db.HeraStatusIdle, db.HeraStatusWorking, db.HeraStatusBlocked, db.HeraStatusDone:
+	default:
+		return toolError(id, fmt.Sprintf("invalid status %q; must be one of idle, working, blocked, done", p.Status))
+	}
+
+	caller, err := s.resolveCallerRole(p.Cwd, p.Orchestrator)
+	if err != nil {
+		return toolError(id, err.Error())
+	}
+
+	if err := s.heraStore.UpsertHeraRoleStatus(caller.role.ID, sv); err != nil {
+		return toolError(id, fmt.Sprintf("update status failed: %v", err))
+	}
+
+	// Mirror to task_meta best-effort.
+	if metaErr := s.heraStore.SetMeta(caller.binding.ArgusTaskID, "hera", "thread_status", p.Status); metaErr != nil {
+		slog.Warn("[hera] meta mirror failed", "tool", "hera_status", "task_id", caller.binding.ArgusTaskID, "err", metaErr)
+	}
+
+	slog.Info("[hera] status ok", "role", caller.role.Name, "status", p.Status, "orch", caller.orch.Name)
+	var b strings.Builder
+	fmt.Fprintf(&b, "Status updated.\n\n")
+	fmt.Fprintf(&b, "- **role**: %s\n", caller.role.Name)
+	fmt.Fprintf(&b, "- **status**: %s\n", p.Status)
+	fmt.Fprintf(&b, "- **orchestrator**: %s\n", caller.orch.Name)
+	return toolResult(id, b.String())
+}
+
+func (s *Server) toolHeraSpawnWorker(id interface{}, _ json.RawMessage) *Response {
+	return toolError(id, "native hera_spawn_worker lands in M4 (born-bound spawn); use the external hera daemon or argus task_create until then")
+}
+
+func (s *Server) toolHeraTreeUpdates(id interface{}, _ json.RawMessage) *Response {
+	return toolError(id, "native hera_tree_updates lands in M5 (subtree roll-up)")
+}
+
+func (s *Server) toolHeraGetMessages(id interface{}, args json.RawMessage) *Response {
+	if !s.heraEnabled() {
+		return toolError(id, "hera not configured")
+	}
+	var p struct {
+		Cwd          string  `json:"cwd"`
+		IDs          []int64 `json:"ids"`
+		Orchestrator string  `json:"orchestrator"`
+	}
+	json.Unmarshal(args, &p) //nolint:errcheck
+
+	if p.Cwd == "" {
+		return toolError(id, "cwd is required")
+	}
+	if len(p.IDs) == 0 {
+		return toolError(id, "ids is required (non-empty list)")
+	}
+
+	caller, err := s.resolveCallerRole(p.Cwd, p.Orchestrator)
+	if err != nil {
+		return toolError(id, err.Error())
+	}
+
+	msgs, err := s.heraSvc.GetByIDs(p.IDs)
+	if err != nil {
+		return toolError(id, fmt.Sprintf("get messages failed: %v", err))
+	}
+
+	// Build id → message map for O(1) per-ID lookup.
+	byID := make(map[int64]*db.HeraMessage, len(msgs))
+	for _, m := range msgs {
+		byID[m.ID] = m
+	}
+
+	type msgEntry = map[string]interface{}
+	results := make([]msgEntry, 0, len(p.IDs))
+	for _, reqID := range p.IDs {
+		m := byID[reqID]
+		if m == nil {
+			results = append(results, msgEntry{"id": reqID, "error": "not found"})
+			continue
+		}
+		// Access rule (M3): from_role or to_role must be in caller's orchestrator.
+		// M5 expands this to the full subtree via SubtreeOrchIDs BFS.
+		if !s.heraMessageInOrch(m, caller.orch.ID) {
+			results = append(results, msgEntry{"id": reqID, "error": "access denied: message not in caller's orchestrator"})
+			continue
+		}
+		fromName := fmt.Sprintf("role:%d", m.FromRoleID)
+		if fromRole, rErr := s.heraStore.HeraRole(m.FromRoleID); rErr == nil {
+			fromName = fromRole.Name
+		}
+		toName := fmt.Sprintf("role:%d", m.ToRoleID)
+		if toRole, rErr := s.heraStore.HeraRole(m.ToRoleID); rErr == nil {
+			toName = toRole.Name
+		}
+		entry := msgEntry{
+			"id":        m.ID,
+			"from_role": fromName,
+			"to_role":   toName,
+			"sent_at":   m.SentAt.Format(time.RFC3339),
+			"tldr":      m.Tldr,
+			"body":      m.Body,
+		}
+		if m.InReplyTo != nil {
+			entry["in_reply_to"] = *m.InReplyTo
+		}
+		results = append(results, entry)
+	}
+
+	out, _ := json.Marshal(map[string]interface{}{"messages": results})
+	return toolResult(id, string(out))
+}
+
+// heraMessageInOrch returns true when the message's sender or recipient role
+// belongs to orchID. M3 access rule — M5 will expand to subtree traversal.
+func (s *Server) heraMessageInOrch(m *db.HeraMessage, orchID int64) bool {
+	if fromRole, err := s.heraStore.HeraRole(m.FromRoleID); err == nil && fromRole.OrchestratorID == orchID {
+		return true
+	}
+	if toRole, err := s.heraStore.HeraRole(m.ToRoleID); err == nil && toRole.OrchestratorID == orchID {
+		return true
+	}
+	return false
+}

--- a/internal/mcp/hera_test.go
+++ b/internal/mcp/hera_test.go
@@ -1,0 +1,895 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/drn/argus/internal/db"
+	"github.com/drn/argus/internal/hera"
+	"github.com/drn/argus/internal/model"
+	"github.com/drn/argus/internal/testutil"
+)
+
+// testHeraServer creates a Server backed by real in-memory SQLite with hera
+// and task management wired. Returns the server and the underlying DB so
+// tests can add tasks, orchestrators, and roles as fixtures.
+func testHeraServer(t *testing.T) (*Server, *db.DB) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	d, err := db.OpenInMemory()
+	testutil.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	s := New(d, 0, "")
+	s.SetTaskManager(
+		func(input TaskCreateInput) (*model.Task, error) {
+			return nil, fmt.Errorf("task creation not supported in this test")
+		},
+		d,
+		&mockStopper{},
+	)
+	heraSvc := hera.New(d, nil) // nil notifier: delivery skipped, messages still persisted
+	s.SetHeraService(heraSvc, d)
+	return s, d
+}
+
+// addHeraTestTask inserts a task with the given worktree into the DB and
+// returns it. The task is immediately usable for cwd-based resolution.
+func addHeraTestTask(t *testing.T, d *db.DB, worktree string) *model.Task {
+	t.Helper()
+	task := &model.Task{
+		Name:     "test-task",
+		Status:   model.StatusInProgress,
+		Project:  "test-project",
+		Worktree: worktree,
+	}
+	testutil.NoError(t, d.Add(task))
+	return task
+}
+
+// --- tools/list tests ---
+
+func TestToolsList_HeraOff(t *testing.T) {
+	// When hera is not wired, hera tools must be absent.
+	s, taskDB, stopper := testServerWithTasks()
+	_ = taskDB
+	_ = stopper
+
+	resp := doRequest(t, s, "tools/list", nil)
+	testutil.NoError(t, respErr(resp))
+
+	result, _ := json.Marshal(resp.Result)
+	var list ToolsListResult
+	testutil.NoError(t, json.Unmarshal(result, &list))
+
+	for _, tool := range list.Tools {
+		if strings.HasPrefix(tool.Name, "hera_") {
+			t.Errorf("hera tool %q present without hera enabled", tool.Name)
+		}
+	}
+}
+
+func TestToolsList_HeraOn(t *testing.T) {
+	s, _ := testHeraServer(t)
+
+	resp := doRequest(t, s, "tools/list", nil)
+	testutil.NoError(t, respErr(resp))
+
+	result, _ := json.Marshal(resp.Result)
+	var list ToolsListResult
+	testutil.NoError(t, json.Unmarshal(result, &list))
+
+	names := make(map[string]bool, len(list.Tools))
+	for _, tool := range list.Tools {
+		names[tool.Name] = true
+	}
+
+	// All 9 hera tools must appear.
+	for _, want := range []string{
+		"hera_new_orchestrator", "hera_join", "hera_send", "hera_inbox",
+		"hera_mark_read", "hera_status", "hera_spawn_worker",
+		"hera_tree_updates", "hera_get_messages",
+	} {
+		if !names[want] {
+			t.Errorf("hera tool missing from tools/list: %s", want)
+		}
+	}
+
+	// KB tools must also be present (additive).
+	if !names["kb_search"] {
+		t.Error("kb_search missing after hera enabled")
+	}
+}
+
+func TestToolsList_DupGuard_HeraEnabled(t *testing.T) {
+	s, _, d := newMCPWithRegistry(t)
+	// Wire hera so the dup-guard activates.
+	heraSvc := hera.New(d, nil)
+	s.SetHeraService(heraSvc, d)
+	s.SetTaskManager(
+		func(input TaskCreateInput) (*model.Task, error) { return nil, nil },
+		d,
+		&mockStopper{},
+	)
+
+	// Register a plugin tool with scope "hera" — must be filtered.
+	testutil.NoError(t, s.registry.Register("hera", ToolRegistration{
+		Name:        "hera_new_orchestrator",
+		Description: "external plugin copy",
+		InputSchema: json.RawMessage(`{}`),
+		CallbackURL: "http://127.0.0.1/cb",
+	}))
+
+	resp := doRequest(t, s, "tools/list", nil)
+	testutil.NoError(t, respErr(resp))
+
+	result, _ := json.Marshal(resp.Result)
+	var list ToolsListResult
+	testutil.NoError(t, json.Unmarshal(result, &list))
+
+	var count int
+	for _, tool := range list.Tools {
+		if tool.Name == "hera_new_orchestrator" {
+			count++
+			// The native one must survive; the plugin description differs.
+			if tool.Description == "external plugin copy" {
+				t.Error("dup-guard failed: plugin hera tool exposed instead of native")
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 hera_new_orchestrator, got %d", count)
+	}
+}
+
+func TestToolsList_DupGuard_IrisScope(t *testing.T) {
+	s, _, d := newMCPWithRegistry(t)
+	heraSvc := hera.New(d, nil)
+	s.SetHeraService(heraSvc, d)
+	s.SetTaskManager(
+		func(input TaskCreateInput) (*model.Task, error) { return nil, nil },
+		d,
+		&mockStopper{},
+	)
+
+	// Register an iris-scope plugin tool — must NOT be filtered.
+	testutil.NoError(t, s.registry.Register("iris", ToolRegistration{
+		Name:        "iris_gh_pr_create",
+		Description: "iris PR create",
+		InputSchema: json.RawMessage(`{}`),
+		CallbackURL: "http://127.0.0.1/cb",
+	}))
+
+	resp := doRequest(t, s, "tools/list", nil)
+	testutil.NoError(t, respErr(resp))
+
+	result, _ := json.Marshal(resp.Result)
+	var list ToolsListResult
+	testutil.NoError(t, json.Unmarshal(result, &list))
+
+	names := make(map[string]bool, len(list.Tools))
+	for _, tool := range list.Tools {
+		names[tool.Name] = true
+	}
+	if !names["iris_gh_pr_create"] {
+		t.Error("iris-scope plugin tool was incorrectly filtered by hera dup-guard")
+	}
+}
+
+// --- hera_new_orchestrator ---
+
+func TestHera_NewOrchestrator(t *testing.T) {
+	s, d := testHeraServer(t)
+	task := addHeraTestTask(t, d, "/wt/alpha")
+
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_new_orchestrator",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd": %q, "name": "myorch", "coordinator_role_name": "coord"
+		}`, task.Worktree)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, false)
+	testutil.Contains(t, cr.Content[0].Text, "**orchestrator**: myorch")
+	testutil.Contains(t, cr.Content[0].Text, "**role_name**: coord")
+	testutil.Contains(t, cr.Content[0].Text, "**kind**: coordinator")
+}
+
+func TestHera_NewOrchestrator_MissingCwd(t *testing.T) {
+	s, _ := testHeraServer(t)
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name:      "hera_new_orchestrator",
+		Arguments: json.RawMessage(`{"name":"x","coordinator_role_name":"c"}`),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, true)
+	testutil.Contains(t, cr.Content[0].Text, "cwd is required")
+}
+
+func TestHera_NewOrchestrator_AlreadyBound(t *testing.T) {
+	s, d := testHeraServer(t)
+	task := addHeraTestTask(t, d, "/wt/alpha")
+
+	// First call succeeds.
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_new_orchestrator",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd": %q, "name": "myorch", "coordinator_role_name": "coord"
+		}`, task.Worktree)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, false)
+
+	// Second call for same task+orch must fail with "already has a live binding".
+	resp2 := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_new_orchestrator",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd": %q, "name": "myorch", "coordinator_role_name": "coord2"
+		}`, task.Worktree)),
+	})
+	testutil.NoError(t, respErr(resp2))
+	cr2 := callResult(t, resp2)
+	testutil.Equal(t, cr2.IsError, true)
+	testutil.Contains(t, cr2.Content[0].Text, "already has a live binding")
+}
+
+// --- hera_join ---
+
+func TestHera_Join_ClaimMode(t *testing.T) {
+	s, d := testHeraServer(t)
+	task := addHeraTestTask(t, d, "/wt/beta")
+
+	// Bootstrap the orchestrator first.
+	doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_new_orchestrator",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd": %q, "name": "myorch", "coordinator_role_name": "coord"
+		}`, task.Worktree)),
+	})
+
+	// Claim mode: omit role_name.
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name:      "hera_join",
+		Arguments: json.RawMessage(fmt.Sprintf(`{"cwd":%q}`, task.Worktree)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, false)
+	testutil.Contains(t, cr.Content[0].Text, "claim mode")
+	testutil.Contains(t, cr.Content[0].Text, "**role_name**: coord")
+	testutil.Contains(t, cr.Content[0].Text, "**unread_message_count**: 0")
+}
+
+func TestHera_Join_AttachMode(t *testing.T) {
+	s, d := testHeraServer(t)
+	coordTask := addHeraTestTask(t, d, "/wt/coord")
+	workerTask := &model.Task{
+		Name:     "worker-task",
+		Status:   model.StatusInProgress,
+		Project:  "test-project",
+		Worktree: "/wt/worker",
+	}
+	testutil.NoError(t, d.Add(workerTask))
+
+	// Bootstrap coordinator.
+	doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_new_orchestrator",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"name":"myorch","coordinator_role_name":"coord"
+		}`, coordTask.Worktree)),
+	})
+
+	// Worker attaches.
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_join",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"orchestrator":"myorch","role_name":"w1","kind":"worker"
+		}`, workerTask.Worktree)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, false)
+	testutil.Contains(t, cr.Content[0].Text, "attach mode")
+	testutil.Contains(t, cr.Content[0].Text, "**role_name**: w1")
+	testutil.Contains(t, cr.Content[0].Text, "**kind**: worker")
+}
+
+func TestHera_Join_CoordinatorKindRejected(t *testing.T) {
+	s, d := testHeraServer(t)
+	task := addHeraTestTask(t, d, "/wt/gamma")
+
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_join",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"orchestrator":"myorch","role_name":"c","kind":"coordinator"
+		}`, task.Worktree)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, true)
+	testutil.Contains(t, cr.Content[0].Text, "coordinator kind is not accepted here")
+}
+
+func TestHera_Join_AlreadyBound(t *testing.T) {
+	s, d := testHeraServer(t)
+	coordTask := addHeraTestTask(t, d, "/wt/c1")
+	workerTask := &model.Task{
+		Name: "wt2", Status: model.StatusInProgress,
+		Project: "p", Worktree: "/wt/w1",
+	}
+	testutil.NoError(t, d.Add(workerTask))
+
+	doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_new_orchestrator",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"name":"myorch","coordinator_role_name":"coord"
+		}`, coordTask.Worktree)),
+	})
+
+	// Attach once.
+	doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_join",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"orchestrator":"myorch","role_name":"w1","kind":"worker"
+		}`, workerTask.Worktree)),
+	})
+
+	// Attach again — must be rejected.
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_join",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"orchestrator":"myorch","role_name":"w2","kind":"worker"
+		}`, workerTask.Worktree)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, true)
+	testutil.Contains(t, cr.Content[0].Text, "already has a live binding")
+}
+
+// --- CallerContext / resolveCallerRole ---
+
+func TestHera_CallerContext_ZeroBindings(t *testing.T) {
+	s, d := testHeraServer(t)
+	task := addHeraTestTask(t, d, "/wt/unbound")
+
+	// status requires resolveCallerRole; task has no binding.
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_status",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"status":"working"
+		}`, task.Worktree)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, true)
+	testutil.Contains(t, cr.Content[0].Text, "not bound to any hera role")
+}
+
+func TestHera_CallerContext_MultipleBindings(t *testing.T) {
+	s, d := testHeraServer(t)
+	ambiguous := &model.Task{
+		Name: "amb", Status: model.StatusInProgress,
+		Project: "p", Worktree: "/wt/amb",
+	}
+	testutil.NoError(t, d.Add(ambiguous))
+
+	// Create two separate orchestrators both binding to the same task.
+	for _, orchName := range []string{"orchA", "orchB"} {
+		orch, err := d.CreateHeraOrchestrator(orchName)
+		testutil.NoError(t, err)
+		_, _, err = d.CreateHeraRoleWithBinding(db.CreateHeraRoleInput{
+			OrchestratorID: orch.ID,
+			Name:           "coord",
+			Kind:           db.HeraKindCoordinator,
+		}, ambiguous.ID, ambiguous.Worktree)
+		testutil.NoError(t, err)
+	}
+
+	// resolveCallerRole without orchestrator param → ErrHeraAmbiguous path.
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_status",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"status":"working"
+		}`, ambiguous.Worktree)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, true)
+	testutil.Contains(t, cr.Content[0].Text, "multiple orchestrators")
+	testutil.Contains(t, cr.Content[0].Text, "orchA")
+	testutil.Contains(t, cr.Content[0].Text, "orchB")
+}
+
+func TestHera_CallerContext_OrchestratorParam(t *testing.T) {
+	s, d := testHeraServer(t)
+	ambiguous := &model.Task{
+		Name: "amb2", Status: model.StatusInProgress,
+		Project: "p", Worktree: "/wt/amb2",
+	}
+	testutil.NoError(t, d.Add(ambiguous))
+
+	for _, orchName := range []string{"orchA", "orchB"} {
+		orch, err := d.CreateHeraOrchestrator(orchName)
+		testutil.NoError(t, err)
+		_, _, err = d.CreateHeraRoleWithBinding(db.CreateHeraRoleInput{
+			OrchestratorID: orch.ID,
+			Name:           "coord",
+			Kind:           db.HeraKindCoordinator,
+		}, ambiguous.ID, ambiguous.Worktree)
+		testutil.NoError(t, err)
+	}
+
+	// Supplying orchestrator= disambiguates.
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_status",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"orchestrator":"orchA","status":"working"
+		}`, ambiguous.Worktree)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, false)
+	testutil.Contains(t, cr.Content[0].Text, "orchA")
+}
+
+// --- hera_send ---
+
+func setupOrchWithWorker(t *testing.T, s *Server, d *db.DB) (coordWorktree, workerWorktree string) {
+	t.Helper()
+	coordTask := &model.Task{
+		Name: "coord-task", Status: model.StatusInProgress,
+		Project: "p", Worktree: "/wt/coord-" + t.Name(),
+	}
+	testutil.NoError(t, d.Add(coordTask))
+
+	workerTask := &model.Task{
+		Name: "worker-task", Status: model.StatusInProgress,
+		Project: "p", Worktree: "/wt/worker-" + t.Name(),
+	}
+	testutil.NoError(t, d.Add(workerTask))
+
+	// Bootstrap orch with coordinator.
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_new_orchestrator",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"name":"test-orch","coordinator_role_name":"coord"
+		}`, coordTask.Worktree)),
+	})
+	cr := callResult(t, resp)
+	if cr.IsError {
+		t.Fatalf("hera_new_orchestrator failed: %s", cr.Content[0].Text)
+	}
+
+	// Attach worker.
+	resp = doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_join",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"orchestrator":"test-orch","role_name":"w1","kind":"worker"
+		}`, workerTask.Worktree)),
+	})
+	cr = callResult(t, resp)
+	if cr.IsError {
+		t.Fatalf("hera_join failed: %s", cr.Content[0].Text)
+	}
+
+	return coordTask.Worktree, workerTask.Worktree
+}
+
+func TestHera_Send_DefaultRoute_WorkerToCoordinator(t *testing.T) {
+	s, d := testHeraServer(t)
+	_, workerWt := setupOrchWithWorker(t, s, d)
+
+	// Worker sends without explicit "to" → defaults to coordinator.
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_send",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"body":"hello coord","tldr":"greeting"
+		}`, workerWt)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, false)
+	testutil.Contains(t, cr.Content[0].Text, "Message sent")
+	testutil.Contains(t, cr.Content[0].Text, "**to**: coord")
+}
+
+func TestHera_Send_ExplicitTo(t *testing.T) {
+	s, d := testHeraServer(t)
+	coordWt, workerWt := setupOrchWithWorker(t, s, d)
+	_ = workerWt
+
+	// Coordinator sends with explicit "to": worker.
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_send",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"to":"w1","body":"task for you","tldr":"assignment"
+		}`, coordWt)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, false)
+	testutil.Contains(t, cr.Content[0].Text, "**to**: w1")
+}
+
+func TestHera_Send_CoordinatorMustSupplyTo(t *testing.T) {
+	s, d := testHeraServer(t)
+	coordWt, _ := setupOrchWithWorker(t, s, d)
+
+	// Coordinator without "to" → error.
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_send",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"body":"x","tldr":"y"
+		}`, coordWt)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, true)
+	testutil.Contains(t, cr.Content[0].Text, "coordinator senders must supply")
+}
+
+func TestHera_Send_UnknownRecipient(t *testing.T) {
+	s, d := testHeraServer(t)
+	coordWt, _ := setupOrchWithWorker(t, s, d)
+
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_send",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"to":"ghost","body":"hello","tldr":"hi"
+		}`, coordWt)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, true)
+	testutil.Contains(t, cr.Content[0].Text, "not found")
+}
+
+// --- hera_inbox ---
+
+func TestHera_Inbox_MarksRead(t *testing.T) {
+	s, d := testHeraServer(t)
+	coordWt, workerWt := setupOrchWithWorker(t, s, d)
+
+	// Worker sends a message to the coordinator.
+	doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_send",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"body":"status update","tldr":"update"
+		}`, workerWt)),
+	})
+
+	// Coordinator reads inbox.
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name:      "hera_inbox",
+		Arguments: json.RawMessage(fmt.Sprintf(`{"cwd":%q}`, coordWt)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, false)
+	testutil.Contains(t, cr.Content[0].Text, "status update")
+
+	// Second inbox call → empty (message was marked read).
+	resp2 := doRequest(t, s, "tools/call", ToolCallParams{
+		Name:      "hera_inbox",
+		Arguments: json.RawMessage(fmt.Sprintf(`{"cwd":%q}`, coordWt)),
+	})
+	testutil.NoError(t, respErr(resp2))
+	cr2 := callResult(t, resp2)
+	testutil.Equal(t, cr2.IsError, false)
+	testutil.Contains(t, cr2.Content[0].Text, "Inbox empty")
+}
+
+// --- hera_mark_read ---
+
+func TestHera_MarkRead(t *testing.T) {
+	s, d := testHeraServer(t)
+	coordWt, workerWt := setupOrchWithWorker(t, s, d)
+
+	// Worker sends two messages.
+	var msgIDs []int64
+	for i, tldr := range []string{"first", "second"} {
+		r := doRequest(t, s, "tools/call", ToolCallParams{
+			Name: "hera_send",
+			Arguments: json.RawMessage(fmt.Sprintf(`{
+				"cwd":%q,"body":"msg %d","tldr":%q
+			}`, workerWt, i, tldr)),
+		})
+		cr := callResult(t, r)
+		if cr.IsError {
+			t.Fatalf("send failed: %s", cr.Content[0].Text)
+		}
+		// Extract message_id from output.
+		var mid int64
+		for _, line := range strings.Split(cr.Content[0].Text, "\n") {
+			fmt.Sscanf(line, "- **message_id**: %d", &mid) //nolint:errcheck
+		}
+		if mid != 0 {
+			msgIDs = append(msgIDs, mid)
+		}
+	}
+
+	idsJSON, _ := json.Marshal(msgIDs)
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_mark_read",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"message_ids":%s
+		}`, coordWt, idsJSON)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, false)
+	testutil.Contains(t, cr.Content[0].Text, fmt.Sprintf("Marked %d", len(msgIDs)))
+}
+
+// --- hera_status ---
+
+func TestHera_Status(t *testing.T) {
+	s, d := testHeraServer(t)
+	_, workerWt := setupOrchWithWorker(t, s, d)
+
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_status",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"status":"working"
+		}`, workerWt)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, false)
+	testutil.Contains(t, cr.Content[0].Text, "**status**: working")
+}
+
+func TestHera_Status_InvalidEnum(t *testing.T) {
+	s, d := testHeraServer(t)
+	task := addHeraTestTask(t, d, "/wt/status-bad")
+
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_status",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"status":"flying"
+		}`, task.Worktree)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, true)
+	testutil.Contains(t, cr.Content[0].Text, "invalid status")
+}
+
+func TestHera_Status_MetaMirrorSoftFail(t *testing.T) {
+	// Verifies that a SetMeta failure does NOT undo the successful status update.
+	// We can't inject SetMeta failures with a real *db.DB, but we can verify
+	// that when the call succeeds the response is a success (not an error), and
+	// that the tool completes even when SetMeta is a no-op (nil task meta row).
+	s, d := testHeraServer(t)
+	_, workerWt := setupOrchWithWorker(t, s, d)
+
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_status",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"status":"done"
+		}`, workerWt)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	// Must succeed regardless of meta mirror outcome.
+	testutil.Equal(t, cr.IsError, false)
+	testutil.Contains(t, cr.Content[0].Text, "**status**: done")
+}
+
+// --- hera_get_messages ---
+
+func TestHera_GetMessages_HappyPath(t *testing.T) {
+	s, d := testHeraServer(t)
+	coordWt, workerWt := setupOrchWithWorker(t, s, d)
+
+	// Worker sends to coord.
+	sendResp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_send",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"body":"hello coord","tldr":"hi"
+		}`, workerWt)),
+	})
+	cr := callResult(t, sendResp)
+	if cr.IsError {
+		t.Fatalf("send failed: %s", cr.Content[0].Text)
+	}
+	var msgID int64
+	for _, line := range strings.Split(cr.Content[0].Text, "\n") {
+		fmt.Sscanf(line, "- **message_id**: %d", &msgID) //nolint:errcheck
+	}
+
+	// Coord fetches by ID.
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_get_messages",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"ids":[%d]
+		}`, coordWt, msgID)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr2 := callResult(t, resp)
+	testutil.Equal(t, cr2.IsError, false)
+	testutil.Contains(t, cr2.Content[0].Text, "hello coord")
+}
+
+func TestHera_GetMessages_AccessRule(t *testing.T) {
+	// Messages outside the caller's orchestrator must return access denied.
+	s, d := testHeraServer(t)
+
+	// Set up orch1 with coord1 + worker1.
+	orchWt1, workerWt1 := setupOrchWithWorker(t, s, d)
+
+	// Set up a second independent orchestrator with a separate task.
+	coordTask2 := &model.Task{
+		Name: "coord2", Status: model.StatusInProgress,
+		Project: "p", Worktree: "/wt/coord2-" + t.Name(),
+	}
+	testutil.NoError(t, d.Add(coordTask2))
+	workerTask2 := &model.Task{
+		Name: "worker2", Status: model.StatusInProgress,
+		Project: "p", Worktree: "/wt/worker2-" + t.Name(),
+	}
+	testutil.NoError(t, d.Add(workerTask2))
+
+	doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_new_orchestrator",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"name":"orch2","coordinator_role_name":"coord2"
+		}`, coordTask2.Worktree)),
+	})
+	doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_join",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"orchestrator":"orch2","role_name":"w2","kind":"worker"
+		}`, workerTask2.Worktree)),
+	})
+
+	// Worker in orch2 sends to coord2.
+	sendResp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_send",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"body":"private","tldr":"private"
+		}`, workerWt1)), // worker1 in orch1
+	})
+	cr := callResult(t, sendResp)
+	if cr.IsError {
+		t.Fatalf("send failed: %s", cr.Content[0].Text)
+	}
+	var msgID int64
+	for _, line := range strings.Split(cr.Content[0].Text, "\n") {
+		fmt.Sscanf(line, "- **message_id**: %d", &msgID) //nolint:errcheck
+	}
+
+	// Worker2 (orch2) tries to fetch a message from orch1 → access denied.
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_get_messages",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"orchestrator":"orch2","ids":[%d]
+		}`, workerTask2.Worktree, msgID)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr2 := callResult(t, resp)
+	testutil.Equal(t, cr2.IsError, false) // per-ID error, not top-level error
+
+	// Result JSON must contain "access denied" for the requested ID.
+	testutil.Contains(t, cr2.Content[0].Text, "access denied")
+
+	_ = orchWt1 // used only to set up orch1
+}
+
+func TestHera_GetMessages_NotFound(t *testing.T) {
+	s, d := testHeraServer(t)
+	coordWt, _ := setupOrchWithWorker(t, s, d)
+
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_get_messages",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"ids":[99999]
+		}`, coordWt)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, false)
+	testutil.Contains(t, cr.Content[0].Text, "not found")
+}
+
+// --- stub tools ---
+
+func TestHera_SpawnWorker_Stub(t *testing.T) {
+	s, _ := testHeraServer(t)
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name:      "hera_spawn_worker",
+		Arguments: json.RawMessage(`{"cwd":"/tmp","prompt":"do something"}`),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, true)
+	testutil.Contains(t, cr.Content[0].Text, "M4")
+}
+
+func TestHera_TreeUpdates_Stub(t *testing.T) {
+	s, _ := testHeraServer(t)
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name:      "hera_tree_updates",
+		Arguments: json.RawMessage(`{"cwd":"/tmp"}`),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, true)
+	testutil.Contains(t, cr.Content[0].Text, "M5")
+}
+
+// --- disabled (heraEnabled=false) ---
+
+func TestHera_Disabled_ReturnsError(t *testing.T) {
+	// Without SetHeraService, all hera tools must return "hera not configured".
+	s, _, _ := testServerWithTasks()
+	for _, name := range []string{
+		"hera_new_orchestrator", "hera_join", "hera_send",
+		"hera_inbox", "hera_mark_read", "hera_status", "hera_get_messages",
+	} {
+		resp := doRequest(t, s, "tools/call", ToolCallParams{
+			Name:      name,
+			Arguments: json.RawMessage(`{"cwd":"/tmp"}`),
+		})
+		testutil.NoError(t, respErr(resp))
+		cr := callResult(t, resp)
+		if !cr.IsError {
+			t.Errorf("%s: expected error when hera not configured, got success", name)
+			continue
+		}
+		testutil.Contains(t, cr.Content[0].Text, "hera not configured")
+	}
+}
+
+// --- Join claim mode reports unread count ---
+
+func TestHera_Join_ClaimMode_UnreadCount(t *testing.T) {
+	s, d := testHeraServer(t)
+	task := addHeraTestTask(t, d, "/wt/uc")
+
+	doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_new_orchestrator",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"name":"ucorch","coordinator_role_name":"coord"
+		}`, task.Worktree)),
+	})
+
+	// Add a second worker task and send messages to the coordinator.
+	wt := &model.Task{
+		Name: "wt-uc", Status: model.StatusInProgress,
+		Project: "p", Worktree: "/wt/uc-worker",
+	}
+	testutil.NoError(t, d.Add(wt))
+	doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_join",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"orchestrator":"ucorch","role_name":"w","kind":"worker"
+		}`, wt.Worktree)),
+	})
+
+	// Worker sends 2 messages.
+	for i := 0; i < 2; i++ {
+		doRequest(t, s, "tools/call", ToolCallParams{
+			Name: "hera_send",
+			Arguments: json.RawMessage(fmt.Sprintf(`{
+				"cwd":%q,"body":"msg","tldr":"t%d"
+			}`, wt.Worktree, i)),
+		})
+	}
+
+	// Coordinator claims — must report 2 unread (HeraInbox, not Service.Inbox).
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name:      "hera_join",
+		Arguments: json.RawMessage(fmt.Sprintf(`{"cwd":%q}`, task.Worktree)),
+	})
+	testutil.NoError(t, respErr(resp))
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, false)
+	testutil.Contains(t, cr.Content[0].Text, "**unread_message_count**: 2")
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/drn/argus/internal/hera"
 	"github.com/drn/argus/internal/kb"
 	"github.com/drn/argus/internal/model"
 )
@@ -156,6 +157,8 @@ type Server struct {
 	messages    MessageStore    // optional; set via SetMessageManager
 	nudger      MessageNudger   // optional; set via SetMessageManager (best-effort)
 	artifacts   ArtifactStore   // optional; set via SetArtifactManager
+	heraSvc     *hera.Service   // optional; set via SetHeraService
+	heraStore   HeraStore       // optional; set via SetHeraService
 	createMu    sync.Mutex
 	creating    int // number of in-flight task_create calls
 	// creatingKeys tracks (project, name) pairs currently being created so
@@ -801,12 +804,22 @@ func (s *Server) handleToolsList(req *Request) *Response {
 	if s.artifactsEnabled() {
 		tools = append(tools, artifactToolDefs...)
 	}
+	if s.heraEnabled() {
+		tools = append(tools, heraToolDefs...)
+	}
 	if s.registry != nil {
 		// Failures here are logged and swallowed: surfacing a registry error
 		// here would break the entire tools/list response for built-in tools
 		// the user did NOT register. Plugin tools are best-effort additive.
 		if plugins, err := s.registry.List(); err == nil {
 			for _, p := range plugins {
+				// DUP-TOOL GUARD (M3): when native hera is enabled, suppress
+				// hera-scope plugin rows — the external Hera daemon may still
+				// be registered and tools/list must not show duplicates.
+				// Other plugin scopes (iris, plannotator, …) pass through.
+				if s.heraEnabled() && p.Scope == "hera" {
+					continue
+				}
 				tools = append(tools, Tool{
 					Name:        p.Name,
 					Description: p.Description,
@@ -889,6 +902,24 @@ func (s *Server) handleToolsCall(req *Request) *Response {
 		return s.toolTaskAsk(req.ID, params.Arguments)
 	case "artifact_register":
 		return s.toolArtifactRegister(req.ID, params.Arguments)
+	case "hera_new_orchestrator":
+		return s.toolHeraNewOrchestrator(req.ID, params.Arguments)
+	case "hera_join":
+		return s.toolHeraJoin(req.ID, params.Arguments)
+	case "hera_send":
+		return s.toolHeraSend(req.ID, params.Arguments)
+	case "hera_inbox":
+		return s.toolHeraInbox(req.ID, params.Arguments)
+	case "hera_mark_read":
+		return s.toolHeraMarkRead(req.ID, params.Arguments)
+	case "hera_status":
+		return s.toolHeraStatus(req.ID, params.Arguments)
+	case "hera_spawn_worker":
+		return s.toolHeraSpawnWorker(req.ID, params.Arguments)
+	case "hera_tree_updates":
+		return s.toolHeraTreeUpdates(req.ID, params.Arguments)
+	case "hera_get_messages":
+		return s.toolHeraGetMessages(req.ID, params.Arguments)
 	default:
 		// Plugin-registered tool? PR 4 — dispatch into the registry which
 		// HTTP-POSTs to the plugin's callback_url and returns the response


### PR DESCRIPTION
## Summary

- Ports all 9 `hera_*` tool schemas verbatim from the external Hera daemon and implements them natively in `internal/mcp/`
- 7 arms fully implemented; 2 stubs redirect to future milestones (`hera_spawn_worker` → M4, `hera_tree_updates` → M5)
- **CallerContext resolver**: cwd → worktree → argus task → live binding(s) → role; `ErrHeraAmbiguous` lists orchestrator names when 2+ bindings match
- **Dup-tool guard**: when `heraEnabled()`, all `scope=="hera"` plugin rows are filtered from `tools/list` — suppresses external Hera daemon duplicates during cutover; non-hera scopes pass through unchanged
- Daemon wiring unconditional (`// M8:` comment; Settings toggle lands in Milestone 8)
- All `SetMeta` task_meta mirror calls are best-effort soft-fail
- `hera_inbox` marks messages as read via explicit `MarkRead` call after `Service.Inbox` (found during testing: description said "marks read" but implementation only cancelled deliveries)

## Test plan

- `make pre-pr` passes (build ✓, vet ✓, fmt-check ✓, lint 0 issues ✓, test-cover-gate 89.4% ✓)
- `make vuln` fails stdlib-only (all 9 findings are `Found in: <pkg>@go1.26.1 / Standard library`, present on `origin/master`, CI uses `continue-on-error`)
- 28 new tests in `internal/mcp/hera_test.go` cover: tools/list on/off, dup-guard (hera-scope filtered, iris-scope passes), all 7 live arms, CallerContext disambiguation (zero/multiple bindings, orchestrator param), stub M4/M5 messages, `heraEnabled=false` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>