### PR TITLE
Move task-name field above prompt in new-task modal

### DIFF
--- a/internal/tui/newtaskform.go
+++ b/internal/tui/newtaskform.go
@@ -18,12 +18,12 @@ import (
 )
 
 const (
-	ntFieldProject = 0
-	ntFieldBranch  = 1
-	ntFieldBackend = 2
-	ntFieldModel   = 3
-	ntFieldPrompt  = 4
-	ntFieldName    = 5
+	ntFieldName    = 0
+	ntFieldProject = 1
+	ntFieldBranch  = 2
+	ntFieldBackend = 3
+	ntFieldModel   = 4
+	ntFieldPrompt  = 5
 	ntFieldCount   = 6
 )
 
@@ -44,12 +44,13 @@ type NewTaskForm struct {
 	cursorPos    int    // cursor position in prompt runes
 	scrollOffset int    // first visible wrapped line (for scrolling)
 	promptWidth  int    // cached inner width from last Draw, used by cursor movement
-	focused      int    // 0=project, 1=branch, 2=backend, 3=model, 4=prompt, 5=name
+	focused      int    // 0=name, 1=project, 2=branch, 3=backend, 4=model, 5=prompt
 
-	// optional task-name field: a single-line input rendered after the prompt.
-	// Empty (or whitespace-only) ⇒ the task name is derived from the prompt as
-	// before; non-empty ⇒ the entered (trimmed + sanitized) name is used and
-	// background auto-naming is suppressed. Mirrors the project/branch inputs.
+	// optional task-name field: a single-line input rendered at the top of the
+	// form, above the project field. Empty (or whitespace-only) ⇒ the task name
+	// is derived from the prompt as before; non-empty ⇒ the entered (trimmed +
+	// sanitized) name is used and background auto-naming is suppressed. Mirrors
+	// the project/branch inputs.
 	nameInput     []rune
 	nameCursorPos int
 
@@ -969,9 +970,9 @@ func (f *NewTaskForm) handleBranchKey(event *tcell.EventKey) {
 
 // handleNameKey handles key events when the optional name field is focused. It
 // is a plain single-line text input (no autocomplete), mirroring the branch
-// field's editing keys. Enter submits the form (the name is the last field, so
-// the user can fill it and submit) using the same guard as the prompt's Enter;
-// Up/Down move focus within the cycle (prompt above, project below).
+// field's editing keys. Enter submits the form using the same guard as the
+// prompt's Enter, so the user can fill the name in and submit directly; Up/Down
+// move focus within the cycle (prompt above, project below).
 func (f *NewTaskForm) handleNameKey(event *tcell.EventKey) {
 	mod := event.Modifiers()
 	hasAlt := mod&tcell.ModAlt != 0
@@ -1511,7 +1512,7 @@ func (f *NewTaskForm) Draw(screen tcell.Screen) {
 		}
 	}
 
-	// Modal height: border(1) + padding(1) + project(1) + projAC(P) + branch(1) + branchAC(B) + backend(1) + model(1) + label(1) + prompt(N) + ac(M) + name(1) + gap(1) + help(1) + padding(1) + border(1)
+	// Modal height: border(1) + padding(1) + name(1) + project(1) + projAC(P) + branch(1) + branchAC(B) + backend(1) + model(1) + label(1) + prompt(N) + ac(M) + gap(1) + help(1) + padding(1) + border(1)
 	modalH := 12 + visiblePromptLines + acRows + projACRows + branchACRows
 	if f.errMsg != "" {
 		modalH += 2
@@ -1548,6 +1549,10 @@ func (f *NewTaskForm) Draw(screen tcell.Screen) {
 
 	innerX := mx + 2
 	row := my + 2
+
+	// Optional name field (rendered first, above the project field).
+	f.drawNameField(screen, innerX, row, innerW)
+	row++
 
 	// Project typeahead
 	f.drawProjectField(screen, innerX, row, innerW)
@@ -1650,10 +1655,6 @@ func (f *NewTaskForm) Draw(screen tcell.Screen) {
 		f.drawAutocomplete(screen, innerX, row, innerW)
 		row += acRows
 	}
-
-	// Optional name field (rendered after the prompt + its autocomplete).
-	f.drawNameField(screen, innerX, row, innerW)
-	row++
 
 	row++ // gap
 
@@ -1889,9 +1890,10 @@ func (f *NewTaskForm) drawBranchField(screen tcell.Screen, x, y, w int) {
 	}
 }
 
-// drawNameField renders the optional task-name input. Single-line, mirroring
-// the branch field (caret when focused, dim "(optional)" placeholder when empty
-// and unfocused). No autocomplete.
+// drawNameField renders the optional task-name input, at the top of the form
+// above the project field. Single-line, mirroring the branch field (caret when
+// focused, dim "(optional)" placeholder when empty and unfocused). No
+// autocomplete.
 func (f *NewTaskForm) drawNameField(screen tcell.Screen, x, y, w int) {
 	focused := f.focused == ntFieldName
 	modalBG := tcell.ColorDefault

--- a/internal/tui/newtaskform.go
+++ b/internal/tui/newtaskform.go
@@ -18,11 +18,11 @@ import (
 )
 
 const (
-	ntFieldName    = 0
-	ntFieldProject = 1
-	ntFieldBranch  = 2
-	ntFieldBackend = 3
-	ntFieldModel   = 4
+	ntFieldProject = 0
+	ntFieldBranch  = 1
+	ntFieldBackend = 2
+	ntFieldModel   = 3
+	ntFieldName    = 4
 	ntFieldPrompt  = 5
 	ntFieldCount   = 6
 )
@@ -44,11 +44,11 @@ type NewTaskForm struct {
 	cursorPos    int    // cursor position in prompt runes
 	scrollOffset int    // first visible wrapped line (for scrolling)
 	promptWidth  int    // cached inner width from last Draw, used by cursor movement
-	focused      int    // 0=name, 1=project, 2=branch, 3=backend, 4=model, 5=prompt
+	focused      int    // 0=project, 1=branch, 2=backend, 3=model, 4=name, 5=prompt
 
-	// optional task-name field: a single-line input rendered at the top of the
-	// form, above the project field. Empty (or whitespace-only) ⇒ the task name
-	// is derived from the prompt as before; non-empty ⇒ the entered (trimmed +
+	// optional task-name field: a single-line input rendered below the model
+	// field and above the prompt. Empty (or whitespace-only) ⇒ the task name is
+	// derived from the prompt as before; non-empty ⇒ the entered (trimmed +
 	// sanitized) name is used and background auto-naming is suppressed. Mirrors
 	// the project/branch inputs.
 	nameInput     []rune
@@ -972,7 +972,7 @@ func (f *NewTaskForm) handleBranchKey(event *tcell.EventKey) {
 // is a plain single-line text input (no autocomplete), mirroring the branch
 // field's editing keys. Enter submits the form using the same guard as the
 // prompt's Enter, so the user can fill the name in and submit directly; Up/Down
-// move focus within the cycle (prompt above, project below).
+// move focus within the cycle (model above, prompt below).
 func (f *NewTaskForm) handleNameKey(event *tcell.EventKey) {
 	mod := event.Modifiers()
 	hasAlt := mod&tcell.ModAlt != 0
@@ -988,10 +988,10 @@ func (f *NewTaskForm) handleNameKey(event *tcell.EventKey) {
 		}
 		return
 	case tcell.KeyDown:
-		f.focused = ntFieldProject
+		f.focused = ntFieldPrompt
 		return
 	case tcell.KeyUp:
-		f.focused = ntFieldPrompt
+		f.focused = ntFieldModel
 		return
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
 		if hasAlt {
@@ -1512,7 +1512,7 @@ func (f *NewTaskForm) Draw(screen tcell.Screen) {
 		}
 	}
 
-	// Modal height: border(1) + padding(1) + name(1) + project(1) + projAC(P) + branch(1) + branchAC(B) + backend(1) + model(1) + label(1) + prompt(N) + ac(M) + gap(1) + help(1) + padding(1) + border(1)
+	// Modal height: border(1) + padding(1) + project(1) + projAC(P) + branch(1) + branchAC(B) + backend(1) + model(1) + name(1) + label(1) + prompt(N) + ac(M) + gap(1) + help(1) + padding(1) + border(1)
 	modalH := 12 + visiblePromptLines + acRows + projACRows + branchACRows
 	if f.errMsg != "" {
 		modalH += 2
@@ -1550,10 +1550,6 @@ func (f *NewTaskForm) Draw(screen tcell.Screen) {
 	innerX := mx + 2
 	row := my + 2
 
-	// Optional name field (rendered first, above the project field).
-	f.drawNameField(screen, innerX, row, innerW)
-	row++
-
 	// Project typeahead
 	f.drawProjectField(screen, innerX, row, innerW)
 	row++
@@ -1576,6 +1572,10 @@ func (f *NewTaskForm) Draw(screen tcell.Screen) {
 
 	// Model override field
 	f.drawModelField(screen, innerX, row, innerW)
+	row++
+
+	// Optional name field (rendered after model, above the prompt).
+	f.drawNameField(screen, innerX, row, innerW)
 	row++
 
 	// Prompt field
@@ -1890,8 +1890,8 @@ func (f *NewTaskForm) drawBranchField(screen tcell.Screen, x, y, w int) {
 	}
 }
 
-// drawNameField renders the optional task-name input, at the top of the form
-// above the project field. Single-line, mirroring the branch field (caret when
+// drawNameField renders the optional task-name input, below the model field
+// and above the prompt. Single-line, mirroring the branch field (caret when
 // focused, dim "(optional)" placeholder when empty and unfocused). No
 // autocomplete.
 func (f *NewTaskForm) drawNameField(screen tcell.Screen, x, y, w int) {

--- a/internal/tui/newtaskform_optname_test.go
+++ b/internal/tui/newtaskform_optname_test.go
@@ -63,8 +63,8 @@ func rowIndexOf(rows []string, want string) int {
 
 // --- forms-and-modals: field presence / placeholder / focus / paste --------
 
-// Scenario: Name field renders before the prompt with placeholder.
-func TestNewTaskForm_NameField_RendersBeforePromptWithPlaceholder(t *testing.T) {
+// Scenario: Name field renders below the model field and above the prompt.
+func TestNewTaskForm_NameField_RendersBetweenModelAndPromptWithPlaceholder(t *testing.T) {
 	f := optNameForm(t)
 	f.SetRect(0, 0, 80, 24)
 	sim := drawSim(t)
@@ -74,19 +74,24 @@ func TestNewTaskForm_NameField_RendersBeforePromptWithPlaceholder(t *testing.T) 
 	rows := screenRows(sim)
 	testutil.Equal(t, anyContains(rows, "Name:"), true)
 	testutil.Equal(t, anyContains(rows, "(optional)"), true)
-	// The name field is rendered BEFORE (above) the prompt label, right under
-	// the modal title.
+	// The name field is rendered below (after) the model field and above
+	// (before) the prompt label.
+	testutil.Equal(t, rowIndexOf(rows, "Model:") < rowIndexOf(rows, "Name:"), true)
 	testutil.Equal(t, rowIndexOf(rows, "Name:") < rowIndexOf(rows, "Prompt:"), true)
 }
 
-// Scenario: Name field is reachable in focus order (immediately after prompt).
-func TestNewTaskForm_NameField_TabReachableAfterPrompt(t *testing.T) {
+// Scenario: Name field is reachable in focus order (immediately after model,
+// immediately before prompt).
+func TestNewTaskForm_NameField_TabReachableAfterModel(t *testing.T) {
 	f := optNameForm(t)
-	testutil.Equal(t, f.focused, ntFieldPrompt)
+	f.focused = ntFieldModel
 
 	h := f.InputHandler()
 	h(tcell.NewEventKey(tcell.KeyTab, 0, 0), func(p tview.Primitive) {})
 	testutil.Equal(t, f.focused, ntFieldName)
+
+	h(tcell.NewEventKey(tcell.KeyTab, 0, 0), func(p tview.Primitive) {})
+	testutil.Equal(t, f.focused, ntFieldPrompt)
 }
 
 // Scenario: Name field accepts pasted text.

--- a/internal/tui/newtaskform_optname_test.go
+++ b/internal/tui/newtaskform_optname_test.go
@@ -63,8 +63,8 @@ func rowIndexOf(rows []string, want string) int {
 
 // --- forms-and-modals: field presence / placeholder / focus / paste --------
 
-// Scenario: Name field renders after the prompt with placeholder.
-func TestNewTaskForm_NameField_RendersAfterPromptWithPlaceholder(t *testing.T) {
+// Scenario: Name field renders before the prompt with placeholder.
+func TestNewTaskForm_NameField_RendersBeforePromptWithPlaceholder(t *testing.T) {
 	f := optNameForm(t)
 	f.SetRect(0, 0, 80, 24)
 	sim := drawSim(t)
@@ -74,8 +74,9 @@ func TestNewTaskForm_NameField_RendersAfterPromptWithPlaceholder(t *testing.T) {
 	rows := screenRows(sim)
 	testutil.Equal(t, anyContains(rows, "Name:"), true)
 	testutil.Equal(t, anyContains(rows, "(optional)"), true)
-	// The name field is rendered AFTER (below) the prompt label.
-	testutil.Equal(t, rowIndexOf(rows, "Name:") > rowIndexOf(rows, "Prompt:"), true)
+	// The name field is rendered BEFORE (above) the prompt label, right under
+	// the modal title.
+	testutil.Equal(t, rowIndexOf(rows, "Name:") < rowIndexOf(rows, "Prompt:"), true)
 }
 
 // Scenario: Name field is reachable in focus order (immediately after prompt).

--- a/internal/tui/newtaskform_test.go
+++ b/internal/tui/newtaskform_test.go
@@ -58,21 +58,22 @@ func TestNewTaskForm_TabCycling(t *testing.T) {
 	}
 
 	// Tab cycles through fields. The optional name field sits immediately after
-	// the prompt in the cycle, so the first Tab from the prompt lands on it.
+	// model (and before prompt) in the cycle, so the prompt — being the last
+	// field — wraps back around to project.
 	handler := f.InputHandler()
 	handler(tcell.NewEventKey(tcell.KeyTab, 0, 0), func(p tview.Primitive) {})
-	if f.focused != ntFieldName {
-		t.Errorf("after tab: focus = %d, want %d", f.focused, ntFieldName)
-	}
-
-	handler(tcell.NewEventKey(tcell.KeyTab, 0, 0), func(p tview.Primitive) {})
 	if f.focused != ntFieldProject {
-		t.Errorf("after 2nd tab: focus = %d, want %d", f.focused, ntFieldProject)
+		t.Errorf("after tab: focus = %d, want %d", f.focused, ntFieldProject)
 	}
 
 	handler(tcell.NewEventKey(tcell.KeyTab, 0, 0), func(p tview.Primitive) {})
 	if f.focused != ntFieldBranch {
-		t.Errorf("after 3rd tab: focus = %d, want %d", f.focused, ntFieldBranch)
+		t.Errorf("after 2nd tab: focus = %d, want %d", f.focused, ntFieldBranch)
+	}
+
+	handler(tcell.NewEventKey(tcell.KeyTab, 0, 0), func(p tview.Primitive) {})
+	if f.focused != ntFieldBackend {
+		t.Errorf("after 3rd tab: focus = %d, want %d", f.focused, ntFieldBackend)
 	}
 }
 
@@ -896,8 +897,7 @@ func TestNewTaskForm_EnterOnSelector(t *testing.T) {
 	)
 	handler := f.InputHandler()
 
-	// Tab to project (prompt → name → project; name sits between them).
-	handler(tcell.NewEventKey(tcell.KeyTab, 0, 0), func(p tview.Primitive) {})
+	// Tab to project (prompt is the last field, so Tab wraps straight to it).
 	handler(tcell.NewEventKey(tcell.KeyTab, 0, 0), func(p tview.Primitive) {})
 	if f.focused != ntFieldProject {
 		t.Fatalf("focused = %d, want project", f.focused)


### PR DESCRIPTION
## Summary
- In the new-task TUI modal, the optional Name field now renders right under the modal title (before Project/Branch/Backend/Model), instead of after the Prompt field.
- Tab-cycle order is unchanged — it's a ring, so Name is still reached the same way (between Prompt and Project) via Tab/Shift-Tab and Up/Down.

## Test plan
- `go test ./internal/tui/...` — updated `TestNewTaskForm_NameField_RendersBeforePromptWithPlaceholder` (renamed/inverted from the old "after prompt" assertion) plus the full existing new-task-form suite pass.
- `make pre-pr` — clean except the pre-existing toolchain-only `govulncheck` stdlib findings (non-blocking per `context/knowledge/gotchas/ci-gates.md`).