### PR TITLE
test(model,orch): cover GenerateSessionID, pin/archive invariant, CycleError

### DIFF
--- a/internal/model/task_test.go
+++ b/internal/model/task_test.go
@@ -1,9 +1,114 @@
 package model
 
 import (
+	"regexp"
 	"testing"
 	"time"
+
+	"github.com/drn/argus/internal/testutil"
 )
+
+// uuidV4Re matches the canonical 8-4-4-4-12 hex form with the version nibble
+// pinned to 4 and the variant nibble pinned to RFC 4122 (8/9/a/b).
+var uuidV4Re = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func TestGenerateSessionID_WellFormedUUIDv4(t *testing.T) {
+	id := GenerateSessionID()
+
+	t.Run("length", func(t *testing.T) {
+		testutil.Equal(t, len(id), 36)
+	})
+	t.Run("rfc4122 version and variant", func(t *testing.T) {
+		if !uuidV4Re.MatchString(id) {
+			t.Errorf("GenerateSessionID() = %q, not a well-formed UUID v4", id)
+		}
+	})
+	t.Run("version nibble is 4", func(t *testing.T) {
+		// Group 3 starts at index 14 (8 hex + hyphen + 4 hex + hyphen).
+		testutil.Equal(t, string(id[14]), "4")
+	})
+	t.Run("variant nibble is 8/9/a/b", func(t *testing.T) {
+		// Group 4 starts at index 19.
+		testutil.Contains(t, "89ab", string(id[19]))
+	})
+}
+
+func TestGenerateSessionID_Unique(t *testing.T) {
+	// Two consecutive calls must differ — IDs pin a Claude conversation, so a
+	// collision would cross-wire sessions.
+	a := GenerateSessionID()
+	b := GenerateSessionID()
+	if a == b {
+		t.Errorf("GenerateSessionID() returned identical IDs on consecutive calls: %q", a)
+	}
+}
+
+func TestTask_SetPinned(t *testing.T) {
+	tests := []struct {
+		name         string
+		initial      Task
+		set          bool
+		wantPinned   bool
+		wantArchived bool
+	}{
+		{"pin-on clears archived", Task{Archived: true}, true, true, false},
+		{"pin-on from clean", Task{}, true, true, false},
+		{"pin-off leaves archived untouched", Task{Archived: true, Pinned: false}, false, false, true},
+		{"pin-off from pinned, archived stays false", Task{Pinned: true}, false, false, false},
+		{"idempotent re-pin keeps archived clear", Task{Pinned: true}, true, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := tt.initial
+			task.SetPinned(tt.set)
+			testutil.Equal(t, task.Pinned, tt.wantPinned)
+			testutil.Equal(t, task.Archived, tt.wantArchived)
+		})
+	}
+}
+
+func TestTask_SetArchived(t *testing.T) {
+	tests := []struct {
+		name         string
+		initial      Task
+		set          bool
+		wantPinned   bool
+		wantArchived bool
+	}{
+		{"archive-on clears pinned", Task{Pinned: true}, true, false, true},
+		{"archive-on from clean", Task{}, true, false, true},
+		{"archive-off leaves pinned untouched", Task{Pinned: true, Archived: false}, false, true, false},
+		{"archive-off from archived, pinned stays false", Task{Archived: true}, false, false, false},
+		{"idempotent re-archive keeps pinned clear", Task{Archived: true}, true, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := tt.initial
+			task.SetArchived(tt.set)
+			testutil.Equal(t, task.Pinned, tt.wantPinned)
+			testutil.Equal(t, task.Archived, tt.wantArchived)
+		})
+	}
+}
+
+func TestTask_PinArchive_MutualExclusion(t *testing.T) {
+	// The two setters must never leave both flags true simultaneously, no
+	// matter the order of operations.
+	t.Run("pin then archive", func(t *testing.T) {
+		task := &Task{}
+		task.SetPinned(true)
+		task.SetArchived(true)
+		testutil.Equal(t, task.Pinned, false)
+		testutil.Equal(t, task.Archived, true)
+	})
+	t.Run("archive then pin", func(t *testing.T) {
+		task := &Task{}
+		task.SetArchived(true)
+		task.SetPinned(true)
+		testutil.Equal(t, task.Pinned, true)
+		testutil.Equal(t, task.Archived, false)
+	})
+}
 
 func TestTask_Elapsed_NotStarted(t *testing.T) {
 	task := &Task{}

--- a/internal/orch/orch_test.go
+++ b/internal/orch/orch_test.go
@@ -386,6 +386,25 @@ func TestSetPlanSlug_MissingTask(t *testing.T) {
 	}
 }
 
+func TestCycleError_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		path []string
+		want string
+	}{
+		{"single node self-loop", []string{"A"}, "cycle detected: [A]"},
+		{"two node cycle", []string{"A", "B", "A"}, "cycle detected: [A B A]"},
+		{"multi node cycle", []string{"A", "B", "C", "A"}, "cycle detected: [A B C A]"},
+		{"empty path", nil, "cycle detected: []"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &CycleError{Path: tt.path}
+			testutil.Equal(t, err.Error(), tt.want)
+		})
+	}
+}
+
 // joinIDs is a tiny helper so testutil.Contains can be used on string slices
 // without pulling strings.Join into every assertion.
 func joinIDs(ids []string) string {


### PR DESCRIPTION
## Summary

Additive, test-only PR. **Zero production-code changes** — adds table-driven unit tests for previously-uncovered pure functions, using `internal/testutil` assertions and `t.Run` subtests per CLAUDE.md.

## Functions now covered

**`internal/model/task.go`**
- `GenerateSessionID()` — asserts a well-formed UUID v4: 36-char length, RFC 4122 version nibble (`4`) and variant nibble (`8`/`9`/`a`/`b`) via regex + index checks, and uniqueness across two consecutive calls.
- `(*Task).SetPinned(bool)` / `(*Task).SetArchived(bool)` — the mutual-exclusivity invariant: setting one true clears the other, setting false leaves the other untouched, idempotent re-set, and an order-independent "both flags never true simultaneously" check.

**`internal/orch/orch.go`**
- `(*CycleError).Error()` — exact `cycle detected: [...]` formatting for single-node, two-node, multi-node, and empty-path cases.

## Coverage delta

| Package | Before | After |
|---|---|---|
| `internal/model` | 93.6% | **100.0%** |
| `internal/orch` | 84.7% | **85.4%** |

Filtered coverage gate: **89.4%** (floor 88) — passes.

## Verification

`make pre-pr` — build / vet / fmt-check / lint-pr / test-cover-gate all green. `make vuln` reports only Go **stdlib** findings (`crypto/tls`, `crypto/x509`, `html/template`, `net*` @ go1.26.1), which are toolchain-only, present on clean `master`, and run with `continue-on-error: true` in CI — non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>