### PR TITLE
Reject hera_move from a live coordinator's own binding

### DIFF
--- a/.claude/skills/hera/SKILL.md
+++ b/.claude/skills/hera/SKILL.md
@@ -191,6 +191,13 @@ or using in-session sub-agents.
 - **`spawn_worker` vs adopt:** native hera has **no adopt step** — workers are born bound at spawn time.
   (The old `depends_on`-driven auto-adopt watcher was retired with the DAG.) To delegate, just
   `hera_spawn_worker`.
+- **Never `hera_move` your OWN coordinator binding to join another team.** `hera_move`'s `kind` is
+  `worker`/`freelance` only — moving away from a live coordinator role ends that binding and orphans
+  the whole orchestrator/subtree you were coordinating, leaving a disconnected freelance/worker stub
+  under the target with no link back to it (hera-freelancer-bug; the tool now rejects this outright).
+  There is no agent-facing tool to nest an existing coordinator + subtree under a new parent — that's
+  the Hera TUI's `J` (adopt/reparent) key, human-only. If a human wants your whole team folded under
+  another coordinator, tell them to press `J` on your orchestrator; don't try to self-relocate.
 - **The coordination decision — in-session sub-agents vs hera workers vs the plan-DAG (settle this
   BEFORE delegating). Delegate with prejudice, but don't be dumb about it:**
   1. **Ephemeral, in-session work** — research, review, fan-out reads, anything that returns results

--- a/internal/mcp/hera.go
+++ b/internal/mcp/hera.go
@@ -831,6 +831,22 @@ func (s *Server) toolHeraMove(id interface{}, args json.RawMessage) *Response {
 		return toolError(id, err.Error())
 	}
 
+	// A coordinator's live binding IS its orchestrator's coordination — ending
+	// it (what a move does) orphans the whole subtree the coordinator was
+	// running, and the destination kind (worker/freelance) carries no
+	// structural link back to that subtree (hera-freelancer-bug: this
+	// silently produced two disconnected "freelance" stubs while their
+	// original orchestrators were left coordinator-less). There is no
+	// agent-facing tool to properly nest an existing coordinator + subtree
+	// under a new parent — that is the Hera TUI's `J` adopt/reparent key,
+	// human-only — so reject rather than silently orphaning it.
+	if caller.role.Kind == db.HeraKindCoordinator {
+		return toolError(id, fmt.Sprintf(
+			"%q is the live coordinator of orchestrator %q; hera_move would end that coordinator binding and orphan its whole subtree instead of moving it. "+
+				"There is no tool for an agent to nest an existing coordinator under a new parent — ask a human to use the Hera TUI's `J` (adopt) key on %q to reparent it under %q",
+			caller.role.Name, caller.orch.Name, caller.orch.Name, p.Orchestrator))
+	}
+
 	targetOrch, err := s.heraStore.HeraOrchestratorByName(p.Orchestrator)
 	if errors.Is(err, db.ErrHeraNotFound) {
 		return toolError(id, fmt.Sprintf("unknown orchestrator %q", p.Orchestrator))

--- a/internal/mcp/hera_test.go
+++ b/internal/mcp/hera_test.go
@@ -813,6 +813,63 @@ func TestHera_Move_CoordinatorKindRejected(t *testing.T) {
 	testutil.Contains(t, cr.Content[0].Text, "hera_new_orchestrator")
 }
 
+// TestHera_Move_SourceCoordinatorRejected covers hera-freelancer-bug: a
+// coordinator calling hera_move on ITSELF (moving away from its own
+// coordinator binding to a worker/freelance role elsewhere) must be rejected,
+// not silently orphan its whole orchestrator subtree. Ground truth: a live
+// coordinator called hera_move(kind="freelance") to join another team,
+// leaving its own orchestrator coordinator-less while creating a disconnected
+// freelance stub under the target with no link back to its former subtree.
+func TestHera_Move_SourceCoordinatorRejected(t *testing.T) {
+	s, d := testHeraServer(t)
+
+	coordTask := addHeraTestTask(t, d, "/wt/source-coord")
+	doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_new_orchestrator",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"name":"orch-source-coord","coordinator_role_name":"coord"
+		}`, coordTask.Worktree)),
+	})
+	orchSource, err := d.HeraOrchestratorByName("orch-source-coord")
+	testutil.NoError(t, err)
+	origBinding, err := d.HeraLiveBindingByTaskAndOrchestrator(coordTask.ID, orchSource.ID)
+	testutil.NoError(t, err)
+
+	targetCoord := addHeraTestTask(t, d, "/wt/target-coord")
+	doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_new_orchestrator",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"name":"orch-target-coord","coordinator_role_name":"coord"
+		}`, targetCoord.Worktree)),
+	})
+
+	resp := doRequest(t, s, "tools/call", ToolCallParams{
+		Name: "hera_move",
+		Arguments: json.RawMessage(fmt.Sprintf(`{
+			"cwd":%q,"orchestrator":"orch-target-coord","role_name":"coordTask","kind":"freelance"
+		}`, coordTask.Worktree)),
+	})
+	if resp.Error != nil {
+		t.Fatalf("hera_move rpc error: %v", resp.Error)
+	}
+	cr := callResult(t, resp)
+	testutil.Equal(t, cr.IsError, true)
+	testutil.Contains(t, cr.Content[0].Text, "coordinator")
+	testutil.Contains(t, cr.Content[0].Text, "orch-source-coord")
+
+	// The original coordinator binding is untouched — no orphaned orchestrator.
+	stillLive, err := d.HeraLiveBindingByTaskAndOrchestrator(coordTask.ID, orchSource.ID)
+	testutil.NoError(t, err)
+	testutil.Equal(t, stillLive.ID, origBinding.ID)
+	testutil.Nil(t, stillLive.EndedAt)
+
+	// Nothing created under the target orchestrator.
+	orchTarget, err := d.HeraOrchestratorByName("orch-target-coord")
+	testutil.NoError(t, err)
+	_, err = d.HeraRoleByName(orchTarget.ID, "coordTask")
+	testutil.ErrorIs(t, err, db.ErrHeraNotFound)
+}
+
 // --- CallerContext / resolveCallerRole ---
 
 func TestHera_CallerContext_ZeroBindings(t *testing.T) {

--- a/internal/skills/builtin/hera/SKILL.md
+++ b/internal/skills/builtin/hera/SKILL.md
@@ -172,6 +172,13 @@ or using in-session sub-agents.
 - **`spawn_worker` vs adopt:** native hera has **no adopt step** — workers are born bound at spawn time.
   (The old `depends_on`-driven auto-adopt watcher was retired with the DAG.) To delegate, just
   `hera_spawn_worker`.
+- **Never `hera_move` your OWN coordinator binding to join another team.** `hera_move`'s `kind` is
+  `worker`/`freelance` only — moving away from a live coordinator role ends that binding and orphans
+  the whole orchestrator/subtree you were coordinating, leaving a disconnected freelance/worker stub
+  under the target with no link back to it (hera-freelancer-bug; the tool now rejects this outright).
+  There is no agent-facing tool to nest an existing coordinator + subtree under a new parent — that's
+  the Hera TUI's `J` (adopt/reparent) key, human-only. If a human wants your whole team folded under
+  another coordinator, tell them to press `J` on your orchestrator; don't try to self-relocate.
 - **The coordination decision — in-session sub-agents vs hera workers vs the plan-DAG (settle this
   BEFORE delegating):**
   1. **Ephemeral, in-session work** — research, review, fan-out reads, anything that returns results

--- a/openspec/changes/archive/2026-07-19-fix-hera-move-coordinator-source-guard/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-19-fix-hera-move-coordinator-source-guard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/archive/2026-07-19-fix-hera-move-coordinator-source-guard/proposal.md
+++ b/openspec/changes/archive/2026-07-19-fix-hera-move-coordinator-source-guard/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+**hera-freelancer-bug** — `hera_move` lets a caller currently holding a LIVE
+COORDINATOR binding relocate itself to a worker/freelance role under a
+different orchestrator. `hera_move` only validates the DESTINATION `kind`
+(rejecting `coordinator`); it never checks the SOURCE role being ended. Ground
+truth from a live repro: two coordinators (each running its own orchestrator
+with its own worker history) each called `hera_move(kind="freelance")` to join
+a new team. Each call ended that coordinator's own coordinator binding
+(`end_reason: "moved"`), leaving its original orchestrator coordinator-less —
+still listed in the rail, but headless, with its whole prior subtree orphaned
+— and created a brand-new, structurally disconnected `freelance` role under
+the target orchestrator with no link back to the subtree it used to run.
+
+There is no agent-facing tool to properly nest an EXISTING coordinator (and
+its subtree) under a new parent — that capability
+(`internal/tui/hera.AdoptOps.ReparentCoordinator`) is wired only to the Hera
+TUI's `J` key, a human-only action. An agentic coordinator reaching for
+`hera_move` to accomplish "join this other team" is reaching for the only
+tool it has, and that tool silently does the wrong thing.
+
+## What Changes
+
+- **`hera_move` rejects the call when the caller's resolved SOURCE binding is
+  coordinator-kind**, ending nothing and creating nothing. The error names the
+  caller's role + orchestrator, explains that this would orphan the whole
+  subtree, and directs the caller to ask a human to use the Hera TUI's `J`
+  (adopt/reparent) key instead — there is no agent-facing equivalent today.
+- No new tool, no new capability, no schema change — a validation guard added
+  to an existing tool, mirroring the existing destination-`kind` guard.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `hera-coordination`: the `hera_move` requirement gains a new rejection case —
+  the caller's SOURCE binding being coordinator-kind is rejected (ending and
+  creating nothing), in addition to the existing "no live binding" /
+  "same orchestrator" / "destination kind=coordinator" rejections.
+
+## Impact
+
+- **Modified code:** `internal/mcp/hera.go` (`toolHeraMove`) — one guard added
+  after `resolveCallerRole`, before any mutation.
+- **Docs:** `.claude/skills/hera/SKILL.md` and
+  `internal/skills/builtin/hera/SKILL.md` — a decision-rule bullet warning
+  agents never to `hera_move` their own coordinator binding, and pointing them
+  at the human-only `J` key instead.
+- **No new key, no new MCP tool, no schema change, no daemon RPC change.**
+  Specs are LOCAL DOCS only (`openspec/project.md`); the quality gate stays
+  `make pre-pr`.

--- a/openspec/changes/archive/2026-07-19-fix-hera-move-coordinator-source-guard/specs/hera-coordination/spec.md
+++ b/openspec/changes/archive/2026-07-19-fix-hera-move-coordinator-source-guard/specs/hera-coordination/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: hera_move relocates the caller's binding to a different orchestrator
+
+The system SHALL, on `hera_move`, relocate the calling task's live hera binding to a different orchestrator: it SHALL resolve the caller's current live binding (via the same cwd→task→binding resolution used elsewhere, accepting an optional `from_orchestrator` to disambiguate when the task holds 2+ live bindings), then — transactionally — end that binding (`ended_at`/`end_reason: "moved"`) and create a new role+binding of kind `worker` or `freelance` under the target `orchestrator` (rejecting `coordinator`, mirroring `hera_join`). It SHALL reject the call, ending and creating nothing, when the calling task holds no live binding at all (directing the caller to `hera_join` or `hera_new_orchestrator` instead — there is nothing to move), when the resolved source orchestrator equals the target orchestrator (a no-op; directing the caller to `hera_join` without `role_name` to see its current binding), or when the resolved SOURCE binding's role is coordinator-kind (a coordinator's binding IS its orchestrator's coordination — ending it would orphan the whole subtree the coordinator was running, leaving a disconnected worker/freelance stub under the target with no structural link back; the rejection names the caller's role and orchestrator and directs the caller to ask a human to use the Hera TUI's `J` adopt/reparent key instead, since no agent-facing tool nests an existing coordinator + subtree under a new parent). The response SHALL report the source orchestrator and role name that were moved, plus the new binding id. Required args: `cwd`, `orchestrator`, `role_name`, `kind`. Optional args: `from_orchestrator`, `status`.
+
+#### Scenario: Happy path moves the binding
+
+- **WHEN** a task holding a live binding under orchestrator A calls hera_move targeting orchestrator B with a role_name and kind
+- **THEN** the binding under A is ended with end_reason "moved", a new role+binding is created under B, and the response reports A + the moved role's name plus the new binding id
+
+#### Scenario: Nothing to move
+
+- **WHEN** an unbound task calls hera_move
+- **THEN** the tool errors that there is nothing to move and directs the caller to hera_join or hera_new_orchestrator, creating no binding
+
+#### Scenario: Moving to the same orchestrator is a no-op error
+
+- **WHEN** a task holding a live binding under orchestrator A calls hera_move targeting orchestrator A
+- **THEN** the tool errors and directs the caller to hera_join without role_name, ending and creating nothing
+
+#### Scenario: Ambiguous caller requires from_orchestrator
+
+- **WHEN** a task holding live bindings under two orchestrators calls hera_move without from_orchestrator
+- **THEN** the tool errors listing the bound orchestrator names, and a follow-up call supplying from_orchestrator succeeds
+
+#### Scenario: Destination kind=coordinator is rejected
+
+- **WHEN** hera_move is called with kind=coordinator
+- **THEN** the tool errors and directs the caller to hera_new_orchestrator
+
+#### Scenario: A live coordinator's own binding cannot be moved
+
+- **WHEN** a task holding a live COORDINATOR binding under orchestrator A calls hera_move targeting orchestrator B with kind=worker or kind=freelance
+- **THEN** the tool errors identifying the caller as orchestrator A's coordinator and directing them to the Hera TUI's `J` adopt/reparent key, and the original coordinator binding under A remains live and unchanged, with no role or binding created under B

--- a/openspec/changes/archive/2026-07-19-fix-hera-move-coordinator-source-guard/tasks.md
+++ b/openspec/changes/archive/2026-07-19-fix-hera-move-coordinator-source-guard/tasks.md
@@ -1,0 +1,25 @@
+## 1. Guard hera_move against moving a live coordinator's own binding
+
+- [x] 1.1 `toolHeraMove` (`internal/mcp/hera.go`) rejects the call, ending and
+  creating nothing, when `resolveCallerRole`'s resolved role is
+  `db.HeraKindCoordinator` — before any mutation (`MoveHeraBinding` is never
+  reached). Error names the caller's role + orchestrator and directs the
+  caller to the Hera TUI's `J` adopt/reparent key.
+
+## 2. Tests
+
+- [x] 2.1 `TestHera_Move_SourceCoordinatorRejected` (`internal/mcp/hera_test.go`):
+  a live coordinator calling `hera_move(kind="freelance")` toward a different
+  orchestrator is rejected; its original coordinator binding stays live and
+  unchanged; no role is created under the target orchestrator.
+- [x] 2.2 Existing `TestHera_Move_*` suite still passes unmodified (worker/
+  freelance source moves, ambiguous multi-binding self-promotion, destination
+  kind=coordinator rejection) — confirms the new guard is scoped to the
+  SOURCE role kind only.
+
+## 3. Docs
+
+- [x] 3.1 `.claude/skills/hera/SKILL.md` and
+  `internal/skills/builtin/hera/SKILL.md` gain a decision-rule bullet: never
+  `hera_move` your own coordinator binding to join another team; ask a human
+  to use the Hera TUI's `J` key instead.

--- a/openspec/specs/hera-coordination/spec.md
+++ b/openspec/specs/hera-coordination/spec.md
@@ -410,7 +410,7 @@ Derived from: `internal/db/hera.go` (`ReviveHeraWorkerToInProgress`), `internal/
 
 ### Requirement: hera_move relocates the caller's binding to a different orchestrator
 
-The system SHALL, on `hera_move`, relocate the calling task's live hera binding to a different orchestrator: it SHALL resolve the caller's current live binding (via the same cwd→task→binding resolution used elsewhere, accepting an optional `from_orchestrator` to disambiguate when the task holds 2+ live bindings), then — transactionally — end that binding (`ended_at`/`end_reason: "moved"`) and create a new role+binding of kind `worker` or `freelance` under the target `orchestrator` (rejecting `coordinator`, mirroring `hera_join`). It SHALL reject the call, ending and creating nothing, when the calling task holds no live binding at all (directing the caller to `hera_join` or `hera_new_orchestrator` instead — there is nothing to move) or when the resolved source orchestrator equals the target orchestrator (a no-op; directing the caller to `hera_join` without `role_name` to see its current binding). The response SHALL report the source orchestrator and role name that were moved, plus the new binding id. Required args: `cwd`, `orchestrator`, `role_name`, `kind`. Optional args: `from_orchestrator`, `status`.
+The system SHALL, on `hera_move`, relocate the calling task's live hera binding to a different orchestrator: it SHALL resolve the caller's current live binding (via the same cwd→task→binding resolution used elsewhere, accepting an optional `from_orchestrator` to disambiguate when the task holds 2+ live bindings), then — transactionally — end that binding (`ended_at`/`end_reason: "moved"`) and create a new role+binding of kind `worker` or `freelance` under the target `orchestrator` (rejecting `coordinator`, mirroring `hera_join`). It SHALL reject the call, ending and creating nothing, when the calling task holds no live binding at all (directing the caller to `hera_join` or `hera_new_orchestrator` instead — there is nothing to move), when the resolved source orchestrator equals the target orchestrator (a no-op; directing the caller to `hera_join` without `role_name` to see its current binding), or when the resolved SOURCE binding's role is coordinator-kind (a coordinator's binding IS its orchestrator's coordination — ending it would orphan the whole subtree the coordinator was running, leaving a disconnected worker/freelance stub under the target with no structural link back; the rejection names the caller's role and orchestrator and directs the caller to ask a human to use the Hera TUI's `J` adopt/reparent key instead, since no agent-facing tool nests an existing coordinator + subtree under a new parent). The response SHALL report the source orchestrator and role name that were moved, plus the new binding id. Required args: `cwd`, `orchestrator`, `role_name`, `kind`. Optional args: `from_orchestrator`, `status`.
 
 #### Scenario: Happy path moves the binding
 
@@ -432,10 +432,15 @@ The system SHALL, on `hera_move`, relocate the calling task's live hera binding 
 - **WHEN** a task holding live bindings under two orchestrators calls hera_move without from_orchestrator
 - **THEN** the tool errors listing the bound orchestrator names, and a follow-up call supplying from_orchestrator succeeds
 
-#### Scenario: Coordinator kind is rejected
+#### Scenario: Destination kind=coordinator is rejected
 
 - **WHEN** hera_move is called with kind=coordinator
 - **THEN** the tool errors and directs the caller to hera_new_orchestrator
+
+#### Scenario: A live coordinator's own binding cannot be moved
+
+- **WHEN** a task holding a live COORDINATOR binding under orchestrator A calls hera_move targeting orchestrator B with kind=worker or kind=freelance
+- **THEN** the tool errors identifying the caller as orchestrator A's coordinator and directing them to the Hera TUI's `J` adopt/reparent key, and the original coordinator binding under A remains live and unchanged, with no role or binding created under B
 
 ### Requirement: hera_rebind reconciles a stuck or drifted binding
 


### PR DESCRIPTION
## Summary
- `hera_move` validated only the *destination* `kind` (rejecting `coordinator`) — it never checked the caller's *current* role, so a live coordinator could relocate its own binding as if it were an ordinary worker/freelance move.
- Add a guard: when the resolved source binding is coordinator-kind, `hera_move` now rejects the call (ending/creating nothing) and points the caller at the Hera TUI's `J` adopt/reparent key.

## Root cause
`toolHeraMove` (`internal/mcp/hera.go`) resolves the caller's live binding via `resolveCallerRole` and only guards the requested destination `kind`. Two live coordinators (`sherlock-3b`, `design-review-drn`) each called `hera_move(kind="freelance")` to join a new orchestrator (`sherlock-july`). Each call:
1. Ended their own coordinator binding (`end_reason: "moved"`), leaving their original orchestrator coordinator-less (still listed in the rail, but headless, with its whole prior subtree orphaned).
2. Created a brand-new `freelance` role+binding under the target orchestrator with zero structural link back to that subtree — the "orphaned freelance references" reported.

Confirmed directly against `~/.argus/data.sql`: both original coordinator bindings show `end_reason='moved'` at the exact timestamp the new freelance bindings were created. There is no agent-facing tool to properly nest an *existing* coordinator + subtree under a new parent — that's `internal/tui/hera.AdoptOps.ReparentCoordinator`, wired only to the Hera TUI's `J` key (human-only). `hera_move` was the only tool available to the agent, and it silently did the wrong thing.

## Test plan
- New regression test `TestHera_Move_SourceCoordinatorRejected`: a live coordinator calling `hera_move` is rejected; its original binding stays live; nothing is created under the target.
- Full existing `TestHera_Move_*` suite still passes (worker/freelance moves, ambiguous multi-binding self-promotion, destination `kind=coordinator` rejection) — the new guard is scoped to the source role kind only.
- `make pre-pr` green (build/vet/fmt-check/lint-pr/test-cover-gate); `make vuln` shows only the known advisory stdlib CVEs, unrelated to this change.
- OpenSpec: `hera-coordination` base spec updated in the same PR (change authored + archived: `fix-hera-move-coordinator-source-guard`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
