### PR TITLE
Fix Hera nuked_at migration crash on pre-BUG-022 DBs

### DIFF
--- a/internal/db/hera_test.go
+++ b/internal/db/hera_test.go
@@ -17,6 +17,58 @@ func heraTestDB(t *testing.T) *DB {
 	return d
 }
 
+// TestCreateHeraTables_MigratesPreNukedAtDB pins the BUG-022 migration-order fix:
+// a DB created before the nuked_at column (hera_orchestrators / hera_roles lacking
+// it) must be migrated in place, not error with "no such column: nuked_at". The
+// nuked_at ADD COLUMN ALTERs run BEFORE the DDL block — the DDL builds
+// `CREATE INDEX ... (nuked_at)` and the `CREATE TABLE IF NOT EXISTS` is a no-op on
+// the pre-existing table, so the column must already be present by then.
+func TestCreateHeraTables_MigratesPreNukedAtDB(t *testing.T) {
+	d := heraTestDB(t)
+
+	// Reset to the pre-BUG-022 shape: drop the current tables and recreate the two
+	// that gained nuked_at WITHOUT the column (and without the nuked indexes). FK
+	// enforcement is off for the destructive reset so dropping parent tables that
+	// child tables (hera_bindings, hera_role_status) still reference doesn't error.
+	_, err := d.conn.Exec(`
+		PRAGMA foreign_keys=off;
+		DROP TABLE IF EXISTS hera_role_status;
+		DROP TABLE IF EXISTS hera_bindings;
+		DROP TABLE IF EXISTS tree_read_cursors;
+		DROP TABLE IF EXISTS hera_roles;
+		DROP TABLE IF EXISTS hera_orchestrators;
+		CREATE TABLE hera_orchestrators (
+			id          INTEGER PRIMARY KEY,
+			name        TEXT NOT NULL,
+			created_at  TEXT NOT NULL,
+			archived_at TEXT,
+			pinned_at   TEXT
+		);
+		CREATE TABLE hera_roles (
+			id              INTEGER PRIMARY KEY,
+			orchestrator_id INTEGER NOT NULL,
+			name            TEXT NOT NULL,
+			kind            TEXT NOT NULL,
+			argus_project   TEXT NOT NULL,
+			prompt          TEXT NOT NULL DEFAULT '',
+			created_at      TEXT NOT NULL,
+			archived_at     TEXT,
+			pinned_at       TEXT
+		);
+		PRAGMA foreign_keys=on;
+	`)
+	testutil.NoError(t, err)
+
+	// The actual regression: this used to fail with "no such column: nuked_at".
+	testutil.NoError(t, d.createHeraTables())
+
+	// nuked_at is now usable on both tables.
+	_, err = d.conn.Exec(`SELECT nuked_at FROM hera_orchestrators`)
+	testutil.NoError(t, err)
+	_, err = d.conn.Exec(`SELECT nuked_at FROM hera_roles`)
+	testutil.NoError(t, err)
+}
+
 // mkOrch creates an active orchestrator and fails the test on error.
 func mkOrch(t *testing.T, d *DB, name string) *HeraOrchestrator {
 	t.Helper()

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -399,6 +399,16 @@ func (d *DB) createTables() error {
 // resume. That cleanup is app-level — see Delete in tasks.go, which ends live
 // bindings, while SetArchived leaves them intact (archive is resumable).
 func (d *DB) createHeraTables() error {
+	// Idempotent ADD COLUMN migration for existing DBs that predate the nuked_at
+	// column (BUG-022 two-state EOL). This MUST run BEFORE the DDL block below: the
+	// DDL creates `CREATE INDEX ... ON hera_*(nuked_at)`, and on a pre-existing DB
+	// the `CREATE TABLE IF NOT EXISTS` is a no-op, so without the column the whole
+	// multi-statement Exec aborts with "no such column: nuked_at". On a fresh DB
+	// these ALTERs fail (table doesn't exist yet) and are intentionally ignored —
+	// the CREATE TABLE below then creates the column inline.
+	d.conn.Exec(`ALTER TABLE hera_orchestrators ADD COLUMN nuked_at TEXT`) //nolint:errcheck
+	d.conn.Exec(`ALTER TABLE hera_roles ADD COLUMN nuked_at TEXT`)         //nolint:errcheck
+
 	ddl := `
 		CREATE TABLE IF NOT EXISTS hera_orchestrators (
 			id          INTEGER PRIMARY KEY,
@@ -508,13 +518,5 @@ func (d *DB) createHeraTables() error {
 	if _, err := d.conn.Exec(ddl); err != nil {
 		return fmt.Errorf("creating hera tables: %w", err)
 	}
-
-	// Idempotent ALTER for existing DBs that predate the nuked_at column (BUG-022
-	// two-state EOL). Safe to call repeatedly — the error for an already-existing
-	// column is intentionally ignored, matching the migration block in Init.
-	d.conn.Exec(`ALTER TABLE hera_orchestrators ADD COLUMN nuked_at TEXT`)                         //nolint:errcheck
-	d.conn.Exec(`ALTER TABLE hera_roles ADD COLUMN nuked_at TEXT`)                                 //nolint:errcheck
-	d.conn.Exec(`CREATE INDEX IF NOT EXISTS idx_hera_orch_nuked  ON hera_orchestrators(nuked_at)`) //nolint:errcheck
-	d.conn.Exec(`CREATE INDEX IF NOT EXISTS idx_hera_roles_nuked ON hera_roles(nuked_at)`)         //nolint:errcheck
 	return nil
 }


### PR DESCRIPTION
## Problem

`#770` (BUG-022) added a `nuked_at` column to the Hera tables. `createHeraTables` runs the entire Hera schema as one multi-statement `Exec`, but placed the idempotent `ALTER TABLE ... ADD COLUMN nuked_at` backfill **after** it. On any DB created before #770:

1. `CREATE TABLE IF NOT EXISTS hera_orchestrators` → no-op (table already exists, no `nuked_at`)
2. `CREATE INDEX ... ON hera_orchestrators(nuked_at)` → `no such column: nuked_at` → whole `Exec` aborts
3. The backfill `ALTER` never runs → column never added → **DB open fails, argus won't start** (both TUI and daemon)

Fresh DBs were unaffected (the column is inline in `CREATE TABLE`), which is why it shipped green.

```
error opening database: creating hera tables: SQL logic error: no such column: nuked_at (1)
```

## Fix

- Move the `ADD COLUMN nuked_at` ALTERs **ahead** of the DDL block — they no-op on fresh DBs (table doesn't exist yet) and backfill on pre-existing ones, so the column is present by the time the `CREATE INDEX ... (nuked_at)` statements run.
- Drop the now-redundant trailing ALTER/index block.

## Test

- `TestCreateHeraTables_MigratesPreNukedAtDB` simulates a pre-`nuked_at` schema and asserts `createHeraTables` migrates in place rather than erroring.

## Verification

- `make build`, `go vet ./internal/db/`, and the `internal/db` + `internal/mcp` suites pass.
- Verified live: rebuilt the binary, restarted the launchd daemon, confirmed clean startup (`daemon listening`) against the real pre-`nuked_at` `data.sql`.

Note: `make pre-pr` not run in full locally — `goimports`/`golangci-lint` weren't installed on the host (`gofmt -l` is clean and no imports changed). CI will run the full gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>