### PR TITLE
Capture claude CLI stderr in autoname failures

### DIFF
--- a/context/knowledge/gotchas/misc.md
+++ b/context/knowledge/gotchas/misc.md
@@ -158,6 +158,7 @@
 - **Goroutine inherits its parent process lifecycle.** TUI-initiated tasks fire `runAutoRename` inside the TUI process; if the user quits before Haiku returns, the rename is lost. Headless paths (HTTP API / MCP) run inside the daemon, so renames survive TUI restarts.
 - **`AutoName` opt-in lives on each call site, not centrally.** Only set `AutoName: true` when the name was string-interpolated from `Prompt` — NOT for fork (`<src>-fork`) or multipart with attachment-derived name (the filename is already meaningful).
 - **`llm.DefaultTimeout` must comfortably exceed claude CLI startup + Haiku latency.** Observed end-to-end is 6-8s (CLI startup 1-2s + model 3-6s) with occasional spikes; setting the timeout near that range produces frequent `signal: killed` failures and silent fallback to the regex slug. 30s gives ample headroom and costs nothing because the goroutine is fire-and-forget. If you ever shrink it, watch `[autoname] failed … signal: killed` in `~/.argus/daemon.log`.
+- **`GenerateName` folds `ExitError.Stderr` into the wrapped error — don't set `cmd.Stderr`.** `cmd.Output()` only populates `ExitError.Stderr` when `cmd.Stderr` is nil; the bare error's `Error()` is just `exit status 1`, so the claude CLI's real failure reason (credit/usage limit, auth, API error) is lost unless folded in. If you ever assign `cmd.Stderr`, `ExitError.Stderr` goes empty and the `[autoname] failed` log line reverts to opaque `exit status 1`. Stderr is truncated to 500 bytes (rune-safe) to keep the log line bounded.
 
 ## Link Extraction
 

--- a/internal/llm/namegen.go
+++ b/internal/llm/namegen.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // DefaultTimeout caps each name-gen call. The claude CLI startup alone
@@ -126,6 +127,15 @@ func GenerateName(ctx context.Context, prompt string) (string, error) {
 
 	out, err := cmd.Output()
 	if err != nil {
+		// cmd.Output() leaves cmd.Stderr nil, so on a non-zero exit the
+		// captured stderr lands in ExitError.Stderr. The error's own
+		// Error() is just "exit status 1" — fold the stderr in so the
+		// failure is actually diagnosable from the autoname log line.
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+			if stderr := strings.TrimSpace(string(exitErr.Stderr)); stderr != "" {
+				return "", fmt.Errorf("claude -p failed: %w: %s", err, truncate(stderr, 500))
+			}
+		}
 		return "", fmt.Errorf("claude -p failed: %w", err)
 	}
 
@@ -134,6 +144,21 @@ func GenerateName(ctx context.Context, prompt string) (string, error) {
 		return "", fmt.Errorf("invalid name from model: %q", strings.TrimSpace(string(out)))
 	}
 	return name, nil
+}
+
+// truncate caps s at max bytes (rune-safe), appending an ellipsis when it
+// trims. Keeps captured stderr from bloating a log line if claude dumps a
+// stack trace or long help text on failure.
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	// Back up to a rune boundary so we don't split a multi-byte sequence.
+	cut := max
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "…"
 }
 
 // sanitizeAndValidate trims whitespace, strips chatty wrappers (leading/

--- a/internal/llm/namegen_test.go
+++ b/internal/llm/namegen_test.go
@@ -129,6 +129,69 @@ func TestGenerateName_PromptFraming(t *testing.T) {
 	}
 }
 
+// setupFailingClaude wires a fake `claude` that writes stderr and exits
+// non-zero, so we can assert GenerateName folds the captured stderr into
+// its error instead of dropping it as a bare "exit status 1".
+func setupFailingClaude(t *testing.T, stderr string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script not portable on Windows")
+	}
+	tmp := t.TempDir()
+	fake := tmp + "/claude"
+	if err := writeExec(fake, "#!/bin/sh\nprintf '"+stderr+"' >&2\nexit 1\n"); err != nil {
+		t.Fatalf("writeExec: %v", err)
+	}
+	t.Setenv("PATH", tmp)
+
+	prev := nameGenCmd
+	t.Cleanup(func() { nameGenCmd = prev })
+	nameGenCmd = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, fake)
+	}
+}
+
+func TestGenerateName_ExitErrorIncludesStderr(t *testing.T) {
+	setupFailingClaude(t, "Credit balance is too low to run this request.")
+
+	_, err := GenerateName(context.Background(), "build a feature")
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	testutil.Contains(t, err.Error(), "claude -p failed")
+	testutil.Contains(t, err.Error(), "Credit balance is too low")
+}
+
+func TestGenerateName_ExitErrorEmptyStderr(t *testing.T) {
+	setupFailingClaude(t, "")
+
+	_, err := GenerateName(context.Background(), "build a feature")
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	// No stderr to fold in — error stays the bare exit-status form.
+	testutil.Contains(t, err.Error(), "claude -p failed: exit status 1")
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"under limit", "short", 10, "short"},
+		{"at limit", "exactly10!", 10, "exactly10!"},
+		{"over limit", "abcdefghij", 5, "abcde…"},
+		{"multibyte boundary", "abcdé", 4, "abcd…"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutil.Equal(t, truncate(tt.in, tt.max), tt.want)
+		})
+	}
+}
+
 func TestGenerateName_InvalidModelOutput(t *testing.T) {
 	setupFakeClaude(t, "Sorry, I cannot help with that.", nil)
 


### PR DESCRIPTION
On a non-zero exit from `claude -p`, the Haiku auto-rename discarded the CLI's stderr — the `[autoname] failed` log line read only `exit status 1`, hiding the real cause (credit/usage limit, auth, transient API error). Fold ExitError.Stderr into the wrapped error (rune-safe, capped at 500 bytes). Empty-stderr exits keep the bare form, so nothing regresses. Non-behavioral diagnostics improvement.

Co-Authored-By: Claude <noreply@anthropic.com>