### PR TITLE
docs(openspec): capture native hera behavior in capability specs

### DIFF
--- a/openspec/specs/hera-coordination/spec.md
+++ b/openspec/specs/hera-coordination/spec.md
@@ -1,0 +1,203 @@
+# Hera Coordination
+
+## Purpose
+
+Hera Coordination is the native substrate beneath the Hera View: the role/orchestrator/binding storage model, the nine `hera_*` MCP tools an agent uses to bootstrap and participate in a coordination session, the born-bound worker spawn primitive, the subtree TLDR roll-up, and the daemon-startup binding reconciliation. It runs in-process in the daemon and reuses primitives Argus already owns (the runner, the worktree engine, the SQLite store).
+
+This is a faithful capture of current native behavior, mirroring the plugin's `hera-coordination` capability split. Each requirement cites the `file:line` it was derived from. Where native is materially different from the plugin, a `NOTE:` flags it.
+
+## Requirements
+
+### Requirement: Orchestrator, role, and binding storage model
+
+The system SHALL store orchestrators (`hera_orchestrators`), roles of kind `coordinator`/`worker`/`freelance` (`hera_roles`), and role↔task bindings (`hera_bindings`). It SHALL enforce, via partial unique indexes over `WHERE ended_at IS NULL`: at most one live binding per role, one live binding per (argus task, orchestrator), and one live binding per (worktree path, orchestrator). A single argus task MAY therefore hold live bindings under several distinct orchestrators at once, but never two under the same one.
+
+Derived from: `internal/db/schema.go:447` (live-role unique index), `internal/db/schema.go:448` (live task+orchestrator unique index), `internal/db/schema.go:449` (live worktree+orchestrator unique index), `internal/db/hera.go:71` (role-kind constants).
+
+#### Scenario: Second live binding under the same orchestrator is rejected
+
+- **WHEN** a task already holds a live binding under an orchestrator and a second live binding under the same orchestrator is attempted
+- **THEN** the unique index rejects it
+
+#### Scenario: Task may bind under multiple orchestrators
+
+- **WHEN** a task holds a live binding under orchestrator A
+- **THEN** it may also hold a live binding under orchestrator B (the constraint is per-orchestrator, not global)
+
+### Requirement: Native hera_* MCP tool surface
+
+The system SHALL register exactly nine native `hera_*` MCP tools with the same names, parameters, descriptions, and required lists as the external Hera daemon: `hera_new_orchestrator`, `hera_join`, `hera_send`, `hera_inbox`, `hera_mark_read`, `hera_status`, `hera_spawn_worker`, `hera_tree_updates`, and `hera_get_messages`. The tools SHALL be available only when the hera service is wired AND task management is enabled (caller resolution via `cwd` requires task management). A dup-tool guard SHALL suppress any plugin tool scoped `hera` while native Hera is enabled, so in-tree and plugin tools never both appear.
+
+Derived from: `internal/mcp/hera.go:54` (`heraToolDefs`, the nine tools), `internal/mcp/hera.go:202` (`SetHeraService`), `internal/mcp/hera.go:210` (`heraEnabled`).
+
+#### Scenario: Tools require task management
+
+- **WHEN** task management is disabled
+- **THEN** the `hera_*` tools report "hera not configured" rather than acting
+
+#### Scenario: Native and plugin hera tools are mutually exclusive
+
+- **WHEN** native Hera is enabled
+- **THEN** any plugin tool scoped `hera` is suppressed so only the in-tree tools appear
+
+### Requirement: Caller role resolution from cwd with orchestrator disambiguation
+
+The system SHALL resolve the calling agent's hera role by mapping `cwd` to an argus task, then to that task's live binding+role. When the task holds exactly one live binding the `orchestrator` argument is optional; when it holds two or more, the tool SHALL return a disambiguation error listing the caller's orchestrator names, and the caller MUST re-call with `orchestrator=<name>`. An unbound task SHALL get an error instructing it to call `hera_join` or `hera_new_orchestrator`.
+
+Derived from: `internal/mcp/hera.go:218` (`resolveCallerRole`), `internal/mcp/hera.go:270` (`buildHeraAmbiguousError`).
+
+#### Scenario: Single binding resolves without orchestrator
+
+- **WHEN** the caller's task holds exactly one live binding and no `orchestrator` is passed
+- **THEN** the role resolves successfully
+
+#### Scenario: Ambiguous binding lists options
+
+- **WHEN** the caller's task holds two or more live bindings and no `orchestrator` is passed
+- **THEN** the tool errors with the list of bound orchestrator names to disambiguate
+
+#### Scenario: Unbound task is guided
+
+- **WHEN** the caller's task holds no live binding
+- **THEN** the tool errors instructing it to call hera_join or hera_new_orchestrator
+
+### Requirement: hera_new_orchestrator bootstraps and claims the coordinator role
+
+The system SHALL, on `hera_new_orchestrator`, create (or idempotently fetch) the named orchestrator, then transactionally create a coordinator role bound to the calling task's worktree, persisting the caller's argus project on the role. It SHALL reject the call when the calling task already holds a live binding under that orchestrator (directing the caller to `hera_join`). It SHALL mirror the role to the `task_meta` "hera" namespace best-effort (a mirror failure never undoes local state). Required args: `cwd`, `name`, `coordinator_role_name`.
+
+Derived from: `internal/mcp/hera.go:287` (`toolHeraNewOrchestrator`), `internal/mcp/hera.go:328` (`CreateHeraRoleWithBinding`), `internal/mcp/hera.go:343` (meta mirror).
+
+#### Scenario: First call creates orchestrator + coordinator binding
+
+- **WHEN** a task with no binding under orchestrator X calls hera_new_orchestrator(name=X)
+- **THEN** orchestrator X exists, a coordinator role bound to the caller is created, and the binding id is returned
+
+#### Scenario: Re-bootstrap under an already-bound orchestrator is rejected
+
+- **WHEN** the caller already holds a live binding under the target orchestrator
+- **THEN** the tool errors and directs the caller to hera_join
+
+### Requirement: hera_join claims an existing role or attaches a new one
+
+The system SHALL support two `hera_join` modes. With `role_name` omitted (claim mode) it SHALL return the caller's existing binding for the resolved orchestrator plus its unread message count, without cancelling any pending doorbell deliveries. With `role_name` + `kind` supplied (attach mode) it SHALL create a new role+binding of kind `worker` or `freelance` (rejecting `coordinator` — that path is `hera_new_orchestrator`), persisting the attaching task's project, optionally setting an initial status, and rejecting a second binding under an orchestrator the task is already bound to. Attach mode requires `orchestrator`.
+
+Derived from: `internal/mcp/hera.go:358` (`toolHeraJoin`), `internal/mcp/hera.go:376` (claim mode), `internal/mcp/hera.go:397` (attach mode + coordinator rejection), `internal/mcp/hera.go:421` (already-bound rejection).
+
+#### Scenario: Claim mode returns the existing binding
+
+- **WHEN** a bound task calls hera_join with no role_name
+- **THEN** the response reports its orchestrator, role name, kind, binding id, and unread count, and does NOT cancel pending deliveries
+
+#### Scenario: Attach mode rejects coordinator kind
+
+- **WHEN** hera_join is called in attach mode with kind=coordinator
+- **THEN** the tool errors and directs the caller to hera_new_orchestrator
+
+#### Scenario: Attach mode creates a worker/freelance role
+
+- **WHEN** an unbound task calls hera_join with orchestrator, role_name, and kind=worker
+- **THEN** a new worker role+binding is created and the binding id is returned
+
+### Requirement: hera_spawn_worker creates a born-bound worker transactionally
+
+The system SHALL, on `hera_spawn_worker`, require the caller to hold a live COORDINATOR binding and create a new argus task (worktree + session) plus, transactionally, a worker role+binding pre-bound to it. The role+binding write is an `AfterPersist` hook inside `agent.CreateAndStart`, joining its LIFO compensating-cleanup stack so any failure unwinds every prior step. The worker's project defaults to the COORDINATOR'S OWN TASK project (authoritative, not `role.ArgusProject`). The role name defaults to a slug of the prompt and is uniquified within the orchestrator. An orientation prefix naming the coordinator + orchestrator is prepended to the delivered prompt; the verbatim prompt is also stored on the role. An optional per-worker `model` is passed through. Required args: `cwd`, `prompt`.
+
+Derived from: `internal/mcp/hera.go:708` (`toolHeraSpawnWorker`), `internal/mcp/hera.go:739` (coordinator-only guard), `internal/mcp/hera.go:746` (project resolution), `internal/mcp/hera.go:767` (orientation prefix), `context/knowledge/gotchas/hera-view.md` (shared `agent.SpawnHeraWorker` primitive).
+
+#### Scenario: Non-coordinator caller is rejected
+
+- **WHEN** a worker or freelance role calls hera_spawn_worker
+- **THEN** the tool errors that only coordinators may spawn workers
+
+#### Scenario: Worker inherits the coordinator's project
+
+- **WHEN** hera_spawn_worker omits `project`
+- **THEN** the worker task is created in the coordinator task's own project
+
+#### Scenario: Spawn failure unwinds cleanly
+
+- **WHEN** the role+binding insert or the later session start fails
+- **THEN** the LIFO compensating stack unwinds the task, worktree, and any prior steps, leaving no orphan worktree, branch, or ghost row
+
+### Requirement: hera_status updates role status and rolls a finished worker
+
+The system SHALL, on `hera_status`, validate the status as one of idle/working/blocked/done, upsert it on the caller's role, and mirror it to the `task_meta` "hera" namespace best-effort. When a WORKER role reports `done` the system SHALL roll its bound task to in_review and stamp `ready_to_close` via `RollHeraWorkerToReview` — the primary BUG-050 trigger for the idle-but-done case the exit hook misses. That roll is worker-kind only, no-ops unless the task is currently in_progress (so it never clobbers a human-set in_review/complete and never auto-completes), leaves the live session running, is idempotent, and is soft-fail (a failure never blocks the status update).
+
+Derived from: `internal/mcp/hera.go:643` (`toolHeraStatus`), `internal/mcp/hera.go:691` (BUG-050 worker roll), `internal/tui/hera/ops.go:193` (the same roll mirrored on the rail `s` key).
+
+#### Scenario: Invalid status is rejected
+
+- **WHEN** hera_status is called with a status other than idle/working/blocked/done
+- **THEN** the tool errors naming the valid values
+
+#### Scenario: Worker done rolls to in_review
+
+- **WHEN** a worker role reports status=done and its task is in_progress
+- **THEN** the task is rolled to in_review and stamped ready_to_close, while the session keeps running
+
+#### Scenario: Done roll never clobbers a non-progress task
+
+- **WHEN** a worker reports done but its task is already in_review or complete
+- **THEN** RollHeraWorkerToReview no-ops and the status update still succeeds
+
+### Requirement: Subtree TLDR roll-up via hera_tree_updates
+
+The system SHALL, on `hera_tree_updates`, scan the caller's orchestrator subtree for messages newer than a cursor and return TLDR-only subject lines (no bodies), capped at 200, with a `next_cursor` equal to the max id returned. The subtree is every orchestrator reachable from the caller's by multi-binding BFS: a child orchestrator hangs off a frontier when its live, non-archived coordinator role's task also holds a live binding under the frontier; archived orchestrators are excluded as descendants (the root is always included). The cursor is stored per-role and auto-advances unless the caller pins an explicit `since` (which overrides and does not advance the stored cursor).
+
+Derived from: `internal/mcp/hera.go:797` (`toolHeraTreeUpdates`), `internal/db/hera_subtree.go:55` (`SubtreeOrchIDs` BFS), `internal/db/hera_subtree.go:125` (`HeraTreeUpdatesSince`), `internal/db/hera_subtree.go:33` (`HeraTreeUpdatesLimit` = 200).
+
+`NOTE:` Native's subtree bridges ONLY through bindings with `ended_at IS NULL` (`workerTaskSet` also requires `r.Live`). Per `docs/RAIL-PARITY-ANALYSIS.md` (Gap #2), the plugin bridges on a coordinator's LATEST binding regardless of liveness (excluding only `reparented`/`user_deleted` end reasons), so native's tree is structurally narrower — it drops every bridge whose binding ended for a benign reason. This is a documented native-vs-plugin difference that persists even with complete data.
+
+#### Scenario: TLDR-only roll-up with paging cursor
+
+- **WHEN** hera_tree_updates is called with no `since`
+- **THEN** it returns subject-line entries for new subtree messages (no bodies), advances the stored per-role cursor, and returns next_cursor
+
+#### Scenario: Explicit since does not advance the cursor
+
+- **WHEN** hera_tree_updates is called with an explicit `since`
+- **THEN** it returns updates after that id but leaves the stored per-role cursor unchanged
+
+#### Scenario: Archived orchestrators are pruned from the subtree
+
+- **WHEN** an orchestrator on the bridging path is archived
+- **THEN** it and its descendants drop out of the subtree scan
+
+### Requirement: Full message bodies via hera_get_messages with subtree access scope
+
+The system SHALL, on `hera_get_messages`, fetch full message bodies by id, restricting access to messages whose sender OR recipient role lives in the caller's orchestrator SUBTREE. An inaccessible or missing id SHALL get a per-id error field rather than a top-level error. Required args: `cwd`, `ids`.
+
+Derived from: `internal/mcp/hera.go:905` (`toolHeraGetMessages`), `internal/mcp/hera.go:931` (subtree resolution), `internal/mcp/hera.go:1017` (`heraRoleInSubtree` access predicate).
+
+#### Scenario: In-subtree message returns its body
+
+- **WHEN** a requested message's sender or recipient is in the caller's subtree
+- **THEN** the full body is returned
+
+#### Scenario: Out-of-subtree id is denied per-id
+
+- **WHEN** a requested id is outside the caller's subtree
+- **THEN** that id gets an "access denied" error entry while other accessible ids still return
+
+#### Scenario: Missing id is reported per-id
+
+- **WHEN** a requested id does not exist
+- **THEN** that id gets a "not found" error entry rather than failing the whole call
+
+### Requirement: Daemon-startup binding reconciliation
+
+The system SHALL, on daemon startup, walk every live binding and end those whose argus task row no longer exists, stamping `end_reason="task_missing"`. This is keyed on task-row existence (not session liveness), so a task deleted while the daemon was down has its orphaned bindings cleaned up. The sweep is idempotent and safe to run on every boot; a transient lookup error leaves the binding live for a later boot to retry.
+
+Derived from: `internal/heraadopt/heraadopt.go:34` (`ReconcileBindings`).
+
+`NOTE:` The former auto-adopt watcher (Milestone 4 rule D4 — adopting a `depends_on`-linked task under a coordinator as a worker) was RETIRED with the `depends_on` DAG. Born-bound workers create their bindings transactionally at spawn time, so there is no link to adopt across. Only this startup reconciliation survives.
+
+#### Scenario: Orphaned binding is ended on boot
+
+- **WHEN** a live binding's argus task row no longer exists at daemon startup
+- **THEN** the binding is ended with end_reason="task_missing"
+
+#### Scenario: Transient error leaves the binding live
+
+- **WHEN** the task lookup returns a transient (non-not-found) error
+- **THEN** the binding is left live for a later boot to re-sweep

--- a/openspec/specs/hera-messaging/spec.md
+++ b/openspec/specs/hera-messaging/spec.md
@@ -1,0 +1,110 @@
+# Hera Messaging
+
+## Purpose
+
+Hera Messaging is the role-addressed message bus beneath the Hera View (comparison area 9: messaging / doorbell surfacing). It persists messages between hera roles durably in SQLite and delivers them to a recipient's live agent pane via the SAME reliable, idle-gated notifier the `task_messages` path uses — no second delivery engine is introduced. This mirrors the plugin's `hera-delivery-receipt` capability.
+
+This is a faithful capture of current native behavior. Each requirement cites `file:line`; native-vs-plugin differences carry a `NOTE:`.
+
+## Requirements
+
+### Requirement: Role-addressed durable message store with caps
+
+The system SHALL persist hera messages addressed role→role, carrying a body, a one-line `tldr` subject, an optional `in_reply_to`, send timestamp, delivery stamp, and read state. It SHALL enforce three caps: body ≤ 64 KiB, recipient unread ≤ 500, and sender rolling 60-second rate ≤ 50 sends/min. It SHALL reject a self-send, a missing or too-long tldr, and a recipient role that is missing or archived. Storage is always durable regardless of delivery outcome.
+
+Derived from: `internal/db/hera_messages.go:42` (`HeraMaxUnreadPerRole`=500, `HeraMaxSendsPerMinute`=50, window=1min), `internal/db/hera_messages.go:15` (body 64 KiB cap), `internal/db/hera_messages.go:80` (`SendHeraMessage` validation), `internal/mcp/hera.go:520` (error mapping in `toolHeraSend`).
+
+#### Scenario: Body over 64 KiB is rejected
+
+- **WHEN** a send carries a body larger than 64 KiB
+- **THEN** the send fails with a body-too-large error and nothing is persisted
+
+#### Scenario: Full inbox is rejected
+
+- **WHEN** the recipient already holds 500 unread messages
+- **THEN** the send fails with an inbox-full error
+
+#### Scenario: Rate limit is enforced
+
+- **WHEN** the sender has emitted 50 messages in the last minute
+- **THEN** the next send fails with a rate-limited error
+
+#### Scenario: Self-send and bad tldr are rejected
+
+- **WHEN** a send targets the sender's own role, omits the tldr, or supplies a tldr over 120 characters
+- **THEN** the send fails with the corresponding validation error
+
+### Requirement: hera_send recipient resolution and defaults
+
+The system SHALL, on `hera_send`, require a non-empty body and tldr. It SHALL resolve the recipient from an explicit `to` role name within the sender's orchestrator, or default it: a worker/freelance sender with no `to` defaults to the orchestrator's active coordinator; a coordinator sender MUST supply an explicit `to`. An unknown `to` role SHALL fail naming the orchestrator. On success it returns the new message id, the recipient name, and the delivery mode.
+
+Derived from: `internal/mcp/hera.go:462` (`toolHeraSend`), `internal/mcp/hera.go:491` (recipient resolution + coordinator-must-supply-to).
+
+#### Scenario: Worker defaults to the coordinator
+
+- **WHEN** a worker calls hera_send with no `to`
+- **THEN** the message is addressed to the orchestrator's active coordinator
+
+#### Scenario: Coordinator must address explicitly
+
+- **WHEN** a coordinator calls hera_send with no `to`
+- **THEN** the call fails requiring an explicit recipient
+
+### Requirement: Reliable doorbell delivery via the shared notifier
+
+The system SHALL deliver a message to the recipient's live argus task by enqueueing a doorbell line through the existing `notify.Notifier` (`ReliableNotify`) — the single idle-gated, exactly-once pane-delivery implementation, the same one `task_messages` uses. The doorbell line carries the from-role name, message id, and tldr. Delivery uses a per-message delivery id prefixed `hera:` so it never collides with `task_messages` delivery ids. Delivery is best-effort and never rolls back the stored message.
+
+Derived from: `internal/hera/service.go:67` (`Send`), `internal/hera/service.go:105` (doorbell line), `internal/hera/service.go:186` (`heraDeliveryID` "hera:" prefix), `internal/hera/service.go:31` (`Notifier` = `notify.Notifier`).
+
+#### Scenario: Live recipient gets a doorbell
+
+- **WHEN** the recipient role holds a live binding
+- **THEN** ReliableNotify enqueues a `[hera from <role>] msg #<id> — <tldr>` doorbell to that task and the message is stamped idle_submit
+
+#### Scenario: Delivery failure does not roll back storage
+
+- **WHEN** the notifier fails or is nil
+- **THEN** the message remains durably stored and the send still succeeds
+
+### Requirement: Delivery-mode stamping for offline recipients
+
+The system SHALL stamp a message's delivery mode at enqueue time: `idle_submit` when delivered to a live binding, `queued_no_binding` when the recipient has no live binding (durable, delivery deferred), and pending/skipped when no notifier is wired. A missing live binding is a soft-fail — the message is stored and no error is returned.
+
+Derived from: `internal/hera/service.go:73` (nil-notifier skip), `internal/hera/service.go:79` (no-binding → `queued_no_binding`), `internal/hera/service.go:113` (`idle_submit` stamp).
+
+#### Scenario: Offline recipient queues without error
+
+- **WHEN** the recipient role has no live binding
+- **THEN** the message is stamped queued_no_binding and the send returns successfully with no delivery
+
+### Requirement: Reading or marking-read cancels pending doorbells
+
+The system SHALL, on `hera_inbox`, return unread messages oldest-first AND cancel pending doorbell deliveries for them (reading implies the recipient saw the doorbell), then mark them read. `hera_mark_read` SHALL mark the supplied ids read for the caller's role and cancel their pending deliveries, returning the count flipped. Cancellation is per-message (delivery id `hera:<id>`), not task-scoped, mirroring `task_message_ack`. The claim-mode `hera_join` path SHALL count unread WITHOUT cancelling deliveries.
+
+Derived from: `internal/hera/service.go:125` (`Inbox` cancels), `internal/hera/service.go:140` (`MarkRead`), `internal/hera/service.go:169` (`cancelDeliveries` per-message), `internal/mcp/hera.go:552` (`toolHeraInbox`), `internal/mcp/hera.go:382` (claim mode does not cancel).
+
+#### Scenario: Inbox read cancels its doorbells
+
+- **WHEN** the caller reads its inbox via hera_inbox
+- **THEN** the returned messages' pending doorbell deliveries are cancelled and the messages are marked read
+
+#### Scenario: Mark-read flips and cancels by id
+
+- **WHEN** hera_mark_read is called with specific ids
+- **THEN** only those rows addressed to the caller are flipped read and their per-message doorbells cancelled, and the flipped count is returned
+
+#### Scenario: Claim-mode join does not cancel
+
+- **WHEN** a task claims its existing role via hera_join (no role_name)
+- **THEN** the unread count is reported but no pending deliveries are cancelled
+
+### Requirement: Doorbell threat-model boundary
+
+The system MAY include user-controlled strings (from-role name and tldr) in the hera doorbell line, acceptable under the cooperative single-user local threat model. The system SHALL NOT add user-controllable strings to the stricter `task_messages` nudge line.
+
+Derived from: `internal/hera/service.go:62` (security NOTE in `Send` doc).
+
+#### Scenario: Hera doorbell carries user strings
+
+- **WHEN** a hera doorbell is composed
+- **THEN** it may embed the sender role name and tldr, unlike the task_messages nudge line which must not

--- a/openspec/specs/hera-view/spec.md
+++ b/openspec/specs/hera-view/spec.md
@@ -1,0 +1,393 @@
+# Hera View
+
+## Purpose
+
+The Hera View is the native, in-tree TUI surface for multi-agent coordination. It is the Argus TUI's always-present second tab (`internal/tui/hera`), rendering the Hera role hierarchy (orchestrators → coordinator/worker/freelance roles) read-only from the SQLite hera store and driving a small set of in-process mutations off the rail cursor. It replaced the retired standalone DAG tab.
+
+This capability captures the CURRENT native behavior of the view across the nine comparison areas Aaron uses to diff native against the original out-of-tree Hera plugin:
+
+1. Rail structure & nesting
+2. Rail sections
+3. Row rendering
+4. Keybindings
+5. Focus & layout
+6. Coordinator/agent panes & details
+7. Archive / prune / delete / teardown
+8. Freelance (adopt)
+
+(Area 9, messaging/doorbell surfacing, is captured in the `hera-messaging` capability; the coordination/tool/storage substrate is in `hera-coordination`.)
+
+This is a faithful state-capture of what the code DOES today, not a redesign. Where native is materially less capable than the plugin spec, the requirement describes native's actual (lesser) behavior and carries a `NOTE:` flagging the gap — derived from `docs/RAIL-PARITY-ANALYSIS.md` and `docs/NATIVE-HERA-FOLLOWUPS.md` and verified against the source.
+
+## Requirements
+
+### Requirement: Hera is the always-present second tab
+
+The system SHALL render the native Hera view as the second tab (`widget.TabHera`, enum slot 1), reachable by the `2` hotkey. The tab is always the native view; the legacy DAG page was deleted with `depends_on`. The `cfg.Hera.Enabled` flag SHALL NOT toggle the view — it only gates daemon-side MCP native-vs-plugin tool registration on the next daemon start.
+
+Derived from: `internal/tui/app.go:2837` (TabHera switch arm), `internal/tui/app.go:2851` (`switchToHeraTab2`), `internal/tui/widget/header.go:18` (TabHera slot), `context/knowledge/gotchas/hera-view.md`.
+
+#### Scenario: Second tab routes to the native Hera page
+
+- **WHEN** the user presses `2` or otherwise switches to the second tab
+- **THEN** the system routes to the `"hera"` page and renders the native Hera view, regardless of `cfg.Hera.Enabled`
+
+#### Scenario: Remote mode degrades the page
+
+- **WHEN** the TUI runs in `--remote` mode where no local `*db.DB` hera reader is available
+- **THEN** the page is constructed with a nil reader and renders an "Hera unavailable in remote mode" banner instead of a rail, wires no session resolver, feeds no panes, and treats every mutation key as an inert no-op
+
+### Requirement: Rail structure is a flat, single-level orchestrator list (area 1)
+
+The system SHALL build the rail as a flattened list of display rows from the read-only model. Every active orchestrator is appended at depth 0 via `appendOrch(o, 0, false)`; an expanded orchestrator's roles are appended one level deeper (`depth+1`). The rail SHALL NOT nest sub-orchestrators under their parent-link worker rows.
+
+Derived from: `internal/tui/hera/rail.go:152` (`buildRows`), `internal/tui/hera/rail.go:206` (`appendOrch`).
+
+`NOTE:` This is a degradation from the plugin, which nested sub-orchestrators under their parent in the rail itself (the plugin's `resolveSubCoordinators` rewrote the flat list into a nested tree). Native renders cross-orchestrator nesting ONLY in the Details-pane orchestration tree (see area 6), never in the rail. Per `docs/RAIL-PARITY-ANALYSIS.md` (Gap #3) and `docs/NATIVE-HERA-FOLLOWUPS.md` ("rail is flat"), this is the largest visible parity gap: an operator with many orchestrators sees N flat rows where the plugin showed a handful of trees.
+
+#### Scenario: Active orchestrators render at depth 0
+
+- **WHEN** the model holds multiple active orchestrators
+- **THEN** each orchestrator header renders at depth 0 and no orchestrator is indented beneath another
+
+#### Scenario: Expanded orchestrator shows its own roles only
+
+- **WHEN** an orchestrator is expanded
+- **THEN** its directly-bound roles render indented under it, but child orchestrators (sub-coordinators bridged by a shared task) do NOT appear nested in the rail
+
+### Requirement: Multi-binding fan-out is structural (area 1)
+
+The system SHALL surface a single argus task bound under two orchestrators once under EACH orchestrator, with no per-task dedupe. This is achieved structurally: `BuildModel` walks orchestrators → their roles → each role's live binding, so a task reached through two distinct role rows appears under both.
+
+Derived from: `internal/tui/hera/model.go:46` (Model doc), `internal/tui/hera/model.go:141` (`BuildModel`), `context/knowledge/gotchas/hera-view.md`.
+
+#### Scenario: Task bound under two orchestrators appears twice
+
+- **WHEN** one argus task holds a live binding under orchestrator A and another under orchestrator B
+- **THEN** the rail shows that task's role once under A and once under B, each as a distinct row
+
+### Requirement: Cursor navigation and collapse over selectable rows (area 1)
+
+The system SHALL move the cursor only across selectable rows (orchestrator headers, roles, freelance roles, the archive expando, and the freelance fold header), skipping rules and plain section labels. After any rebuild the cursor SHALL be re-pinned to the same logical row (by role id, or negated orchestrator id) when it still exists, and clamped onto a selectable row otherwise. Collapse state (per-orchestrator, freelance, archive) SHALL survive rebuilds.
+
+Derived from: `internal/tui/hera/rail.go:43` (`selectable`), `internal/tui/hera/rail.go:119` (`currentRef`), `internal/tui/hera/rail.go:134` (`restoreCursor`), `internal/tui/hera/rail.go:230` (`step`), `internal/tui/hera/rail.go:257` (`clampCursor`), `internal/tui/hera/rail.go:287` (`ToggleCollapse`).
+
+#### Scenario: Down/up skip non-selectable rows
+
+- **WHEN** the cursor steps past a rule or plain header
+- **THEN** it lands on the next selectable row in that direction, or stays put if none exists
+
+#### Scenario: Cursor survives a rebuild
+
+- **WHEN** the model is replaced and the rail rebuilds
+- **THEN** the cursor re-pins to the previously selected role/orchestrator if it still exists, else clamps onto a selectable row
+
+#### Scenario: Collapse toggles the row under the cursor
+
+- **WHEN** the user presses Space on an orchestrator header, the freelance fold header, or the archive expando
+- **THEN** that section's collapsed flag flips, the rows rebuild, and the cursor is restored
+
+### Requirement: Rail sections — Pinned, Active, Freelance, Archive (area 2)
+
+The system SHALL render the rail in a fixed section order: a "Pinned" section (only when pinned orchestrators exist), the active orchestrators (no header, like the task list's active section), a "Freelance (N)" fold section (only when freelance roles exist), and an "Archive (N)" expando section at the bottom (only when archived orchestrators exist). The Freelance section defaults expanded; the Archive section defaults collapsed. When the model is entirely empty the rail renders a single "No hera orchestrators" placeholder row.
+
+Derived from: `internal/tui/hera/rail.go:152` (`buildRows`), `internal/tui/hera/rail.go:88` (`NewRail` archive default), `internal/tui/hera/model.go:54` (Model sections).
+
+#### Scenario: Pinned section appears only when populated
+
+- **WHEN** at least one orchestrator is pinned
+- **THEN** a "Pinned" header renders above the active list with the pinned orchestrators under it
+
+#### Scenario: Archive section collapsed by default
+
+- **WHEN** archived orchestrators exist
+- **THEN** an "Archive (N)" expando renders at the bottom, collapsed by default, expanding only when toggled
+
+#### Scenario: Empty model shows a placeholder
+
+- **WHEN** there are no orchestrators or freelance roles at all
+- **THEN** the rail renders a single non-selectable "No hera orchestrators" row
+
+### Requirement: Orchestrator and role row rendering (area 3)
+
+The system SHALL render an orchestrator header with a fold chevron (▸ collapsed / ▾ expanded), a coordinator marker glyph, the orchestrator name, and a right-aligned live-role count `(N)` (count of roles with a live binding). It SHALL render a role row with a status glyph (see status-icon precedence) followed by the role name. Selection is indicated by a `›` marker in the gutter and the selected palette; archived placement dims the row's text style (the glyph itself never lies — only the style dims).
+
+Derived from: `internal/tui/hera/rail.go:391` (`drawRow`), `internal/tui/hera/rail.go:437` (`drawOrchRow`), `internal/tui/hera/rail.go:470` (`drawRoleRow`), `internal/tui/hera/rail.go:498` (`liveRoleCount`).
+
+#### Scenario: Orchestrator header shows live count
+
+- **WHEN** an orchestrator has three roles, two of which hold live bindings
+- **THEN** its header renders `(2)` right-aligned
+
+#### Scenario: Archived row dims without changing its glyph
+
+- **WHEN** a role is rendered in the archive section
+- **THEN** its text and status glyph render in the dimmed style while the glyph identity is unchanged
+
+### Requirement: Status-icon precedence on role rows (area 3)
+
+The system SHALL choose a role row's status glyph by this precedence: (1) `ready_to_close` wins over everything with a distinct review glyph; otherwise (2) the hera role status when present — working, blocked, done, or idle each map to a distinct glyph/style; otherwise (3) binding presence (`Live`) renders a "live" glyph; otherwise (4) an unbound/dimmed glyph. `ready_to_close` is read from the task-addressed `task_meta` "hera" namespace, not the hera tables.
+
+Derived from: `internal/tui/hera/rail.go:514` (`statusIcon`), `internal/tui/hera/model.go:214` (`buildRoleView` reads `ready_to_close`).
+
+#### Scenario: ready_to_close overrides status
+
+- **WHEN** a role's bound task carries `meta:hera.ready_to_close=true` AND the role status is working
+- **THEN** the row renders the review/ready glyph, not the working glyph
+
+#### Scenario: Hera role status drives the glyph
+
+- **WHEN** a role has a status row of `blocked` and is not ready_to_close
+- **THEN** the row renders the needs-input/blocked glyph
+
+#### Scenario: Live-but-statusless role
+
+- **WHEN** a role holds a live binding but has no status row and is not ready_to_close
+- **THEN** the row renders the in-review "live" glyph rather than the unbound glyph
+
+### Requirement: Rail keybindings (area 4)
+
+The system SHALL bind the following keys while the rail holds focus: `j`/`k` and Down/Up move the cursor; Space collapses/expands the row under the cursor; `Tab`/`Backtab` and `Ctrl+Alt+Left`/`Ctrl+Alt+Right` walk the focus ladder; `Ctrl+Q` returns focus to the rail; `Enter` enters the selected role's pane (restarting a dead session first); `w` spawns a worker under the selected coordinator's orchestrator; `r` renames the selected role/orchestrator; `a` toggles archive; `P` toggles pin; `s`/`S` advance/revert the selected role's hera status; `Ctrl+D` deletes the selected role/orchestrator. Every bound key SHALL appear in the help overlay's "Hera View (rail)" section.
+
+Derived from: `internal/tui/hera/rail.go:548` (rail `InputHandler`), `internal/tui/hera/page.go:288` (page `InputHandler` focus ladder), `internal/tui/hera/page.go:371` (`handleRailMutation`), `internal/tui/modal/help.go:70` (help overlay Hera section).
+
+`NOTE:` Native deliberately OMITS several plugin rail keys: `n` (new orchestrator — canonical path is the `hera_new_orchestrator` MCP tool), `J` (adopt/reparent freelancer), `/` (rail name filter), `Ctrl+R` (hera-prune — Tasks-tab-only in native), `l` (toggle archived visibility), and `Ctrl+Z` (fullscreen pane). Plain Left/Right are unused by the rail (free for future horizontal nav). Per `docs/NATIVE-HERA-FOLLOWUPS.md`, these are known parity gaps; `Cmd+↑/↓` rail-selection-while-pane-focused collides at the byte level with agent-view task navigation and remains an unresolved rebinding decision.
+
+#### Scenario: Mutation key acts on the current selection
+
+- **WHEN** the rail is focused and the user presses `a` on a selected role
+- **THEN** the archive-toggle callback fires for that role's `(role, orchestrator)` selection and the key does not leak to navigation
+
+#### Scenario: Omitted plugin key is inert
+
+- **WHEN** the user presses `/`, `n`, `J`, or `l` while the rail is focused
+- **THEN** nothing happens (no filter, no new-orchestrator, no adopt, no archive-visibility toggle) because native binds none of them
+
+#### Scenario: Help overlay lists every rail key
+
+- **WHEN** the help overlay is opened
+- **THEN** its "Hera View (rail)" section lists `j`/`k`, space, Tab/Ctrl+Q, Enter, `w`, `r`, `a`, `P`, `s`/`S`, and `Ctrl+D`
+
+### Requirement: Three-region focus model and ladder (area 5)
+
+The system SHALL track focus across three regions — rail, coordinator (HERA/middle) pane, and agent/details (right) region — via a focus machine that never lands focus on an absent region. `Advance`/`Retreat` step only through present regions; when a focused region disappears focus rebalances to the nearest present one (the rail is always present, so the fallback terminates). `Ctrl+Q` forces focus back to the rail. Mouse clicks focus the region under the cursor only if that region is present.
+
+Derived from: `internal/tui/hera/focus.go:34` (`FocusMachine`), `internal/tui/hera/focus.go:68` (`rebalance`), `internal/tui/hera/focus.go:89` (`Advance`/`Retreat`), `internal/tui/hera/focus.go:131` (`SetRegion`), `internal/tui/hera/page.go:447` (`MouseHandler`).
+
+#### Scenario: Advance skips an absent pane
+
+- **WHEN** the agent region is absent (narrow terminal) and focus advances from the coordinator pane
+- **THEN** focus does not move to the absent agent region (stays at the right-most present region)
+
+#### Scenario: Focus rebalances off a disappearing region
+
+- **WHEN** focus is on the agent region and that region becomes absent on the next layout
+- **THEN** focus bumps to the coordinator pane if present, else to the rail
+
+#### Scenario: Ctrl+Q returns to the rail
+
+- **WHEN** any pane is focused and the user presses `Ctrl+Q`
+- **THEN** focus returns to the rail
+
+### Requirement: Three-region layout computed in Draw (area 5)
+
+The system SHALL lay out the view as rail | coordinator pane | agent/details region, computing rects in `Draw` (not via a tview.Flex). The rail is a fixed width (`heraRailWidth`); the remaining width splits evenly between the coordinator pane and the agent region. When the terminal is too narrow for a right area the rail takes the full width and both right regions are marked absent so focus cannot land on them. Every region paints through `widget.DrawBorderedPanel`/`FillArea` to cover its full bounding rect, and the view SHALL NOT call `screen.Sync()` for content updates.
+
+Derived from: `internal/tui/hera/panes.go:14` (`heraRailWidth`), `internal/tui/hera/page.go:176` (`Draw`), `internal/tui/hera/page.go:208` (present-flag reconciliation), `context/knowledge/gotchas/hera-view.md` (no-Sync rule).
+
+#### Scenario: Narrow terminal hides the right regions
+
+- **WHEN** the terminal is narrower than the rail width plus a usable right area
+- **THEN** the rail fills the width and both right regions are marked absent
+
+#### Scenario: Drawing the full view never calls Sync
+
+- **WHEN** the view draws with live panes and a details region
+- **THEN** `screen.Sync()` is called zero times
+
+### Requirement: Coordinator (HERA) pane always shows the orchestrator's coordinator (area 6)
+
+The system SHALL feed the middle (HERA) pane from the SELECTED ORCHESTRATOR's coordinator task session at all times, regardless of whether the selected role is a coordinator or a worker. The pane is a live `terminal.TerminalPane` fed from the in-process runner's ring buffer (polled on Draw), NOT via SSE or a proxy. When the selected role is itself the coordinator, the HERA pane shows that task.
+
+Derived from: `internal/tui/hera/panes.go:30` (coord-vs-agent rule), `internal/tui/hera/panes.go:59` (`applySelection`), `internal/tui/hera/model.go:89` (`CoordTaskID`), `internal/tui/hera/panes.go:24` (`SessionResolver` seam).
+
+`NOTE:` Native feeds panes by POLLING the daemon-owned PTY ring buffer through an in-process `SessionResolver` seam wired to `runner.Get`. The plugin's WebSocket `/view` server, per-binding SSE PTY proxy, and snapshot pre-load (`hera-view` plugin spec) have NO native equivalent and are not ported.
+
+#### Scenario: Selecting a worker still shows its coordinator in HERA
+
+- **WHEN** a worker role under orchestrator A is selected
+- **THEN** the HERA (middle) pane shows A's coordinator task session, while the agent pane shows the worker's task
+
+#### Scenario: Multi-binding disambiguation feeds two contexts
+
+- **WHEN** a task is a worker in A and a coordinator in B, and the operator selects each role in turn
+- **THEN** selecting the A-role feeds HERA from A's coordinator and the agent pane from the shared task; selecting the B-role feeds HERA from the shared task (B's coordinator = itself) and renders B's roster — the disambiguator is always the selected role's orchestrator, never the bare task ID
+
+### Requirement: Agent/details region is mode-switched by the selected role (area 6)
+
+The system SHALL render the right region as a live AGENT terminal when a worker/freelance/leaf role is selected, and as a read-only Details summary (worker roster) when a coordinator role is selected. A coordinator selection renders the agent pane unbound (no terminal).
+
+Derived from: `internal/tui/hera/panes.go:59` (`applySelection` detailsMode), `internal/tui/hera/model.go:120` (`IsCoordinator`), `internal/tui/hera/details.go:23` (`DetailsView`), `internal/tui/hera/page.go:221` (Draw mode branch).
+
+#### Scenario: Worker selection shows a terminal
+
+- **WHEN** a worker role is selected
+- **THEN** the right region shows the worker's live agent terminal
+
+#### Scenario: Coordinator selection shows the details region
+
+- **WHEN** a coordinator role is selected
+- **THEN** the right region renders the Details roster (no terminal) stacked over the orchestration tree
+
+### Requirement: Details region stacks roster over the orchestration tree (area 6)
+
+For a coordinator selection the system SHALL render BOTH the read-only `" Details "` roster (top) and the embedded `" Orchestration Tree "` graph (bottom) at once with no toggle. The roster is sized to its natural content height, capped at half the region (so the tree keeps at least half), clamped to a minimum of 3 rows and to the region height; the tree fills the remainder and is skipped when fewer than 2 rows remain. The tree is the ONLY interactive surface — every key in the details region forwards to it (j/k/arrow cursor nav + Enter), and coordinator-region clicks route to it.
+
+Derived from: `internal/tui/hera/page.go:238` (`drawDetailsRegion`), `internal/tui/hera/page.go:343` (`handleDetailsKey`), `internal/tui/hera/details.go:44` (`ContentHeight`).
+
+#### Scenario: Both panels render together
+
+- **WHEN** a coordinator is selected and the region is tall enough
+- **THEN** the `" Details "` roster and the `" Orchestration Tree "` graph both render, with no `" DAG "` title
+
+#### Scenario: Enter on a tree node opens its agent view
+
+- **WHEN** the details region is focused and the user presses Enter on a tree node
+- **THEN** the wired `OnEnter` callback fires to jump to that node's agent view
+
+### Requirement: Orchestration tree projects the role hierarchy in-memory (area 6)
+
+The system SHALL project the embedded graph's nodes from the rail's already-built model via `heraTreeNodes` — a pure in-memory read with no DB call and no provider seam. The graph renders the role hierarchy (coordinator → workers → sub-coordinators), NOT the retired `depends_on` edges. Each worker gets a synthetic edge to its orchestrator's coordinator; a sub-coordinator collapses to one node keyed by task ID, carrying both a parent edge (its worker role under the parent) and child edges (its own workers). The subtree is discovered by multi-binding BFS: orchestrator C is a child of P when C's live coordinator task is bound as a non-coordinator worker under P. Archived orchestrators are pruned as descendants; the coordinator root takes no self-edge (cycle-safe). Node colour comes from the bound task's argus status/result.
+
+Derived from: `internal/tui/hera/tree.go:24` (`heraTreeNodes`), `internal/tui/hera/tree.go:108` (`workerTaskSet`), `internal/tui/hera/page.go:352` (`rebuildDAG`), `internal/tui/hera/model.go:26` (`TaskStatus`/`TaskResult`).
+
+#### Scenario: Coordinator + workers renders a real tree
+
+- **WHEN** a coordinator with bound workers is selected
+- **THEN** the tree shows each worker as a child node of the coordinator root
+
+#### Scenario: Sub-coordinator bridges two subtrees
+
+- **WHEN** a worker task under P is also the coordinator of child orchestrator C
+- **THEN** that task collapses to one node holding both its parent edge (under P) and its child edges (C's workers)
+
+#### Scenario: No orchestrator selected yields an empty graph
+
+- **WHEN** no orchestrator is selected
+- **THEN** the tree renders empty without panic
+
+### Requirement: PR indicator in the roster (area 6)
+
+The system SHALL mark a roster task with a `PR` indicator when that task carries a non-empty `url` in the daemon-populated `task_meta` "pr" namespace. The indicator is best-effort and read once per refresh via `ListMetaByNamespace("pr")`; it is never fetched by the view. A `ready` mark renders for a `ready_to_close` worker, and both marks may appear together.
+
+Derived from: `internal/tui/hera/details.go:158` (`roleMark`), `internal/tui/hera/page.go:160` (`doRefresh` reads "pr" namespace).
+
+#### Scenario: PR mark from cached meta
+
+- **WHEN** a roster task's "pr" meta has a non-empty url
+- **THEN** its roster row shows a `PR` mark
+
+### Requirement: PTY size alignment on bind (area 6)
+
+The system SHALL resize a bound session to the (narrower) hera pane when binding it, by calling `ForceResyncPTY()` so a session previously sized for the full-width main agent view is resized down on the next Draw, with `SyncPanes()` issuing the Resize RPC off the main thread. Pane operations on the tview thread SHALL use only lock-free/local session methods; the blocking resize RPC runs only from the tick goroutine. The view SHALL NOT use `screen.Sync()` to paper over a size mismatch.
+
+Derived from: `internal/tui/hera/panes.go:86` (`bindPane` ForceResyncPTY), `internal/tui/hera/panes.go:153` (`SyncPanes`), `internal/tui/hera/panes.go:172` (`forwardKey` main-thread-safe reads), `context/knowledge/gotchas/hera-view.md`.
+
+#### Scenario: Bind resizes a full-width session down
+
+- **WHEN** a session sized for the full-width agent view is bound into a hera pane
+- **THEN** `ForceResyncPTY` arms an unconditional resize and `SyncPanes` applies it off the main thread
+
+#### Scenario: Off-tab SyncPanes is a no-op
+
+- **WHEN** `SyncPanes` is called while the Hera tab is not active
+- **THEN** no resize fires (panes not drawn this frame have zero pending resize), so it cannot fight the main agent view's resize of the same task
+
+### Requirement: Debounced rail refresh on the UI thread (area 6)
+
+The system SHALL rebuild the rail model via a goroutine-free, timer-free debounced `Refresher` driven by the app tick and tab entry. `Schedule()` coalesces bursts into one rebuild per debounce window; tab entry forces an immediate flush. Rebuilds run on the tview thread because hera-store reads are mutex-guarded and fast (the "never on the UI thread" rule is about git, not DB reads). After `SetModel` the selection is re-derived and the panes rebound, so stale model pointers are refreshed.
+
+Derived from: `internal/tui/hera/refresher.go` (`Refresher`), `internal/tui/hera/page.go:138` (`ScheduleRefresh`), `internal/tui/hera/page.go:150` (`doRefresh`), `internal/tui/hera/panes.go:59` (`applySelection` re-run).
+
+#### Scenario: Burst of writes coalesces to one rebuild
+
+- **WHEN** several store writes schedule refreshes within one debounce window
+- **THEN** the rail rebuilds once
+
+#### Scenario: Tab entry forces a fresh rail
+
+- **WHEN** the Hera tab is opened
+- **THEN** the refresher flushes immediately so the rail is current the instant the tab appears
+
+### Requirement: Archive, pin, rename, delete, and status ops act on the selection (area 7)
+
+The system SHALL apply each mutation to the SELECTED `(role, orchestrator)` from the rail cursor, never a bare task ID. Archive and pin toggles read the current row state from the store to choose direction. Pinning clears archived state (pin and archive are mutually exclusive). Rename surfaces a name-conflict error for the caller to display. Status advance/revert step the hera role status ladder (idle → working → blocked → done), clamped at the ends, and reaching `done` on a WORKER role also rolls the bound task to in_review (soft-fail). Mutations are thin adapters over existing store methods; the spawn path is the shared `agent.SpawnHeraWorker` primitive, run off the main thread.
+
+Derived from: `internal/tui/hera/ops.go:85` (`ArchiveToggle`), `internal/tui/hera/ops.go:118` (`PinToggle`), `internal/tui/hera/ops.go:150` (`Rename`), `internal/tui/hera/ops.go:168` (`StepStatus`), `internal/tui/hera/ops.go:66` (status ladder), `context/knowledge/gotchas/hera-view.md` (M6c).
+
+#### Scenario: Archive toggle reads current state
+
+- **WHEN** the selected role is currently archived and the user presses `a`
+- **THEN** the op unarchives it (direction is read from the store row, not the possibly-stale model flag)
+
+#### Scenario: Worker reaching done rolls its task to in_review
+
+- **WHEN** `s` advances a worker role to `done`
+- **THEN** the hera status is set to done AND `RollHeraWorkerToReview` rolls the bound task to in_review (the roll is soft-fail so the status update always lands)
+
+#### Scenario: Status step on an orchestrator header is a no-op
+
+- **WHEN** `s`/`S` is pressed with the cursor on an orchestrator header (no role)
+- **THEN** nothing happens (only roles carry status)
+
+### Requirement: Conservative delete semantics for multi-binding safety (area 7)
+
+The system SHALL destroy the underlying argus task + worktree when deleting a ROLE ONLY if that task has exactly one live binding; a multi-bound task is PRESERVED (deleting it would end another orchestrator's binding to the same task). Deleting an ORCHESTRATOR cascades its hera rows (roles + bindings + status) but PRESERVES every underlying argus task, so one keystroke can never wipe multiple live worktrees. Orphaned tasks are deleted individually from the Tasks tab. Delete (always) and archive-of-a-live-row gate behind a confirmation modal; rename and spawn-prompt use a text-input modal.
+
+Derived from: `internal/tui/hera/ops.go:206` (`DeleteRole`), `internal/tui/hera/ops.go:216` (`DeleteOrchestrator`), `context/knowledge/gotchas/hera-view.md` (M6c delete semantics), `internal/tui/hera/page.go:374` (Ctrl+D → OnDelete).
+
+`NOTE:` This is a documented divergence from the plugin's `DeleteRole`, which destroyed the task more aggressively. Native trades plugin parity for multi-binding safety. Native also has NO rail prune verb (the plugin's `Ctrl+R` "prune all done coords + agents" is Tasks-tab-only in native) — see `docs/NATIVE-HERA-FOLLOWUPS.md`.
+
+#### Scenario: Deleting a sole-bound role destroys the task
+
+- **WHEN** a role is deleted and its task has exactly one live binding
+- **THEN** the role row is removed and the underlying argus task + worktree are destroyed
+
+#### Scenario: Deleting a multi-bound role preserves the task
+
+- **WHEN** a role is deleted and its task holds live bindings in more than one orchestrator
+- **THEN** only that role's row is removed; the task and its other-orchestrator binding survive
+
+#### Scenario: Deleting an orchestrator preserves its tasks
+
+- **WHEN** an orchestrator is deleted
+- **THEN** its roles, bindings, and status rows cascade away but every underlying argus task remains as an unbound task
+
+### Requirement: Enter restarts a dead session then enters the pane (area 7)
+
+The system SHALL, on `Enter` over a selected role with a bound task that has no live session, fire the reattach callback to restart the session, then advance focus into the pane. A live row just advances focus; an empty selection only advances focus.
+
+Derived from: `internal/tui/hera/page.go:376` (Enter arm in `handleRailMutation`).
+
+#### Scenario: Enter on a dead session reattaches
+
+- **WHEN** Enter is pressed on a role whose task has no live session
+- **THEN** the reattach callback fires and focus advances into the pane
+
+### Requirement: Freelance roles hoisted into a top-level section (area 8)
+
+The system SHALL hoist active freelance-kind roles into a top-level "Freelance" rail section rather than nesting them under their orchestrator. `BuildModel` skips active freelance-kind roles when filling an orchestrator's roles and appends them to `Model.Freelance`, sorted by name. The native view SHALL NOT provide a manual adopt/reparent affordance.
+
+Derived from: `internal/tui/hera/model.go:189` (freelance hoist), `internal/tui/hera/model.go:206` (sort), `internal/tui/hera/rail.go:174` (Freelance section).
+
+`NOTE:` This is a reduced interpretation of the plugin's Freelance concept. The plugin derived freelance entries from UNMANAGED live argus tasks and grouped them by repo, and offered a `J` key to adopt a freelancer into a chosen coordinator. Native's read-only hera store has no unmanaged-task data source, so the Freelance section reflects only roles explicitly created with kind `freelance` (via `hera_join`), and the `J` adopt key is omitted. The former auto-adopt watcher (Milestone 4 rule D4) was retired with the `depends_on` DAG — born-bound workers create their bindings transactionally at spawn time, so there is no link to adopt across. Only the daemon-startup binding reconciliation survives (see `hera-coordination`). Per `docs/NATIVE-HERA-FOLLOWUPS.md`, restoring an adopt picker is an open follow-up.
+
+#### Scenario: Freelance role appears in its own section
+
+- **WHEN** a role of kind `freelance` is active under some orchestrator
+- **THEN** it renders in the top-level "Freelance (N)" section, not nested under that orchestrator
+
+#### Scenario: No adopt affordance
+
+- **WHEN** the operator looks for a way to adopt/reparent a freelancer from the rail
+- **THEN** there is none (`J` is unbound); adoption is not a native rail operation


### PR DESCRIPTION
## What

Author OpenSpec capability specs describing how argus's **native** hera actually behaves today, so they can be diffed against the original hera plugin's specs to surface merge-induced regressions. This is a faithful state-capture of current behavior (not a redesign).

Mirrors the plugin's capability split:

- **`openspec/specs/hera-view/spec.md`** — the TUI surface (comparison areas 1–8): rail structure & nesting, sections, row rendering, keybindings, focus & layout, coordinator/agent panes & details, archive/prune/delete/teardown, freelance.
- **`openspec/specs/hera-coordination/spec.md`** — storage/binding model, the 9 `hera_*` MCP tools, born-bound spawn, subtree roll-up, daemon-startup reconciliation.
- **`openspec/specs/hera-messaging/spec.md`** — comparison area 9: role-addressed delivery, reliable doorbell, caps.

## How it's written

- Every requirement cites the `file:line` it was derived from.
- Where native is materially less capable than the plugin spec, the requirement describes native's **actual (lesser) behavior** and carries a `NOTE:` flagging the gap (cross-checked against `docs/RAIL-PARITY-ANALYSIS.md` and `docs/NATIVE-HERA-FOLLOWUPS.md`). No invented behavior.
- All three pass `openspec validate --strict`.

## Most significant native vs. plugin gaps captured

- **Rail is flat** (every orchestrator at depth 0) — no cross-orchestrator nesting; the hierarchy renders only in the Details-pane tree.
- **Subtree bridges only through live bindings** (`ended_at IS NULL` + `r.Live`); the plugin bridged on a coordinator's latest binding regardless of liveness, so native's tree is structurally narrower even with complete data.
- **Omitted rail keys** vs the plugin: `n` (new orchestrator), `J` (adopt), `/` (filter), `l` (toggle archived visibility), `Ctrl+R` (prune), `Ctrl+Z` (fullscreen).
- **Conservative delete**: role delete destroys the task only when it's the sole binding; orchestrator delete preserves all argus tasks.
- **Reduced freelance**: only roles explicitly created `kind=freelance`; no unmanaged-task source, no repo grouping, no adopt key; auto-adopt watcher retired with the DAG.
- **No WebSocket `/view` / SSE PTY proxy** — panes are fed by polling the in-process runner ring buffer.

## Notes

- Docs-only change; nothing in CI, the Makefile, or the Go build depends on `openspec/` (per `openspec/project.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>