### PR TITLE
refactor(daemon): extract logRPCErr helper for repeated rpc error logging

### DIFF
--- a/internal/daemon/rpc.go
+++ b/internal/daemon/rpc.go
@@ -23,6 +23,16 @@ type RPCService struct {
 	daemon *Daemon
 }
 
+// logRPCErr logs an RPC handler error under the given method name and returns
+// err.Error() for assignment to the response's Error field. It folds the
+// repeated `resp.Error = err.Error(); slog.Error(method, "err", err)` pair
+// that several handlers share into one call. Handlers whose error log carries
+// extra structured fields (e.g. ClipboardSet's "task") keep their inline form.
+func logRPCErr(method string, err error) string {
+	slog.Error(method, "err", err)
+	return err.Error()
+}
+
 // BootInfo returns the daemon's boot-time identity (binary path + mtime).
 // The TUI uses this to detect when the on-disk binary has been rebuilt since
 // the daemon started, and prompt the user to restart.
@@ -70,8 +80,7 @@ func (s *RPCService) KBSearch(req *KBSearchReq, resp *KBSearchResp) error {
 	}
 	results, err := s.daemon.db.KBSearch(sanitized, req.Limit)
 	if err != nil {
-		resp.Error = err.Error()
-		slog.Error("rpc.KBSearch", "err", err)
+		resp.Error = logRPCErr("rpc.KBSearch", err)
 		return nil
 	}
 	for _, r := range results {
@@ -94,8 +103,7 @@ func (s *RPCService) KBIngest(req *KBIngestReq, resp *KBIngestResp) error {
 	doc.IngestedAt = time.Now()
 	doc.ModifiedAt = time.Now()
 	if err := s.daemon.db.KBUpsert(&doc); err != nil {
-		resp.Error = err.Error()
-		slog.Error("rpc.KBIngest", "err", err)
+		resp.Error = logRPCErr("rpc.KBIngest", err)
 	} else {
 		slog.Info("rpc.KBIngest ok", "path", req.Path)
 	}
@@ -107,8 +115,7 @@ func (s *RPCService) KBList(req *KBListReq, resp *KBListResp) error {
 	slog.Info("rpc.KBList", "prefix", req.Prefix, "limit", req.Limit)
 	docs, err := s.daemon.db.KBList(req.Prefix, req.Limit)
 	if err != nil {
-		resp.Error = err.Error()
-		slog.Error("rpc.KBList", "err", err)
+		resp.Error = logRPCErr("rpc.KBList", err)
 		return nil
 	}
 	for _, doc := range docs {
@@ -133,8 +140,7 @@ func (s *RPCService) UpdateSelf(_ *Empty, resp *UpdateSelfResp) error {
 	out, err := selfupdate.Run(cfg.Argus.SourcePath)
 	resp.Output = out
 	if err != nil {
-		resp.Error = err.Error()
-		slog.Error("rpc.UpdateSelf failed", "err", err)
+		resp.Error = logRPCErr("rpc.UpdateSelf failed", err)
 	} else {
 		slog.Info("rpc.UpdateSelf ok")
 	}

--- a/internal/daemon/rpc_test.go
+++ b/internal/daemon/rpc_test.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"net"
 	"net/rpc"
 	"os"
@@ -875,6 +877,29 @@ func TestRPC_StopSession_NotFound(t *testing.T) {
 	testutil.NoError(t, c.Call("Daemon.StopSession", &TaskIDReq{TaskID: "no-such"}, &resp))
 	testutil.False(t, resp.OK)
 	testutil.NotEqual(t, resp.Error, "")
+}
+
+// TestLogRPCErr verifies the helper returns err.Error() (for assignment to a
+// response's Error field) regardless of the method name passed for logging. It
+// folds the repeated `resp.Error = err.Error(); slog.Error(method, "err", err)`
+// pair shared by several RPC handlers, so the contract under test is purely
+// that the returned string equals err.Error().
+func TestLogRPCErr(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		err    error
+	}{
+		{"simple error", "rpc.KBSearch", errors.New("boom")},
+		{"wrapped error", "rpc.KBList", fmt.Errorf("list failed: %w", errors.New("db closed"))},
+		{"method with suffix", "rpc.UpdateSelf failed", errors.New("go install: exit status 1")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := logRPCErr(tt.method, tt.err)
+			testutil.Equal(t, got, tt.err.Error())
+		})
+	}
 }
 
 // _ keeps agent referenced.


### PR DESCRIPTION
## What

Several JSON-RPC handlers in `internal/daemon/rpc.go` repeated the same two-line pair:

```go
resp.Error = err.Error()
slog.Error("rpc.<Method>", "err", err)
```

This adds a free helper:

```go
func logRPCErr(method string, err error) string {
	slog.Error(method, "err", err)
	return err.Error()
}
```

and replaces the exact-matching blocks in **KBSearch**, **KBIngest**, **KBList**, and **UpdateSelf** with a single `resp.Error = logRPCErr("rpc.X", err)` call.

## No behavior or log-output change

- Method-name strings and `slog` output are **byte-identical**.
- Surrounding control flow (`return nil` / `else`) is unchanged.
- The heterogeneous response types are **NOT** unified behind an interface — each keeps its own `.Error string` field (that would be churn and risk).

## Scope decisions (kept output identical)

- **ClipboardSet** keeps its inline form: its log carries an extra `"task", req.TaskID` structured field the fixed-signature helper can't reproduce.
- **LinkTasks / UnlinkTasks / GetDeps / ListDAG / HaltDownstream / SetPlanSlug** do `resp.Error = err.Error()` with **no** `slog.Error` — left untouched so the helper never adds a log line that wasn't there before.

## Did NOT touch the #707 exit-caching path

No changes to `sessioncore.go`, `supervisor.go`, `stream.go`, or `daemon.go`. The diff is confined to `internal/daemon/rpc.go` + `internal/daemon/rpc_test.go`.

## Tests / gates

- Added table-driven `TestLogRPCErr` (subtests + `internal/testutil`) asserting the helper returns `err.Error()`.
- `make pre-pr`: build / vet / fmt-check / lint-pr / test-cover-gate all green (filtered coverage 89.4% ≥ 88 floor). The only `vuln` findings are stdlib/toolchain CVEs (`crypto/tls`, `crypto/x509`, `html/template` @ go1.26.1) that also fail on clean master and are non-blocking per CI's `continue-on-error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>