### PR TITLE
Fix BUG-020: detect AskUserQuestion chooser as needs-input

### DIFF
--- a/internal/agent/needsinput.go
+++ b/internal/agent/needsinput.go
@@ -9,6 +9,14 @@ import (
 	"github.com/drn/argus/internal/sanitize"
 )
 
+// needsInputChooserFooterRe matches the footer line of Claude Code's
+// AskUserQuestion chooser widget. The footer always renders "Enter to select"
+// and "Esc to cancel" on the same line, separated by navigation hints
+// ("↑/↓ to navigate" and middle-dot separators). Both phrases must appear on
+// the same line — [^\n\r]* explicitly bars newlines — so an isolated
+// "Esc to cancel" elsewhere in the output doesn't trigger it.
+var needsInputChooserFooterRe = regexp.MustCompile(`Enter to select[^\n\r]*Esc to cancel`)
+
 // needsInputSelectionRe is the visible-text signature of Claude Code's
 // selection UI: U+276F (❯) followed (after zero or more horizontal whitespace
 // characters) by "1.". The same widget renders AskUserQuestion overlays,
@@ -39,12 +47,15 @@ var needsInputSelectionRe = regexp.MustCompile(`❯[ \t]*1\.`)
 const needsInputTailWindow = 16 * 1024
 
 // DetectNeedsInput returns true if the tail of `buf` indicates the agent is
-// blocked waiting for the user. Two signals fire:
+// blocked waiting for the user. Three signals fire:
 //
-//  1. Claude's numbered-selection prompt UI (`❯ 1.`) — AskUserQuestion overlays,
-//     permission prompts, and plan-mode confirms all render through this widget.
-//  2. The assistant's most recent text response ends with `?` — captures
-//     plain-text questions where Claude stops generating without invoking the
+//  1. Claude's numbered-selection prompt UI (`❯ 1.`) — permission prompts and
+//     plan-mode confirms render through this widget.
+//  2. The AskUserQuestion chooser footer (`Enter to select … Esc to cancel`) —
+//     the full-screen chooser widget clears the viewport so earlier ❯ 1. rows
+//     are gone; the footer line is the reliable signature.
+//  3. The assistant's most recent text response ends with `?` — captures
+//     plain-text questions where Claude stops generating without invoking a
 //     selection widget (e.g. "Want me to ship it?").
 //
 // Pair with an "is idle" check at the call site — a prompt the agent is still
@@ -59,6 +70,9 @@ func DetectNeedsInput(buf []byte) bool {
 	}
 	stripped := sanitize.StripANSI(string(tail))
 	if needsInputSelectionRe.MatchString(stripped) {
+		return true
+	}
+	if needsInputChooserFooterRe.MatchString(stripped) {
 		return true
 	}
 	return endsInQuestion(stripped)

--- a/internal/agent/needsinput_test.go
+++ b/internal/agent/needsinput_test.go
@@ -167,6 +167,49 @@ func TestDetectNeedsInput(t *testing.T) {
 			"❯\u00a0 \r\r⏺ Shipped it.\r✻ Brewed for 3s\r\r❯\u00a0 \r\r",
 			false,
 		},
+
+		// AskUserQuestion chooser — footer signature
+		{
+			// AskUserQuestion renders a full-screen chooser widget. The distinctive
+			// signature is the footer line containing both "Enter to select" and
+			// "Esc to cancel". The ❯ cursor on the option does NOT follow the "❯ 1."
+			// numbered format, so the existing selection regex doesn't catch it.
+			"askuserquestion chooser footer fires",
+			"  ❯  Execute in this session\n     Copy to clipboard\n\n  Enter to select · \u2191/\u2193 to navigate · Esc to cancel\n",
+			true,
+		},
+		{
+			// AskUserQuestion with a box border — footer inside a box still fires
+			"askuserquestion chooser in box fires",
+			"\u256d\u2500 How should we proceed? \u256e\n\u2502 ❯  Execute in this session  \u2502\n\u2502    Copy to clipboard          \u2502\n\u251c\u2500\u2500\u2500\u251e\n\u2502  Enter to select · \u2191/\u2193 to navigate · Esc to cancel \u2502\n\u2570\u2500\u2500\u2500\u256f\n",
+			true,
+		},
+		{
+			// Real ANSI-wrapped footer: each phrase in dim SGR pairs, separated
+			// by middle-dot separators. After ANSI strip it collapses to plain text.
+			"askuserquestion chooser with ANSI-wrapped footer fires",
+			"\x1b[2mEnter to select\x1b[0m · \x1b[2m\u2191/\u2193 to navigate\x1b[0m · \x1b[2mEsc to cancel\x1b[0m",
+			true,
+		},
+		{
+			// Only "Esc to cancel" present — not enough without "Enter to select"
+			"esc-to-cancel alone does not fire",
+			"Press Esc to cancel the current operation.\n❯\u00a0 \r\r",
+			false,
+		},
+		{
+			// Only "Enter to select" present — not enough without "Esc to cancel"
+			"enter-to-select alone does not fire",
+			"Press Enter to select a file from the list.\n❯\u00a0 \r\r",
+			false,
+		},
+		{
+			// Both phrases on separate lines — must NOT match; chooser footer is
+			// always a single continuous line with both phrases.
+			"chooser phrases on separate lines do not fire",
+			"Enter to select.\nPress Esc to cancel.\n❯\u00a0 \r\r",
+			false,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `needsInputChooserFooterRe` to `DetectNeedsInput` in `internal/agent/needsinput.go`
- The AskUserQuestion chooser renders a full-screen widget whose options do NOT follow the numbered `❯ 1.` format the existing regex targets
- The footer line `Enter to select … Esc to cancel` is always present on a single continuous line — this is the reliable signature
- Regex uses `[^\n\r]*` to bar newlines between the two phrases, preventing false-positives from isolated occurrences of either phrase in output

## Signature matched

```
Enter to select[^\n\r]*Esc to cancel
```

Matches all footer forms after ANSI strip:
- `Enter to select · ↑/↓ to navigate · Esc to cancel` (plain)
- `│  Enter to select · ↑/↓ to navigate · Esc to cancel │` (inside box border)
- After stripping SGR dim pairs around each phrase

## False-positive guards

- `Esc to cancel` alone → false
- `Enter to select` alone → false  
- Both phrases on separate lines → false (newline between them breaks `[^\n\r]*`)

## Tests

6 new test cases in `TestDetectNeedsInput`:
- 3 positive fixtures (plain footer, box-bordered footer, ANSI-wrapped footer)
- 3 false-positive guards (each phrase alone, phrases on separate lines)

## Pre-PR

All gates green: build ✓ vet ✓ fmt-check ✓ lint-pr ✓ test-cover-gate 89.6% ✓

`make vuln` shows stdlib-only CVEs (GO-2026-5039, GO-2026-5037) — CI runs govulncheck with `continue-on-error: true` for stdlib findings per project policy.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>