### PR TITLE
Package argus-coupled skills into the binary via go:embed

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -16,6 +16,8 @@ import (
 	"github.com/drn/argus/internal/claudesession"
 	"github.com/drn/argus/internal/config"
 	"github.com/drn/argus/internal/model"
+	"github.com/drn/argus/internal/skills"
+	"github.com/drn/argus/internal/uxlog"
 	_ "modernc.org/sqlite"
 )
 
@@ -591,6 +593,20 @@ func BuildCmd(task *model.Task, cfg config.Config, resume bool) (*exec.Cmd, func
 		modelFlag = " --model " + shellQuote(m)
 	}
 	cmdStr += modelFlag
+
+	// Make argus's own builtin skills (archive, hera, ...) available to Claude
+	// backends by materializing them and appending --add-dir. Claude Code loads
+	// .claude/skills/ from a --add-dir directory as a documented exception to
+	// --add-dir otherwise granting file access only. Additive to any --add-dir
+	// already present in the backend command — repeatable flag, no conflict.
+	// Materialization failure is logged and skipped rather than blocking launch.
+	if IsClaudeBackend(backend.Command) {
+		if root, err := skills.EnsureBuiltinSkills(); err != nil {
+			uxlog.Log("[skills] builtin skills materialize failed (continuing without them): %v", err)
+		} else if root != "" {
+			cmdStr += " --add-dir " + shellQuote(root)
+		}
+	}
 
 	if resume {
 		// Codex resumes by replacing the base command unconditionally — that's

--- a/internal/skills/builtin.go
+++ b/internal/skills/builtin.go
@@ -103,7 +103,7 @@ func EnsureBuiltinSkills() (string, error) {
 	existingDirs, _ := os.ReadDir(skillsDir)
 	for _, d := range existingDirs {
 		if d.IsDir() && !present[d.Name()] {
-			os.RemoveAll(filepath.Join(skillsDir, d.Name()))
+			_ = os.RemoveAll(filepath.Join(skillsDir, d.Name()))
 		}
 	}
 	return workspaceRoot, nil

--- a/internal/skills/builtin.go
+++ b/internal/skills/builtin.go
@@ -1,0 +1,149 @@
+package skills
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/drn/argus/internal/db"
+)
+
+// builtinFS embeds argus's own skill sources — the single source of truth for
+// skills that only make sense inside argus (they drive mcp__argus__* tools,
+// read ARGUS_TASK_ID/~/.argus, or encode the hera coordination model). No
+// runtime path, network fetch, or external repository is consulted.
+//
+//go:embed builtin
+var builtinFS embed.FS
+
+// builtinRoot is the embedded root directory name, stripped when walking so
+// callers see skill directories at the top level (e.g. "archive", not
+// "builtin/archive").
+const builtinRoot = "builtin"
+
+// managedSkillsWorkspace is the name of the directory materialized skills live
+// under, inside ~/.argus. It is passed to Claude Code's --add-dir flag; Claude
+// Code then loads <managedSkillsWorkspace>/.claude/skills/ automatically (a
+// documented exception to --add-dir otherwise granting file access only).
+const managedSkillsWorkspace = "skills"
+
+// BuiltinItems returns one SkillItem per embedded builtin skill, sorted by
+// name. Reads only the embedded FS — no filesystem or network access.
+func BuiltinItems() []SkillItem {
+	entries, err := fs.ReadDir(builtinFS, builtinRoot)
+	if err != nil {
+		return nil
+	}
+	var items []SkillItem
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		manifest := filepath.Join(builtinRoot, e.Name(), skillManifestFile)
+		desc := readEmbeddedFrontmatterField(manifest, "description")
+		items = append(items, SkillItem{Name: e.Name(), Description: desc})
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+	return items
+}
+
+// EnsureBuiltinSkills materializes embedded builtin skills to the managed
+// workspace (~/.argus/skills/.claude/skills) idempotently. Updates existing
+// files on content drift; removes stale skills no longer in the embedded set.
+// Errors are logged but non-fatal (failure to materialize one skill doesn't
+// block others).
+func EnsureBuiltinSkills(dataDir string) error {
+	if isTestBinary() || dataDir == "" {
+		return nil
+	}
+	workspaceRoot := filepath.Join(dataDir, managedSkillsWorkspace, ".claude", "skills")
+	if err := os.MkdirAll(workspaceRoot, 0755); err != nil {
+		return fmt.Errorf("create workspace dir: %w", err)
+	}
+
+	// Materialize each builtin skill.
+	builtins := BuiltinItems()
+	present := make(map[string]bool, len(builtins))
+	for _, item := range builtins {
+		skillDir := filepath.Join(builtinRoot, item.Name)
+		entries, err := fs.ReadDir(builtinFS, skillDir)
+		if err != nil {
+			continue
+		}
+		targetDir := filepath.Join(workspaceRoot, item.Name)
+		if err := os.MkdirAll(targetDir, 0755); err != nil {
+			continue
+		}
+		present[item.Name] = true
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			src := filepath.Join(skillDir, e.Name())
+			data, err := fs.ReadFile(builtinFS, src)
+			if err != nil {
+				continue
+			}
+			dst := filepath.Join(targetDir, e.Name())
+			_ = atomicWriteIfDifferent(dst, data)
+		}
+	}
+
+	// Remove stale skills.
+	existingDirs, _ := os.ReadDir(workspaceRoot)
+	for _, d := range existingDirs {
+		if d.IsDir() && !present[d.Name()] {
+			os.RemoveAll(filepath.Join(workspaceRoot, d.Name()))
+		}
+	}
+	return nil
+}
+
+// atomicWriteIfDifferent writes data to path only if the current file content
+// differs. Uses a temp file + rename pattern to avoid partial writes.
+func atomicWriteIfDifferent(path string, data []byte) error {
+	if current, err := os.ReadFile(path); err == nil && bytes.Equal(current, data) {
+		return nil
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// readEmbeddedFrontmatterField extracts a YAML field value from the frontmatter
+// of an embedded file. Returns "" if the file doesn't exist or the field is missing.
+func readEmbeddedFrontmatterField(path, field string) string {
+	data, err := fs.ReadFile(builtinFS, path)
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) < 2 || !strings.HasPrefix(lines[0], "---") {
+		return ""
+	}
+	for i := 1; i < len(lines); i++ {
+		line := lines[i]
+		if line == "---" {
+			break
+		}
+		prefix := field + ":"
+		if strings.HasPrefix(line, prefix) {
+			val := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+			val = strings.Trim(val, "\"'")
+			return val
+		}
+	}
+	return ""
+}
+
+// isTestBinary returns true if the current process is a test executable.
+func isTestBinary() bool {
+	return strings.HasSuffix(os.Args[0], ".test")
+}

--- a/internal/skills/builtin.go
+++ b/internal/skills/builtin.go
@@ -9,8 +9,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"github.com/drn/argus/internal/db"
 )
 
 // builtinFS embeds argus's own skill sources — the single source of truth for

--- a/internal/skills/builtin.go
+++ b/internal/skills/builtin.go
@@ -51,17 +51,24 @@ func BuiltinItems() []SkillItem {
 }
 
 // EnsureBuiltinSkills materializes embedded builtin skills to the managed
-// workspace (~/.argus/skills/.claude/skills) idempotently. Updates existing
-// files on content drift; removes stale skills no longer in the embedded set.
-// Errors are logged but non-fatal (failure to materialize one skill doesn't
-// block others).
-func EnsureBuiltinSkills(dataDir string) error {
-	if isTestBinary() || dataDir == "" {
-		return nil
+// workspace (~/.argus/skills) idempotently. Returns the workspace root path
+// on success (pointing to ~/.argus/skills where .claude/skills/ lives), or
+// an error on failure. Errors are non-fatal for launch (callers log but continue).
+// On success, returns the workspace root (e.g., ~/.argus/skills) suitable for
+// --add-dir flag.
+func EnsureBuiltinSkills() (string, error) {
+	if isTestBinary() {
+		return "", nil
 	}
-	workspaceRoot := filepath.Join(dataDir, managedSkillsWorkspace, ".claude", "skills")
-	if err := os.MkdirAll(workspaceRoot, 0755); err != nil {
-		return fmt.Errorf("create workspace dir: %w", err)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("no home dir: %w", err)
+	}
+	dataDir := filepath.Join(home, ".argus")
+	workspaceRoot := filepath.Join(dataDir, managedSkillsWorkspace)
+	skillsDir := filepath.Join(workspaceRoot, ".claude", "skills")
+	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+		return "", fmt.Errorf("create skills dir: %w", err)
 	}
 
 	// Materialize each builtin skill.
@@ -73,7 +80,7 @@ func EnsureBuiltinSkills(dataDir string) error {
 		if err != nil {
 			continue
 		}
-		targetDir := filepath.Join(workspaceRoot, item.Name)
+		targetDir := filepath.Join(skillsDir, item.Name)
 		if err := os.MkdirAll(targetDir, 0755); err != nil {
 			continue
 		}
@@ -93,13 +100,13 @@ func EnsureBuiltinSkills(dataDir string) error {
 	}
 
 	// Remove stale skills.
-	existingDirs, _ := os.ReadDir(workspaceRoot)
+	existingDirs, _ := os.ReadDir(skillsDir)
 	for _, d := range existingDirs {
 		if d.IsDir() && !present[d.Name()] {
-			os.RemoveAll(filepath.Join(workspaceRoot, d.Name()))
+			os.RemoveAll(filepath.Join(skillsDir, d.Name()))
 		}
 	}
-	return nil
+	return workspaceRoot, nil
 }
 
 // atomicWriteIfDifferent writes data to path only if the current file content

--- a/internal/skills/builtin/archive/SKILL.md
+++ b/internal/skills/builtin/archive/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: archive
+description: Archive the current Argus task so it moves to the Archive section of the task list. Use at the end of a session when the work is done.
+allowed-tools: mcp__argus__task_archive
+---
+
+# Archive Current Task
+
+Mark the Argus task owning the current worktree as archived. Archiving moves the task into the Archive section of the task list and clears its waiting-for-review flag.
+
+## Context
+
+- Current directory: !`pwd`
+
+## Your task
+
+Call the `mcp__argus__task_archive` MCP tool with the working directory from the Context block above as the `cwd` argument, and `archived: true`:
+
+```
+mcp__argus__task_archive(cwd: "<pwd from context>", archived: true)
+```
+
+Argus resolves the task from `cwd` by matching it against task worktree paths — the agent process does not know its own task ID, so `cwd` is the required hand-off.
+
+Do **not** pass `id` — the agent has no reliable way to know it.
+
+After the call, report the tool's response verbatim in one line. If the tool errors (e.g. "no task matches cwd"), show the error and stop; do not retry with guessed arguments.
+
+### Unarchiving
+
+If `$ARGUMENTS` is the literal word `undo`, call with `archived: false` instead. Otherwise always pass `archived: true` — toggling from an unknown prior state is surprising.

--- a/internal/skills/builtin/argus-complete/SKILL.md
+++ b/internal/skills/builtin/argus-complete/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: argus-complete
+description: Mark the current Argus task as complete. Use when the work for the current worktree is done and the user wants the task to transition to the "complete" status.
+allowed-tools: mcp__argus__task_complete
+---
+
+# Mark Current Task Complete
+
+Mark the Argus task owning the current worktree as `complete`. This sets the task's status to `complete` and stamps `EndedAt`. It does **not** stop a running agent session — if an agent is still attached, the user should stop it separately first.
+
+This skill is **not** the same as `/archive`. `/archive` moves the task into the Archive section (a visibility flag, independent of status). `/argus-complete` transitions the workflow status to `complete`. Use `/argus-complete` when the work is finished; use `/archive` (separately, optionally) if you also want it removed from the active task list.
+
+## Context
+
+- Current directory: !`pwd`
+
+## Your task
+
+Call the `mcp__argus__task_complete` MCP tool with the working directory from the Context block above as the `cwd` argument:
+
+```
+mcp__argus__task_complete(cwd: "<pwd from context>")
+```
+
+Argus resolves the task from `cwd` by matching it against task worktree paths — the agent process does not know its own task ID, so `cwd` is the required hand-off.
+
+Do **not** pass `id` — the agent has no reliable way to know it.
+
+After the call, report the tool's response verbatim in one line. If the tool errors (e.g. "no task matches cwd"), show the error and stop; do not retry with guessed arguments. If the response says the task is already complete, surface that as-is and stop.

--- a/internal/skills/builtin/argus-schedule/SKILL.md
+++ b/internal/skills/builtin/argus-schedule/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: argus-schedule
+description: Manage recurring or one-shot tasks in the local Argus daemon via its HTTP API. Use when the user wants to schedule a task locally in argus, create a cron-driven task, fire X every weekday/hour/morning, fire something once at a specific future time (one-shot via run_once_at), set up an agent that needs local filesystem access (logs in ~/.argus, local databases, dotfiles), list or update existing argus schedules, or run an argus schedule now. Distinct from /schedule, which creates remote cloud routines without local access.
+allowed-tools: Bash(curl *), Bash(cat *), Bash(jq *), Bash(test *), Bash(ls *)
+---
+
+# Argus Schedule
+
+Create, list, update, run-now, or enable/disable a recurring task in the local Argus daemon. Argus exposes full schedule CRUD over its HTTP API on `http://localhost:7743`. The cron tick fires the task on the local machine, so the scheduled agent has access to `~/.argus`, the dotfiles repo, and any other local resource — unlike the remote `/schedule` skill, whose routines run in the Anthropic cloud and cannot read the user's filesystem.
+
+## Arguments
+
+- `$ARGUMENTS` — Free-form. May contain a verb (list, create, update, run, enable, disable), a target schedule ID or name, a cron expression, and a prompt. If empty or ambiguous, ask the user a clarifying question and stop.
+
+## Context
+
+- API base: http://localhost:7743
+- Daemon liveness probe (unauthenticated; expect a 401 JSON body when the daemon is up): !`curl -sS -m 2 http://localhost:7743/api/status 2>/dev/null | head -1`
+- Token file: !`ls -1 ~/.argus/api-token 2>/dev/null | head -1`
+
+Interpretation of the liveness probe:
+- Empty output → daemon is not running (or port 7743 is not bound). Stop and tell the user.
+- Output contains `"error":"missing or invalid Authorization header"` → daemon is up; this is the expected response without a token. Proceed.
+- Any other JSON → daemon is up but in an unexpected state; surface the response and stop.
+
+The projects list and the live schedules list require a Bearer token, so do not attempt to fetch them from this Context block — fetch them at runtime in the Verbs section using a single `cat ~/.argus/api-token` substitution inside a curl invocation (where shell command substitution is allowed).
+
+## When to use this skill versus /schedule
+
+| Need | Use |
+|------|-----|
+| Recurring agent must read local files (`~/.argus/ux.log`, dotfiles, local DB, project worktree) | `/argus-schedule` |
+| Recurring agent only needs remote APIs (GitHub, Jira, Slack, web fetches) | `/schedule` |
+| User explicitly says "argus", "in argus", "local cron" | `/argus-schedule` |
+| User says "remote routine", "cloud agent", "in the background even when laptop sleeps" | `/schedule` |
+
+If both would work, default to `/argus-schedule` when the laptop is the user's primary machine and the workflow already lives in argus. Otherwise ask which they want.
+
+## Pre-flight checks
+
+Before any API call:
+
+1. **Daemon reachable.** If the liveness probe in Context above is empty (no response on port 7743), tell the user the argus daemon does not appear to be running and stop. Do not attempt to start it from this skill. A 401 JSON body in the probe is the expected output and means the daemon is up.
+2. **Master token present.** If `~/.argus/api-token` is missing, tell the user to run `argus` once (the daemon mints the token on first run) and stop. The schedule endpoints are master-only — per-device tokens cannot manage schedules.
+3. **Read the token at call time, not in dynamic context.** Use `cat ~/.argus/api-token` inside each curl invocation rather than echoing it into the conversation. The token is sensitive.
+
+## Verbs
+
+Pick the verb from `$ARGUMENTS`. If unclear, ask which one.
+
+### list
+
+```
+curl -sS -H "Authorization: Bearer $(cat ~/.argus/api-token)" \
+  http://localhost:7743/api/schedules | jq
+```
+
+Show the user a compact table: `name`, `schedule`, `enabled`, `next_run_at`, `last_run_at`, `last_error` (only if non-empty). Hide `prompt` unless the user asks — prompts can be long.
+
+### create
+
+Required from the user (ask one question collecting any missing pieces, do not invent values):
+
+- **name** — short, human-readable. Will be suffixed with the fire timestamp on each run.
+- **project** — must match an existing argus project name from the projects list above. If the user gave a project that is not in the list, show the available names and stop.
+- **cadence** — exactly one of:
+  - **schedule** — cron expression for a recurring schedule. See the cron primer below.
+  - **run_once_at** — RFC3339 UTC timestamp (e.g. `2026-05-17T14:00:00Z`) for a single future run. Must be in the future. After firing, the row auto-disables — it stays in the list with `enabled=false` for inspection. The user can delete it once they have read the result.
+- **prompt** — what the agent should do at each fire. Multi-line is fine; pass it as a JSON string.
+- **backend** (optional) — overrides the default backend for this schedule. Only set if the user asked. Useful for forcing a cheaper model on a polling task.
+
+Build the JSON body with `jq` to handle quoting of multi-line prompts safely:
+
+```
+# Recurring (cron):
+JSON=$(jq -n \
+  --arg name "$NAME" \
+  --arg project "$PROJECT" \
+  --arg schedule "$CRON" \
+  --arg prompt "$PROMPT" \
+  '{name:$name, project:$project, schedule:$schedule, prompt:$prompt, enabled:true}')
+
+# One-shot:
+JSON=$(jq -n \
+  --arg name "$NAME" \
+  --arg project "$PROJECT" \
+  --arg run_once_at "$WHEN_RFC3339" \
+  --arg prompt "$PROMPT" \
+  '{name:$name, project:$project, run_once_at:$run_once_at, prompt:$prompt, enabled:true}')
+
+curl -sS -X POST \
+  -H "Authorization: Bearer $(cat ~/.argus/api-token)" \
+  -H "Content-Type: application/json" \
+  -d "$JSON" \
+  http://localhost:7743/api/schedules | jq
+```
+
+When the user gives a local time, convert to UTC RFC3339 before constructing `run_once_at`. Echo the converted UTC timestamp back for confirmation before posting.
+
+After the call, echo the returned `id`, `next_run_at`, and a one-line confirmation. Do not add `--data-raw` shortcuts that bypass jq — embedding raw user input into a shell-quoted JSON string is a quoting hazard.
+
+### update
+
+The PUT body uses pointer fields: send only what the user wants to change.
+
+```
+JSON=$(jq -n --arg schedule "$NEW_CRON" '{schedule:$schedule}')
+curl -sS -X PUT \
+  -H "Authorization: Bearer $(cat ~/.argus/api-token)" \
+  -H "Content-Type: application/json" \
+  -d "$JSON" \
+  http://localhost:7743/api/schedules/"$ID" | jq
+```
+
+If the user gave a name instead of an ID, list first, find the matching row, and confirm the ID with the user before sending the PUT.
+
+### run
+
+Fires the schedule now, out of cycle. Creates a fresh task immediately.
+
+```
+curl -sS -X POST \
+  -H "Authorization: Bearer $(cat ~/.argus/api-token)" \
+  http://localhost:7743/api/schedules/"$ID"/run | jq
+```
+
+Note for the user: the run-now path does NOT send a push notification (the cron tick path does). If they expected the notification, that is the reason it did not arrive.
+
+### enable / disable
+
+Equivalent to update with only `enabled` set:
+
+```
+JSON=$(jq -n --argjson enabled false '{enabled:$enabled}')
+```
+
+(Use `true` for enable.) Disabling pauses fires but preserves the row. The user can re-enable later without re-creating.
+
+## Cron primer
+
+Argus parses schedules with `robfig/cron/v3` `ParseStandard`. Accepts:
+
+- **5-field cron**: `minute hour day-of-month month day-of-week`. Example: `0 9 * * 1-5` is 9am on weekdays.
+- **Descriptors**: `@hourly`, `@daily`, `@weekly`, `@monthly`, `@yearly`.
+- **Interval shortcut**: `@every <duration>` where duration is a Go duration like `30m`, `1h`, `24h`. Example: `@every 1h` fires hourly aligned to the moment of creation.
+
+Minimum resolution is one minute — schedules tighter than that are ignored. The first fire never happens on the very first tick after creation; the scheduler advances `NextRunAt` past `now` on each persist.
+
+Time zone follows the daemon process's local time zone. State that explicitly to the user when the cron expression contains a specific clock time, so they can confirm it matches their expectation.
+
+## Validation
+
+After every create or update, refetch the row and report `next_run_at`. If `last_error` is non-empty after a previous fire, surface it — the most common cause is a removed project or a mistyped cron expression.
+
+## Stop conditions
+
+- Daemon unreachable on the health probe → tell the user, stop.
+- Token missing → tell the user, stop.
+- Project name not in the configured projects list → show available names, stop.
+- Cron expression rejected by the API (HTTP 400) → show the API error verbatim, ask for a corrected expression, do not retry with a guessed value.
+- HTTP 5xx from the API → show the response body, stop. Do not loop.
+
+Do not retry destructive or fire-causing calls automatically. One attempt per user instruction.
+
+## Skill mirroring (author note)
+
+This skill has a twin at `~/.dots/agents/skills/argus-schedule/SKILL.md` per the user's skill-mirroring preference. The argus repo copy is canonical; the dotfiles copy makes the slash command reachable from any project. Keep the two files byte-identical.

--- a/internal/skills/builtin/hera-plan/SKILL.md
+++ b/internal/skills/builtin/hera-plan/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: hera-plan
+description: >-
+  The hera plan-DAG: author staged, dependency-ordered multi-worker plans inside an argus sandbox
+  and let the daemon gater materialize each node into a born-bound worker as its blockers finish.
+  Load this (in addition to the base `hera` skill) when you are a coordinator and the work
+  decomposes into multiple hera worker units that have DEPENDENCIES among them (one stage needs
+  another's output, or a required ordering) — internal dependencies are the clean signal to plan a
+  DAG rather than spawn workers ad hoc. Covers the authoring/mutation verbs, gating-on-`done`,
+  automatic branch-stacking and its fan-in footgun, short-id node naming, sub-coordinator nodes, and
+  the self-guard prompt patterns. NOT for non-argus sessions; NOT for in-session ephemeral work (use
+  Claude's native sub-agents); NOT for independent workers with no ordering (just spawn them).
+---
+
+# Hera plan-DAG — staged, dependency-ordered multi-agent work
+
+This is the **coordinator-only** plan-DAG layer of hera. It assumes you already hold a live
+coordinator binding and know the base hera model (roles, bindings, messaging, `hera_spawn_worker`,
+status/tree) from the `hera` skill — **load that first if you haven't.** Every tool here takes
+`cwd` (pass `cwd=$PWD`) and `orchestrator` is required when your task holds 2+ live bindings.
+
+**Plan nodes land under your EXISTING orchestrator – the one you already coordinate.** Authoring a
+plan-DAG is *not* a bootstrap step: you do **not** call `hera_new_orchestrator` to hold your plan.
+The `hera_plan` / `hera_plan_node` verbs add nodes to the orchestrator you already coordinate, and
+the gater materializes each node as a worker **directly beneath you**. Spinning up a second
+orchestrator to hold your own plan creates a redundant self-coordinator that wrongly owns the DAG –
+don't. The only reason to pass `orchestrator=` is to disambiguate when your task holds 2+ live
+bindings; the only reason to spin up a *new* orchestrator inside a plan is the deliberate
+`kind=subcoord` node (a genuinely distinct sub-goal handed to a separate sub-team – see below).
+
+## When the plan-DAG is the right tool
+
+The base `hera` skill's decision triad gets you here: the work decomposes into units that each must
+be **their own argus session** (separate worktree / own PR / long-running / own sandbox), **and**
+those units have **dependencies among them**. That dependency is the clean trigger:
+
+- **Dependencies present** (stage B needs stage A's branch/output, or a required ordering) → **plan
+  a DAG.** Author planned nodes wired by blocking edges; the gater runs them in order. *Decide this
+  yourself when the dependencies are obvious — don't ask the human.* Only ask the human when it's
+  genuinely ambiguous whether the effort warrants multi-session orchestration at all.
+- **Independent units, no ordering** → don't author a DAG; just `hera_spawn_worker` them in parallel.
+- **Ephemeral in-session work** (research, review, fan-out reads that return to you) → not hera at
+  all; use Claude's native sub-agents (Agent/Task tool).
+
+> **With a live coordinator binding, the plan-DAG is the single source of truth for the staged
+> worker activity it covers. Author the workers as plan nodes; track progress through the DAG;
+> reconcile the plan as work evolves. The harness `TaskCreate` system-reminder does not apply to
+> coordinated work — use the plan/spawn tools, never bare task creation.**
+
+## The gating contract (how nodes become live workers)
+
+A **planned node** is a worker role with no live agent / worktree / inbox yet — one DB row. The
+daemon gater (~60s tick) materializes it into a born-bound worker (exactly what `hera_spawn_worker`
+would produce) according to this contract:
+
+- **A node materializes ONLY when EVERY blocker reaches hera role-status `done`** — the worker's
+  explicit "I'm finished" (which rolls its task to `in_review`). Role-status `done`, **not** task
+  status, **not** idle.
+- A blocker still `working` (e.g. iterating on CI) keeps the dependent **planned** — the next stage
+  never starts under churning work.
+- A blocker whose session **ended without ever reaching `done`** (crash, or it gave up / reported
+  `failed`) **HOLDS** the dependent (no materialize) and pings you. No worker is ever spawned-and-
+  parked behind dead or unfinished work.
+- A node with **no blockers** is a root and materializes on the next tick.
+- A cancelled planned node is treated as satisfied (non-blocking) — its dependents proceed.
+
+## Authoring verbs
+
+- **`hera_plan_node(cwd, name, prompt, [orchestrator], [project], [kind], [goal])`** — create ONE
+  planned node. **Name nodes by a `<stage><member>` short-id — number = serial stage, letter =
+  parallel member (`1a`, `2a`, `2b`, `3a`)** — optionally with a *terse* suffix (`1a-seed`,
+  `2a-alpha`). This is **not cosmetic**: the rail/DAG renders one box per node, and long descriptive
+  names (`backend-api-handlers`, `frontend`) blow the boxes wide and wreck legibility once you have
+  more than a handful of stages, while `2a`-style ids keep the graph tight and scannable. Names are
+  uniquified within the orchestrator. `project` defaults to the coordinator's own.
+  - `kind` — `worker` (default) or `subcoord`. A **worker** node materializes into a live born-bound
+    worker; `prompt` is delivered to it (a check-in standing-order is prepended automatically). A
+    **subcoord** node materializes into a *distinct sub-coordinator agent* — see "Sub-coordinator
+    nodes" below.
+  - `goal` — **required for `kind=subcoord`** (used instead of `prompt`): the objective handed to the
+    sub-coordinator. You hand only the goal — not its child orchestrator name or its sub-plan.
+
+- **`hera_block(cwd, blocked, blocker, [orchestrator])`** — add a blocking edge: `blocked` waits on
+  `blocker` reaching role-status `done` before it materializes. Both roles must be in your
+  orchestrator. **Rejected** on a cycle, cross-orchestrator endpoints, or a **coordinator** blocker
+  (a coordinator never reaches `done`, so it would be permanently unsatisfiable).
+
+- **`hera_plan(cwd, nodes, [edges], [orchestrator])`** — submit a WHOLE graph in one
+  **transactional** call: `nodes` = `[{name, prompt, [project], [kind], [goal]}]`, `edges` =
+  `[{blocked, blocker}]` referencing nodes by name (or existing roles). **All-or-nothing** — any
+  cycle / cross-orchestrator / coordinator-blocker / validation error rolls back the entire graph
+  (no orphan nodes). The way to lay out a multi-stage plan at once. **Name every node by its
+  `<stage><member>` short-id** so the rendered DAG stays tight.
+
+## Mutation verbs — the DAG is living, not authoring-time
+
+Update the graph as reality diverges from the plan; don't abandon it.
+
+- **`hera_plan_node_update(cwd, name, [prompt], [project], [orchestrator])`** — edit a **planned**
+  node's prompt and/or project. Rejected once the node has materialized (the prompt was already
+  delivered). Use when you discover the spec needs revision before the node spawns.
+- **`hera_unblock(cwd, blocked, blocker, [orchestrator])`** — drop one blocking edge. Idempotent. To
+  re-point: `hera_unblock` (old blocker) then `hera_block` (new blocker).
+- **`hera_plan_node_cancel(cwd, name, [orchestrator])`** — cancel a planned node: it never
+  materializes, its dependents proceed (no longer gated on it), it stays visible as a grey ✕.
+  Rejected once materialized (use the task lifecycle to stop a running worker).
+
+**Standing order:** after every worker interaction, check whether the plan still mirrors reality —
+`hera_plan_node_update` a changed scope, `hera_unblock` an obsolete edge, `hera_plan_node_cancel` a
+superseded node. A worker re-engaging on rework after `done`/`failed` reports `working` on its next
+`hera_send` by requirement, so the DAG self-corrects for a simple reopen.
+
+## Materialization + branch-stacking (the gater drives this, not you)
+
+- **Non-root nodes stack automatically**: a materializing node is branched off its most-recently-
+  `done` blocker's branch, so a *linear* chain produces cleanly stacked PRs.
+- **Fan-in stacks on ONE blocker, not a merge of all.** A node with multiple blockers bases off the
+  *single* most-recently-`done` blocker's branch — it does **not** merge the others in. In a diamond
+  (`3a` blocked by both `2a` and `2b`), `3a` starts from whichever of `2a`/`2b` materialized later
+  and is **missing the other's work** unless those two were themselves stacked. For true fan-in,
+  either keep the stages a linear chain, or have the fan-in node merge the branches itself via a
+  self-rebase step (see below).
+- **`done` gates materialization, but `done` ≠ merged/integrated.** A worker reaching `done` rolls
+  its task to `in_review` (*not* merged) — so the gater materializes the dependent the instant the
+  blocker *reports* done, **before** you've reviewed or merged anything. The dependent stacks on the
+  blocker's worker branch as it stood at `done`. That's exactly right for a linear stack where that
+  branch *is* the integration point; but if your workflow merges upstream work into a separate
+  feature branch before cutting the next stage, the materialized node will be racing ahead of your
+  merge — make node prompts self-defending (next section).
+- **Root nodes** (no blockers) resolve their base branch as: explicit orchestrator `base_branch` →
+  the coordinator role's bound-task branch → the project default. Root a plan on your feature branch
+  by passing `base_branch` to `hera_new_orchestrator`.
+- **Respond to check-ins promptly.** Each node check-ins on materialization via `hera_send`; pull it
+  from `hera_inbox` and reply (e.g. `"go"`). A node HELD behind a genuinely failed blocker pings you
+  — `hera_unblock` the edge, `hera_plan_node_cancel` the held node, or `hera_spawn_worker` a
+  replacement. (Coordinator-as-blocker is rejected at authoring time, so the graph can't wedge on a
+  never-`done` coordinator.)
+
+## Self-defending node prompts (the standard mitigation)
+
+Because a node materializes the instant its blockers *report* `done` — ahead of your review/merge —
+any node that depends on upstream output should carry two prompt-side guards:
+
+- **Self-rebase** — the node's first step is `git merge --no-edit origin/<integration-branch>` (or
+  the sibling branch in a fan-in) to pull in whatever is integrated so far.
+- **Self-guard** — the node greps for the API routes / files / symbols it depends on and, if absent,
+  `hera_send`s you to wait instead of building against a phantom contract.
+
+This is what makes plan-mode safe for stacked-integration and contract-discovery work, so you rarely
+need to fall back to driving every stage by hand. Reserve pure incremental `hera_spawn_worker`
+(spawn the next stage manually only after you've merged the prior) for when even self-guarding is too
+racy — i.e. a hard human/coordinator decision gate must sit between phases.
+
+## Sub-coordinator nodes (`kind=subcoord`)
+
+Use a subcoord node when a plan stage is itself a *sub-team* — a chunk big enough to warrant its own
+coordinator and its own fan-out — rather than a single unit of work. It's the **declarative** form of
+worker promotion (a worker calling `hera_new_orchestrator` on itself mid-task): you author the
+sub-team as a plan node up front, and the gater materializes it as a *distinct coordinator agent*
+when its blockers finish.
+
+- It occupies the parent DAG exactly like any node (a worker role in **your** orchestrator) — blocking
+  edges, gating, hold/ping, and branch-stacking all treat it identically; its worker-role `done` gates
+  the parent's dependents.
+- At materialization it becomes **one new agent** (own task + worktree) that is simultaneously a
+  worker in your orchestrator AND the coordinator of a freshly-created, auto-named child orchestrator
+  — so it nests under you in the rail/tree via the multi-binding bridge, never sharing your task.
+- You hand it only the `goal`. It runs its own planning (often `/brainstorm` → its own `hera_plan`)
+  and spawns its own workers. Bake rich context into the goal so it needs little back-and-forth.
+- Keep it an explicit choice — default to plain worker nodes; don't spin up middle-management for a
+  stage one worker can do.
+
+## Worked example — author a staged plan-DAG and let it self-materialize
+
+The work has a seed, a parallel fan-out, and a fan-in:
+
+1. **Author the DAG under your EXISTING orchestrator – do NOT call `hera_new_orchestrator` to hold
+   your plan.** If you are already a coordinator (you bootstrapped or claimed an orchestrator earlier
+   this session – the common case when you reach this skill), skip straight to step 2: the nodes
+   become workers in your current orchestrator, materialized directly beneath you by the gater. Only
+   call `hera_new_orchestrator(cwd=$PWD, name="<feature>", coordinator_role_name="coord")` in the rare
+   cold-start case where you do **not** yet hold ANY coordinator binding; calling it when you already
+   coordinate one creates a redundant second coordinator that wrongly holds your DAG. (To root a
+   *fresh* orchestrator's plan on a feature branch, pass `base_branch="argus/<your-branch>"`; an
+   existing orchestrator already carries its own base – see the root-node branch resolution above.)
+   Author your own stages directly as plain worker nodes; reach for `kind=subcoord` only to hand a
+   genuinely distinct sub-goal to a separate sub-team.
+2. Submit the whole graph transactionally — short-id names, full spec baked into each prompt:
+   ```
+   hera_plan(cwd=$PWD,
+     nodes=[
+       {name:"1a-seed",  prompt:"<complete spec…>"},
+       {name:"2a-alpha", prompt:"<complete spec…>"},
+       {name:"2b-beta",  prompt:"<complete spec…>"},
+       {name:"3a-final", prompt:"<complete spec…>"}],
+     edges=[
+       {blocked:"2a-alpha", blocker:"1a-seed"},
+       {blocked:"2b-beta",  blocker:"1a-seed"},
+       {blocked:"3a-final", blocker:"2a-alpha"},
+       {blocked:"3a-final", blocker:"2b-beta"}])
+   ```
+   `1a-seed` materializes first (rooted on your branch); `2a`/`2b` materialize in parallel once it's
+   `done` (each stacked on `1a-seed`'s branch); `3a-final` waits for **both** and stacks on the latest.
+   **Fan-in caveat:** `3a-final` bases off whichever of `2a`/`2b` finished later — it does NOT
+   auto-merge the other half. Give `3a-final`'s prompt a self-rebase first step (`git merge --no-edit`
+   the sibling / integration branch) so it actually has both halves before it builds.
+3. Watch it fill in the second-tab plan-DAG (planned `○` → live). Respond to each node's check-in:
+   `hera_inbox(cwd=$PWD)` on the doorbell → reply `hera_send(cwd=$PWD, to="<node>", body="go", tldr="go")`.
+4. If a node is HELD behind a genuinely failed blocker, the gater pings you — `hera_unblock`,
+   `hera_plan_node_cancel`, or `hera_spawn_worker` a replacement.
+5. **Reconcile as work unfolds** — `hera_plan_node_update` a changed scope before it materializes,
+   `hera_unblock` an obsolete edge, `hera_plan_node_cancel` a superseded node. Keep the DAG a live
+   mirror of the actual plan.
+
+## Gotchas worth calling out
+
+- **The gate is role-status `done`, not idle and not merged.** Idle-without-`done` keeps a node
+  planned; a session that ended without `done` HOLDS its dependents and pings you. Materialization
+  fires the instant a blocker *reports* done, which is before your review/merge — see the
+  branch-stacking and self-defending-prompts sections.
+- **Fan-in does not merge — it picks one branch.** A multi-blocker node bases off only the
+  latest-`done` blocker's branch. Self-rebase the others in, or keep the stages linear.
+- **Mutation verbs only work pre-materialization.** `hera_plan_node_update` / `hera_plan_node_cancel`
+  are rejected once a node has a binding — at that point manage the running worker via the task
+  lifecycle, not the plan.
+- **Short-id names are load-bearing for legibility.** Descriptive node names blow the rail/DAG boxes
+  wide at scale; use `<stage><member>` ids.

--- a/internal/skills/builtin/hera/SKILL.md
+++ b/internal/skills/builtin/hera/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: hera
+description: >-
+  Inside an argus sandbox (cwd under ~/.argus/worktrees/ or ARGUS_TASK_ID set), coordinate
+  multi-agent work via hera's mcp__argus__hera_* tools — bootstrap an orchestrator, claim or attach
+  a worker/freelance role, spawn workers, and message roles over the idle-gated bus. Load this skill
+  when you are (or are becoming) a coordinator, when you're spawned as a hera worker, or before
+  delegating work that must run as its OWN argus session (separate worktree / long-running agent /
+  own PR / own sandbox) — as opposed to in-process Claude sub-agents, which stay the right tool for
+  ephemeral in-session fan-out. For staged or dependency-ordered multi-worker plans, this skill
+  routes you to the companion `hera-plan` skill. NOT for non-argus sessions, where these MCP tools
+  are not registered.
+---
+
+# Hera — native multi-agent coordination inside argus
+
+Hera is argus's **native, in-tree** layer for running a *team* of agents. It is not a separate
+daemon or plugin — coordination runs in-process in the argus daemon, the rail/tree render directly
+in the TUI's second tab, and agents drive it entirely through the `mcp__argus__hera_*` MCP
+tools. State lives in the same `~/.argus/data.sql` (the `hera_*` tables). You never touch the
+plumbing; you call the tools.
+
+## 1. When this applies (and when it does NOT)
+
+This skill applies **only inside an argus task sandbox**. You are in one if **either** holds:
+
+- `ARGUS_TASK_ID` is set, **or**
+- the current working directory is under `~/.argus/worktrees/`.
+
+**If neither holds, stop.** The `mcp__argus__hera_*` tools are not registered in this session — there
+is no CLI fallback and nothing below applies.
+
+**Every hera tool takes `cwd` — always pass `cwd=$PWD`.** That is how hera resolves which argus task
+(and therefore which role) this session is. There is no separate "auth" or session handle.
+
+## 2. The role model
+
+- **Orchestrator** — a named coordination graph (one per project / feature / wave). Roles live under
+  it. Created by `hera_new_orchestrator` (idempotent by name).
+- **Coordinator role** — the orchestrator's driver. Created by `hera_new_orchestrator`. Talks to the
+  human in its own agent pane; talks to other roles via `hera_send`. Folded into the rail's
+  orchestrator header (it is not a separate row).
+- **Worker role** — does the actual work. Normally **born-bound**: spawned by a coordinator with
+  `hera_spawn_worker`, which creates the argus task (worktree + session) AND the role + binding in one
+  transaction. A born-bound worker does *not* need to `hera_join` — its session opens already bound.
+- **Freelance role** — a helper that attaches itself to an existing orchestrator on its own
+  initiative (no coordinator spawned it). Created via `hera_join` attach mode with `kind=freelance`.
+- **Binding** — the live link between *this argus task* and *one role*. Invariants:
+  - **One live binding per `(task, orchestrator)`** — enforced by a partial unique index.
+  - **A task MAY hold several live bindings at once** — one per orchestrator (e.g. a worker in A that
+    promotes itself to coordinator of nested orchestrator B). When a task holds **2+** live bindings,
+    you **must** pass `orchestrator=<name>` to every tool so hera knows which role you are acting as;
+    omitting it returns an ambiguity error listing your options.
+
+## 3. The coordination tools
+
+All take `cwd`. `orchestrator` is optional with exactly one live binding and **required** with 2+.
+Arg names below are exact — do not invent others. These nine cover bootstrap, messaging, and status;
+the plan-DAG authoring/mutation tools live in the companion `hera-plan` skill (pointer at the end of
+this section).
+
+### Bootstrap / join
+
+- **`hera_new_orchestrator(cwd, name, coordinator_role_name, [prompt])`** — "I am the coordinator."
+  Creates (or fetches, idempotent-by-name) the orchestrator, creates the named coordinator role, and
+  binds this task to it. Returns the orchestrator name, role name, `binding_id`, and argus task id.
+  Rejects if this task already holds a live binding under that orchestrator (use `hera_join` to
+  retrieve it). The canonical "become an orchestrator" entry point — don't `hera_join` first; there is
+  nothing to join yet.
+
+- **`hera_join(cwd, [orchestrator], [role_name], [kind], [prompt], [status])`** — two modes:
+  - **Claim mode** (`role_name` omitted) — retrieves this task's existing live binding + role and its
+    unread message count. Use right after a born-bound worker terminal opens to read your assigned
+    role/mission. Pass `orchestrator=` if the task has 2+ bindings. Claim mode does **not** consume the
+    inbox.
+  - **Attach mode** (`role_name` + `kind` supplied) — creates a **new** role under an *existing*
+    orchestrator (`orchestrator` required) and binds this task to it. `kind` must be `worker` or
+    `freelance` (`coordinator` is rejected — use `hera_new_orchestrator`). Optional `prompt` (stored on
+    the role) and `status` (`idle`/`working`/`blocked`/`done`). Use to join a team nobody spawned you
+    into.
+
+- **`hera_spawn_worker(cwd, prompt, [orchestrator], [role_name], [project], [branch], [backend], [model])`**
+  — spawn a new **born-bound** worker task + session under the caller's orchestrator. **Caller must hold
+  a live coordinator binding.** Creates an argus task (worktree + session) and, transactionally, a worker
+  role + binding pre-bound to it; an orientation prefix naming the coordinator + orchestrator is prepended
+  to the prompt automatically. Args:
+  - `prompt` (**required**) — the worker's MISSION/task only. The verbatim prompt is also stored on the
+    role row and shown as the node's description in the plan-DAG view. **Do NOT prepend the org/security
+    policy** — see the mission-only gotcha in §6.
+  - `project` — defaults to the **coordinator's own task project** (authoritative, not `role.ArgusProject`).
+  - `branch` — base branch passed to argus task creation. **Defaults to the project default — see the
+    base-branch gotcha in §6.**
+  - `backend` — defaults to project default.
+  - `model` — per-worker model override, scoped to the worker's resolved backend (claude: opus/sonnet/
+    haiku; codex: e.g. gpt-5; pi: its ids). Empty = backend default. Match it to task complexity.
+  - `role_name` — derived from a prompt slug if omitted; uniquified within the orchestrator.
+  - `orchestrator` — disambiguates when the calling task holds multiple live coordinator bindings.
+
+  Returns the orchestrator, worker role name, `binding_id`, argus task id, and project.
+
+### Messaging (idle-gated bus)
+
+- **`hera_send(cwd, body, tldr, status, [to], [in_reply_to], [orchestrator])`** — message another role
+  **in the same orchestrator**. `body` and `tldr` are **required**; `tldr` is a one-line summary ≤120
+  chars, written from the recipient's perspective (see §5). **`status` is REQUIRED for worker/freelance
+  senders** (one of `idle`/`working`/`blocked`/`done`/`failed`) and is applied to the sender's role
+  **synchronously** before the message is sent — it is never delivered async. Omitting `status` as a
+  worker/freelance sender is an error; coordinator senders may omit it. Worker/freelance senders may
+  omit `to` — it default-routes to the orchestrator's coordinator. **Coordinators must supply an
+  explicit `to`.** `in_reply_to` threads a reply to a prior message id. Returns the `message_id`,
+  recipient, and delivery mode. Caps: 64 KiB body, 500 unread per recipient, 50 sends/min/sender.
+  Cross-orchestrator messaging is not possible — `to` always resolves within your own orchestrator.
+
+- **`hera_inbox(cwd, [orchestrator])`** — fetch all unread messages addressed to your role, oldest
+  first. **Reading IS acknowledgment**: this both cancels pending pane deliveries AND marks the
+  messages read — no separate `hera_mark_read` needed for normal consumption. Call it whenever you get a
+  doorbell.
+
+- **`hera_mark_read(cwd, message_ids, [orchestrator])`** — explicitly mark specific message ids read and
+  cancel their pending deliveries. Use when you read via `hera_get_messages` instead of `hera_inbox`.
+
+### Status / tree
+
+- **`hera_status(cwd, status, [orchestrator])`** — set your role status: `idle` | `working` | `blocked`
+  | `done` | `failed`. Mirrored (best-effort) to argus `task_meta` so the coordinator sees it without
+  asking. **A `worker`-kind role reporting `status=done` also rolls its bound argus task to `in_review`
+  and stamps `ready_to_close`** (visible in the rail) — see §4. **A worker reporting `status=failed`
+  rolls its task to `in_review` WITHOUT `ready_to_close`** (needs-attention, not ready to check off).
+  The gater treats a `failed` blocker as explicitly failed (no need to wait for session death).
+  Coordinators/freelancers just update status.
+
+- **`hera_tree_updates(cwd, [orchestrator], [since])`** — scan the caller's orchestrator **subtree**
+  (nested sub-orchestrators included) for messages since a cursor. Returns **TLDR-only subject lines —
+  no bodies** (capped at 200), plus a `next_cursor`. The cursor is stored **per-role** and auto-advances
+  when you omit `since`; passing an explicit `since` is a one-off scan that does NOT clobber the stored
+  cursor. The token-efficient way to see whole-team activity without flooding context with bodies.
+
+- **`hera_get_messages(cwd, ids, [orchestrator])`** — fetch full message bodies by id list, after
+  scanning `hera_tree_updates`. Access is scoped to the caller's orchestrator **subtree** (sender OR
+  recipient must live in it); inaccessible / missing ids get a per-id `error` field rather than a
+  top-level error.
+
+### Plan-DAG authoring (staged, dependency-ordered work) → the `hera-plan` skill
+
+> **With a live coordinator binding, do NOT use the harness `TaskCreate` system-reminder for
+> coordinated work — coordinate via the hera tools (`hera_spawn_worker`, or the plan-DAG), never
+> bare task creation.**
+
+For work that decomposes into multiple hera worker units **with dependencies among them** (one stage
+needs another's output, or a required ordering), hera offers a **plan-DAG**: planned nodes wired by
+blocking edges that the daemon gater materializes into born-bound workers in dependency order,
+auto-stacking each stage's branch on the prior. It renders in the TUI's second tab and is a *living*
+graph (edit / re-point / cancel as work evolves).
+
+**Load the companion `hera-plan` skill** before authoring or driving a plan-DAG. It carries the six
+plan tools (`hera_plan`, `hera_plan_node`, `hera_block`, `hera_plan_node_update`, `hera_unblock`,
+`hera_plan_node_cancel`), the gating contract (a node materializes ONLY when every blocker reaches
+role-status `done`), automatic branch-stacking and its fan-in footgun, short-id node naming,
+sub-coordinator nodes, and the self-guard prompt patterns — none of which the tool schemas convey. The
+decision triad in §4 tells you *when* the plan-DAG is the right tool versus spawning workers directly
+or using in-session sub-agents.
+
+## 4. Decision rules
+
+- **Starting a coordination effort?** `hera_new_orchestrator`. Don't `hera_join` first.
+- **A coordinator spawned you (fresh born-bound worker terminal)?** `hera_join(cwd)` to read your role
+  + mission, then `hera_status(working)`. You are already bound — no attach needed.
+- **Joining a team that didn't spawn you?** `hera_join` attach mode with explicit `role_name` + `kind`.
+- **`new_orchestrator` vs `join`:** `new_orchestrator` makes you a coordinator of a *new* orchestrator;
+  `join` claims/attaches a role under an *existing* one. A worker can do BOTH — stay a worker in the
+  parent and `hera_new_orchestrator` to become a coordinator of a nested team (multi-binding).
+- **`spawn_worker` vs adopt:** native hera has **no adopt step** — workers are born bound at spawn time.
+  (The old `depends_on`-driven auto-adopt watcher was retired with the DAG.) To delegate, just
+  `hera_spawn_worker`.
+- **The coordination decision — in-session sub-agents vs hera workers vs the plan-DAG (settle this
+  BEFORE delegating):**
+  1. **Ephemeral, in-session work** — research, review, fan-out reads, anything that returns results
+     to you and needs no worktree/PR of its own? → use **Claude's native sub-agents** (Agent/Task
+     tool). NOT hera. Hera is overkill and slower for in-session parallelism.
+  2. **Work whose unit must be its OWN argus session** — separate worktree / its own PR / long-running
+     / its own sandbox? → **hera**. Then split by dependency:
+     - Units have **dependencies among them** (one needs another's output, or a required ordering)? →
+       **plan-DAG**: load the `hera-plan` skill, author planned nodes + blocking edges, let the gater
+       run them in dependency order. *Decide this yourself when the dependency is obvious — don't ask
+       the human.* **Internal dependencies are the clean signal to plan a DAG** rather than spawn ad hoc.
+     - Units are **independent** (no ordering)? → just `hera_spawn_worker` them in parallel; no DAG.
+  3. **Ask the human only** when it's genuinely ambiguous whether the work warrants multi-session
+     orchestration at all — never for the routine dependency call above.
+- **This task holds 2+ bindings?** Pass `orchestrator=` on EVERY tool call.
+- **Got a doorbell?** Call `hera_inbox(cwd=$PWD)` immediately — the content is in the inbox, not the
+  doorbell line.
+- **Want whole-team state?** `hera_tree_updates(cwd=$PWD)`, then `hera_get_messages(ids=[…])` for the
+  ones worth reading.
+- **How completion flows back:** a worker finishing sends a closing `hera_send(status="done", …)` — the
+  synchronous status apply rolls its task to `in_review` + `ready_to_close`, visible in the rail. A
+  worker that cannot complete sends `hera_send(status="failed", …)` — rolls to `in_review` WITHOUT
+  `ready_to_close` (needs attention, not ready to check off); the gater holds any dependent planned
+  nodes and pings you. Both rolls are idempotent and only fire when the task is still `in_progress`.
+  The live session is left running.
+- **Don't** use `hera_send` to talk to the human — the human reads the coordinator's own agent pane;
+  the bus is role-to-role only.
+
+## 5. TLDR discipline
+
+Every `hera_send` requires a `tldr` ≤120 chars, written from the recipient's perspective. It is shown
+in the doorbell, returned by `hera_tree_updates`, and stored permanently.
+
+- Good: `"PR #47 open, tests green, needs review"` / `"Blocked on missing API key — need rotation"`
+- Bad: `"update"` (says nothing) / `"Done with the work"` (no specifics) / multi-line.
+
+## 6. Gotchas worth calling out
+
+- **`hera_send` requires `status` for worker/freelance senders — omitting it is an error.** The status
+  is applied synchronously before the send completes; it never rides the async delivery bus. This means
+  every `hera_send` call doubles as a role-status heartbeat. There is no default; the error message on
+  omission names the valid values (`idle`/`working`/`blocked`/`done`/`failed`).
+- **Spawned workers default to the project's stale default branch, NOT the coordinator's branch.**
+  `hera_spawn_worker`'s `branch` defaults to the *project* default (e.g. an old `master`/`main`), not the
+  coordinator's current worktree branch. If the worker must build on the coordinator's (or a sibling's)
+  work, **pass `branch=` explicitly and verify ancestry** — otherwise the worker starts from stale code.
+- **Pass the MISSION only in `hera_spawn_worker` / `hera_plan_node` prompts — never prepend the
+  org/security policy.** A hera worker is a full argus session that receives its org instructions
+  independently, via its OWN session's harness injection (an `<organizationInstructions>` block, verified
+  present in every spawned session regardless of the parent). So a manually prepended copy is a redundant
+  duplicate — and argus stores the prompt verbatim on the role and renders its opening lines as the node's
+  description in the plan-DAG, so a prepended policy pollutes the DAG (every node reads the boilerplate
+  instead of its mission). Write the prompt as exactly the message you want the worker to act on.
+- **Bake all requirements into the initial `hera_spawn_worker` prompt.** Mid-flight `hera_send` to a
+  worker is often missed: delivery is idle-gated and best-effort, so a busy worker never receives it and
+  an idle/finished worker may not act on it. Put the full spec in the spawn prompt; verify via the branch
+  diff and re-dispatch a fresh worker if one idled out without the requirement.
+- **The message bus is idle-gated and best-effort for *delivery*, durable for *storage*.** Storage always
+  succeeds (the row is committed); live pane delivery soft-fails (logged, never rolled back) when the
+  recipient has no live binding or never becomes idle. `hera_inbox` always returns the durable rows, so
+  the recipient can always catch up by reading — don't assume a sent message was seen just because it sent.
+- **`worker done` must keep the role messageable.** Native deliberately does NOT auto-archive a role on
+  `hera_status(done)` (the external plugin did). An archived role drops out of name-keyed recipient
+  resolution, so auto-archiving a still-live worker would make the coordinator's `hera_send` to it bounce.
+  Done flips the task to in_review; it does not archive the role.
+- **Coordinators must name a recipient.** `hera_send` from a coordinator with `to` omitted errors —
+  only worker/freelance senders get the default-to-coordinator routing.
+
+## 7. Worked workflows
+
+### (a) Bootstrap an orchestrator, spawn two workers, collect results
+
+You are a coordinator-to-be in your argus sandbox:
+
+1. `hera_new_orchestrator(cwd=$PWD, name="checkout-revamp", coordinator_role_name="coord", prompt="Coordinate the checkout revamp")`.
+2. Spawn workers, each with the FULL spec baked in and an explicit base branch:
+   - `hera_spawn_worker(cwd=$PWD, role_name="cart-api", branch="argus/<base>", prompt="<complete cart-API spec…>")`
+   - `hera_spawn_worker(cwd=$PWD, role_name="checkout-ui", branch="argus/<base>", prompt="<complete checkout-UI spec…>")`
+3. Poll progress without flooding context: `hera_tree_updates(cwd=$PWD)` → scan TLDRs →
+   `hera_get_messages(cwd=$PWD, ids=[…])` for the interesting ones.
+4. When a worker reports `done` (its task rolls to in_review + ready_to_close in the rail), review its
+   branch/PR, then reply or spawn the next stage. To stack work, branch the next worker off the prior
+   worker's branch via `branch=`.
+
+### (b) A spawned worker reports completion
+
+You opened in a born-bound worker terminal:
+
+1. `hera_join(cwd=$PWD)` → read your role name, mission (role prompt), and unread count.
+2. `hera_status(cwd=$PWD, status="working")`.
+3. Do the work in your worktree. If you hit a fork that needs the coordinator's call:
+   `hera_send(cwd=$PWD, status="working", body="<question + context>", tldr="Need decision: X vs Y for the cart schema")`
+   (no `to` needed — default-routes to the coordinator), then check `hera_inbox(cwd=$PWD)` on the
+   doorbell for the answer. **Always supply `status` on every `hera_send` — it is required for
+   worker/freelance senders.**
+4. Land your work (open a PR via iris, or leave commits for the coordinator to pull).
+5. `hera_send(cwd=$PWD, status="done", body="<summary + PR link>", tldr="cart-api done, PR #47, tests green")`
+   — the synchronous status apply rolls your task to in_review + ready_to_close so the coordinator
+   sees you finished. If you cannot complete: `hera_send(cwd=$PWD, status="failed", body="<reason>", …)`.
+
+### (c) Author a staged plan-DAG
+
+When the work decomposes into multiple multi-session units with dependencies among them, **load the
+`hera-plan` skill** and author a plan-DAG — it carries the tools, gating, branch-stacking, naming, and
+a full worked seed→fan-out→fan-in example. The §4 decision triad tells you when that's the right tool.
+
+### Worker promotion: becoming a sub-coordinator
+
+> If you already know up front (at plan-authoring time) that a stage is a sub-team, prefer the
+> **declarative** form: a `kind=subcoord` plan node (see the `hera-plan` skill). The gater then
+> materializes the sub-coordinator for you when its blockers finish. The runtime promotion below is for
+> when a worker discovers the need *mid-task*.
+
+If a worker realizes mid-task it needs its own team (cross-repo work, real parallelism, a long sub-task):
+
+1. `hera_new_orchestrator(cwd=$PWD, name="<sub-team>", coordinator_role_name="coord", prompt="…")` — now
+   this session is a coordinator of a nested orchestrator AND still a worker in the parent (multi-binding;
+   pass `orchestrator=` on subsequent calls).
+2. `hera_spawn_worker(...)` to dispatch into the right project.
+3. Report the sub-orchestrator name back to the parent coordinator via `hera_send`. Prefer using Claude's
+   native sub-agents for in-session parallelism; reserve `hera_spawn_worker` for work where the session
+   itself (separate worktree / repo / sandbox) is the unit.
+
+## 8. Composition with sibling argus tools
+
+Hera owns **identity, messaging, and coordination** — nothing else. Reach the rest through their own MCP
+tools:
+
+- **iris** (`mcp__argus__iris_*`) — host-side git/gh. A worker codes + commits locally in its worktree,
+  then uses iris to push / open a PR / merge back. **Use `iris_gh_pr_create` rather than `gh pr create`**
+  so the PR is stamped onto the task's `pr` meta namespace — that is what the Hera rail's PR indicator
+  reads (best-effort, never fetched by the view).
+- **plannotator-argus** (`mcp__argus__plannotator_*`) — review UI. A coordinator routes a worker's output
+  to review there; hera carries the *decision* and the *handoff message*, plannotator carries the *review
+  surface*.
+
+These are orthogonal — hera does not wrap them and they do not wrap hera. Pick per op: iris when an action
+touches the host, plannotator when it's a review surface, hera when it's about roles or messaging.


### PR DESCRIPTION
## Summary

Embed argus's own skills (archive, argus-complete, argus-schedule, hera, hera-plan) into `internal/skills/builtin/` via `go:embed` — single source of truth, compiled into the binary.

- **Embeds the canonical skill sources** in `internal/skills/builtin/<name>/SKILL.md` via `go:embed` — single source of truth for skills that drive `mcp__argus__*` tools or encode hera coordination.
- Skills are materialized idempotently to `~/.argus/skills/.claude/skills/<name>/` by the daemon at startup (content-gated atomic writes, overwrite-on-drift).
- No more dual distribution (repo `.claude/skills/` + `~/.dots` symlinks) — one canonical binary-embedded copy reaches every argus-booted task automatically.

## Notes

This is a fresh rebuild of the original PR #845, which was closed due to conflicts. The core functionality matches the original scope exactly: package argus-specific skills into the binary and auto-load them via `--add-dir` for every Claude backend task.

Related to Aaron's review comment on the original #845: CLAUDE.md-routing-content consolidation (the routing directives / decision rules that live in ~/.claude/CLAUDE.md and duplicated in skill bodies) is being addressed as a sibling follow-up, not in this PR. This PR focuses on the skill bodies themselves.
