### PR TITLE
Fix file-action hotkeys swallowed in diff mode

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3191,6 +3191,18 @@ func (a *App) handleDiffKey(event *tcell.EventKey) *tcell.EventKey {
 			case keymap.ActDiffScrollUp:
 				a.agentPane.DiffScrollUp(1)
 				return nil
+			case keymap.ActDiffFinder:
+				a.openInFinder()
+				return nil
+			case keymap.ActDiffOpen:
+				a.openFile()
+				return nil
+			case keymap.ActDiffEditor:
+				a.openInEditor()
+				return nil
+			case keymap.ActDiffTerminal:
+				a.openTerminal()
+				return nil
 			}
 		}
 		// `q` exits diff mode — structural "back", reserved (not rebindable in

--- a/internal/tui/forms_render_test.go
+++ b/internal/tui/forms_render_test.go
@@ -143,6 +143,53 @@ func TestApp_HandleDiffKey_Scroll(t *testing.T) {
 	testutil.Equal(t, app.agentPane.InDiffMode(), false)
 }
 
+// f/o/e/t must still open the selected file while a diff is being displayed
+// (BUG: these used to be swallowed by handleDiffKey once Enter entered diff
+// mode, since it only resolved CtxDiff, never CtxFilePnl).
+func TestApp_HandleDiffKey_FileHotkeysStillWork(t *testing.T) {
+	d := testDB(t)
+	runner := agent.NewRunner(nil)
+	app := New(d, runner, false)
+
+	app.mode = modeAgent
+	app.filePanel.SetRect(0, 0, 40, 20)
+	app.filePanel.SetFiles([]gitutil.ChangedFile{{Status: "M", Path: "a.go"}})
+	app.worktreeDir = t.TempDir()
+	app.agentPane.EnterDiffMode("+1\n-2", "a.go")
+
+	var systemArgs [][]string
+	var editorArgs [][]string
+	var termHits int
+	oldSystem := systemOpener
+	oldEditor := editorOpener
+	oldTerm := terminalOpener
+	t.Cleanup(func() { systemOpener = oldSystem; editorOpener = oldEditor; terminalOpener = oldTerm })
+	systemOpener = func(args ...string) error { systemArgs = append(systemArgs, args); return nil }
+	editorOpener = func(wt, path string) error { editorArgs = append(editorArgs, []string{wt, path}); return nil }
+	terminalOpener = func(string) error { termHits++; return nil }
+
+	wantFile := app.worktreeDir + "/a.go"
+
+	got := app.handleDiffKey(tcell.NewEventKey(tcell.KeyRune, 'f', 0))
+	testutil.Nil(t, got)
+	testutil.DeepEqual(t, systemArgs[len(systemArgs)-1], []string{"-R", wantFile})
+
+	got = app.handleDiffKey(tcell.NewEventKey(tcell.KeyRune, 'o', 0))
+	testutil.Nil(t, got)
+	testutil.DeepEqual(t, systemArgs[len(systemArgs)-1], []string{wantFile})
+
+	got = app.handleDiffKey(tcell.NewEventKey(tcell.KeyRune, 'e', 0))
+	testutil.Nil(t, got)
+	testutil.DeepEqual(t, editorArgs[len(editorArgs)-1], []string{app.worktreeDir, "a.go"})
+
+	got = app.handleDiffKey(tcell.NewEventKey(tcell.KeyRune, 't', 0))
+	testutil.Nil(t, got)
+	testutil.Equal(t, termHits, 1)
+
+	// Still in diff mode — these hotkeys don't exit it.
+	testutil.Equal(t, app.agentPane.InDiffMode(), true)
+}
+
 func TestApp_HandleDiffKey_PgUpPgDown(t *testing.T) {
 	d := testDB(t)
 	runner := agent.NewRunner(nil)

--- a/internal/tui/keymap/actions.go
+++ b/internal/tui/keymap/actions.go
@@ -79,6 +79,10 @@ const (
 	ActDiffSplit      Action = "diff.split"
 	ActDiffScrollDown Action = "diff.scroll_down"
 	ActDiffScrollUp   Action = "diff.scroll_up"
+	ActDiffFinder     Action = "diff.finder"
+	ActDiffOpen       Action = "diff.open"
+	ActDiffEditor     Action = "diff.editor"
+	ActDiffTerminal   Action = "diff.terminal"
 
 	// Settings (letter commands; arrows/h/l/enter are structural)
 	ActSettingsDown     Action = "settings.nav_down"
@@ -134,6 +138,7 @@ var defaultSpecs = map[Context]map[Action]string{
 	},
 	CtxDiff: {
 		ActDiffSplit: "s", ActDiffScrollDown: "j", ActDiffScrollUp: "k",
+		ActDiffFinder: "f", ActDiffOpen: "o", ActDiffEditor: "e", ActDiffTerminal: "t",
 	},
 	CtxSettings: {
 		ActSettingsDown: "j", ActSettingsUp: "k", ActSettingsDelete: "d",
@@ -171,6 +176,7 @@ var actionLabels = map[Action]string{
 	ActFileOpen: "open file", ActFileEditor: "open in editor", ActFileTerminal: "open terminal",
 
 	ActDiffSplit: "toggle split/unified", ActDiffScrollDown: "scroll down", ActDiffScrollUp: "scroll up",
+	ActDiffFinder: "reveal in Finder", ActDiffOpen: "open file", ActDiffEditor: "open in editor", ActDiffTerminal: "open terminal",
 
 	ActSettingsDown: "navigate down", ActSettingsUp: "navigate up", ActSettingsDelete: "delete / set default",
 	ActSettingsNew: "new", ActSettingsEdit: "edit", ActSettingsQuickAdd: "quick add projects",
@@ -223,7 +229,8 @@ var contextOrder = map[Context][]Action{
 		ActAgentPaneLeft, ActAgentPaneRight, ActAgentTaskPrev, ActAgentTaskNext,
 		ActAgentScrollUp, ActAgentScrollDown, ActAgentScrollPgUp, ActAgentScrollPgDn, ActAgentScrollEnd},
 	CtxFilePnl: {ActFileDown, ActFileUp, ActFileFinder, ActFileOpen, ActFileEditor, ActFileTerminal},
-	CtxDiff:    {ActDiffSplit, ActDiffScrollDown, ActDiffScrollUp},
+	CtxDiff: {ActDiffSplit, ActDiffScrollDown, ActDiffScrollUp,
+		ActDiffFinder, ActDiffOpen, ActDiffEditor, ActDiffTerminal},
 	CtxSettings: {ActSettingsDown, ActSettingsUp, ActSettingsNew, ActSettingsEdit, ActSettingsDelete,
 		ActSettingsQuickAdd, ActSettingsApple, ActSettingsToggle, ActSettingsRun, ActSettingsModel},
 	CtxHeraRail: {ActHeraSpawn, ActHeraNewCoord, ActHeraRename, ActHeraArchive, ActHeraPin,

--- a/internal/tui/keymap/actions.go
+++ b/internal/tui/keymap/actions.go
@@ -75,7 +75,11 @@ const (
 	ActFileEditor   Action = "filepanel.editor"
 	ActFileTerminal Action = "filepanel.terminal"
 
-	// Diff view
+	// Diff view. Finder/Open/Editor/Terminal deliberately mirror the
+	// filepanel actions below (same keys, same handlers) rather than reusing
+	// them directly: Resolve is scoped per Context with an independent
+	// override table, and handleDiffKey never resolves CtxFilePnl, so these
+	// hotkeys would go dead in diff mode without their own CtxDiff entries.
 	ActDiffSplit      Action = "diff.split"
 	ActDiffScrollDown Action = "diff.scroll_down"
 	ActDiffScrollUp   Action = "diff.scroll_up"

--- a/internal/tui/keymap/keymap_test.go
+++ b/internal/tui/keymap/keymap_test.go
@@ -77,6 +77,10 @@ func TestResolve_Defaults(t *testing.T) {
 		{CtxHeraRail, ev(tcell.KeyRune, 'w', 0), ActHeraSpawn},
 		{CtxHeraRail, ev(tcell.KeyCtrlD, 0, 0), ActHeraDelete},
 		{CtxDiff, ev(tcell.KeyRune, 's', 0), ActDiffSplit},
+		{CtxDiff, ev(tcell.KeyRune, 'f', 0), ActDiffFinder},
+		{CtxDiff, ev(tcell.KeyRune, 'o', 0), ActDiffOpen},
+		{CtxDiff, ev(tcell.KeyRune, 'e', 0), ActDiffEditor},
+		{CtxDiff, ev(tcell.KeyRune, 't', 0), ActDiffTerminal},
 	}
 	for _, tt := range tests {
 		t.Run(string(tt.want), func(t *testing.T) {

--- a/openspec/changes/archive/2026-07-14-fix-diff-mode-file-hotkeys/proposal.md
+++ b/openspec/changes/archive/2026-07-14-fix-diff-mode-file-hotkeys/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+In the agent view's file panel, the file-action hotkeys (`f` reveal in Finder,
+`o` open file, `e` open in editor, `t` open terminal) work while a file is
+merely selected/highlighted in the list, but stop working the moment `Enter`
+displays that file's diff. `App.handleGlobalKey` routes every key to
+`handleDiffKey` once `agentPane.InDiffMode()` is true, and `handleDiffKey` only
+resolves the `keymap.CtxDiff` action table (split-toggle + scroll), never
+`CtxFilePnl` — so `f`/`o`/`e`/`t` are silently swallowed while a diff is
+displayed. The selected file (`filePanel.SelectedFile()`) is still correct in
+diff mode (arrow-key file navigation already depends on this), so there's no
+reason these hotkeys should stop working.
+
+## What Changes
+
+- **The diff-view keymap context gains its own Finder/Open/Editor/Terminal
+  actions**, bound to the same default keys as the file panel (`f`/`o`/`e`/`t`),
+  dispatched to the existing `openInFinder`/`openFile`/`openInEditor`/
+  `openTerminal` handlers against the currently-selected file.
+- No change to file-panel-mode behavior, diff entry/exit, or any other hotkey.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `keybindings`: the diff-view context (`CtxDiff`) now also resolves the
+  file-action hotkeys (reveal in Finder, open file, open in editor, open
+  terminal), previously only available in the file-panel context.

--- a/openspec/changes/archive/2026-07-14-fix-diff-mode-file-hotkeys/specs/keybindings/spec.md
+++ b/openspec/changes/archive/2026-07-14-fix-diff-mode-file-hotkeys/specs/keybindings/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: File-action hotkeys remain available while viewing a diff
+
+The diff-view context (`CtxDiff`) SHALL also resolve the file-action hotkeys
+(reveal in Finder, open file, open in editor, open terminal) against the
+currently selected file, so a user does not lose these hotkeys the moment
+`Enter` displays a file's diff.
+
+#### Scenario: Finder hotkey works while a diff is displayed
+
+- **WHEN** a file's diff is currently displayed (diff mode active)
+- **AND** the user presses the reveal-in-Finder key (default `f`)
+- **THEN** the currently selected file is revealed in Finder, same as when the
+  file panel (not the diff) has focus
+
+#### Scenario: Open/editor/terminal hotkeys work while a diff is displayed
+
+- **WHEN** a file's diff is currently displayed (diff mode active)
+- **AND** the user presses the open-file, open-in-editor, or open-terminal key
+  (defaults `o`/`e`/`t`)
+- **THEN** the corresponding action runs against the currently selected file
+  (or the worktree directory, for open-terminal), same as when the file panel
+  has focus

--- a/openspec/changes/archive/2026-07-14-fix-diff-mode-file-hotkeys/tasks.md
+++ b/openspec/changes/archive/2026-07-14-fix-diff-mode-file-hotkeys/tasks.md
@@ -1,0 +1,21 @@
+## 1. Keymap
+
+- [x] 1.1 Add `ActDiffFinder`/`ActDiffOpen`/`ActDiffEditor`/`ActDiffTerminal` to
+      `internal/tui/keymap/actions.go` (defaults `f`/`o`/`e`/`t`, labels,
+      `contextOrder[CtxDiff]`).
+
+## 2. Dispatch
+
+- [x] 2.1 In `internal/tui/app.go` `handleDiffKey`, dispatch the new actions to
+      `openInFinder`/`openFile`/`openInEditor`/`openTerminal`.
+
+## 3. Tests
+
+- [x] 3.1 Keymap unit test: `CtxDiff` resolves `f`/`o`/`e`/`t` to the new
+      actions.
+- [x] 3.2 `app` test: pressing `f`/`o`/`e`/`t` while `InDiffMode()` invokes the
+      corresponding opener stub with the selected file.
+
+## 4. Docs
+
+- [x] 4.1 Archive this change into `openspec/specs/keybindings/spec.md`.

--- a/openspec/specs/keybindings/spec.md
+++ b/openspec/specs/keybindings/spec.md
@@ -72,3 +72,26 @@ The system SHALL generate the help overlay's argus sections from the keymap so t
 - **WHEN** the task-list `new` action is rebound to `x`
 - **THEN** the help overlay's Task List section shows `x` for "new task"
 
+### Requirement: File-action hotkeys remain available while viewing a diff
+
+The diff-view context (`CtxDiff`) SHALL also resolve the file-action hotkeys
+(reveal in Finder, open file, open in editor, open terminal) against the
+currently selected file, so a user does not lose these hotkeys the moment
+`Enter` displays a file's diff.
+
+#### Scenario: Finder hotkey works while a diff is displayed
+
+- **WHEN** a file's diff is currently displayed (diff mode active)
+- **AND** the user presses the reveal-in-Finder key (default `f`)
+- **THEN** the currently selected file is revealed in Finder, same as when the
+  file panel (not the diff) has focus
+
+#### Scenario: Open/editor/terminal hotkeys work while a diff is displayed
+
+- **WHEN** a file's diff is currently displayed (diff mode active)
+- **AND** the user presses the open-file, open-in-editor, or open-terminal key
+  (defaults `o`/`e`/`t`)
+- **THEN** the corresponding action runs against the currently selected file
+  (or the worktree directory, for open-terminal), same as when the file panel
+  has focus
+


### PR DESCRIPTION
Pressing Enter in the file panel to view a file's diff silently broke the
file-action hotkeys (f=reveal in Finder, o=open file, e=open in editor,
t=open terminal): handleDiffKey only resolved the CtxDiff keymap context,
never CtxFilePnl where those actions lived.

Mirrors the four actions into CtxDiff (same default keys, same handlers),
dispatched against the still-valid filePanel.SelectedFile(). Adds keymap +
app-level test coverage, and an openspec change archived in the same PR.

Co-Authored-By: Claude <noreply@anthropic.com>