### PR TITLE
Sync shipped diligence-profile seeds with live tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,13 +385,13 @@ A task's **archetype** names *what kind of job* it is. It is an optional task pr
 | Archetype | What it is | `default` model |
 |-----------|------------|-----------------|
 | `brainstorm` | Exploratory design / ideation | `opus` |
-| `orchestrator` | Coordinator that delegates and routes work (default for hera coordinators) | `opus` |
-| `big_build` | Large, multi-file implementation | `opus` |
+| `orchestrator` | Coordinator that delegates and routes work (default for hera coordinators) | `sonnet` |
+| `big_build` | Large, multi-file implementation | `sonnet` |
 | `code_slice` | A scoped implementation slice (default for hera workers) | `sonnet` |
 | `bug_fix` | A targeted defect fix | `sonnet` |
 | `review` | A code / plan review pass | `opus` |
 | `security_review` | A security-focused review | `opus` |
-| `synthesis` | Consolidating multiple inputs into one result | `opus` |
+| `synthesis` | Consolidating multiple inputs into one result | `sonnet` |
 | `spec_audit` | Auditing spec coverage / conformance | `sonnet` |
 | `ci_loop` | A mechanical CI-green loop | `haiku` |
 | `verify` | Verification / acceptance checking | `haiku` |
@@ -416,7 +416,7 @@ The DB stores **only** the project→profile *name* – never a profile body, an
 - **Seed profiles** – three documented examples ship embedded in the binary (`internal/profiles/seeds/`), installable via **Settings → Hera → "Install Default Profiles"** or `argus profiles install-defaults`; either writes any seed name not already present into `~/.argus/profiles/` and never overwrites an existing (possibly customized) file. Installation is always an explicit action – nothing auto-installs on daemon startup. You can also copy a seed by hand into `~/.argus/profiles/` or a repo's `.argus/profiles/` and adapt it.
   - `default` – balanced allocation across all 13 archetypes (the table above).
   - `lean` – `extends = "default"`, minimal process (single review pass, no gating) for daily-driven personal tooling.
-  - `customer_grade` – `extends = "default"`, turned-up rigor (two review passes, gating, a security spot-check) plus a reviewer `[panel]`, for customer-facing code with no dogfooding loop.
+  - `customer_grade` – `extends = "default"`, turned-up rigor (two review passes, gating, a security spot-check) plus a reviewer `[panel]`, for customer-facing code with no dogfooding loop. Also re-escalates `orchestrator`/`big_build`/`spec_audit` back to `opus` and swaps `brainstorm`/`review` to `fable` for this tier specifically.
 - **Project binding** – **Settings → project view** shows a validated select-list of on-disk profiles; only profiles that pass validation are selectable, and the chosen name persists as the project's default binding. The new-agent modal also lets you pick a profile for that spawn. An unbound project resolves the `default` profile.
 - **`effort` / `window`** – each `[archetype.<name>]` entry may also carry `effort` (∈ `low`/`medium`/`high`) and `window` (∈ `200k`/`1m`). These are validated and surfaced in the plan/DAG view, but currently only `model` is wired into hera spawn resolution — and, for Claude's native sub-agent dispatch, `effort` is threadable only through a `Workflow` script's `agent()` (`opts.effort`), since the built-in `Agent`/`Task` tool has no effort parameter as of this writing (see the [`resolve-archetype-model`](#agent-facing-skills) skill).
 - **Reviewer `[panel]`** – a profile may carry an opaque `[panel]` block, composed and consumed by the cross-vendor review work (`hera-spawn-review`); validation enforces its grammar when the reviewer-panel validator is wired in, falling back to structural well-formedness otherwise.

--- a/internal/profiles/seeds/customer_grade.toml
+++ b/internal/profiles/seeds/customer_grade.toml
@@ -2,7 +2,9 @@
 #
 # For customer-facing code with no dogfooding loop: inherits default's model
 # allocation but turns up the rigor — two review passes, gating enabled, and a
-# security spot-check — plus a reviewer panel.
+# security spot-check — plus a reviewer panel. Also re-escalates a few
+# archetypes default cheapened to sonnet (orchestrator, big_build) back up,
+# and swaps brainstorm/review to fable for this tier specifically.
 #
 # Documented EXAMPLE, embedded as an install seed — Settings > Hera > "Install
 # Default Profiles", `argus profiles install-defaults`, or copy + adapt by
@@ -10,6 +12,22 @@
 # Validate with: argus validate customer_grade
 
 extends = "default"
+
+[archetype.brainstorm]
+model  = "fable"
+effort = "high"
+
+[archetype.orchestrator]
+model = "opus"
+
+[archetype.big_build]
+model = "opus"
+
+[archetype.spec_audit]
+model = "opus"
+
+[archetype.review]
+model = "fable"
 
 [rigor]
 review_passes       = 2

--- a/internal/profiles/seeds/default.toml
+++ b/internal/profiles/seeds/default.toml
@@ -23,10 +23,10 @@ model  = "opus"
 effort = "high"
 
 [archetype.orchestrator]
-model = "opus"
+model = "sonnet"
 
 [archetype.big_build]
-model = "opus"
+model = "sonnet"
 
 [archetype.code_slice]
 model = "sonnet"
@@ -41,7 +41,7 @@ model = "opus"
 model = "opus"
 
 [archetype.synthesis]
-model = "opus"
+model = "sonnet"
 
 [archetype.spec_audit]
 model = "sonnet"

--- a/internal/profiles/seeds_test.go
+++ b/internal/profiles/seeds_test.go
@@ -70,13 +70,13 @@ func TestSeeds_DefaultArchetypeDefaultsMatchFramework(t *testing.T) {
 	testutil.NoError(t, err)
 	want := map[string]string{
 		"brainstorm":      "opus",
-		"orchestrator":    "opus",
-		"big_build":       "opus",
+		"orchestrator":    "sonnet",
+		"big_build":       "sonnet",
 		"code_slice":      "sonnet",
 		"bug_fix":         "sonnet",
 		"review":          "opus",
 		"security_review": "opus",
-		"synthesis":       "opus",
+		"synthesis":       "sonnet",
 		"spec_audit":      "sonnet",
 		"ci_loop":         "haiku",
 		"verify":          "haiku",

--- a/internal/profiles/validate_test.go
+++ b/internal/profiles/validate_test.go
@@ -14,7 +14,7 @@ import (
 func testKnownModels(command string) []string {
 	switch command {
 	case "claude":
-		return []string{"opus", "sonnet", "haiku"}
+		return []string{"opus", "sonnet", "haiku", "fable"}
 	case "codex":
 		return []string{"gpt-5-codex", "gpt-5"}
 	default:

--- a/internal/review/seeds_test.go
+++ b/internal/review/seeds_test.go
@@ -15,7 +15,7 @@ import (
 func testKnownModels(command string) []string {
 	switch command {
 	case "claude":
-		return []string{"opus", "sonnet", "haiku"}
+		return []string{"opus", "sonnet", "haiku", "fable"}
 	case "codex":
 		return []string{"gpt-5-codex", "gpt-5"}
 	default:


### PR DESCRIPTION
## Summary
- Recalibrate the embedded `default` seed profile's `orchestrator`/`big_build`/`synthesis` archetypes from `opus` to `sonnet`, matching the profile actually in daily use.
- Add `customer_grade`'s archetype re-escalation overrides (`orchestrator`/`big_build`/`spec_audit` back to `opus`, `brainstorm`/`review` to `fable`), same source.
- Update the README archetype table and `TestSeeds_DefaultArchetypeDefaultsMatchFramework` to match.
- Fix a pre-existing drift bug surfaced along the way: `internal/profiles/validate_test.go` and `internal/review/seeds_test.go` each hand-mirror `agent.KnownModels("claude")` (to avoid an import cycle), and both mirrors were missing `"fable"`, which the real `agent.KnownModels` already includes. This made the new `customer_grade` fable overrides fail their test-mirrored validation while passing real validation (confirmed live via `profile_resolve`). Fixed both mirrors to include `fable`.

`lean.toml` is untouched — it was already identical to what's in use.

## Test plan
- [x] `go test ./...` — full suite green
- [x] `go test -race -count=1 ./internal/profiles/... ./internal/review/... ./cmd/argus/...`
- [x] `goimports -l .` — clean
- [x] `golangci-lint run --new-from-rev=origin/master ./...` — 0 issues
- [x] Confirmed `customer_grade`'s new archetype overrides resolve validly against real backend config via `mcp__argus__profile_resolve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
