### PR TITLE
refactor(api): consolidate error-response writes into writeErr helper

### DIFF
--- a/internal/api/artifacts.go
+++ b/internal/api/artifacts.go
@@ -18,13 +18,13 @@ func (s *Server) handleListArtifacts(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	task, err := s.db.Get(id)
 	if err != nil || task == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 	arts, err := s.db.Artifacts(id)
 	if err != nil {
 		uxlog.Log("[api] artifacts list failed: id=%s err=%v", id, err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	if arts == nil {
@@ -55,20 +55,20 @@ func (s *Server) handleGetArtifact(w http.ResponseWriter, r *http.Request) {
 	art, err := s.db.GetArtifact(id, filename)
 	if err != nil {
 		uxlog.Log("[api] artifact lookup failed: id=%s file=%q err=%v", id, filename, err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	if art == nil {
 		// Unregistered filename (or path-traversal attempt) — no row, no serve.
 		uxlog.Log("[api] artifact 404 (no manifest row): id=%s file=%q", id, filename)
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "artifact not found"})
+		writeErr(w, http.StatusNotFound, "artifact not found", nil)
 		return
 	}
 
 	full, ok := resolveArtifactPath(id, art.Filename)
 	if !ok {
 		uxlog.Log("[api] artifact path escaped dir, refusing: id=%s file=%q", id, art.Filename)
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "invalid artifact path"})
+		writeErr(w, http.StatusForbidden, "invalid artifact path", nil)
 		return
 	}
 
@@ -76,14 +76,14 @@ func (s *Server) handleGetArtifact(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// Row exists but bytes are gone (manual deletion / disk loss).
 		uxlog.Log("[api] artifact open failed: id=%s file=%q err=%v", id, art.Filename, err)
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "artifact bytes not found"})
+		writeErr(w, http.StatusNotFound, "artifact bytes not found", nil)
 		return
 	}
 	defer f.Close()
 
 	info, err := f.Stat()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 

--- a/internal/api/clipboard.go
+++ b/internal/api/clipboard.go
@@ -36,7 +36,7 @@ func (s *Server) handleClipboardGet(w http.ResponseWriter, r *http.Request) {
 	}
 	id := r.PathValue("id")
 	if _, err := s.db.Get(id); err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 	text, ok := s.clipboard.Get(id)
@@ -52,12 +52,12 @@ func (s *Server) handleClipboardGet(w http.ResponseWriter, r *http.Request) {
 // instead. Reuses the daemon's clipboard.Store so size limits and TTL apply.
 func (s *Server) handleClipboardSet(w http.ResponseWriter, r *http.Request) {
 	if s.clipboard == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "clipboard unavailable"})
+		writeErr(w, http.StatusServiceUnavailable, "clipboard unavailable", nil)
 		return
 	}
 	id := r.PathValue("id")
 	if _, err := s.db.Get(id); err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 	// Cap body before json.Decode to prevent a streamed multi-MiB payload
@@ -67,12 +67,12 @@ func (s *Server) handleClipboardSet(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, clipboard.MaxTextSize+4096)
 	var req clipboardSetReq
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", nil)
 		return
 	}
 	if err := s.clipboard.Set(id, req.Text); err != nil {
 		uxlog.Log("[clipboard] set rejected: task=%s err=%v", id, err)
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusBadRequest, "", err)
 		return
 	}
 	uxlog.Log("[clipboard] set: task=%s bytes=%d", id, len(req.Text))
@@ -84,12 +84,12 @@ func (s *Server) handleClipboardSet(w http.ResponseWriter, r *http.Request) {
 // Copy button hides everywhere.
 func (s *Server) handleClipboardClear(w http.ResponseWriter, r *http.Request) {
 	if s.clipboard == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "clipboard unavailable"})
+		writeErr(w, http.StatusServiceUnavailable, "clipboard unavailable", nil)
 		return
 	}
 	id := r.PathValue("id")
 	if _, err := s.db.Get(id); err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 	s.clipboard.Clear(id)

--- a/internal/api/events_stream.go
+++ b/internal/api/events_stream.go
@@ -111,7 +111,7 @@ func (s *Server) emitForTest(ev model.Event) model.Event {
 func (s *Server) handleEventsStream(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "streaming not supported"})
+		writeErr(w, http.StatusInternalServerError, "streaming not supported", nil)
 		return
 	}
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -51,7 +51,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 
 	tasks, err := s.db.Tasks()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load tasks: " + err.Error()})
+		writeErr(w, http.StatusInternalServerError, "failed to load tasks", err)
 		return
 	}
 	var tc taskCounts
@@ -192,7 +192,7 @@ func (s *Server) sessionStateMaps() (runningSet, idleSet, needsInputSet map[stri
 func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
 	tasks, err := s.db.Tasks()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load tasks: " + err.Error()})
+		writeErr(w, http.StatusInternalServerError, "failed to load tasks", err)
 		return
 	}
 
@@ -251,7 +251,7 @@ func (s *Server) handleGetTask(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	task, err := s.db.Get(id)
 	if err != nil || task == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 	runningSet, idleSet, needsInputSet := s.sessionStateMaps()
@@ -315,19 +315,19 @@ func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 	var req createTaskReq
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1MB limit
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	if req.Project == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "project is required"})
+		writeErr(w, http.StatusBadRequest, "project is required", nil)
 		return
 	}
 	if req.Prompt == "" && req.Name == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name or prompt is required"})
+		writeErr(w, http.StatusBadRequest, "name or prompt is required", nil)
 		return
 	}
 	if err := s.validateBackend(req.Backend); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusBadRequest, "", err)
 		return
 	}
 	autoName := req.Name == ""
@@ -339,7 +339,7 @@ func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 
 	task, err := s.createTask(name, req.Prompt, req.Project, req.Backend, req.Model, autoName)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 
@@ -368,19 +368,19 @@ func (s *Server) handleCreateTaskMultipart(w http.ResponseWriter, r *http.Reques
 
 	name, prompt, project, backend, taskModel, atts, err := parseMultipartTaskForm(r)
 	if err != nil {
-		writeJSON(w, statusForUploadErr(err), map[string]string{"error": err.Error()})
+		writeErr(w, statusForUploadErr(err), "", err)
 		return
 	}
 	if project == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "project is required"})
+		writeErr(w, http.StatusBadRequest, "project is required", nil)
 		return
 	}
 	if prompt == "" && name == "" && len(atts) == 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name, prompt, or files required"})
+		writeErr(w, http.StatusBadRequest, "name, prompt, or files required", nil)
 		return
 	}
 	if err := s.validateBackend(backend); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusBadRequest, "", err)
 		return
 	}
 	// autoName fires only when name was synthesized from prompt — not from
@@ -406,7 +406,7 @@ func (s *Server) handleCreateTaskMultipart(w http.ResponseWriter, r *http.Reques
 	})
 	if err != nil {
 		uxlog.Log("[uploads] create task failed name=%q project=%q files=%d err=%v", name, project, len(atts), err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 
@@ -424,12 +424,12 @@ func (s *Server) handleStopTask(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	task, err := s.db.Get(id)
 	if err != nil || task == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 
 	if err := s.runner.Stop(id); err != nil && !errors.Is(err, agent.ErrSessionNotFound) {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 
@@ -463,7 +463,7 @@ func (s *Server) handleRestartTask(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	task, err := s.db.Get(id)
 	if err != nil || task == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 
@@ -471,7 +471,7 @@ func (s *Server) handleRestartTask(w http.ResponseWriter, r *http.Request) {
 	// (no live session, or session.IsIdle()) are exactly what this endpoint
 	// targets — they should be restarted, not rejected.
 	if sess := s.runner.Get(task.ID); sess != nil && !sess.IsIdle() {
-		writeJSON(w, http.StatusConflict, map[string]string{"error": "task already running"})
+		writeErr(w, http.StatusConflict, "task already running", nil)
 		return
 	}
 
@@ -482,7 +482,7 @@ func (s *Server) handleRestartTask(w http.ResponseWriter, r *http.Request) {
 	sess, reattached, err := s.runner.StartOrReattach(task, cfg, 24, 80, true)
 	if err != nil {
 		uxlog.Log("[api] restart: start failed task=%s err=%v", id, err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 
@@ -512,7 +512,7 @@ func (s *Server) handleResumeTask(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	task, err := s.db.Get(id)
 	if err != nil || task == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 
@@ -532,7 +532,7 @@ func (s *Server) handleResumeTask(w http.ResponseWriter, r *http.Request) {
 		// the check to atomic without auditing the StartOrReattach call
 		// sites that share the same pattern.
 		if sess := s.runner.Get(task.ID); sess != nil && !sess.IsIdle() {
-			writeJSON(w, http.StatusConflict, map[string]string{"error": "task already running"})
+			writeErr(w, http.StatusConflict, "task already running", nil)
 			return
 		}
 	}
@@ -550,7 +550,7 @@ func (s *Server) handleResumeTask(w http.ResponseWriter, r *http.Request) {
 	sess, reattached, err := s.runner.StartOrReattach(task, cfg, 24, 80, resume)
 	if err != nil {
 		uxlog.Log("[api] resume: start failed task=%s status=%s err=%v", id, prevStatus, err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 
@@ -584,7 +584,7 @@ func (s *Server) handleDeleteTask(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	task, err := s.db.Get(id)
 	if err != nil || task == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 
@@ -606,7 +606,7 @@ func (s *Server) handleDeleteTask(w http.ResponseWriter, r *http.Request) {
 	os.RemoveAll(agent.ArtifactsDir(id)) //nolint:errcheck,gosec // G304: id validated by db.Get; ArtifactsDir roots at ~/.argus/artifacts/<id>
 
 	if err := s.db.Delete(id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	events.Emit(model.EventTypeTaskDeleted, id, nil)
@@ -647,12 +647,12 @@ func (s *Server) setArchive(w http.ResponseWriter, r *http.Request, archived boo
 	id := r.PathValue("id")
 	task, err := s.db.Get(id)
 	if err != nil || task == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 	task.SetArchived(archived)
 	if err := s.db.Update(task); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	// Mirror the MCP task_archive cleanup so the archive surface stays
@@ -680,24 +680,24 @@ func (s *Server) handleRenameTask(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	task, err := s.db.Get(id)
 	if err != nil || task == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 	var req renameReq
 	r.Body = http.MaxBytesReader(w, r.Body, 4*1024)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	name := strings.TrimSpace(req.Name)
 	if name == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+		writeErr(w, http.StatusBadRequest, "name is required", nil)
 		return
 	}
 	// Targeted rename — avoids racing concurrent status changes from the
 	// agent process. Mirrors the MCP task_rename and TUI rename modal paths.
 	if err := s.db.Rename(task.ID, name); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"name": name})
@@ -713,13 +713,13 @@ func (s *Server) handleSetStatus(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	task, err := s.db.Get(id)
 	if err != nil || task == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 	var req statusSetReq
 	r.Body = http.MaxBytesReader(w, r.Body, 1024)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	var st model.Status
@@ -733,12 +733,12 @@ func (s *Server) handleSetStatus(w http.ResponseWriter, r *http.Request) {
 	case "complete":
 		st = model.StatusComplete
 	default:
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown status: " + req.Status})
+		writeErr(w, http.StatusBadRequest, "unknown status: "+req.Status, nil)
 		return
 	}
 	task.SetStatus(st)
 	if err := s.db.Update(task); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": task.Status.String()})
@@ -754,7 +754,7 @@ func (s *Server) handleStopAll(w http.ResponseWriter, r *http.Request) {
 	// Mark every running task as in_review.
 	tasks, err := s.db.Tasks()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	stopped := 0
@@ -793,7 +793,7 @@ func (s *Server) handlePruneCompleted(w http.ResponseWriter, r *http.Request) {
 		Runner: s.runner,
 	})
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 
@@ -822,13 +822,13 @@ func (s *Server) handleForkTask(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	src, err := s.db.Get(id)
 	if err != nil || src == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 	var req forkReq
 	r.Body = http.MaxBytesReader(w, r.Body, 64*1024)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	name := strings.TrimSpace(req.Name)
@@ -844,7 +844,7 @@ func (s *Server) handleForkTask(w http.ResponseWriter, r *http.Request) {
 		project = src.Project
 	}
 	if project == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "project is required (source task has no project)"})
+		writeErr(w, http.StatusBadRequest, "project is required (source task has no project)", nil)
 		return
 	}
 	// Fork name is structured ("<src>-fork" or user-typed); never auto-rename.
@@ -853,7 +853,7 @@ func (s *Server) handleForkTask(w http.ResponseWriter, r *http.Request) {
 	// setting.
 	task, err := s.createTask(name, prompt, project, src.Backend, src.Model, false)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	// task.forked is plugin-visible context — it carries the parent linkage
@@ -928,14 +928,14 @@ func (s *Server) handleGetOutput(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no output available"})
+		writeErr(w, http.StatusNotFound, "no output available", nil)
 		return
 	}
 	defer f.Close()
 
 	info, err := f.Stat()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	fileSize := info.Size()
@@ -964,7 +964,7 @@ func (s *Server) handleGetOutput(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := f.Seek(startOff, io.SeekStart); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	if clean {
@@ -1022,7 +1022,7 @@ func (s *Server) handleGetLinks(w http.ResponseWriter, r *http.Request) {
 		defer f.Close()
 		info, err := f.Stat()
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusInternalServerError, "", err)
 			return
 		}
 		offset := info.Size() - int64(linksReadCap)
@@ -1032,7 +1032,7 @@ func (s *Server) handleGetLinks(w http.ResponseWriter, r *http.Request) {
 		f.Seek(offset, io.SeekStart) //nolint:errcheck
 		raw, err = io.ReadAll(f)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusInternalServerError, "", err)
 			return
 		}
 	}
@@ -1052,18 +1052,18 @@ func (s *Server) handleWriteInput(w http.ResponseWriter, r *http.Request) {
 
 	sess := s.runner.Get(id)
 	if sess == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no active session"})
+		writeErr(w, http.StatusNotFound, "no active session", nil)
 		return
 	}
 
 	data, err := io.ReadAll(io.LimitReader(r.Body, 64*1024))
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusBadRequest, "", err)
 		return
 	}
 
 	if _, err := sess.WriteInput(data); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 
@@ -1086,7 +1086,7 @@ func (s *Server) handleGetSize(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	sess := s.runner.Get(id)
 	if sess == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no active session"})
+		writeErr(w, http.StatusNotFound, "no active session", nil)
 		return
 	}
 	cols, rows := sess.PTYSize()
@@ -1102,26 +1102,26 @@ func (s *Server) handleResize(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	sess := s.runner.Get(id)
 	if sess == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no active session"})
+		writeErr(w, http.StatusNotFound, "no active session", nil)
 		return
 	}
 	var req resizeReq
 	r.Body = http.MaxBytesReader(w, r.Body, 1024)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	if req.Cols == 0 || req.Rows == 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "cols and rows must be > 0"})
+		writeErr(w, http.StatusBadRequest, "cols and rows must be > 0", nil)
 		return
 	}
 	// Sanity bounds — terminals beyond these are pathological.
 	if req.Cols > 1000 || req.Rows > 1000 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "cols/rows out of range"})
+		writeErr(w, http.StatusBadRequest, "cols/rows out of range", nil)
 		return
 	}
 	if err := sess.Resize(req.Rows, req.Cols); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 
@@ -1252,13 +1252,13 @@ func (s *Server) handleStreamOutput(w http.ResponseWriter, r *http.Request) {
 
 	sess := s.runner.Get(id)
 	if sess == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no active session"})
+		writeErr(w, http.StatusNotFound, "no active session", nil)
 		return
 	}
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "streaming not supported"})
+		writeErr(w, http.StatusInternalServerError, "streaming not supported", nil)
 		return
 	}
 
@@ -1478,7 +1478,7 @@ func projectFromJSON(req projectJSON) config.Project {
 func (s *Server) handleListProjectsFull(w http.ResponseWriter, r *http.Request) {
 	projects, err := s.db.Projects()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	out := make([]projectJSON, 0, len(projects))
@@ -1503,15 +1503,15 @@ func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 	var req projectJSON
 	r.Body = http.MaxBytesReader(w, r.Body, 4*1024)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	if strings.TrimSpace(req.Name) == "" || strings.TrimSpace(req.Path) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name and path are required"})
+		writeErr(w, http.StatusBadRequest, "name and path are required", nil)
 		return
 	}
 	if err := s.db.SetProject(req.Name, projectFromJSON(req)); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, req)
@@ -1522,16 +1522,16 @@ func (s *Server) handleUpdateProject(w http.ResponseWriter, r *http.Request) {
 	var req projectJSON
 	r.Body = http.MaxBytesReader(w, r.Body, 4*1024)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	// Path is required on update too.
 	if strings.TrimSpace(req.Path) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path is required"})
+		writeErr(w, http.StatusBadRequest, "path is required", nil)
 		return
 	}
 	if err := s.db.SetProject(name, projectFromJSON(req)); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	req.Name = name
@@ -1541,7 +1541,7 @@ func (s *Server) handleUpdateProject(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDeleteProject(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if err := s.db.DeleteProject(name); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"deleted": name})
@@ -1561,7 +1561,7 @@ type backendJSON struct {
 func (s *Server) handleListBackends(w http.ResponseWriter, r *http.Request) {
 	backends, err := s.db.Backends()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	out := make([]backendJSON, 0, len(backends))
@@ -1587,15 +1587,15 @@ func (s *Server) handleCreateBackend(w http.ResponseWriter, r *http.Request) {
 	var req backendJSON
 	r.Body = http.MaxBytesReader(w, r.Body, 4*1024)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	if strings.TrimSpace(req.Name) == "" || strings.TrimSpace(req.Command) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name and command are required"})
+		writeErr(w, http.StatusBadRequest, "name and command are required", nil)
 		return
 	}
 	if err := s.db.SetBackend(req.Name, config.Backend{Command: req.Command, PromptFlag: req.PromptFlag, Model: req.Model}); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, req)
@@ -1611,15 +1611,15 @@ func (s *Server) handleUpdateBackend(w http.ResponseWriter, r *http.Request) {
 	var req backendJSON
 	r.Body = http.MaxBytesReader(w, r.Body, 4*1024)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	if strings.TrimSpace(req.Command) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "command is required"})
+		writeErr(w, http.StatusBadRequest, "command is required", nil)
 		return
 	}
 	if err := s.db.SetBackend(name, config.Backend{Command: req.Command, PromptFlag: req.PromptFlag, Model: req.Model}); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	req.Name = name
@@ -1633,7 +1633,7 @@ func (s *Server) handleDeleteBackend(w http.ResponseWriter, r *http.Request) {
 	}
 	name := r.PathValue("name")
 	if err := s.db.DeleteBackend(name); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"deleted": name})
@@ -1678,7 +1678,7 @@ func (s *Server) handleGitStatus(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	task, err := s.db.Get(id)
 	if err != nil || task == nil || task.Worktree == "" {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task or worktree not found"})
+		writeErr(w, http.StatusNotFound, "task or worktree not found", nil)
 		return
 	}
 	msg := gitutil.FetchGitStatus(task.ID, task.Worktree)
@@ -1689,7 +1689,7 @@ func (s *Server) handleGitDiff(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	task, err := s.db.Get(id)
 	if err != nil || task == nil || task.Worktree == "" {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task or worktree not found"})
+		writeErr(w, http.StatusNotFound, "task or worktree not found", nil)
 		return
 	}
 	path := r.URL.Query().Get("path")
@@ -1697,7 +1697,7 @@ func (s *Server) handleGitDiff(w http.ResponseWriter, r *http.Request) {
 		// Reject absolute paths — gitutil.FetchFileDiff falls back to
 		// `git diff --no-index <path>` which would otherwise read arbitrary
 		// files (e.g. /etc/passwd) for files not in the worktree.
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "valid path query param required"})
+		writeErr(w, http.StatusBadRequest, "valid path query param required", nil)
 		return
 	}
 	msg := gitutil.FetchFileDiff(task.ID, task.Worktree, path)
@@ -1708,12 +1708,12 @@ func (s *Server) handleFileTree(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	task, err := s.db.Get(id)
 	if err != nil || task == nil || task.Worktree == "" {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task or worktree not found"})
+		writeErr(w, http.StatusNotFound, "task or worktree not found", nil)
 		return
 	}
 	dir := r.URL.Query().Get("dir")
 	if strings.Contains(dir, "..") || filepath.IsAbs(dir) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid dir"})
+		writeErr(w, http.StatusBadRequest, "invalid dir", nil)
 		return
 	}
 	msg := gitutil.FetchDirFiles(task.ID, task.Worktree, dir)
@@ -1762,6 +1762,27 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		log.Printf("[api] json encode error: %v", err)
 	}
+}
+
+// writeErr writes a standard `{"error": "..."}` JSON body at the given status.
+// It is the single helper behind the error-response sites across internal/api,
+// replacing the repeated inline writeJSON(..., map[string]string{"error": ...}).
+//
+// The emitted message is composed to stay byte-identical to the call sites it
+// replaces:
+//   - msg == "", err != nil  -> err.Error()            (the bare err.Error() form)
+//   - msg != "", err != nil  -> msg + ": " + err.Error() (the "prefix: " + err form)
+//   - msg != "", err == nil  -> msg                     (a static message)
+//   - msg == "", err == nil  -> ""                      (degenerate; avoid)
+func writeErr(w http.ResponseWriter, status int, msg string, err error) {
+	text := msg
+	switch {
+	case err != nil && msg != "":
+		text = msg + ": " + err.Error()
+	case err != nil:
+		text = err.Error()
+	}
+	writeJSON(w, status, map[string]string{"error": text})
 }
 
 func sanitizeName(prompt string) string {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2851,6 +2851,60 @@ func TestWriteJSON_EncodeError(t *testing.T) {
 	testutil.Equal(t, rec.Code, http.StatusOK)
 }
 
+func TestWriteErr(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		msg      string
+		err      error
+		wantCode int
+		wantBody string
+	}{
+		{
+			name:     "bare error, no message",
+			status:   http.StatusInternalServerError,
+			msg:      "",
+			err:      fmt.Errorf("boom"),
+			wantCode: http.StatusInternalServerError,
+			wantBody: `{"error":"boom"}`,
+		},
+		{
+			name:     "message prefix with error",
+			status:   http.StatusBadRequest,
+			msg:      "invalid JSON",
+			err:      fmt.Errorf("unexpected EOF"),
+			wantCode: http.StatusBadRequest,
+			wantBody: `{"error":"invalid JSON: unexpected EOF"}`,
+		},
+		{
+			name:     "static message, no error",
+			status:   http.StatusNotFound,
+			msg:      "task not found",
+			err:      nil,
+			wantCode: http.StatusNotFound,
+			wantBody: `{"error":"task not found"}`,
+		},
+		{
+			name:     "empty message and nil error",
+			status:   http.StatusBadRequest,
+			msg:      "",
+			err:      nil,
+			wantCode: http.StatusBadRequest,
+			wantBody: `{"error":""}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			writeErr(rec, tc.status, tc.msg, tc.err)
+			testutil.Equal(t, rec.Code, tc.wantCode)
+			testutil.Equal(t, rec.Header().Get("Content-Type"), "application/json")
+			// json.Encoder appends a trailing newline; trim it for comparison.
+			testutil.Equal(t, strings.TrimRight(rec.Body.String(), "\n"), tc.wantBody)
+		})
+	}
+}
+
 // --- LoadOrCreateToken edge cases ---
 
 func TestLoadOrCreateToken_MkdirError(t *testing.T) {

--- a/internal/api/linking.go
+++ b/internal/api/linking.go
@@ -46,7 +46,7 @@ func (s *Server) handleLinkTask(w http.ResponseWriter, r *http.Request) {
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, 4*1024)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	if err := orch.Link(s.db, id, req.ParentID); err != nil {
@@ -105,7 +105,7 @@ func (s *Server) handleSetPlanSlug(w http.ResponseWriter, r *http.Request) {
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, 4*1024)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	if err := orch.SetPlanSlug(s.db, id, req.PlanSlug); err != nil {
@@ -150,10 +150,10 @@ func (s *Server) handleDAG(w http.ResponseWriter, r *http.Request) {
 func (s *Server) writeOrchError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, orch.ErrEmptyID):
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusBadRequest, "", err)
 	case errors.Is(err, db.ErrTaskNotFound):
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusNotFound, "", err)
 	default:
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 	}
 }

--- a/internal/api/mcp_tools.go
+++ b/internal/api/mcp_tools.go
@@ -37,18 +37,18 @@ const maxRegisterMCPToolBytes = 256 * 1024
 // caller's scope, so a master credential has no scope to enforce against.
 func (s *Server) handleRegisterMCPTool(w http.ResponseWriter, r *http.Request) {
 	if s.mcpRegistry == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "mcp registry not configured"})
+		writeErr(w, http.StatusServiceUnavailable, "mcp registry not configured", nil)
 		return
 	}
 	scope := pluginScopeFromAuth(r)
 	if scope == "" {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "plugin-scoped token required"})
+		writeErr(w, http.StatusForbidden, "plugin-scoped token required", nil)
 		return
 	}
 	var body registerMCPToolReq
 	r.Body = http.MaxBytesReader(w, r.Body, maxRegisterMCPToolBytes)
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	err := s.mcpRegistry.Register(scope, mcp.ToolRegistration{
@@ -59,7 +59,7 @@ func (s *Server) handleRegisterMCPTool(w http.ResponseWriter, r *http.Request) {
 		AuthHeader:  body.AuthHeader,
 	})
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusBadRequest, "", err)
 		return
 	}
 	uxlog.Log("[plugin] mcp tool registered: scope=%s name=%s", scope, body.Name)
@@ -71,12 +71,12 @@ func (s *Server) handleRegisterMCPTool(w http.ResponseWriter, r *http.Request) {
 // cleanup). A device token cannot — device tokens have no plugin namespace.
 func (s *Server) handleUnregisterMCPTool(w http.ResponseWriter, r *http.Request) {
 	if s.mcpRegistry == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "mcp registry not configured"})
+		writeErr(w, http.StatusServiceUnavailable, "mcp registry not configured", nil)
 		return
 	}
 	name := r.PathValue("name")
 	if strings.TrimSpace(name) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name required"})
+		writeErr(w, http.StatusBadRequest, "name required", nil)
 		return
 	}
 	authTag := r.Header.Get("X-Argus-Auth")
@@ -86,7 +86,7 @@ func (s *Server) handleUnregisterMCPTool(w http.ResponseWriter, r *http.Request)
 		// Master removes anything — pass empty scope, Registry interprets
 		// that as the cleanup-credential.
 		if err := s.mcpRegistry.Unregister("", name); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusBadRequest, "", err)
 			return
 		}
 	case scope != "":
@@ -95,14 +95,14 @@ func (s *Server) handleUnregisterMCPTool(w http.ResponseWriter, r *http.Request)
 			// errors.New — string-match the substring so a 403 (vs 400)
 			// is returned for the cross-scope rejection.
 			if strings.Contains(err.Error(), "not owned") {
-				writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+				writeErr(w, http.StatusForbidden, "", err)
 				return
 			}
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusBadRequest, "", err)
 			return
 		}
 	default:
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "plugin-scoped or master token required"})
+		writeErr(w, http.StatusForbidden, "plugin-scoped or master token required", nil)
 		return
 	}
 	uxlog.Log("[plugin] mcp tool unregistered: auth=%s scope=%s name=%s", authTag, scope, name)

--- a/internal/api/messages.go
+++ b/internal/api/messages.go
@@ -26,10 +26,10 @@ func (s *Server) handleListInbox(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if _, err := s.db.Get(id); err != nil {
 		if errors.Is(err, db.ErrTaskNotFound) {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusNotFound, "", err)
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 
@@ -54,7 +54,7 @@ func (s *Server) handleListInbox(w http.ResponseWriter, r *http.Request) {
 			// Fall back to second-precision RFC3339 before bailing.
 			t, err = time.Parse(time.RFC3339, since)
 			if err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid since (must be RFC3339): " + err.Error()})
+				writeErr(w, http.StatusBadRequest, "invalid since (must be RFC3339)", err)
 				return
 			}
 		}
@@ -63,7 +63,7 @@ func (s *Server) handleListInbox(w http.ResponseWriter, r *http.Request) {
 	if l := q.Get("limit"); l != "" {
 		n, err := strconv.Atoi(l)
 		if err != nil || n < 0 {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid limit"})
+			writeErr(w, http.StatusBadRequest, "invalid limit", nil)
 			return
 		}
 		filter.Limit = n
@@ -71,7 +71,7 @@ func (s *Server) handleListInbox(w http.ResponseWriter, r *http.Request) {
 
 	msgs, err := s.db.Inbox(id, filter)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	if msgs == nil {
@@ -80,7 +80,7 @@ func (s *Server) handleListInbox(w http.ResponseWriter, r *http.Request) {
 
 	unreadCount, err := s.db.UnreadCount(id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 
@@ -106,10 +106,10 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	from := r.PathValue("id")
 	if _, err := s.db.Get(from); err != nil {
 		if errors.Is(err, db.ErrTaskNotFound) {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusNotFound, "", err)
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 
@@ -121,15 +121,15 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		InReplyTo string `json:"in_reply_to"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	if req.To == "" || req.Body == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "to and body are required"})
+		writeErr(w, http.StatusBadRequest, "to and body are required", nil)
 		return
 	}
 	if _, err := s.db.Get(req.To); err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "recipient task not found: " + req.To})
+		writeErr(w, http.StatusNotFound, "recipient task not found: "+req.To, nil)
 		return
 	}
 
@@ -140,7 +140,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	// Validate at the handler so an unknown kind returns 400, not the 500
 	// the default branch would produce from a generic Validate() error.
 	if !model.ValidMessageKind(kind) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid kind %q (want note|question|answer)", req.Kind)})
+		writeErr(w, http.StatusBadRequest, fmt.Sprintf("invalid kind %q (want note|question|answer)", req.Kind), nil)
 		return
 	}
 
@@ -157,9 +157,9 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			errors.Is(err, db.ErrMessageSelfSend),
 			errors.Is(err, db.ErrMessageInboxFull),
 			errors.Is(err, db.ErrMessageRateLimited):
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusBadRequest, "", err)
 		default:
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusInternalServerError, "", err)
 		}
 		return
 	}
@@ -186,10 +186,10 @@ func (s *Server) handleAckInbox(w http.ResponseWriter, r *http.Request) {
 	// with handleListInbox which does the same check up front.
 	if _, err := s.db.Get(id); err != nil {
 		if errors.Is(err, db.ErrTaskNotFound) {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusNotFound, "", err)
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, 64*1024)
@@ -200,7 +200,7 @@ func (s *Server) handleAckInbox(w http.ResponseWriter, r *http.Request) {
 		MessageIDs []string `json:"message_ids"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	ids := req.IDs
@@ -208,20 +208,20 @@ func (s *Server) handleAckInbox(w http.ResponseWriter, r *http.Request) {
 		ids = req.MessageIDs
 	}
 	if len(ids) == 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "ids is required"})
+		writeErr(w, http.StatusBadRequest, "ids is required", nil)
 		return
 	}
 	// Cap mirrors the MCP `task_message_ack` surface (maxAckIDsPerCall).
 	// Above 500 we'd start brushing against SQLite's 999-variable cap on
 	// the IN-clause `AckMessages` builds, surfacing as a 500.
 	if len(ids) > db.MaxInboxLimit {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("too many ids (max %d per call)", db.MaxInboxLimit)})
+		writeErr(w, http.StatusBadRequest, fmt.Sprintf("too many ids (max %d per call)", db.MaxInboxLimit), nil)
 		return
 	}
 
 	n, err := s.db.AckMessages(id, ids)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"acked": n})

--- a/internal/api/notify.go
+++ b/internal/api/notify.go
@@ -33,52 +33,52 @@ type cancelNotifyResp struct {
 // handleNotify handles POST /api/tasks/{id}/notify.
 func (s *Server) handleNotify(w http.ResponseWriter, r *http.Request) {
 	if s.notifier == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "reliable delivery not available"})
+		writeErr(w, http.StatusServiceUnavailable, "reliable delivery not available", nil)
 		return
 	}
 
 	taskID := r.PathValue("id")
 	task, err := s.db.Get(taskID)
 	if err != nil || task == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, 64*1024)
 	var req notifyReq
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 
 	if req.Text == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "text is required"})
+		writeErr(w, http.StatusBadRequest, "text is required", nil)
 		return
 	}
 	if req.Submit == nil || !*req.Submit {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "submit must be true"})
+		writeErr(w, http.StatusBadRequest, "submit must be true", nil)
 		return
 	}
 	if req.DeliveryID == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "delivery_id is required"})
+		writeErr(w, http.StatusBadRequest, "delivery_id is required", nil)
 		return
 	}
 	if len(req.DeliveryID) > 128 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "delivery_id too long (max 128 bytes)"})
+		writeErr(w, http.StatusBadRequest, "delivery_id too long (max 128 bytes)", nil)
 		return
 	}
 	if !reDeliveryID.MatchString(req.DeliveryID) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "delivery_id must contain only alphanumeric characters, hyphens, or underscores"})
+		writeErr(w, http.StatusBadRequest, "delivery_id must contain only alphanumeric characters, hyphens, or underscores", nil)
 		return
 	}
 	// deadline_ms=0 means "use the default (5 minutes)". Any explicit value
 	// must be between 1000ms (1 second) and 3600000ms (1 hour).
 	if req.DeadlineMS != 0 && req.DeadlineMS < 1000 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "deadline_ms minimum is 1000 (1 second); use 0 for the default (5 minutes)"})
+		writeErr(w, http.StatusBadRequest, "deadline_ms minimum is 1000 (1 second); use 0 for the default (5 minutes)", nil)
 		return
 	}
 	if req.DeadlineMS > 3_600_000 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "deadline_ms exceeds maximum of 3600000 (1 hour)"})
+		writeErr(w, http.StatusBadRequest, "deadline_ms exceeds maximum of 3600000 (1 hour)", nil)
 		return
 	}
 
@@ -115,7 +115,7 @@ func (s *Server) handleNotify(w http.ResponseWriter, r *http.Request) {
 // handleCancelNotify handles DELETE /api/tasks/{id}/notify/{delivery_id}.
 func (s *Server) handleCancelNotify(w http.ResponseWriter, r *http.Request) {
 	if s.notifier == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "reliable delivery not available"})
+		writeErr(w, http.StatusServiceUnavailable, "reliable delivery not available", nil)
 		return
 	}
 

--- a/internal/api/plugin_settings.go
+++ b/internal/api/plugin_settings.go
@@ -55,25 +55,25 @@ func authScope(r *http.Request) string {
 func (s *Server) handleRegisterPluginSection(w http.ResponseWriter, r *http.Request) {
 	scope := authScope(r)
 	if scope == "" {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "plugin-scoped token required"})
+		writeErr(w, http.StatusForbidden, "plugin-scoped token required", nil)
 		return
 	}
 
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, pluginSectionMaxBodyBytes))
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "read body: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "read body", err)
 		return
 	}
 
 	sec, err := settings.ParseSection(scope, body)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusBadRequest, "", err)
 		return
 	}
 
 	pluginRow, err := db.FromSection(sec)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusBadRequest, "", err)
 		return
 	}
 
@@ -89,7 +89,7 @@ func (s *Server) handleRegisterPluginSection(w http.ResponseWriter, r *http.Requ
 
 	id, err := s.db.UpsertPluginSection(pluginRow)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	if s.pluginSections != nil {
@@ -120,28 +120,28 @@ func (s *Server) handleUnregisterPluginSection(w http.ResponseWriter, r *http.Re
 	pathScope := r.PathValue("scope")
 	pathTitle := r.PathValue("title")
 	if pathScope == "" || pathTitle == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "scope and title path segments are required"})
+		writeErr(w, http.StatusBadRequest, "scope and title path segments are required", nil)
 		return
 	}
 
 	caller := authScope(r)
 	master := r.Header.Get("X-Argus-Auth") == "master"
 	if !master && caller != pathScope {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "cannot unregister another plugin's section"})
+		writeErr(w, http.StatusForbidden, "cannot unregister another plugin's section", nil)
 		return
 	}
 
 	removed, err := s.db.DeletePluginSection(pathScope, pathTitle)
 	if err != nil {
 		if errors.Is(err, db.ErrPluginSectionInvalid) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusBadRequest, "", err)
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	if !removed {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "section not found"})
+		writeErr(w, http.StatusNotFound, "section not found", nil)
 		return
 	}
 	if s.pluginSections != nil {
@@ -169,7 +169,7 @@ type pluginSectionJSON struct {
 func (s *Server) handleListPluginSections(w http.ResponseWriter, r *http.Request) {
 	rows, err := s.db.ListPluginSections()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	out := make([]pluginSectionJSON, 0, len(rows))
@@ -208,26 +208,26 @@ func (s *Server) handleSubmitPluginSectionValues(w http.ResponseWriter, r *http.
 	scope := r.PathValue("scope")
 	title := r.PathValue("title")
 	if scope == "" || title == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "scope and title path segments are required"})
+		writeErr(w, http.StatusBadRequest, "scope and title path segments are required", nil)
 		return
 	}
 
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, pluginSectionMaxBodyBytes))
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "read body: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "read body", err)
 		return
 	}
 	// Validate JSON well-formedness up front so a malformed body doesn't get
 	// forwarded to the plugin (which would have to reject it itself).
 	var probe map[string]any
 	if err := json.Unmarshal(body, &probe); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "body must be a JSON object: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "body must be a JSON object", err)
 		return
 	}
 
 	rows, err := s.db.ListPluginSections()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	var (
@@ -244,7 +244,7 @@ func (s *Server) handleSubmitPluginSectionValues(w http.ResponseWriter, r *http.
 		}
 	}
 	if !found {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "section not found"})
+		writeErr(w, http.StatusNotFound, "section not found", nil)
 		return
 	}
 
@@ -255,7 +255,7 @@ func (s *Server) handleSubmitPluginSectionValues(w http.ResponseWriter, r *http.
 	}
 	statusCode, respBody, perr := submit(r.Context(), callbackURL, authHeader, body)
 	if perr != nil {
-		writeJSON(w, http.StatusBadGateway, map[string]string{"error": perr.Error()})
+		writeErr(w, http.StatusBadGateway, "", perr)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/plugin_views.go
+++ b/internal/api/plugin_views.go
@@ -55,7 +55,7 @@ func (s *Server) handleCreatePluginView(w http.ResponseWriter, r *http.Request) 
 	var req pluginViewCreateReq
 	r.Body = http.MaxBytesReader(w, r.Body, 4*1024)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	reg := views.New(s.db)
@@ -64,11 +64,11 @@ func (s *Server) handleCreatePluginView(w http.ResponseWriter, r *http.Request) 
 		switch {
 		case errors.Is(err, views.ErrTitleRequired),
 			errors.Is(err, views.ErrCallbackURLRequired):
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusBadRequest, "", err)
 		case errors.Is(err, views.ErrViewExists):
-			writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusConflict, "", err)
 		default:
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusInternalServerError, "", err)
 		}
 		return
 	}
@@ -117,12 +117,12 @@ func (s *Server) handleDeletePluginView(w http.ResponseWriter, r *http.Request) 
 	idStr := r.PathValue("id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+		writeErr(w, http.StatusBadRequest, "invalid id", nil)
 		return
 	}
 	all, err := s.db.PluginViews()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	var match *pluginViewJSON
@@ -137,16 +137,16 @@ func (s *Server) handleDeletePluginView(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	if match == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "view not found"})
+		writeErr(w, http.StatusNotFound, "view not found", nil)
 		return
 	}
 	if hasScope && match.Scope != scope {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "view belongs to a different scope"})
+		writeErr(w, http.StatusForbidden, "view belongs to a different scope", nil)
 		return
 	}
 	reg := views.New(s.db)
 	if err := reg.Unregister(match.Scope, match.Title); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"deleted": match.ID})

--- a/internal/api/push.go
+++ b/internal/api/push.go
@@ -25,7 +25,7 @@ type pushSubscribeReq struct {
 
 func (s *Server) handleVapidPublicKey(w http.ResponseWriter, r *http.Request) {
 	if s.push == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "push not available"})
+		writeErr(w, http.StatusServiceUnavailable, "push not available", nil)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"public_key": s.push.PublicKey()})
@@ -33,17 +33,17 @@ func (s *Server) handleVapidPublicKey(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handlePushSubscribe(w http.ResponseWriter, r *http.Request) {
 	if s.push == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "push not available"})
+		writeErr(w, http.StatusServiceUnavailable, "push not available", nil)
 		return
 	}
 	var req pushSubscribeReq
 	r.Body = http.MaxBytesReader(w, r.Body, 16*1024)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	if req.Endpoint == "" || req.Keys.P256dh == "" || req.Keys.Auth == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "endpoint and keys required"})
+		writeErr(w, http.StatusBadRequest, "endpoint and keys required", nil)
 		return
 	}
 	id, err := s.db.AddPushSubscription(db.PushSubscription{
@@ -54,7 +54,7 @@ func (s *Server) handlePushSubscribe(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		uxlog.Log("[push] subscribe failed: %v", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	uxlog.Log("[push] subscribed id=%d label=%q", id, req.Label)
@@ -64,7 +64,7 @@ func (s *Server) handlePushSubscribe(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handlePushList(w http.ResponseWriter, r *http.Request) {
 	subs, err := s.db.PushSubscriptions()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	type subView struct {
@@ -92,11 +92,11 @@ func (s *Server) handlePushList(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handlePushUnsubscribe(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+		writeErr(w, http.StatusBadRequest, "invalid id", nil)
 		return
 	}
 	if err := s.db.DeletePushSubscription(id); err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusNotFound, "", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]int64{"deleted": id})
@@ -108,7 +108,7 @@ func (s *Server) handlePushUnsubscribe(w http.ResponseWriter, r *http.Request) {
 // notification to your own devices — no RCE/credential risk).
 func (s *Server) handlePushTest(w http.ResponseWriter, r *http.Request) {
 	if s.push == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "push not available"})
+		writeErr(w, http.StatusServiceUnavailable, "push not available", nil)
 		return
 	}
 	uxlog.Log("[push] test push triggered")

--- a/internal/api/raw.go
+++ b/internal/api/raw.go
@@ -43,7 +43,7 @@ func worktreeWithinRoot(p string) bool {
 func (s *Server) handleListTasksRaw(w http.ResponseWriter, r *http.Request) {
 	tasks, err := s.db.Tasks()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	if tasks == nil {
@@ -58,7 +58,7 @@ func (s *Server) handleGetTaskRaw(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	task, err := s.db.Get(id)
 	if err != nil || task == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 	writeJSON(w, http.StatusOK, task)
@@ -79,11 +79,11 @@ func (s *Server) handleUpdateTaskRaw(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, 256*1024)
 	var task model.Task
 	if err := json.NewDecoder(r.Body).Decode(&task); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	if task.ID != id {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "body id does not match path id"})
+		writeErr(w, http.StatusBadRequest, "body id does not match path id", nil)
 		return
 	}
 	// Pin worktree-related fields to the DB's existing values. A master
@@ -91,7 +91,7 @@ func (s *Server) handleUpdateTaskRaw(w http.ResponseWriter, r *http.Request) {
 	// `git worktree remove` at an arbitrary path.
 	existing, err := s.db.Get(id)
 	if err != nil || existing == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		writeErr(w, http.StatusNotFound, "task not found", nil)
 		return
 	}
 	task.Worktree = existing.Worktree
@@ -99,10 +99,10 @@ func (s *Server) handleUpdateTaskRaw(w http.ResponseWriter, r *http.Request) {
 	task.BaseBranch = existing.BaseBranch
 	if err := s.db.Update(&task); err != nil {
 		if errors.Is(err, db.ErrTaskNotFound) {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusNotFound, "", err)
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, &task)
@@ -117,7 +117,7 @@ func (s *Server) handleAddTaskRaw(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, 256*1024)
 	var task model.Task
 	if err := json.NewDecoder(r.Body).Decode(&task); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	// The body is untrusted (single-tier auth opens this to any token). Unlike
@@ -127,11 +127,11 @@ func (s *Server) handleAddTaskRaw(w http.ResponseWriter, r *http.Request) {
 	// new-task path, fork, schedule-fire) leave it empty or supply an in-root
 	// path.
 	if task.Worktree != "" && !worktreeWithinRoot(task.Worktree) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "worktree must be within the worktrees root"})
+		writeErr(w, http.StatusBadRequest, "worktree must be within the worktrees root", nil)
 		return
 	}
 	if err := s.db.Add(&task); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, &task)
@@ -144,10 +144,10 @@ func (s *Server) handleGetScheduleRaw(w http.ResponseWriter, r *http.Request) {
 	sched, err := s.db.GetSchedule(id)
 	if err != nil {
 		if errors.Is(err, db.ErrScheduleNotFound) {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusNotFound, "", err)
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, sched)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -233,7 +233,7 @@ func (s *Server) handleVendor(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleListProjects(w http.ResponseWriter, r *http.Request) {
 	projects, err := s.db.Projects()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load projects: " + err.Error()})
+		writeErr(w, http.StatusInternalServerError, "failed to load projects", err)
 		return
 	}
 	names := make([]string, 0, len(projects))

--- a/internal/api/schedules.go
+++ b/internal/api/schedules.go
@@ -97,7 +97,7 @@ func (s *Server) handleListSchedules(w http.ResponseWriter, r *http.Request) {
 	// covers backends CRUD, self-update, and token mint/revoke).
 	schedules, err := s.db.Schedules()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load schedules: " + err.Error()})
+		writeErr(w, http.StatusInternalServerError, "failed to load schedules", err)
 		return
 	}
 	out := make([]scheduleJSON, 0, len(schedules))
@@ -111,24 +111,24 @@ func (s *Server) handleCreateSchedule(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxScheduleBodyBytes)
 	var req scheduleRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	sched := &model.ScheduledTask{
 		Enabled: true, // default new schedules to enabled
 	}
 	if err := applyScheduleRequest(sched, req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusBadRequest, "", err)
 		return
 	}
 	if err := sched.Validate(); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusBadRequest, "", err)
 		return
 	}
 	// Pre-populate NextRunAt so the UI shows it before the first tick lands.
 	sched.NextRunAt = sched.NextFire(time.Now())
 	if err := s.db.AddSchedule(sched); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	uxlog.Log("[schedules] created %s (%s) schedule=%q run_once_at=%s project=%q enabled=%v", sched.ID, sched.Name, sched.Schedule, formatRunOnce(sched.RunOnceAt), sched.Project, sched.Enabled)
@@ -147,30 +147,30 @@ func formatRunOnce(t time.Time) string {
 func (s *Server) handleUpdateSchedule(w http.ResponseWriter, r *http.Request) {
 	id := strings.TrimSpace(r.PathValue("id"))
 	if id == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "id required"})
+		writeErr(w, http.StatusBadRequest, "id required", nil)
 		return
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, maxScheduleBodyBytes)
 	var req scheduleRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	sched, err := s.db.GetSchedule(id)
 	if err != nil {
 		if errors.Is(err, db.ErrScheduleNotFound) {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": "schedule not found"})
+			writeErr(w, http.StatusNotFound, "schedule not found", nil)
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	if err := applyScheduleRequest(sched, req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusBadRequest, "", err)
 		return
 	}
 	if err := sched.Validate(); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusBadRequest, "", err)
 		return
 	}
 	if req.Schedule != nil || req.RunOnceAt != nil {
@@ -193,7 +193,7 @@ func (s *Server) handleUpdateSchedule(w http.ResponseWriter, r *http.Request) {
 	// parse error is stale by definition once Validate passes here.
 	sched.LastError = ""
 	if err := s.db.UpdateSchedule(sched); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	uxlog.Log("[schedules] updated %s (%s) schedule=%q enabled=%v", sched.ID, sched.Name, sched.Schedule, sched.Enabled)
@@ -203,15 +203,15 @@ func (s *Server) handleUpdateSchedule(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDeleteSchedule(w http.ResponseWriter, r *http.Request) {
 	id := strings.TrimSpace(r.PathValue("id"))
 	if id == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "id required"})
+		writeErr(w, http.StatusBadRequest, "id required", nil)
 		return
 	}
 	if err := s.db.DeleteSchedule(id); err != nil {
 		if errors.Is(err, db.ErrScheduleNotFound) {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": "schedule not found"})
+			writeErr(w, http.StatusNotFound, "schedule not found", nil)
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	uxlog.Log("[schedules] deleted %s", id)
@@ -220,21 +220,21 @@ func (s *Server) handleDeleteSchedule(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleRunSchedule(w http.ResponseWriter, r *http.Request) {
 	if s.scheduler == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "scheduler not running"})
+		writeErr(w, http.StatusServiceUnavailable, "scheduler not running", nil)
 		return
 	}
 	id := strings.TrimSpace(r.PathValue("id"))
 	if id == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "id required"})
+		writeErr(w, http.StatusBadRequest, "id required", nil)
 		return
 	}
 	task, err := s.scheduler.RunNow(id)
 	if err != nil {
 		if errors.Is(err, db.ErrScheduleNotFound) {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": "schedule not found"})
+			writeErr(w, http.StatusNotFound, "schedule not found", nil)
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	uxlog.Log("[schedules] run-now %s -> task %s", id, task.ID)

--- a/internal/api/selfupdate.go
+++ b/internal/api/selfupdate.go
@@ -43,12 +43,12 @@ func (s *Server) handleSetSourcePath(w http.ResponseWriter, r *http.Request) {
 	var req sourcePathReq
 	r.Body = http.MaxBytesReader(w, r.Body, 4*1024)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	path := strings.TrimSpace(req.Path)
 	if err := s.db.SetConfigValue("argus.source_path", path); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"path": path})

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -124,7 +124,7 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 	var req updateSettingsReq
 	r.Body = http.MaxBytesReader(w, r.Body, 64*1024)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	if req.Sandbox != nil && authOrigin(r) != "master" {
@@ -134,7 +134,7 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 	updates := buildSettingsUpdates(req)
 	for k, v := range updates {
 		if err := s.db.SetConfigValue(k, v); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusInternalServerError, "", err)
 			return
 		}
 		uxlog.Log("[api] settings %s = %q", k, v)
@@ -227,7 +227,7 @@ func (s *Server) handleGetLog(w http.ResponseWriter, r *http.Request) {
 	// rooted at db.DataDir(). gosec's taint analysis can't see that.
 	path, err := logPath(r.PathValue("name"))
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusBadRequest, "", err)
 		return
 	}
 	// Default tail = 64KB, max 1MB.
@@ -244,7 +244,7 @@ func (s *Server) handleGetLog(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")

--- a/internal/api/task_meta.go
+++ b/internal/api/task_meta.go
@@ -60,17 +60,17 @@ func (s *Server) handleGetMeta(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if _, err := s.db.Get(id); err != nil {
 		if errors.Is(err, db.ErrTaskNotFound) {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusNotFound, "", err)
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 
 	namespace := r.URL.Query().Get("namespace")
 	rows, err := s.db.ListMeta(id, namespace)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	entries := make([]metaEntryJSON, 0, len(rows))
@@ -115,17 +115,17 @@ func (s *Server) handlePutMeta(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if _, err := s.db.Get(id); err != nil {
 		if errors.Is(err, db.ErrTaskNotFound) {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusNotFound, "", err)
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, taskMetaMaxBodyBytes)
 	var req metaPutReq
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 
@@ -141,7 +141,7 @@ func (s *Server) handlePutMeta(w http.ResponseWriter, r *http.Request) {
 		req.Namespace = scope
 	}
 	if req.Namespace == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "namespace is required"})
+		writeErr(w, http.StatusBadRequest, "namespace is required", nil)
 		return
 	}
 
@@ -151,14 +151,14 @@ func (s *Server) handlePutMeta(w http.ResponseWriter, r *http.Request) {
 	batchSet := len(req.Entries) > 0
 	switch {
 	case !singleSet && !batchSet:
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "either {key,value} or {entries} is required"})
+		writeErr(w, http.StatusBadRequest, "either {key,value} or {entries} is required", nil)
 		return
 	case singleSet && batchSet:
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "set either {key,value} or {entries}, not both"})
+		writeErr(w, http.StatusBadRequest, "set either {key,value} or {entries}, not both", nil)
 		return
 	case singleSet:
 		if req.Key == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "key is required"})
+			writeErr(w, http.StatusBadRequest, "key is required", nil)
 			return
 		}
 		// SetMeta's only validation (ErrMetaInvalidKey on empty task_id /
@@ -166,17 +166,17 @@ func (s *Server) handlePutMeta(w http.ResponseWriter, r *http.Request) {
 		// above already enforce all three are non-empty. So any error
 		// returned is a SQL-tier failure and maps to 500.
 		if err := s.db.SetMeta(id, req.Namespace, req.Key, req.Value); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusInternalServerError, "", err)
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"written": 1})
 	case batchSet:
 		if err := s.db.SetMetaBatch(id, req.Namespace, req.Entries); err != nil {
 			if errors.Is(err, db.ErrMetaInvalidKey) {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				writeErr(w, http.StatusBadRequest, "", err)
 				return
 			}
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeErr(w, http.StatusInternalServerError, "", err)
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"written": len(req.Entries)})

--- a/internal/api/tokens.go
+++ b/internal/api/tokens.go
@@ -28,7 +28,7 @@ func (s *Server) handleListTokens(w http.ResponseWriter, r *http.Request) {
 	}
 	tokens, err := s.db.APITokens()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	out := make([]tokenView, 0, len(tokens))
@@ -63,7 +63,7 @@ func (s *Server) handleCreateToken(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, 4*1024)
 	// Empty body is allowed (label defaults to "device"); reject other decode errors.
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeErr(w, http.StatusBadRequest, "invalid JSON", err)
 		return
 	}
 	if req.Label == "" {
@@ -71,7 +71,7 @@ func (s *Server) handleCreateToken(w http.ResponseWriter, r *http.Request) {
 	}
 	plain, id, err := MintToken(s.db, req.Label)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusInternalServerError, "", err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]any{
@@ -87,7 +87,7 @@ func (s *Server) handleRevokeToken(w http.ResponseWriter, r *http.Request) {
 	}
 	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+		writeErr(w, http.StatusBadRequest, "invalid id", nil)
 		return
 	}
 	// Snapshot the scope before revoke so the plugin-MCP cascade can target
@@ -98,7 +98,7 @@ func (s *Server) handleRevokeToken(w http.ResponseWriter, r *http.Request) {
 	// DefaultIdleWindow.
 	tok, _ := s.db.FindAPITokenByID(id)
 	if err := s.db.RevokeAPIToken(id); err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		writeErr(w, http.StatusNotFound, "", err)
 		return
 	}
 	if tok != nil && tok.Scope != "" && s.mcpRegistry != nil {

--- a/internal/api/uploads.go
+++ b/internal/api/uploads.go
@@ -234,7 +234,7 @@ func (s *Server) handleUploadFiles(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	task, err := s.db.Get(id)
 	if err != nil || task == nil || task.Worktree == "" {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task or worktree not found"})
+		writeErr(w, http.StatusNotFound, "task or worktree not found", nil)
 		return
 	}
 
@@ -242,11 +242,11 @@ func (s *Server) handleUploadFiles(w http.ResponseWriter, r *http.Request) {
 	atts, err := parseUploadOnlyForm(r)
 	if err != nil {
 		uxlog.Log("[uploads] parse failed task=%s err=%v", id, err)
-		writeJSON(w, statusForUploadErr(err), map[string]string{"error": err.Error()})
+		writeErr(w, statusForUploadErr(err), "", err)
 		return
 	}
 	if len(atts) == 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "no files provided"})
+		writeErr(w, http.StatusBadRequest, "no files provided", nil)
 		return
 	}
 
@@ -256,7 +256,7 @@ func (s *Server) handleUploadFiles(w http.ResponseWriter, r *http.Request) {
 	if err := os.MkdirAll(dir, 0o750); err != nil { //nolint:gosec // path constant + worktree
 		uxlog.Log("[uploads] mkdir failed task=%s dir=%s err=%v", id, dir, err)
 		// Don't echo the absolute path back to the client — uxlog has it.
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "could not create attachments directory"})
+		writeErr(w, http.StatusInternalServerError, "could not create attachments directory", nil)
 		return
 	}
 
@@ -265,14 +265,14 @@ func (s *Server) handleUploadFiles(w http.ResponseWriter, r *http.Request) {
 		final, ferr := uniquePath(dir, a.Name)
 		if ferr != nil {
 			uxlog.Log("[uploads] uniquePath failed task=%s name=%q err=%v", id, a.Name, ferr)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "could not allocate filename"})
+			writeErr(w, http.StatusInternalServerError, "could not allocate filename", nil)
 			return
 		}
 		// Names are sanitized by parseUploadOnlyForm (filepath.Base + ASCII filter)
 		// and written under the worktree-relative `dir`; `final` cannot escape.
 		if werr := os.WriteFile(final, a.Data, 0o600); werr != nil { //nolint:gosec // path validated above
 			uxlog.Log("[uploads] write failed task=%s path=%s err=%v", id, final, werr)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "could not save attachment"})
+			writeErr(w, http.StatusInternalServerError, "could not save attachment", nil)
 			return
 		}
 		saved = append(saved, "./"+agent.AttachmentsDir+"/"+filepath.Base(final))


### PR DESCRIPTION
## What

Consolidate the repeated API error-response boilerplate in `internal/api` behind a single `writeErr` helper.

The package emitted the JSON error shape `{"error": "..."}` via the inline pattern `writeJSON(w, status, map[string]string{"error": <msg>})` at ~234 call sites across 19 files, with three recurring forms and inconsistent phrasing:

```go
writeJSON(w, s, map[string]string{"error": err.Error()})                 // bare
writeJSON(w, s, map[string]string{"error": "invalid JSON: " + err.Error()}) // prefixed
writeJSON(w, s, map[string]string{"error": "task not found"})            // static
```

## Change

A single helper added next to the existing `writeJSON` (handlers.go), following the same conventions as `writeJSON` / `writeOrchError`:

```go
func writeErr(w http.ResponseWriter, status int, msg string, err error)
```

It composes the message so the emitted JSON stays **byte-identical** to every site it replaces:

| msg | err | emitted `"error"` |
|-----|-----|-------------------|
| `""` | non-nil | `err.Error()` |
| set | non-nil | `msg + ": " + err.Error()` |
| set | `nil` | `msg` |

### Before / after

```go
// before
writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load tasks: " + err.Error()})
// after
writeErr(w, http.StatusInternalServerError, "failed to load tasks", err)

// before
writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
// after
writeErr(w, http.StatusNotFound, "task not found", nil)
```

All ~234 inline error sites across handlers.go, linking.go (incl. `writeOrchError`), push.go, settings.go, messages.go, schedules.go, raw.go, mcp_tools.go, plugin_settings.go, plugin_views.go, notify.go, tokens.go, task_meta.go, artifacts.go, clipboard.go, uploads.go, selfupdate.go, events_stream.go, and routes.go now call `writeErr`.

## Behavior / output unchanged

No status codes or resulting error strings change. The on-the-wire JSON for every converted site is identical to before. The only non-error `writeJSON` calls (`map[string]any{...}` success responses) are untouched.

## Tests

Adds `TestWriteErr` — table-driven (`t.Run` subtests, `internal/testutil` assertions, `httptest.NewRecorder`) — covering the bare, prefixed, static, and degenerate forms. The full `internal/api` suite passes unchanged.

## Verification

`make pre-pr` clean except `make vuln`, which reports **9 Go standard-library findings only** (`crypto/tls`, `crypto/x509`, `html/template`, `net/http` @ go1.26.1) — fixable only by a toolchain bump, identical on a clean `master` tree (verified via `git stash`), and non-blocking in CI (`continue-on-error: true`). All other gates pass: build, vet, fmt-check, lint-pr, and test-cover-gate (89.4% ≥ 88 floor).

Scope was kept strictly within `internal/api`; no UX-rendering/Sync code, `cmd/argus` fd-2 guards, or `internal/daemon` paths were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
