### PR TITLE
fix(hera): rail starts fully collapsed on first run (BUG-009)

### DIFF
--- a/internal/tui/hera/persist_test.go
+++ b/internal/tui/hera/persist_test.go
@@ -53,14 +53,22 @@ func TestRail_StateStoreRestores(t *testing.T) {
 }
 
 func TestRail_StateStoreMalformedKeepsDefaults(t *testing.T) {
-	for _, blob := range []string{"", "   ", "not json", "{"} {
+	// Malformed blobs keep the expanded default (not the first-run-collapse
+	// path). Empty/whitespace-only blobs are the first-run case and trigger
+	// collapse; genuinely malformed JSON does not.
+	for _, blob := range []string{"not json", "{"} {
 		t.Run("blob="+blob, func(t *testing.T) {
 			fs := &fakeStore{load: blob}
 			r := NewRail()
 			r.SetStateStore(fs)
-			testutil.Equal(t, r.archiveCollapsed, true) // default preserved
-			testutil.Equal(t, len(r.collapsed), 0)
+			testutil.Equal(t, r.archiveCollapsed, true)
+			testutil.Equal(t, len(r.collapsed), 0) // no collapse seeded yet
 			testutil.Equal(t, r.pendingSelRef, int64(0))
+			testutil.Equal(t, r.firstRunCollapse, false) // NOT first-run path
+			// After model load, orchestrators stay expanded (malformed ≠ first run).
+			r.SetModel(twoOrchModel())
+			testutil.Equal(t, r.collapsed[1], false)
+			testutil.Equal(t, r.collapsed[2], false)
 		})
 	}
 	// A load error also keeps defaults (logged, not fatal).
@@ -68,12 +76,60 @@ func TestRail_StateStoreMalformedKeepsDefaults(t *testing.T) {
 	r := NewRail()
 	r.SetStateStore(fs)
 	testutil.Equal(t, r.archiveCollapsed, true)
+	testutil.Equal(t, r.firstRunCollapse, false)
+}
+
+func TestRail_FirstRunFullyCollapsed(t *testing.T) {
+	// No saved state (empty blob) → rail starts fully collapsed on first model
+	// build (BUG-009 fix). Both empty string and whitespace-only trigger this.
+	for _, blob := range []string{"", "   "} {
+		t.Run("blob="+blob, func(t *testing.T) {
+			fs := &fakeStore{load: blob}
+			r := NewRail()
+			r.SetStateStore(fs)
+			testutil.Equal(t, r.firstRunCollapse, true)
+			testutil.Equal(t, len(r.collapsed), 0) // not yet seeded (no model)
+
+			r.SetModel(twoOrchModel())
+			// Both orchestrators from twoOrchModel (ids 1 and 2) must be collapsed.
+			testutil.Equal(t, r.collapsed[1], true)
+			testutil.Equal(t, r.collapsed[2], true)
+			testutil.Equal(t, r.firstRunCollapse, false) // one-shot: consumed
+		})
+	}
+}
+
+func TestRail_FirstRunCollapseIsOneShot(t *testing.T) {
+	// After the first non-empty model build, later rebuilds do NOT re-collapse
+	// orchestrators that the user expanded.
+	fs := &fakeStore{load: ""}
+	r := NewRail()
+	r.SetStateStore(fs)
+	r.SetModel(twoOrchModel())
+	testutil.Equal(t, r.collapsed[1], true) // seeded on first build
+
+	// User expands orch-1.
+	delete(r.collapsed, 1)
+	// Rebuild (e.g. a tick refresh) must NOT re-collapse orch-1.
+	r.SetModel(twoOrchModel())
+	testutil.Equal(t, r.collapsed[1], false) // stays expanded
+	testutil.Equal(t, r.collapsed[2], true)  // untouched
+}
+
+func TestRail_FirstRunNoStoreNoCollapse(t *testing.T) {
+	// Without a store, no first-run collapse fires (remote mode / unset store).
+	r := NewRail()
+	r.SetModel(twoOrchModel())
+	testutil.Equal(t, r.collapsed[1], false)
+	testutil.Equal(t, r.collapsed[2], false)
 }
 
 func TestRail_PersistsOnToggleAndCursorMove(t *testing.T) {
-	fs := &fakeStore{}
+	// Use a non-empty blob (valid prior state) so this is NOT a first-run — both
+	// orchestrators start expanded and we test the toggle/cursor persist paths.
+	fs := &fakeStore{load: `{"archive_collapsed":true}`}
 	r := NewRail()
-	r.SetStateStore(fs) // empty load → defaults; store wired
+	r.SetStateStore(fs) // restores archive_collapsed=true, no first-run flag
 	r.SetModel(twoOrchModel())
 	testutil.Equal(t, len(fs.saved), 0) // SetModel/restore never persists
 
@@ -143,6 +199,14 @@ func TestPage_RailStatePersistsAcrossPages(t *testing.T) {
 	seedBoundRole(t, d, o1, "wkr", db.HeraKindWorker, "tw")
 	o2 := seedOrch(t, d, "orch-b")
 	seedBoundRole(t, d, o2, "coord", db.HeraKindCoordinator, "tb")
+
+	// Pre-seed a minimal prior-session blob so this test exercises the
+	// restore-and-persist path, not first-run behaviour (first-run collapse is
+	// covered by TestRail_FirstRunFullyCollapsed and
+	// TestRail_FirstRunCollapseIsOneShot).
+	if err := d.SaveRailState(`{"archive_collapsed":true}`); err != nil {
+		t.Fatal(err)
+	}
 
 	// Page 1: wire the real *db.DB store, collapse the first orchestrator.
 	p1 := NewHeraPage(d)

--- a/internal/tui/hera/rail.go
+++ b/internal/tui/hera/rail.go
@@ -136,6 +136,11 @@ type Rail struct {
 	// live cursor wins.
 	store         RailStateStore
 	pendingSelRef int64
+	// firstRunCollapse is true when no saved rail state exists (first run). On
+	// the first non-empty model build, ALL orchestrators are seeded as collapsed
+	// so the rail starts fully collapsed instead of fully expanded. One-shot:
+	// cleared after the seed, just like pendingSelRef.
+	firstRunCollapse bool
 }
 
 // NewRail builds an empty rail. Archive starts collapsed (matches the task
@@ -212,7 +217,10 @@ func (r *Rail) SetStateStore(s RailStateStore) {
 		return
 	}
 	if strings.TrimSpace(raw) == "" {
-		return // nothing persisted yet — keep defaults
+		// Nothing persisted yet (first run) — start fully collapsed on the
+		// first model build instead of defaulting to fully expanded.
+		r.firstRunCollapse = true
+		return
 	}
 	var st railViewState
 	if err := json.Unmarshal([]byte(raw), &st); err != nil {
@@ -462,6 +470,17 @@ func (r *Rail) buildRows() {
 	if r.model.IsEmpty() {
 		r.rows = append(r.rows, railRow{kind: rrEmpty, label: "No hera orchestrators"})
 		return
+	}
+
+	// On first run (no saved state) collapse ALL orchestrators so the rail
+	// opens in a tidy summary view. One-shot: cleared after the seed.
+	if r.firstRunCollapse {
+		for _, sec := range [][]OrchView{r.model.Pinned, r.model.Active, r.model.Archived} {
+			for _, o := range sec {
+				r.collapsed[o.ID] = true
+			}
+		}
+		r.firstRunCollapse = false
 	}
 
 	// Nesting machinery: each child orchestrator's SINGLE canonical parent is
@@ -910,6 +929,9 @@ func (r *Rail) Selection() Selection {
 
 // Rows returns the flattened row count (test seam).
 func (r *Rail) Rows() int { return len(r.rows) }
+
+// OrchCollapsed reports whether the given orchestrator ID is folded (test seam).
+func (r *Rail) OrchCollapsed(id int64) bool { return r.collapsed[id] }
 
 // CursorIndex returns the cursor's row index (test seam).
 func (r *Rail) CursorIndex() int { return r.cursor }

--- a/internal/tui/hera_mutations_smoke_test.go
+++ b/internal/tui/hera_mutations_smoke_test.go
@@ -16,10 +16,23 @@ import (
 // heraTabCursorOnWorker switches to the Hera tab and moves the cursor onto the
 // worker role. After the coordinator fold the rows are orch header=0 (the
 // coordinator) and worker=1, so a single Down lands on the worker.
+// On first run the orchestrator starts collapsed — this helper expands it first.
 func heraTabCursorOnWorker(t *testing.T, app *App, sim tcell.SimulationScreen) {
 	t.Helper()
 	sim.InjectKey(tcell.KeyRune, '2', 0)
 	syncUI(t, app.tapp)
+	// Expand the orchestrator if it started collapsed (first-run default).
+	// After the expand the header is still row 0, and the single worker is row 1.
+	var collapsed bool
+	readUI(t, app.tapp, func() {
+		if o := app.heraPage.Rail().SelectedOrch(); o != nil {
+			collapsed = app.heraPage.Rail().OrchCollapsed(o.ID)
+		}
+	})
+	if collapsed {
+		sim.InjectKey(tcell.KeyRune, ' ', 0) // expand
+		syncUI(t, app.tapp)
+	}
 	sim.InjectKey(tcell.KeyRune, 'j', 0) // → worker (coord folded into header)
 	syncUI(t, app.tapp)
 }
@@ -200,6 +213,17 @@ func TestSmoke_HeraDeleteRoleMultiBindingIsolation(t *testing.T) {
 	defer stop()
 	sim.InjectKey(tcell.KeyRune, '2', 0)
 	syncUI(t, app.tapp)
+	// Expand orch-a if it started collapsed (first-run default).
+	var collapsed bool
+	readUI(t, app.tapp, func() {
+		if o := app.heraPage.Rail().SelectedOrch(); o != nil {
+			collapsed = app.heraPage.Rail().OrchCollapsed(o.ID)
+		}
+	})
+	if collapsed {
+		sim.InjectKey(tcell.KeyRune, ' ', 0) // expand orch-a
+		syncUI(t, app.tapp)
+	}
 	// orch-a is first (alpha order); its worker role is row 1.
 	sim.InjectKey(tcell.KeyRune, 'j', 0)
 	syncUI(t, app.tapp)
@@ -251,6 +275,17 @@ func TestSmoke_HeraCascadeDeleteSubtree(t *testing.T) {
 	defer stop()
 	sim.InjectKey(tcell.KeyRune, '2', 0)
 	syncUI(t, app.tapp)
+	// Expand orch-a if collapsed (first-run default) so its bridge worker is visible.
+	var collapsed bool
+	readUI(t, app.tapp, func() {
+		if o := app.heraPage.Rail().SelectedOrch(); o != nil {
+			collapsed = app.heraPage.Rail().OrchCollapsed(o.ID)
+		}
+	})
+	if collapsed {
+		sim.InjectKey(tcell.KeyRune, ' ', 0)
+		syncUI(t, app.tapp)
+	}
 	// orch-c nests under orch-a's "w" row (row 1, the bridge).
 	sim.InjectKey(tcell.KeyRune, 'j', 0)
 	syncUI(t, app.tapp)
@@ -307,6 +342,17 @@ func TestSmoke_HeraCascadeDeleteDepth2Count(t *testing.T) {
 	defer stop()
 	sim.InjectKey(tcell.KeyRune, '2', 0)
 	syncUI(t, app.tapp)
+	// Expand orch-a if collapsed (first-run default) so its bridge worker is visible.
+	var collapsed bool
+	readUI(t, app.tapp, func() {
+		if o := app.heraPage.Rail().SelectedOrch(); o != nil {
+			collapsed = app.heraPage.Rail().OrchCollapsed(o.ID)
+		}
+	})
+	if collapsed {
+		sim.InjectKey(tcell.KeyRune, ' ', 0)
+		syncUI(t, app.tapp)
+	}
 	// Row 1 is orch-a's workerR (bridges orch-c); cascade subtree = {orch-c, orch-g}.
 	sim.InjectKey(tcell.KeyRune, 'j', 0)
 	syncUI(t, app.tapp)

--- a/internal/tui/hera_smoke_test.go
+++ b/internal/tui/hera_smoke_test.go
@@ -113,15 +113,24 @@ func TestSmoke_HeraRailCursorNavAndCollapse(t *testing.T) {
 	sim.InjectKey(tcell.KeyRune, '2', 0)
 	syncUI(t, app.tapp)
 
-	var rowsExpanded, cursorAfterJ int
+	// First-run (no saved state): the orchestrator starts fully collapsed — only
+	// the header row is visible. Space expands it to show the worker.
 	readUI(t, app.tapp, func() {
-		rowsExpanded = app.heraPage.Rail().Rows()
-		testutil.Equal(t, app.heraPage.Rail().CursorIndex(), 0)
+		testutil.Equal(t, app.heraPage.Rail().Rows(), 1)        // collapsed: only header
+		testutil.Equal(t, app.heraPage.Rail().CursorIndex(), 0) // cursor on header
+		testutil.Equal(t, app.heraPage.Rail().OrchCollapsed(orch), true)
 	})
-	testutil.Equal(t, rowsExpanded, 2) // orch header (coord folded in) + 1 worker
+
+	sim.InjectKey(tcell.KeyRune, ' ', 0) // expand
+	syncUI(t, app.tapp)
+	readUI(t, app.tapp, func() {
+		testutil.Equal(t, app.heraPage.Rail().Rows(), 2) // header + worker
+		testutil.Equal(t, app.heraPage.Rail().OrchCollapsed(orch), false)
+	})
 
 	sim.InjectKey(tcell.KeyRune, 'j', 0) // cursor down to a role
 	syncUI(t, app.tapp)
+	var cursorAfterJ int
 	readUI(t, app.tapp, func() { cursorAfterJ = app.heraPage.Rail().CursorIndex() })
 	testutil.Equal(t, cursorAfterJ, 1)
 
@@ -228,6 +237,17 @@ func TestSmoke_HeraTabSelectionThreadsThroughRunner(t *testing.T) {
 	})
 
 	// Navigate: orch header (row 0, the folded coordinator) → worker role (1).
+	// First run starts collapsed — expand the orch before navigating down.
+	var collapsed bool
+	readUI(t, app.tapp, func() {
+		if o := app.heraPage.Rail().SelectedOrch(); o != nil {
+			collapsed = app.heraPage.Rail().OrchCollapsed(o.ID)
+		}
+	})
+	if collapsed {
+		sim.InjectKey(tcell.KeyRune, ' ', 0)
+		syncUI(t, app.tapp)
+	}
 	sim.InjectKey(tcell.KeyRune, 'j', 0)
 	syncUI(t, app.tapp)
 	var sel hera.Selection

--- a/openspec/changes/rail-state-persist/specs/hera-view/spec.md
+++ b/openspec/changes/rail-state-persist/specs/hera-view/spec.md
@@ -17,7 +17,17 @@ TUI restart and a daemon restart or crash. The persisted state SHALL include:
 Persistence SHALL use the existing `config` key-value table under a single key
 (`hera.rail_view_state`), serialized as JSON — NO new table and NO schema migration.
 Only non-default fold entries SHALL be serialized (orchestrators default expanded,
-expandos default closed), so an absent or empty value restores all defaults.
+expandos default closed), so a saved value can always round-trip correctly.
+
+**First-run (no saved state):** When the stored blob is absent or empty, the rail
+SHALL start FULLY COLLAPSED on the first non-empty model build — all orchestrators
+collapsed, Archive section collapsed (existing default). This one-shot seed fires
+only once; after the first model build the live cursor and toggle state take over.
+Subsequent model rebuilds SHALL NOT re-collapse orchestrators the operator expanded.
+
+A malformed blob (present but not parseable as JSON) keeps the expanded default
+(NOT the first-run collapse) — malformed data is treated as a corruption, not a
+first launch. A load error also keeps defaults, logged but never fatal.
 
 Restore SHALL apply the fold maps and section booleans immediately on construction
 (they key off stable database ids, valid before any model is loaded) and SHALL apply
@@ -25,11 +35,10 @@ the selection after the first model build, reusing the rail's existing cursor-re
 machinery. The selection restore SHALL be ONE-SHOT: once applied (or once the operator
 moves the cursor), later rebuilds keep the live cursor, not the stale persisted ref.
 
-Saving SHALL occur on every fold toggle and selection move. A malformed or absent
-persisted value SHALL be tolerated (fall back to defaults), never fatal. In remote mode
-(no local database) the persistence seam SHALL be absent and the rail SHALL operate
-normally without persisting. Transient FILTER state (the `/` query and input mode) is
-NOT part of the persisted state, and a filter-driven rebuild SHALL NOT trigger a save.
+Saving SHALL occur on every fold toggle and selection move. In remote mode (no local
+database) the persistence seam SHALL be absent and the rail SHALL operate normally
+without persisting. Transient FILTER state (the `/` query and input mode) is NOT part
+of the persisted state, and a filter-driven rebuild SHALL NOT trigger a save.
 
 Derived from: `internal/tui/hera/rail.go` (`RailStateStore` seam, `railViewState`,
 load-on-store-set, one-shot pending-selection restore, save-on-change), `internal/db/hera_rail_state.go`
@@ -41,10 +50,17 @@ load-on-store-set, one-shot pending-selection restore, save-on-change), `interna
 - **WHEN** the operator collapses some orchestrators, opens a per-coordinator Archive expando, folds the Freelance section, and selects a row, then argus restarts and reopens the Hera tab
 - **THEN** the rail MUST restore exactly those collapsed orchestrators, that open expando, the Freelance fold, and the selected row
 
-#### Scenario: Defaults restore from an absent or malformed value
+#### Scenario: First run starts fully collapsed
 
-- **WHEN** no persisted rail state exists, or the stored value is malformed
+- **WHEN** no persisted rail state exists (absent or empty stored blob) and the first model with orchestrators is loaded
+- **THEN** the rail MUST start fully collapsed — all orchestrators collapsed, Archive section collapsed
+- **AND** the fully-collapsed state MUST be one-shot: subsequent model rebuilds MUST keep the live fold state, not re-collapse
+
+#### Scenario: Malformed value falls back to defaults
+
+- **WHEN** the stored value is present but not valid JSON (malformed or truncated)
 - **THEN** the rail MUST fall back to its defaults (orchestrators expanded, expandos closed, Freelance expanded, Archive collapsed) without error
+- **AND** the first-run collapse MUST NOT fire (malformed data is treated as prior state, not first launch)
 
 #### Scenario: Selection restore is one-shot
 


### PR DESCRIPTION
## Summary

- Adds a one-shot `firstRunCollapse bool` flag to `Rail` — set when no persisted state exists (absent or whitespace-only blob), cleared after the first non-empty model build seeds all orchestrators as collapsed
- `buildRows()` iterates Pinned + Active + Archived on first non-empty model and sets `collapsed[id] = true` for every orchestrator, then clears the flag so subsequent rebuilds keep live state
- Malformed blobs (present but invalid JSON) keep the expanded default — treated as corruption, not first launch
- No store wired (remote mode) = no first-run collapse

## Changes

- `internal/tui/hera/rail.go` – `firstRunCollapse` field, `SetStateStore` empty-blob path, `buildRows` seed, `OrchCollapsed(id) bool` test seam
- `internal/tui/hera/persist_test.go` – 4 new tests (`TestRail_FirstRunFullyCollapsed`, `TestRail_FirstRunCollapseIsOneShot`, `TestRail_FirstRunNoStoreNoCollapse`); updated `TestRail_StateStoreMalformedKeepsDefaults` and `TestPage_RailStatePersistsAcrossPages` to pre-seed non-empty blobs so they exercise restore paths, not first-run
- `internal/tui/hera_smoke_test.go` – updated cursor-nav and selection-thread tests to expand-if-collapsed before navigating
- `internal/tui/hera_mutations_smoke_test.go` – `heraTabCursorOnWorker` and 3 cascade/isolation tests now use `OrchCollapsed` to detect and expand before navigating
- `openspec/changes/rail-state-persist/specs/hera-view/spec.md` – split Defaults scenario into two: "First run starts fully collapsed" + "Malformed value falls back to defaults"

## Test plan

- `make pre-pr` passes clean (build + vet + fmt + lint + test-cover-gate at 89.7%)
- `make vuln` has stdlib-only findings (GO-2026-5039, GO-2026-5037 in net/textproto / crypto/x509 — fixable only by bumping Go toolchain; CI has `continue-on-error: true` for this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>