### PR TITLE
Gate hera skill imperatives on role-evidence, not bare sandbox residency

### DIFF
--- a/.claude/skills/hera-plan/SKILL.md
+++ b/.claude/skills/hera-plan/SKILL.md
@@ -19,6 +19,11 @@ coordinator binding and know the base hera model (roles, bindings, messaging, `h
 status/tree) from the `hera` skill — **load that first if you haven't.** Every tool here takes
 `cwd` (pass `cwd=$PWD`) and `orchestrator` is required when your task holds 2+ live bindings.
 
+Like the base `hera` skill, this only applies once you already hold that coordinator binding — merely
+running inside an argus sandbox is not a reason to author a plan-DAG. A bare argus task with no
+coordinator binding should stay solo (or, at most, offer hera as an option to the human) rather than
+reach for this skill.
+
 **Plan nodes land under your EXISTING orchestrator – the one you already coordinate.** Authoring a
 plan-DAG is *not* a bootstrap step: you do **not** call `hera_new_orchestrator` to hold your plan.
 The `hera_plan` / `hera_plan_node` verbs add nodes to the orchestrator you already coordinate, and

--- a/.claude/skills/hera/SKILL.md
+++ b/.claude/skills/hera/SKILL.md
@@ -22,13 +22,29 @@ plumbing; you call the tools.
 
 ## 1. When this applies (and when it does NOT)
 
-This skill applies **only inside an argus task sandbox**. You are in one if **either** holds:
+The `mcp__argus__hera_*` tools are only *registered* inside an argus task sandbox. You are in one if
+**either** holds:
 
 - `ARGUS_TASK_ID` is set, **or**
 - the current working directory is under `~/.argus/worktrees/`.
 
-**If neither holds, stop.** The `mcp__argus__hera_*` tools are not registered in this session — there
-is no CLI fallback and nothing below applies.
+**If neither holds, stop.** The tools are not registered in this session — there is no CLI fallback and
+nothing below applies.
+
+**Sandbox residency alone is NOT a reason to use hera.** Most argus sessions are plain solo tasks that
+should stay solo. The "coordinate via hera, never hand-roll it" imperative in this skill applies only
+once this session already has evidence of being hera-managed:
+
+- it was **spawned as a hera worker** — its prompt carries the orientation prefix naming the
+  coordinator + orchestrator (see `hera_spawn_worker`'s prompt contract in §3), or
+- it already **holds, or is actively creating** (e.g. via `hera_new_orchestrator`), a
+  coordinator/freelance binding for this session.
+
+**No such evidence?** This is a bare argus task the human is driving directly. Don't assume hera and
+don't self-promote into a coordinator just because the work could be split up — at most, mention hera as
+an available option for multi-session work ("this could be split into a hera team with its own
+worktrees/PRs per stage if you want — say so, or I'll keep it in this session") and only act on it if
+they opt in. Once you're spawned/promoted per the bullets above, everything below governs.
 
 **Every hera tool takes `cwd` — always pass `cwd=$PWD`.** That is how hera resolves which argus task
 (and therefore which role) this session is. There is no separate "auth" or session handle.

--- a/claude/snippets/hera.md
+++ b/claude/snippets/hera.md
@@ -6,10 +6,27 @@ audience: [shared]
 
 If `ARGUS_TASK_ID` is unset and `$PWD` is not under `~/.argus/worktrees/`, ignore this section.
 
-Inside an argus sandbox, coordinating a *team* of agent sessions runs through **hera**'s `mcp__argus__hera_*` tools — never hand-roll it, and don't use bare `TaskCreate` for coordinated work.
+Being inside an argus sandbox is not, by itself, a reason to use hera — most argus sessions are plain
+solo tasks that should stay solo. The rules below apply only once this session already has evidence of
+being hera-managed:
 
-- **If you are spawned as a hera worker, or you hold (or are creating) a coordinator binding: load the `hera` skill in full before coordinating.** The tool schemas alone don't convey the role model, messaging, or decision rules.
+- it was **spawned as a hera worker** (its prompt carries the orientation prefix naming the coordinator
+  + orchestrator), or
+- it already **holds, or is actively creating** (e.g. via `hera_new_orchestrator`), a
+  coordinator/freelance binding.
+
+**With that evidence:** coordinating a *team* of agent sessions runs through **hera**'s
+`mcp__argus__hera_*` tools — never hand-roll it, and don't use bare `TaskCreate` for coordinated work.
+
+- **Load the `hera` skill in full before coordinating.** The tool schemas alone don't convey the role
+  model, messaging, or decision rules.
 - **Pick the right tool for the work:**
   - Ephemeral in-session fan-out (research, review, parallel reads that return to you) → Claude's native sub-agents, NOT hera.
   - Work whose unit must be its own argus session (own worktree / PR / sandbox / long-running) → hera workers via `hera_spawn_worker`.
   - Those units have dependencies among them (one needs another's output, or a required ordering)? → a **plan-DAG**: load the `hera-plan` skill and author planned nodes wired by blocking edges. **Internal dependencies are the clean signal to plan a DAG** — decide it yourself when the dependency is obvious; only ask the human when it's genuinely unclear the work even warrants multi-session orchestration.
+
+**No such evidence?** This is a bare argus task the human is driving directly — don't assume hera and
+don't self-promote into a coordinator just because the work could be split up. At most, mention hera as
+an available option for multi-session work (e.g. "this could be split into a hera team with its own
+worktrees/PRs per stage if you want — say so, or I'll keep it in this session") and only act on it if
+they opt in.


### PR DESCRIPTION
## Summary

- A session merely running inside an argus sandbox (`ARGUS_TASK_ID` set / cwd under `~/.argus/worktrees/`) was told — via `claude/snippets/hera.md` (compiled into the user's global CLAUDE.md) and echoed in `.claude/skills/hera/SKILL.md` / `.claude/skills/hera-plan/SKILL.md` — to route ALL multi-agent coordination through hera and "never hand-roll it," even when it holds no hera role at all.
- Narrows the "must use hera" imperative in all three files so it fires only once the session already has evidence of being hera-managed: spawned as a hera worker (orientation-prefixed prompt), or already holding/creating a coordinator/freelance binding.
- Absent that evidence, guidance now softens to an offer ("this could be split into a hera team... say so, or I'll keep it in this session") instead of a mandate.
- The existing decision tree for native-sub-agent vs `hera_spawn_worker` vs plan-DAG (once a session IS hera-managed) is untouched.
- Checked `context/knowledge/gotchas/orchestration.md` and README.md for the same over-broad framing — both are purely architectural/mechanical documentation with no agent-facing "always hera" imperative, so no changes needed there.
- Documentation/skill-instruction only; no application code touched; no openspec change folder per this repo's own exemption for non-behavioral docs edits.

## Test plan

- [x] Reviewed diffs for consistency across `claude/snippets/hera.md`, `.claude/skills/hera/SKILL.md`, `.claude/skills/hera-plan/SKILL.md`
- [x] Searched repo for other echoes of the old "always hera" framing — none found beyond the three files changed
- N/A — docs/skill-instruction only, no runtime behavior to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>