### PR TITLE
Modal text inputs: word-wise editing via meta (Option) keys

### DIFF
--- a/internal/tui/fuzzylinkpicker.go
+++ b/internal/tui/fuzzylinkpicker.go
@@ -97,19 +97,42 @@ func (m *FuzzyLinkPickerModal) InputHandler() func(event *tcell.EventKey, setFoc
 			m.qCursor = 0
 			m.refilter()
 		case tcell.KeyLeft:
-			if m.qCursor > 0 {
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				m.qCursor = widget.WordLeftPos(m.query, m.qCursor)
+			} else if m.qCursor > 0 {
 				m.qCursor--
 			}
 		case tcell.KeyRight:
-			if m.qCursor < len(m.query) {
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				m.qCursor = widget.WordRightPos(m.query, m.qCursor)
+			} else if m.qCursor < len(m.query) {
 				m.qCursor++
 			}
+		case tcell.KeyDelete:
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				m.query, m.qCursor = widget.DeleteWordRight(m.query, m.qCursor)
+			} else if m.qCursor < len(m.query) {
+				m.query = append(m.query[:m.qCursor], m.query[m.qCursor+1:]...)
+			}
+			m.refilter()
 		case tcell.KeyHome, tcell.KeyCtrlA:
 			m.qCursor = 0
 		case tcell.KeyEnd, tcell.KeyCtrlE:
 			m.qCursor = len(m.query)
 		case tcell.KeyRune:
 			r := event.Rune()
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				switch r {
+				case 'b', 'B':
+					m.qCursor = widget.WordLeftPos(m.query, m.qCursor)
+				case 'f', 'F':
+					m.qCursor = widget.WordRightPos(m.query, m.qCursor)
+				case 'd', 'D':
+					m.query, m.qCursor = widget.DeleteWordRight(m.query, m.qCursor)
+					m.refilter()
+				}
+				return
+			}
 			m.query = append(m.query[:m.qCursor], append([]rune{r}, m.query[m.qCursor:]...)...)
 			m.qCursor++
 			m.refilter()

--- a/internal/tui/fuzzylinkpicker_test.go
+++ b/internal/tui/fuzzylinkpicker_test.go
@@ -204,3 +204,23 @@ func TestFuzzyLinkPickerModal_MatchesLabel(t *testing.T) {
 	testutil.Equal(t, len(m.filtered), 1)
 	testutil.Equal(t, m.filtered[0].Label, "My Docs Page")
 }
+
+// Meta (Alt/Option) word-motion keys on the link picker query.
+func TestFuzzyLinkPickerModal_AltWordMotion(t *testing.T) {
+	m := NewFuzzyLinkPickerModal([]Link{{Label: "x", URL: "y"}})
+	h := m.InputHandler()
+	m.query = []rune("foo bar")
+	m.qCursor = 7
+
+	h(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModAlt), func(tview.Primitive) {})
+	testutil.Equal(t, m.qCursor, 4)
+
+	m.qCursor = 7
+	h(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModAlt), func(tview.Primitive) {})
+	testutil.Equal(t, string(m.query), "foo ")
+
+	m.query = []rune("foo bar")
+	m.qCursor = 0
+	h(tcell.NewEventKey(tcell.KeyDelete, 0, tcell.ModAlt), func(tview.Primitive) {})
+	testutil.Equal(t, string(m.query), " bar")
+}

--- a/internal/tui/herapicker.go
+++ b/internal/tui/herapicker.go
@@ -104,19 +104,42 @@ func (m *OrchPickerModal) InputHandler() func(event *tcell.EventKey, setFocus fu
 			m.qCursor = 0
 			m.refilter()
 		case tcell.KeyLeft:
-			if m.qCursor > 0 {
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				m.qCursor = widget.WordLeftPos(m.query, m.qCursor)
+			} else if m.qCursor > 0 {
 				m.qCursor--
 			}
 		case tcell.KeyRight:
-			if m.qCursor < len(m.query) {
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				m.qCursor = widget.WordRightPos(m.query, m.qCursor)
+			} else if m.qCursor < len(m.query) {
 				m.qCursor++
 			}
+		case tcell.KeyDelete:
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				m.query, m.qCursor = widget.DeleteWordRight(m.query, m.qCursor)
+			} else if m.qCursor < len(m.query) {
+				m.query = append(m.query[:m.qCursor], m.query[m.qCursor+1:]...)
+			}
+			m.refilter()
 		case tcell.KeyHome, tcell.KeyCtrlA:
 			m.qCursor = 0
 		case tcell.KeyEnd, tcell.KeyCtrlE:
 			m.qCursor = len(m.query)
 		case tcell.KeyRune:
 			r := event.Rune()
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				switch r {
+				case 'b', 'B':
+					m.qCursor = widget.WordLeftPos(m.query, m.qCursor)
+				case 'f', 'F':
+					m.qCursor = widget.WordRightPos(m.query, m.qCursor)
+				case 'd', 'D':
+					m.query, m.qCursor = widget.DeleteWordRight(m.query, m.qCursor)
+					m.refilter()
+				}
+				return
+			}
 			m.query = append(m.query[:m.qCursor], append([]rune{r}, m.query[m.qCursor:]...)...)
 			m.qCursor++
 			m.refilter()

--- a/internal/tui/herapicker_test.go
+++ b/internal/tui/herapicker_test.go
@@ -89,3 +89,23 @@ func TestOrchPickerModal_DrawEmptyList(t *testing.T) {
 	screen.SetSize(80, 24)
 	m.Draw(screen) // must not panic on the empty-list branch
 }
+
+// Meta (Alt/Option) word-motion keys on the orchestrator picker query.
+func TestOrchPickerModal_AltWordMotion(t *testing.T) {
+	m := NewOrchPickerModal("t", orchs())
+	h := m.InputHandler()
+	m.query = []rune("foo bar")
+	m.qCursor = 7
+
+	h(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModAlt), func(tview.Primitive) {})
+	testutil.Equal(t, m.qCursor, 4)
+
+	m.qCursor = 7
+	h(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModAlt), func(tview.Primitive) {})
+	testutil.Equal(t, string(m.query), "foo ")
+
+	m.query = []rune("foo bar")
+	m.qCursor = 0
+	h(tcell.NewEventKey(tcell.KeyDelete, 0, tcell.ModAlt), func(tview.Primitive) {})
+	testutil.Equal(t, string(m.query), " bar")
+}

--- a/internal/tui/newtaskform.go
+++ b/internal/tui/newtaskform.go
@@ -988,6 +988,10 @@ func (f *NewTaskForm) handleModelCustomKey(event *tcell.EventKey) {
 		f.modelInput, f.modelCursorPos = widget.DeleteWordLeft(f.modelInput, f.modelCursorPos)
 		return
 	case tcell.KeyDelete:
+		if hasAlt {
+			f.modelInput, f.modelCursorPos = widget.DeleteWordRight(f.modelInput, f.modelCursorPos)
+			return
+		}
 		if f.modelCursorPos < len(f.modelInput) {
 			f.modelInput = append(f.modelInput[:f.modelCursorPos], f.modelInput[f.modelCursorPos+1:]...)
 		}

--- a/internal/tui/newtaskform_test.go
+++ b/internal/tui/newtaskform_test.go
@@ -1807,6 +1807,25 @@ func TestNewTaskForm_ModelCustomTyping(t *testing.T) {
 	testutil.Equal(t, string(f.modelInput), "")
 }
 
+// The model custom field's meta+Delete deletes the word to the right,
+// completing its word-deletion vocabulary (it already has Alt+Backspace/Alt+d).
+func TestNewTaskForm_ModelCustomAltDelete(t *testing.T) {
+	f := NewNewTaskForm(
+		map[string]config.Project{"p": {}}, "p",
+		map[string]config.Backend{"b": {}}, "b",
+	)
+	handler := f.InputHandler()
+	enterCustomModel(t, f, handler)
+
+	for _, r := range "foo bar" {
+		handler(tcell.NewEventKey(tcell.KeyRune, r, 0), nil)
+	}
+	handler(tcell.NewEventKey(tcell.KeyCtrlA, 0, 0), nil) // cursor to start
+	handler(tcell.NewEventKey(tcell.KeyDelete, 0, tcell.ModAlt), nil)
+	testutil.Equal(t, string(f.modelInput), " bar")
+	testutil.Equal(t, f.modelCursorPos, 0)
+}
+
 func TestNewTaskForm_ModelNonCustomIgnoresRunes(t *testing.T) {
 	f := NewNewTaskForm(
 		map[string]config.Project{"p": {}}, "p",

--- a/internal/tui/projectform.go
+++ b/internal/tui/projectform.go
@@ -235,14 +235,20 @@ func (pf *ProjectForm) HandleKey(ev *tcell.EventKey) {
 		return
 	}
 
-	// Text field input.
+	// Text field input. Alt-modified keys provide word-wise motion/deletion
+	// (Option+Arrow / Option+Delete on macOS terminals), mirroring the
+	// RenameTaskForm bindings via the shared widget word-boundary helpers.
+	f := pf.focused
+	hasAlt := ev.Modifiers()&tcell.ModAlt != 0
+	readOnly := pf.editMode && f == pfFieldName
 	switch ev.Key() {
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
-		f := pf.focused
-		if pf.editMode && f == pfFieldName {
+		if readOnly {
 			return
 		}
-		if pf.cursors[f] > 0 {
+		if hasAlt {
+			pf.fields[f], pf.cursors[f] = widget.DeleteWordLeft(pf.fields[f], pf.cursors[f])
+		} else if pf.cursors[f] > 0 {
 			pf.fields[f] = append(pf.fields[f][:pf.cursors[f]-1], pf.fields[f][pf.cursors[f]:]...)
 			pf.cursors[f]--
 		}
@@ -250,22 +256,68 @@ func (pf *ProjectForm) HandleKey(ev *tcell.EventKey) {
 			pf.updatePathAC()
 		}
 		return
+	case tcell.KeyCtrlW:
+		if readOnly {
+			return
+		}
+		pf.fields[f], pf.cursors[f] = widget.DeleteWordLeft(pf.fields[f], pf.cursors[f])
+		if f == pfFieldPath {
+			pf.updatePathAC()
+		}
+		return
+	case tcell.KeyDelete:
+		if readOnly {
+			return
+		}
+		if hasAlt {
+			pf.fields[f], pf.cursors[f] = widget.DeleteWordRight(pf.fields[f], pf.cursors[f])
+		} else if pf.cursors[f] < len(pf.fields[f]) {
+			pf.fields[f] = append(pf.fields[f][:pf.cursors[f]], pf.fields[f][pf.cursors[f]+1:]...)
+		}
+		if f == pfFieldPath {
+			pf.updatePathAC()
+		}
+		return
 	case tcell.KeyLeft:
-		if pf.cursors[pf.focused] > 0 {
-			pf.cursors[pf.focused]--
+		if hasAlt {
+			pf.cursors[f] = widget.WordLeftPos(pf.fields[f], pf.cursors[f])
+		} else if pf.cursors[f] > 0 {
+			pf.cursors[f]--
 		}
 		return
 	case tcell.KeyRight:
-		if pf.cursors[pf.focused] < len(pf.fields[pf.focused]) {
-			pf.cursors[pf.focused]++
+		if hasAlt {
+			pf.cursors[f] = widget.WordRightPos(pf.fields[f], pf.cursors[f])
+		} else if pf.cursors[f] < len(pf.fields[f]) {
+			pf.cursors[f]++
 		}
 		return
+	case tcell.KeyHome, tcell.KeyCtrlA:
+		pf.cursors[f] = 0
+		return
+	case tcell.KeyEnd, tcell.KeyCtrlE:
+		pf.cursors[f] = len(pf.fields[f])
+		return
 	case tcell.KeyRune:
-		if pf.editMode && pf.focused == pfFieldName {
+		if readOnly {
 			return
 		}
-		f := pf.focused
 		r := ev.Rune()
+		if hasAlt {
+			// Alt+B: word left, Alt+F: word right, Alt+D: delete word right.
+			switch r {
+			case 'b', 'B':
+				pf.cursors[f] = widget.WordLeftPos(pf.fields[f], pf.cursors[f])
+			case 'f', 'F':
+				pf.cursors[f] = widget.WordRightPos(pf.fields[f], pf.cursors[f])
+			case 'd', 'D':
+				pf.fields[f], pf.cursors[f] = widget.DeleteWordRight(pf.fields[f], pf.cursors[f])
+				if f == pfFieldPath {
+					pf.updatePathAC()
+				}
+			}
+			return
+		}
 		pf.fields[f] = append(pf.fields[f][:pf.cursors[f]], append([]rune{r}, pf.fields[f][pf.cursors[f]:]...)...)
 		pf.cursors[f]++
 		if f == pfFieldPath {

--- a/internal/tui/projectform_test.go
+++ b/internal/tui/projectform_test.go
@@ -650,3 +650,128 @@ func TestProjectForm_SetError(t *testing.T) {
 	pf.SetError("oops")
 	testutil.Equal(t, pf.errMsg, "oops")
 }
+
+// Word-motion bindings (Option+Arrow / Option+Delete on macOS, plus the
+// Alt+b/f/d and Ctrl/Home/End aliases) on the Name text field.
+func TestProjectForm_NameField_AltWordMotion(t *testing.T) {
+	t.Run("alt+left jumps word left", func(t *testing.T) {
+		pf := NewProjectForm()
+		pf.focused = pfFieldName
+		typeRunes(pf, "foo bar baz")
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModAlt))
+		testutil.Equal(t, pf.cursors[pfFieldName], 8) // start of "baz"
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModAlt))
+		testutil.Equal(t, pf.cursors[pfFieldName], 4) // start of "bar"
+	})
+
+	t.Run("alt+right jumps word right", func(t *testing.T) {
+		pf := NewProjectForm()
+		pf.focused = pfFieldName
+		typeRunes(pf, "foo bar")
+		pf.cursors[pfFieldName] = 0
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModAlt))
+		testutil.Equal(t, pf.cursors[pfFieldName], 3) // end of "foo"
+	})
+
+	t.Run("alt+backspace deletes word left", func(t *testing.T) {
+		pf := NewProjectForm()
+		pf.focused = pfFieldName
+		typeRunes(pf, "foo bar baz")
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModAlt))
+		testutil.Equal(t, string(pf.fields[pfFieldName]), "foo bar ")
+		testutil.Equal(t, pf.cursors[pfFieldName], 8)
+	})
+
+	t.Run("alt+delete deletes word right", func(t *testing.T) {
+		pf := NewProjectForm()
+		pf.focused = pfFieldName
+		typeRunes(pf, "foo bar")
+		pf.cursors[pfFieldName] = 0
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyDelete, 0, tcell.ModAlt))
+		testutil.Equal(t, string(pf.fields[pfFieldName]), " bar")
+		testutil.Equal(t, pf.cursors[pfFieldName], 0)
+	})
+
+	t.Run("alt+b / alt+f / alt+d via rune", func(t *testing.T) {
+		pf := NewProjectForm()
+		pf.focused = pfFieldName
+		typeRunes(pf, "foo bar")
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyRune, 'b', tcell.ModAlt))
+		testutil.Equal(t, pf.cursors[pfFieldName], 4)
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyRune, 'f', tcell.ModAlt))
+		testutil.Equal(t, pf.cursors[pfFieldName], 7)
+		pf.cursors[pfFieldName] = 0
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyRune, 'd', tcell.ModAlt))
+		testutil.Equal(t, string(pf.fields[pfFieldName]), " bar")
+	})
+
+	t.Run("ctrl+w deletes word left", func(t *testing.T) {
+		pf := NewProjectForm()
+		pf.focused = pfFieldName
+		typeRunes(pf, "foo bar")
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlW, 0, tcell.ModNone))
+		testutil.Equal(t, string(pf.fields[pfFieldName]), "foo ")
+	})
+
+	t.Run("home and end move to edges", func(t *testing.T) {
+		pf := NewProjectForm()
+		pf.focused = pfFieldName
+		typeRunes(pf, "foobar")
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyHome, 0, tcell.ModNone))
+		testutil.Equal(t, pf.cursors[pfFieldName], 0)
+		pf.HandleKey(tcell.NewEventKey(tcell.KeyEnd, 0, tcell.ModNone))
+		testutil.Equal(t, pf.cursors[pfFieldName], 6)
+	})
+}
+
+// Word-motion on the Path field also refreshes the autocomplete dropdown.
+func TestProjectForm_PathField_AltDeleteUpdatesAC(t *testing.T) {
+	root := setupACDirs(t, "alpha", "beta")
+	pf := NewProjectForm()
+	pf.focused = pfFieldPath
+	typeRunes(pf, root+"/al")
+	testutil.Equal(t, pf.pathAC.Open(), true)
+
+	// Alt+Backspace removes the "al" word so the dropdown reflects the dir again.
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModAlt))
+	testutil.Equal(t, string(pf.fields[pfFieldPath]), root+"/")
+}
+
+// The name field stays read-only under word-motion keys in edit mode.
+func TestProjectForm_EditMode_NameReadOnlyUnderWordMotion(t *testing.T) {
+	pf := NewProjectForm()
+	pf.LoadProject("myproj", config.Project{Path: "/tmp"})
+	pf.focused = pfFieldName // force focus to the (normally skipped) name field
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModAlt))
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyDelete, 0, tcell.ModAlt))
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlW, 0, tcell.ModNone))
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyRune, 'd', tcell.ModAlt))
+	testutil.Equal(t, string(pf.fields[pfFieldName]), "myproj")
+}
+
+// Plain (non-Alt) Delete forward-deletes the character under the cursor.
+func TestProjectForm_PlainDeleteForwardDeletes(t *testing.T) {
+	pf := NewProjectForm()
+	pf.focused = pfFieldName
+	typeRunes(pf, "foo")
+	pf.cursors[pfFieldName] = 0
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyDelete, 0, tcell.ModNone))
+	testutil.Equal(t, string(pf.fields[pfFieldName]), "oo")
+	testutil.Equal(t, pf.cursors[pfFieldName], 0)
+
+	// Plain Delete at end of field is a no-op.
+	pf.cursors[pfFieldName] = 2
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyDelete, 0, tcell.ModNone))
+	testutil.Equal(t, string(pf.fields[pfFieldName]), "oo")
+}
+
+// Word motion is field-agnostic — verify it on the Backend field too.
+func TestProjectForm_BackendField_AltWordMotion(t *testing.T) {
+	pf := NewProjectForm()
+	pf.focused = pfFieldBackend
+	typeRunes(pf, "claude code")
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModAlt))
+	testutil.Equal(t, string(pf.fields[pfFieldBackend]), "claude ")
+	pf.HandleKey(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModAlt))
+	testutil.Equal(t, pf.cursors[pfFieldBackend], 0)
+}

--- a/internal/tui/quickaddform.go
+++ b/internal/tui/quickaddform.go
@@ -361,28 +361,43 @@ func (f *QuickAddForm) handleDirInputKey(ev *tcell.EventKey) {
 		return
 
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
-		if f.dirCursor > 0 {
+		if ev.Modifiers()&tcell.ModAlt != 0 {
+			f.dirPath, f.dirCursor = widget.DeleteWordLeft(f.dirPath, f.dirCursor)
+			f.updateDirAutocomplete()
+		} else if f.dirCursor > 0 {
 			f.dirPath = append(f.dirPath[:f.dirCursor-1], f.dirPath[f.dirCursor:]...)
 			f.dirCursor--
 			f.updateDirAutocomplete()
 		}
 		return
 
+	case tcell.KeyCtrlW:
+		f.dirPath, f.dirCursor = widget.DeleteWordLeft(f.dirPath, f.dirCursor)
+		f.updateDirAutocomplete()
+		return
+
 	case tcell.KeyDelete:
-		if f.dirCursor < len(f.dirPath) {
+		if ev.Modifiers()&tcell.ModAlt != 0 {
+			f.dirPath, f.dirCursor = widget.DeleteWordRight(f.dirPath, f.dirCursor)
+			f.updateDirAutocomplete()
+		} else if f.dirCursor < len(f.dirPath) {
 			f.dirPath = append(f.dirPath[:f.dirCursor], f.dirPath[f.dirCursor+1:]...)
 			f.updateDirAutocomplete()
 		}
 		return
 
 	case tcell.KeyLeft:
-		if f.dirCursor > 0 {
+		if ev.Modifiers()&tcell.ModAlt != 0 {
+			f.dirCursor = widget.WordLeftPos(f.dirPath, f.dirCursor)
+		} else if f.dirCursor > 0 {
 			f.dirCursor--
 		}
 		return
 
 	case tcell.KeyRight:
-		if f.dirCursor < len(f.dirPath) {
+		if ev.Modifiers()&tcell.ModAlt != 0 {
+			f.dirCursor = widget.WordRightPos(f.dirPath, f.dirCursor)
+		} else if f.dirCursor < len(f.dirPath) {
 			f.dirCursor++
 		}
 		return
@@ -408,6 +423,18 @@ func (f *QuickAddForm) handleDirInputKey(ev *tcell.EventKey) {
 
 	case tcell.KeyRune:
 		r := ev.Rune()
+		if ev.Modifiers()&tcell.ModAlt != 0 {
+			switch r {
+			case 'b', 'B':
+				f.dirCursor = widget.WordLeftPos(f.dirPath, f.dirCursor)
+			case 'f', 'F':
+				f.dirCursor = widget.WordRightPos(f.dirPath, f.dirCursor)
+			case 'd', 'D':
+				f.dirPath, f.dirCursor = widget.DeleteWordRight(f.dirPath, f.dirCursor)
+				f.updateDirAutocomplete()
+			}
+			return
+		}
 		f.dirPath = append(f.dirPath[:f.dirCursor], append([]rune{r}, f.dirPath[f.dirCursor:]...)...)
 		f.dirCursor++
 		f.updateDirAutocomplete()

--- a/internal/tui/quickaddform_test.go
+++ b/internal/tui/quickaddform_test.go
@@ -551,3 +551,30 @@ func TestQuickAddForm_HandleSelection_EnterNoSelection(t *testing.T) {
 	f.HandleKey(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
 	testutil.Contains(t, f.errMsg, "No repos selected")
 }
+
+// Meta (Alt/Option) word-motion keys on the quick-add directory input.
+func TestQuickAddForm_DirAltWordMotion(t *testing.T) {
+	f := NewQuickAddForm(nil)
+	f.dirPath = []rune("/Users/me/proj")
+	f.dirCursor = len(f.dirPath)
+
+	// Alt+Backspace deletes the trailing word ("proj"); '/' is a delimiter.
+	f.handleDirInputKey(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModAlt))
+	testutil.Equal(t, string(f.dirPath), "/Users/me/")
+
+	// Alt+Left then Alt+Left walks back over "me" and "Users".
+	f.handleDirInputKey(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModAlt))
+	testutil.Equal(t, f.dirCursor, 7) // start of "me"
+	f.handleDirInputKey(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModAlt))
+	testutil.Equal(t, f.dirCursor, 1) // start of "Users"
+
+	// Alt+Delete from here removes "Users".
+	f.handleDirInputKey(tcell.NewEventKey(tcell.KeyDelete, 0, tcell.ModAlt))
+	testutil.Equal(t, string(f.dirPath), "//me/")
+
+	// Ctrl+W deletes the word left from the end.
+	f.dirPath = []rune("/a/bbb")
+	f.dirCursor = len(f.dirPath)
+	f.handleDirInputKey(tcell.NewEventKey(tcell.KeyCtrlW, 0, 0))
+	testutil.Equal(t, string(f.dirPath), "/a/")
+}

--- a/internal/tui/scheduleform.go
+++ b/internal/tui/scheduleform.go
@@ -168,28 +168,63 @@ func (sf *ScheduleForm) HandleKey(ev *tcell.EventKey) {
 		return
 	}
 
-	// Text field input.
+	// Text field input. Alt-modified keys provide word-wise motion/deletion
+	// (Option+Arrow / Option+Delete on macOS) via the shared word-boundary
+	// helpers, consistent with the other modal text inputs.
+	f := sf.focused
+	hasAlt := ev.Modifiers()&tcell.ModAlt != 0
 	switch ev.Key() {
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
-		f := sf.focused
-		if sf.cursors[f] > 0 {
+		if hasAlt {
+			sf.fields[f], sf.cursors[f] = widget.DeleteWordLeft(sf.fields[f], sf.cursors[f])
+		} else if sf.cursors[f] > 0 {
 			sf.fields[f] = append(sf.fields[f][:sf.cursors[f]-1], sf.fields[f][sf.cursors[f]:]...)
 			sf.cursors[f]--
 		}
 		return
+	case tcell.KeyCtrlW:
+		sf.fields[f], sf.cursors[f] = widget.DeleteWordLeft(sf.fields[f], sf.cursors[f])
+		return
+	case tcell.KeyDelete:
+		if hasAlt {
+			sf.fields[f], sf.cursors[f] = widget.DeleteWordRight(sf.fields[f], sf.cursors[f])
+		} else if sf.cursors[f] < len(sf.fields[f]) {
+			sf.fields[f] = append(sf.fields[f][:sf.cursors[f]], sf.fields[f][sf.cursors[f]+1:]...)
+		}
+		return
 	case tcell.KeyLeft:
-		if sf.cursors[sf.focused] > 0 {
-			sf.cursors[sf.focused]--
+		if hasAlt {
+			sf.cursors[f] = widget.WordLeftPos(sf.fields[f], sf.cursors[f])
+		} else if sf.cursors[f] > 0 {
+			sf.cursors[f]--
 		}
 		return
 	case tcell.KeyRight:
-		if sf.cursors[sf.focused] < len(sf.fields[sf.focused]) {
-			sf.cursors[sf.focused]++
+		if hasAlt {
+			sf.cursors[f] = widget.WordRightPos(sf.fields[f], sf.cursors[f])
+		} else if sf.cursors[f] < len(sf.fields[f]) {
+			sf.cursors[f]++
 		}
 		return
+	case tcell.KeyHome, tcell.KeyCtrlA:
+		sf.cursors[f] = 0
+		return
+	case tcell.KeyEnd, tcell.KeyCtrlE:
+		sf.cursors[f] = len(sf.fields[f])
+		return
 	case tcell.KeyRune:
-		f := sf.focused
 		r := ev.Rune()
+		if hasAlt {
+			switch r {
+			case 'b', 'B':
+				sf.cursors[f] = widget.WordLeftPos(sf.fields[f], sf.cursors[f])
+			case 'f', 'F':
+				sf.cursors[f] = widget.WordRightPos(sf.fields[f], sf.cursors[f])
+			case 'd', 'D':
+				sf.fields[f], sf.cursors[f] = widget.DeleteWordRight(sf.fields[f], sf.cursors[f])
+			}
+			return
+		}
 		sf.fields[f] = append(sf.fields[f][:sf.cursors[f]], append([]rune{r}, sf.fields[f][sf.cursors[f]:]...)...)
 		sf.cursors[f]++
 		return

--- a/internal/tui/scheduleform_test.go
+++ b/internal/tui/scheduleform_test.go
@@ -339,3 +339,32 @@ func TestScheduleForm_Draw_TinyRect(t *testing.T) {
 	t.Cleanup(func() { screen.Fini() })
 	sf.Draw(screen) // must not panic
 }
+
+// Meta (Alt/Option) word-motion keys on the schedule form's text fields.
+func TestScheduleForm_AltWordMotion(t *testing.T) {
+	sf := NewScheduleForm([]string{"p"}, []string{})
+	sf.focused = sfFieldName
+	for _, r := range "foo bar" {
+		sf.HandleKey(tcell.NewEventKey(tcell.KeyRune, r, 0))
+	}
+
+	// Alt+Left jumps to the start of "bar".
+	sf.HandleKey(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModAlt))
+	testutil.Equal(t, sf.cursors[sfFieldName], 4)
+
+	// Alt+Backspace deletes the word left.
+	sf.HandleKey(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModAlt))
+	testutil.Equal(t, string(sf.fields[sfFieldName]), "bar")
+	testutil.Equal(t, sf.cursors[sfFieldName], 0)
+
+	// Alt+Delete deletes the word right.
+	sf.HandleKey(tcell.NewEventKey(tcell.KeyDelete, 0, tcell.ModAlt))
+	testutil.Equal(t, string(sf.fields[sfFieldName]), "")
+
+	// Ctrl+W deletes the word left.
+	for _, r := range "alpha beta" {
+		sf.HandleKey(tcell.NewEventKey(tcell.KeyRune, r, 0))
+	}
+	sf.HandleKey(tcell.NewEventKey(tcell.KeyCtrlW, 0, 0))
+	testutil.Equal(t, string(sf.fields[sfFieldName]), "alpha ")
+}

--- a/internal/tui/sessionpicker.go
+++ b/internal/tui/sessionpicker.go
@@ -102,19 +102,42 @@ func (m *SessionPickerModal) InputHandler() func(event *tcell.EventKey, setFocus
 			m.qCursor = 0
 			m.refilter()
 		case tcell.KeyLeft:
-			if m.qCursor > 0 {
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				m.qCursor = widget.WordLeftPos(m.query, m.qCursor)
+			} else if m.qCursor > 0 {
 				m.qCursor--
 			}
 		case tcell.KeyRight:
-			if m.qCursor < len(m.query) {
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				m.qCursor = widget.WordRightPos(m.query, m.qCursor)
+			} else if m.qCursor < len(m.query) {
 				m.qCursor++
 			}
+		case tcell.KeyDelete:
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				m.query, m.qCursor = widget.DeleteWordRight(m.query, m.qCursor)
+			} else if m.qCursor < len(m.query) {
+				m.query = append(m.query[:m.qCursor], m.query[m.qCursor+1:]...)
+			}
+			m.refilter()
 		case tcell.KeyHome, tcell.KeyCtrlA:
 			m.qCursor = 0
 		case tcell.KeyEnd, tcell.KeyCtrlE:
 			m.qCursor = len(m.query)
 		case tcell.KeyRune:
 			r := event.Rune()
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				switch r {
+				case 'b', 'B':
+					m.qCursor = widget.WordLeftPos(m.query, m.qCursor)
+				case 'f', 'F':
+					m.qCursor = widget.WordRightPos(m.query, m.qCursor)
+				case 'd', 'D':
+					m.query, m.qCursor = widget.DeleteWordRight(m.query, m.qCursor)
+					m.refilter()
+				}
+				return
+			}
 			m.query = append(m.query[:m.qCursor], append([]rune{r}, m.query[m.qCursor:]...)...)
 			m.qCursor++
 			m.refilter()

--- a/internal/tui/sessionpicker_test.go
+++ b/internal/tui/sessionpicker_test.go
@@ -184,3 +184,30 @@ func TestSessionPicker_DrawVariousSizesNoPanic(t *testing.T) {
 		m.Draw(screen) // must not panic
 	}
 }
+
+// Meta (Alt/Option) word-motion keys on the session picker query.
+func TestSessionPicker_AltWordMotion(t *testing.T) {
+	m := NewSessionPickerModal(sampleSessions(), "")
+	h := m.InputHandler()
+	m.query = []rune("foo bar")
+	m.qCursor = 7
+
+	h(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModAlt), nil)
+	testutil.Equal(t, m.qCursor, 4) // start of "bar"
+
+	// Alt+Backspace from the end deletes the trailing word.
+	m.qCursor = 7
+	h(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModAlt), nil)
+	testutil.Equal(t, string(m.query), "foo ")
+
+	// Alt+Delete word-right from the start.
+	m.query = []rune("foo bar")
+	m.qCursor = 0
+	h(tcell.NewEventKey(tcell.KeyDelete, 0, tcell.ModAlt), nil)
+	testutil.Equal(t, string(m.query), " bar")
+
+	// Alt+f cursor motion: from start of " bar", skip the space + "bar" to end.
+	m.qCursor = 0
+	h(tcell.NewEventKey(tcell.KeyRune, 'f', tcell.ModAlt), nil)
+	testutil.Equal(t, m.qCursor, 4)
+}

--- a/internal/tui/taskswitcher.go
+++ b/internal/tui/taskswitcher.go
@@ -192,19 +192,42 @@ func (m *TaskSwitcherModal) InputHandler() func(event *tcell.EventKey, setFocus 
 			m.qCursor = 0
 			m.refilter()
 		case tcell.KeyLeft:
-			if m.qCursor > 0 {
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				m.qCursor = widget.WordLeftPos(m.query, m.qCursor)
+			} else if m.qCursor > 0 {
 				m.qCursor--
 			}
 		case tcell.KeyRight:
-			if m.qCursor < len(m.query) {
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				m.qCursor = widget.WordRightPos(m.query, m.qCursor)
+			} else if m.qCursor < len(m.query) {
 				m.qCursor++
 			}
+		case tcell.KeyDelete:
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				m.query, m.qCursor = widget.DeleteWordRight(m.query, m.qCursor)
+			} else if m.qCursor < len(m.query) {
+				m.query = append(m.query[:m.qCursor], m.query[m.qCursor+1:]...)
+			}
+			m.refilter()
 		case tcell.KeyHome, tcell.KeyCtrlA:
 			m.qCursor = 0
 		case tcell.KeyEnd, tcell.KeyCtrlE:
 			m.qCursor = len(m.query)
 		case tcell.KeyRune:
 			r := event.Rune()
+			if event.Modifiers()&tcell.ModAlt != 0 {
+				switch r {
+				case 'b', 'B':
+					m.qCursor = widget.WordLeftPos(m.query, m.qCursor)
+				case 'f', 'F':
+					m.qCursor = widget.WordRightPos(m.query, m.qCursor)
+				case 'd', 'D':
+					m.query, m.qCursor = widget.DeleteWordRight(m.query, m.qCursor)
+					m.refilter()
+				}
+				return
+			}
 			m.query = append(m.query[:m.qCursor], append([]rune{r}, m.query[m.qCursor:]...)...)
 			m.qCursor++
 			m.refilter()

--- a/internal/tui/taskswitcher_test.go
+++ b/internal/tui/taskswitcher_test.go
@@ -498,3 +498,23 @@ func TestTaskSwitcher_DrawVariousSizesNoPanic(t *testing.T) {
 		m.Draw(screen) // must not panic
 	}
 }
+
+// Meta (Alt/Option) word-motion keys on the task switcher query.
+func TestTaskSwitcher_AltWordMotion(t *testing.T) {
+	m := NewTaskSwitcherModal(sampleSwitcherEntries())
+	h := m.InputHandler()
+	m.query = []rune("foo bar")
+	m.qCursor = 7
+
+	h(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModAlt), func(tview.Primitive) {})
+	testutil.Equal(t, m.qCursor, 4)
+
+	m.qCursor = 7
+	h(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModAlt), func(tview.Primitive) {})
+	testutil.Equal(t, string(m.query), "foo ")
+
+	m.query = []rune("foo bar")
+	m.qCursor = 0
+	h(tcell.NewEventKey(tcell.KeyDelete, 0, tcell.ModAlt), func(tview.Primitive) {})
+	testutil.Equal(t, string(m.query), " bar")
+}

--- a/openspec/specs/forms-and-modals/spec.md
+++ b/openspec/specs/forms-and-modals/spec.md
@@ -194,6 +194,32 @@ Every modal that accepts typed text SHALL implement a paste handler that inserts
 - **WHEN** multi-line text is pasted into a single-line filter input
 - **THEN** newline and carriage-return characters are dropped and the remaining characters are appended
 
+### Requirement: Word-wise text editing
+
+Every editable modal text input field that maintains an edit cursor — the new-task prompt, the project form (name/path/backend), the rename field, the schedule form fields, the quick-add directory input, and every fuzzy/search picker query (task switcher, session picker, hera picker, link picker) — SHALL respond to meta- (Alt/Option-) modified editing keys so word-wise navigation and deletion behave consistently across all forms, matching the conventions of native terminal line editors. Specifically, a focused editable text field SHALL support: meta+Left and meta+Right (equivalently meta+b and meta+f) to move the cursor one word left or right; meta+Backspace (equivalently Ctrl+W) to delete the word before the cursor; meta+Delete (equivalently meta+d) to delete the word after the cursor; and Home/Ctrl+A and End/Ctrl+E to move the cursor to the start or end of the field. Word boundaries SHALL be computed by the shared word-boundary helper so all fields segment identically. These keys SHALL leave a read-only field (e.g. the project name in edit mode) unchanged, and on fields backed by autocomplete or live filtering the edit SHALL refresh the dependent state. Unrecognized meta+rune combinations SHALL be swallowed (a no-op), never inserted as literal characters.
+
+Two narrow exceptions apply. A pure incremental-search filter that does not maintain an edit cursor (the AppleEvents picker filter) is out of scope, as word motion has no cursor to operate on. The new-task model `custom…` input maintains an edit cursor but reserves Left/Right for cycling the model selector, so it SHALL provide Home/Ctrl+A and End/Ctrl+E positioning plus the full word- and line-deletion set (meta+Backspace, Ctrl+W, meta+Delete, meta+d, Ctrl+U, Ctrl+K) rather than arrow-based word motion.
+
+#### Scenario: Meta+arrow moves by word
+
+- **WHEN** an editable text field is focused with multi-word content and the user presses meta+Left then meta+Right
+- **THEN** the cursor moves to the previous word boundary and then back to the next word boundary
+
+#### Scenario: Meta+Backspace deletes the previous word
+
+- **WHEN** the cursor sits at the end of a multi-word text field and the user presses meta+Backspace
+- **THEN** the word before the cursor is removed and the cursor moves to the new boundary
+
+#### Scenario: Meta+Delete deletes the next word
+
+- **WHEN** the cursor sits at the start of a multi-word text field and the user presses meta+Delete
+- **THEN** the word after the cursor is removed and the cursor stays in place
+
+#### Scenario: Word editing leaves read-only fields untouched
+
+- **WHEN** a read-only text field is focused and the user presses any word-wise editing key
+- **THEN** the field value is unchanged
+
 ### Requirement: AppleEvents allowlist picker
 
 The AppleEvents picker SHALL present a filterable, multi-select list of scriptable apps, pre-populated from a project's existing allowlist, with selections that persist across filter changes. When the trimmed filter is a syntactically valid dotted bundle identifier that matches no scanned app and is not already selected, the picker SHALL offer a synthetic "Add custom" row for it. The confirmed result SHALL be the selected bundle identifiers in a deterministic sorted order.


### PR DESCRIPTION
## Summary

The "New Project" modal's project-name input did not respond to macOS **Option+Arrow / Option+Delete** — those arrive as Alt-modified key events, and the form only handled plain Backspace/Left/Right/Rune. This brings **every cursor-bearing modal text input** to parity with the established `RenameTaskForm` / `NewTaskForm` convention, using the shared `internal/tui/widget` word-boundary helpers so all fields segment identically.

Keys now supported on each editable text field:
- `meta+Left` / `meta+Right` (and `meta+b` / `meta+f`) — word motion
- `meta+Backspace` / `Ctrl+W` — delete word left
- `meta+Delete` / `meta+d` — delete word right
- `Home`/`Ctrl+A`, `End`/`Ctrl+E` — line motion
- unrecognized `meta+rune` is swallowed (readline semantics)

**Fields updated:** project form (name/path/backend), schedule form, quick-add directory input, and the fuzzy/search picker queries (task switcher, session picker, hera/orchestrator picker, link picker). Also completed the new-task model `custom…` input's deletion set with `meta+Delete`. Path/dir fields refresh autocomplete and picker queries re-filter on edit; read-only fields (project name in edit mode) stay unchanged.

## Spec

Adds a **Word-wise text editing** requirement to `openspec/specs/forms-and-modals/spec.md`, scoped to cursor-bearing editable fields. Two carve-outs are documented honestly: the cursorless AppleEvents picker filter (no edit cursor), and the new-task model `custom…` input (reserves Left/Right for selector cycling, so it offers Home/End + word/line deletion rather than arrow motion).

## Test plan

- `make test` / `make test-cover-gate` — green (filtered coverage 89.5% ≥ 88% floor)
- New tests: `*_AltWordMotion` for every updated field, `TestProjectForm_PlainDeleteForwardDeletes`, `TestProjectForm_BackendField_AltWordMotion`, `TestNewTaskForm_ModelCustomAltDelete`, read-only-guard coverage
- Reviewed via three independent fresh-eyes passes (0 blocking, 0 warning at convergence)

## CI note

`make vuln` reports 9 Go **standard-library** CVEs (`@go1.26.1`, fixed in go1.26.2) — toolchain-only, unrelated to this diff, and the CI `vuln` step runs with `continue-on-error: true`. All other gates (build, vet, fmt-check, lint-pr, test-cover-gate) pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>