### PR TITLE
fix(modal): word-wrap ConfirmModal message

### DIFF
--- a/context/knowledge/testing.md
+++ b/context/knowledge/testing.md
@@ -157,6 +157,8 @@ The reference helpers live in `internal/tui/smoke_test.go`:
 
 For mouse-focus regressions: inject a click on a non-interactive panel and assert `app.GetFocus()` stayed on the interactive widget. See `TestSmoke_Click*` for the pattern.
 
+**When asserting on rendered cells, call `sim.Show()` before `sim.GetContents()`.** A widget's `Draw` writes the back buffer; `GetContents()` returns the *front* buffer, which is only synced on `Show()`. Drawing then reading back without `Show()` yields an all-blank grid (silent false negative — the test "passes" the panic check but sees no content). See `TestConfirmModal_LongMessageWraps` in `internal/tui/modal/confirm_test.go`.
+
 ## Mocking the Daemon
 
 The TUI's `Client` and `RemoteSession` (`internal/daemon/client/`) talk to the daemon via a Unix socket. Tests start a tiny in-process daemon-like listener that:

--- a/internal/tui/modal/confirm.go
+++ b/internal/tui/modal/confirm.go
@@ -63,8 +63,11 @@ func (m *ConfirmModal) Draw(screen tcell.Screen) {
 	// Word-wrap the message so it never overflows the border (the title and
 	// footer stay single-line; only the body grows).
 	lines := wrapErrorBody(m.message, formW-4)
-	// Cap body lines so a pathological message can't exceed the screen.
-	maxBody := max(height-6, 1)
+	// The modal has 6 rows of fixed chrome (top border, title, blank, blank,
+	// footer, bottom border); the body fills whatever height is left. Floor at
+	// 0 — not 1 — so a terminal too short to hold even one body row drops the
+	// message rather than overlapping the footer onto it.
+	maxBody := max(height-6, 0)
 	if len(lines) > maxBody {
 		lines = lines[:maxBody]
 	}

--- a/internal/tui/modal/confirm.go
+++ b/internal/tui/modal/confirm.go
@@ -56,22 +56,33 @@ func (m *ConfirmModal) Draw(screen tcell.Screen) {
 	}
 
 	formW := min(64, width-4)
-	formH := 8
-	formX := x + (width-formW)/2
-	formY := y + (height-formH)/2
-	if formY < y {
-		formY = y
+	if formW < 12 {
+		formW = width
 	}
+
+	// Word-wrap the message so it never overflows the border (the title and
+	// footer stay single-line; only the body grows).
+	lines := wrapErrorBody(m.message, formW-4)
+	// Cap body lines so a pathological message can't exceed the screen.
+	maxBody := max(height-6, 1)
+	if len(lines) > maxBody {
+		lines = lines[:maxBody]
+	}
+	formH := min(6+len(lines), height)
+	formX := x + (width-formW)/2
+	formY := max(y+(height-formH)/2, y)
 
 	// Clear the modal area so no stale cells survive (no Sync — full-rect cover).
 	for row := formY; row < formY+formH && row < y+height; row++ {
-		for col := formX; col < formX+formW; col++ {
+		for col := formX; col < formX+formW && col < x+width; col++ {
 			screen.SetContent(col, row, ' ', nil, tcell.StyleDefault)
 		}
 	}
 
 	widget.DrawBorder(screen, formX, formY, formW, formH, theme.StyleFocusedBorder)
 	widget.DrawText(screen, formX+2, formY+1, formW-4, m.title, theme.StyleTitle)
-	widget.DrawText(screen, formX+2, formY+3, formW-4, m.message, theme.StyleNormal)
+	for i, line := range lines {
+		widget.DrawText(screen, formX+2, formY+3+i, formW-4, line, theme.StyleNormal)
+	}
 	widget.DrawText(screen, formX+2, formY+formH-2, formW-4, "Enter / y = confirm    Esc / n = cancel", theme.StyleDimmed)
 }

--- a/internal/tui/modal/confirm_test.go
+++ b/internal/tui/modal/confirm_test.go
@@ -1,6 +1,7 @@
 package modal
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/drn/argus/internal/testutil"
@@ -42,4 +43,46 @@ func TestConfirmModal_DrawNoPanic(t *testing.T) {
 	m := NewConfirmModal("Delete role wkr?", "Removes the role and ends its binding.")
 	m.SetRect(0, 0, 80, 24)
 	m.Draw(sim) // must not panic and must cover its rect
+}
+
+// screenText reads back the simulation screen as one string per row.
+func screenText(sim tcell.SimulationScreen, w, h int) []string {
+	cells, _, _ := sim.GetContents()
+	rows := make([]string, h)
+	for y := range h {
+		runes := make([]rune, 0, w)
+		for x := range w {
+			runes = append(runes, cells[y*w+x].Runes...)
+		}
+		rows[y] = string(runes)
+	}
+	return rows
+}
+
+func TestConfirmModal_LongMessageWraps(t *testing.T) {
+	sim := tcell.NewSimulationScreen("UTF-8")
+	testutil.NoError(t, sim.Init())
+	defer sim.Fini()
+	const w, h = 80, 24
+	sim.SetSize(w, h)
+
+	// A long message that exceeds the modal's inner width must wrap onto
+	// multiple rows rather than truncate at the right border.
+	msg := "Removes the orchestrator and all its roles. The underlying argus tasks are left intact and can be reused."
+	m := NewConfirmModal("Delete orchestrator argus-refactor?", msg)
+	m.SetRect(0, 0, w, h)
+	m.Draw(sim)
+	sim.Show() // flush back buffer so GetContents reflects the draw
+
+	rows := screenText(sim, w, h)
+	// The tail of the message must appear somewhere on screen — proof it
+	// wasn't clipped at the first visual line.
+	var found bool
+	for _, r := range rows {
+		if strings.Contains(r, "reused") {
+			found = true
+			break
+		}
+	}
+	testutil.Equal(t, found, true)
 }

--- a/internal/tui/modal/confirm_test.go
+++ b/internal/tui/modal/confirm_test.go
@@ -1,6 +1,7 @@
 package modal
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -93,7 +94,7 @@ func TestConfirmModal_LongMessageWraps(t *testing.T) {
 func TestConfirmModal_TinyTerminal(t *testing.T) {
 	msg := "Removes the orchestrator and all its roles and cannot be undone."
 	for _, h := range []int{1, 2, 3, 4, 5, 6, 7} {
-		t.Run("height-"+string(rune('0'+h)), func(t *testing.T) {
+		t.Run(fmt.Sprintf("height-%d", h), func(t *testing.T) {
 			sim := tcell.NewSimulationScreen("UTF-8")
 			testutil.NoError(t, sim.Init())
 			defer sim.Fini()

--- a/internal/tui/modal/confirm_test.go
+++ b/internal/tui/modal/confirm_test.go
@@ -86,3 +86,22 @@ func TestConfirmModal_LongMessageWraps(t *testing.T) {
 	}
 	testutil.Equal(t, found, true)
 }
+
+// TestConfirmModal_TinyTerminal pins the height-clamp bounds: a terminal too
+// short for the 6-row chrome must drop body lines (maxBody floors at 0) rather
+// than panic on a negative slice index or overlap the footer onto the body.
+func TestConfirmModal_TinyTerminal(t *testing.T) {
+	msg := "Removes the orchestrator and all its roles and cannot be undone."
+	for _, h := range []int{1, 2, 3, 4, 5, 6, 7} {
+		t.Run("height-"+string(rune('0'+h)), func(t *testing.T) {
+			sim := tcell.NewSimulationScreen("UTF-8")
+			testutil.NoError(t, sim.Init())
+			defer sim.Fini()
+			const w = 40
+			sim.SetSize(w, h)
+			m := NewConfirmModal("Delete orchestrator?", msg)
+			m.SetRect(0, 0, w, h)
+			m.Draw(sim) // must not panic at any small height
+		})
+	}
+}


### PR DESCRIPTION
The delete-orchestrator confirmation modal rendered its message on a
single clipped line, truncating long text at the right border. Reuse the
package's wrapErrorBody helper to word-wrap the body across multiple
lines and size the modal height dynamically, mirroring ErrorModal and
ReconnectModal. Fixes all ConfirmModal callers (Hera archive-of-live and
delete confirmations).

Also hardens the height clamp so terminals too short for the 6-row chrome
drop body lines rather than overlap the footer or panic on a negative
slice index, with a tiny-terminal regression test across heights 1-7.

Documents the SimulationScreen Show()-before-GetContents() test gotcha.

Co-Authored-By: Claude <noreply@anthropic.com>