### PR TITLE
docs(claude): route spec-worthy changes through the OpenSpec workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Argus is a terminal-native LLM code orchestrator built with Go + tcell/tview. It manages multiple Claude Code / Codex sessions with task tracking, git worktree isolation, and keyboard-driven workflow.
 
+## Spec-Driven Development (OpenSpec)
+
+**Route every spec-worthy change through the OpenSpec workflow in `openspec/`.** Any behavioral change — new features, changed behavior, new endpoints/keybindings/MCP tools, altered invariants — gets a change folder *before* you write code:
+
+1. Create `openspec/changes/<name>/` with a `proposal.md`, delta specs under `specs/<capability>/spec.md`, and a `tasks.md`.
+2. Get the change approved before implementing.
+3. Implement against the tasks, keeping deltas in sync as requirements shift.
+4. `openspec archive <name>` once shipped — this merges the deltas into the base specs under `openspec/specs/<capability>/`.
+
+Skip the change folder only for genuinely non-behavioral work: docs, comments, formatting, test-only edits, and mechanical refactors that don't alter behavior. When unsure, write the change.
+
+**These specs are LOCAL DOCS only** (see `openspec/project.md`) — nothing in CI, the Makefile, or the Go build reads them, and that stays true. Never wire `openspec validate` (or any spec tooling) into Go CI or a `make` target. The quality gate is and stays `make pre-pr`.
+
 ## Build & Run
 
 ```bash


### PR DESCRIPTION
## What

Adds a new `## Spec-Driven Development (OpenSpec)` section to `CLAUDE.md`, right after "What This Is".

The repo carries an `openspec/` directory (proposal + delta specs + tasks workflow) alongside drn's `context/` knowledge system, but `CLAUDE.md` had **no rule** pointing Claude at the openspec change workflow. As a result, behavioral changes have been landing without openspec artifacts. This corrects that.

## The rule

- Route every behavioral / spec-worthy change through `openspec/changes/<name>/` (`proposal.md` + delta specs under `specs/<capability>/spec.md` + `tasks.md`) **before** writing code.
- Get the change approved, implement against the tasks, then `openspec archive <name>`.
- Skip the change folder only for genuinely non-behavioral work (docs, comments, formatting, test-only edits, mechanical refactors).

## Respects the local-docs invariant

`openspec/project.md` is explicit that OpenSpec specs in this repo are **LOCAL DOCS only** — nothing in CI, the Makefile, or the Go build reads them. The new section preserves that: it forbids wiring `openspec validate` (or any spec tooling) into Go CI or a `make` target. The quality gate is and stays `make pre-pr`.

## Why no openspec change folder for this PR

This is a governance / documentation bootstrap edit to `CLAUDE.md` itself — not a behavioral code change — so per the rule it lands as a direct edit + PR rather than going through a full change folder. No Go code, CI, or build target is touched (+13 lines, docs only); `make pre-pr` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>