### PR TITLE
Add script/iris-check + script/iris-build for host-side iris gating

### DIFF
--- a/script/iris-build
+++ b/script/iris-build
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# iris-build — host-side build entrypoint for iris.
+#
+# iris's `iris_run_build(task_id)` prefers `script/iris-build` when present,
+# running it in a task's worktree on the HOST (full Go toolchain available).
+# This is a thin wrapper over `make build`; an optional target arg passes
+# through (e.g. `script/iris-build vet`).
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+exec make build "$@"

--- a/script/iris-check
+++ b/script/iris-check
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# iris-check — host-side quality-gate entrypoint for iris.
+#
+# iris's `iris_run_checks(task_id, check)` executes `script/iris-check <check>`
+# in a task's worktree on the HOST, where the full Go toolchain (goimports,
+# golangci-lint, govulncheck) is installed. This lets sandboxed agents run
+# argus's own gates without opening a speculative PR just to make CI run them.
+#
+# A single check token (argv[1]) maps to a Makefile target:
+#
+#     token    -> make target
+#     ------------------------
+#     pre-pr   -> pre-pr           (full CI mirror: build+vet+fmt-check+lint-pr+vuln+test-cover-gate)
+#     lint     -> lint-pr          (golangci-lint --new-from-rev=origin/master)
+#     fmt      -> fmt-check        (goimports -l . must be empty)
+#     vet      -> vet              (go vet ./...)
+#     vuln     -> vuln             (govulncheck ./...)
+#     test     -> test            (go test -race -count=1 ./...)
+#     cover    -> test-cover-gate  (race suite + coverage floor)
+#     build    -> build            (go build ./...)
+#
+# The resolved `make` command is exec'd so its exit code and combined output
+# pass straight through to iris (which surfaces a non-zero exit + output verbatim).
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+usage() {
+	echo "usage: script/iris-check <pre-pr|lint|fmt|vet|vuln|test|cover|build>" >&2
+}
+
+if [ "$#" -ne 1 ]; then
+	usage
+	exit 2
+fi
+
+case "$1" in
+	pre-pr) target=pre-pr ;;
+	lint)   target=lint-pr ;;
+	fmt)    target=fmt-check ;;
+	vet)    target=vet ;;
+	vuln)   target=vuln ;;
+	test)   target=test ;;
+	cover)  target=test-cover-gate ;;
+	build)  target=build ;;
+	*)
+		echo "unknown check: $1" >&2
+		usage
+		exit 2
+		;;
+esac
+
+exec make "$target"


### PR DESCRIPTION
## Why

iris exposes `iris_run_checks(task_id, check)`, which executes `script/iris-check <check>` in a task's worktree **host-side** — where the full Go toolchain (goimports, golangci-lint, govulncheck) is installed. argus shipped no such script, so sandboxed agents couldn't run argus's own quality gates host-side and had to open a speculative PR just to get CI to run them. `iris_run_build` similarly prefers `script/iris-build`. These two scripts close that gap.

## What

Two executable bash entrypoints under `script/` (mode `100755`).

### `script/iris-check`

Dispatcher mapping a single check token (argv[1]) to the argus Makefile gate targets:

| token  | make target       | runs                                                            |
| ------ | ----------------- | --------------------------------------------------------------- |
| pre-pr | `pre-pr`          | full CI mirror: build+vet+fmt-check+lint-pr+vuln+test-cover-gate |
| lint   | `lint-pr`         | golangci-lint --new-from-rev=origin/master                      |
| fmt    | `fmt-check`       | goimports -l . must be empty                                    |
| vet    | `vet`             | go vet ./...                                                    |
| vuln   | `vuln`            | govulncheck ./...                                               |
| test   | `test`            | go test -race -count=1 ./...                                    |
| cover  | `test-cover-gate` | race suite + coverage floor                                     |
| build  | `build`           | go build ./...                                                  |

- `set -euo pipefail`; `cd` to repo root via `$(dirname "$0")/..`.
- Unknown/empty token: prints a usage line listing valid tokens to stderr and `exit 2`.
- `exec`s the resolved `make` command so its exit code and combined output pass straight through (iris surfaces non-zero exit + output verbatim).

### `script/iris-build`

Thin wrapper: `set -euo pipefail`, `cd` to repo root, `exec make build "$@"` (optional target arg passes through).

## Notes

- Dev tooling only — no Go code, no spec change, no README change. These scripts are not read by CI, the Makefile, or the Go build.
- Verified: `bash -n` clean on both; `script/iris-check bogus` prints usage and exits 2; both staged as git mode `100755`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>