### PR TITLE
Fix hera rail agent-count badge to count the whole subtree

### DIFF
--- a/internal/tui/hera/bug024_test.go
+++ b/internal/tui/hera/bug024_test.go
@@ -116,8 +116,8 @@ func TestRail_StatusStepAnchorsCursorAndUpdatesGlyph(t *testing.T) {
 	postGlyph, _ := statusIcon(after, false, 0)
 	testutil.Equal(t, postGlyph, theme.IconNeedsInput)
 
-	// The coordinator's live-role count badge stays numeric (never "(?)").
-	testutil.Equal(t, liveRoleCount(&r.model.Active[0]), 2)
+	// The coordinator's agent-count badge stays numeric (never "(?)").
+	testutil.Equal(t, r.model.SubtreeAgentCount(o), 2)
 }
 
 // roleViewByID builds the model and returns the RoleView for roleID under orch.

--- a/internal/tui/hera/model.go
+++ b/internal/tui/hera/model.go
@@ -638,6 +638,38 @@ func (m Model) BridgeSubtree(rootID int64) []*OrchView {
 	return out
 }
 
+// SubtreeAgentCount returns the total number of non-coordinator roles — every
+// worker row plus every bridged sub-coordinator row — across the WHOLE
+// orchestration subtree rooted at orchID: itself plus every orchestrator
+// nested beneath it through the worker→coordinator bridge, at any depth. It
+// counts archived (Tier-1 hidden, greyed-into-the-per-coordinator-Archive-
+// bucket) roles too: this is the "expand every fold and count the rows
+// yourself" number, not a liveness count — a role does not stop being an
+// on-disk agent just because it was tucked into the Archive bucket (archiving
+// a role only stamps hera_roles.archived_at; it never ends the role's
+// binding, so a stale Live-only count would still include it, just silently,
+// which is the rail's original miscount). A NUKED role or orchestrator can
+// never inflate this: BuildModel excludes both from the Model entirely, so
+// only a role whose on-disk workspace has genuinely never been reclaimed (or
+// was reclaimed via plain task-archive, not nuke) is counted. Each
+// orchestrator's OWN coordinator role is excluded (folded into its header);
+// a nested sub-coordinator is counted exactly once — via the bridging WORKER
+// row in its parent — because its own coordinator role (the SAME underlying
+// task, reached when its orchestrator is visited in the walk) is likewise
+// excluded, so the two representations of one agent are never double-counted.
+// Zero when orchID is unknown.
+func (m Model) SubtreeAgentCount(orchID int64) int {
+	n := 0
+	for _, o := range m.BridgeSubtree(orchID) {
+		for i := range o.Roles {
+			if o.Roles[i].Kind == db.HeraKindWorker {
+				n++
+			}
+		}
+	}
+	return n
+}
+
 // bridgeTaskID returns a role's structural bridge key: its latest-binding task
 // (BridgeTaskID), falling back to the live TaskID when the model did not
 // populate the bridge field (older callers / hand-built test fixtures). In

--- a/internal/tui/hera/model_test.go
+++ b/internal/tui/hera/model_test.go
@@ -409,6 +409,45 @@ func TestModel_CoordBridgeNoFalsePositives(t *testing.T) {
 	testutil.Equal(t, len(m.consumedSet(m.bridgeIndex())), 0)
 }
 
+// TestModel_SubtreeAgentCount_IncludesArchivedRegardlessOfLiveness pins the
+// rail header badge fix: archiving a role (the `a` hide key) only stamps
+// hera_roles.archived_at — it never ends the role's binding — so a role
+// tucked into the coordinator's greyed-out Archive bucket keeps Live=true
+// forever. The badge must count it anyway (a Live-gated count silently
+// double-reports it as still "current"); Live plays no part in the count at
+// all, archived or not.
+func TestModel_SubtreeAgentCount_IncludesArchivedRegardlessOfLiveness(t *testing.T) {
+	o := orchView(1, "orch", "tc", wk("current", "t1"))
+	o.Roles = append(o.Roles,
+		RoleView{Name: "hidden-not-torn-down", Kind: db.HeraKindWorker, Live: true, Archived: true, TaskID: "t2"},
+		RoleView{Name: "hidden-binding-ended", Kind: db.HeraKindWorker, Live: false, Archived: true, TaskID: "t3"},
+	)
+	m := Model{Active: []OrchView{o}}
+
+	// coord excluded, all 3 workers counted regardless of Live/Archived.
+	testutil.Equal(t, m.SubtreeAgentCount(1), 3)
+}
+
+// TestModel_SubtreeAgentCount_RecursesIntoNestedSubcoordAndItsArchive pins the
+// other half of the fix: the badge must recurse into bridged sub-coordinators
+// (a nested sub-team spawned from a worker row) rather than stopping at the
+// orchestrator's own direct roles, and it must count that nested subtree's
+// own archived workers too — while never double-counting the bridging worker
+// row in the parent against the SAME agent's coordinator role in the child.
+func TestModel_SubtreeAgentCount_RecursesIntoNestedSubcoordAndItsArchive(t *testing.T) {
+	// R(coord tr, worker bridge→tc) → C(coord tc, worker wc, archived worker).
+	r := orchView(1, "R", "tr", wk("bridge", "tc"))
+	c := orchView(2, "C", "tc", wk("wc", "twc"))
+	c.Roles = append(c.Roles, RoleView{Name: "hidden", Kind: db.HeraKindWorker, Live: true, Archived: true, TaskID: "t-hidden"})
+	m := Model{Active: []OrchView{r, c}}
+
+	// C alone: its own coord excluded, wc + hidden counted = 2.
+	testutil.Equal(t, m.SubtreeAgentCount(2), 2)
+	// R's subtree: R's coord excluded, "bridge" counted once (not also C's
+	// coord, the same underlying task) + C's wc + hidden = 3.
+	testutil.Equal(t, m.SubtreeAgentCount(1), 3)
+}
+
 // TestBuildModel_PopulatesDetailsFields proves the additive coordinator-Details
 // projection inputs (orch + role creation, the live binding's worktree + start,
 // the role-status update time, and the bound task name) flow into the model.

--- a/internal/tui/hera/rail.go
+++ b/internal/tui/hera/rail.go
@@ -1781,9 +1781,9 @@ func (r *Rail) drawOrchRow(screen tcell.Screen, x, y, w int, row railRow, select
 	if remaining <= 0 {
 		return
 	}
-	live := liveRoleCount(o)
+	agents := r.model.SubtreeAgentCount(o.ID)
 	label := o.Name
-	count := fmt.Sprintf(" (%d)", live)
+	count := fmt.Sprintf(" (%d)", agents)
 	if len(label)+len(count) > remaining {
 		widget.DrawText(screen, col, y, remaining, label, nameStyle)
 		return
@@ -1937,19 +1937,6 @@ func kanbanStatusOf(o *OrchView) db.HeraKanbanStatus {
 		return db.HeraKanbanActive
 	}
 	return o.KanbanStatus
-}
-
-// liveRoleCount counts live, non-coordinator roles (the agents shown under the
-// header). The coordinator is folded into the header itself, so it never inflates
-// the (N) child count.
-func liveRoleCount(o *OrchView) int {
-	n := 0
-	for i := range o.Roles {
-		if o.Roles[i].Live && o.Roles[i].Kind != db.HeraKindCoordinator {
-			n++
-		}
-	}
-	return n
 }
 
 // statusIcon picks the glyph + style for a role row by delegating to the shared

--- a/internal/tui/hera/rail_test.go
+++ b/internal/tui/hera/rail_test.go
@@ -90,8 +90,8 @@ func TestRail_CoordinatorFoldsIntoHeader(t *testing.T) {
 	// "Active (2)" header (add-kanban-focus-fold).
 	testutil.Equal(t, r.Rows(), 5)
 
-	// liveRoleCount excludes the folded coordinator: orch-1 has 1 live worker.
-	testutil.Equal(t, liveRoleCount(&r.model.Active[0]), 1)
+	// SubtreeAgentCount excludes the folded coordinator: orch-1 has 1 worker.
+	testutil.Equal(t, r.model.SubtreeAgentCount(1), 1)
 }
 
 func TestRail_OrchHeaderCarriesCoordinatorGlyph(t *testing.T) {

--- a/openspec/changes/archive/2026-07-20-fix-hera-rail-subtree-count/proposal.md
+++ b/openspec/changes/archive/2026-07-20-fix-hera-rail-subtree-count/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+A top-level coordinator's rail header renders a right-aligned `(N)` badge
+computed by `liveRoleCount`: it counts the orchestrator's OWN direct roles
+where `Live == true`, excluding only the coordinator. This miscounts in two
+ways, confirmed against a live repro (`sherlock-land-pr-45`, whose header
+showed `(10)`):
+
+- **Archiving a role never ends its binding.** Hiding a worker into the
+  coordinator's greyed-out Archive bucket (the `a` key /
+  `db.ArchiveHeraRole`) only stamps `hera_roles.archived_at`; the role's
+  `hera_binding.ended_at` is untouched (bindings only end via explicit
+  teardown: nuke/delete/reparent/detach). So an archived role keeps
+  `Live == true` forever and still counts toward the badge — 9 of
+  `sherlock-land-pr-45`'s reported `(10)` were roles already sitting in its
+  own `Archive (9)` bucket, not current work.
+- **The badge never recurses into nested (bridged) sub-coordinators.** A
+  worker row that bridges to a child orchestrator (a sub-team spawned mid-run)
+  is itself counted once, but that child's own workers — and its own Archive
+  bucket — are invisible to the parent's badge entirely.
+
+The result is a number that matches neither "how many agents are genuinely
+live under this coordinator" nor "how many rows would I see if I expanded
+every fold and counted them myself" — it's an artifact of a binding-lifecycle
+detail (`ended_at` staying null) that has nothing to do with what's rendered.
+
+## What Changes
+
+- Replace `liveRoleCount` (single-level, `Live`-gated) with
+  `Model.SubtreeAgentCount(orchID)`: it walks the same `BridgeSubtree` used by
+  the `Ctrl+D` cascade and `C` clear-archive, and counts every non-coordinator
+  role (worker rows, including bridging sub-coordinator rows) across every
+  orchestrator in that subtree — archived (Tier-1 hidden) roles included,
+  liveness ignored entirely.
+- A NUKED role/orchestrator can never inflate the count: `BuildModel` already
+  excludes both from the `Model` outright (defense-in-depth, matching the
+  existing "Tier-2 EOL" guard), so a role whose on-disk workspace was
+  genuinely torn down is never counted — only what's still visibly present in
+  the rail (live or archived-but-not-nuked) is.
+- Each orchestrator's own coordinator role stays excluded (folded into its
+  header); a nested sub-coordinator is counted exactly once via its parent's
+  bridging worker row, never doubled against its own coordinator role in the
+  child orchestrator (the same underlying task).
+- No new keybinding, no new tool, no schema change — a rendering-only fix to
+  one existing badge.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `hera-view`: the "Orchestrator and role row rendering" requirement's `(N)`
+  badge semantics change from a single-level live-role count to a whole-
+  subtree, archive-inclusive, liveness-agnostic agent count.

--- a/openspec/changes/archive/2026-07-20-fix-hera-rail-subtree-count/specs/hera-view/spec.md
+++ b/openspec/changes/archive/2026-07-20-fix-hera-rail-subtree-count/specs/hera-view/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Orchestrator and role row rendering (area 3)
+
+The system SHALL render an orchestrator header with a fold chevron (▸ collapsed / ▾ expanded), a coordinator marker glyph, the orchestrator name, and a right-aligned agent count `(N)`. The count SHALL be the total number of non-coordinator roles (worker rows, including bridged sub-coordinator rows) across the orchestrator's WHOLE bridge subtree — itself plus every orchestrator nested beneath it through the worker→coordinator bridge, at any depth — INCLUDING roles currently hidden in a per-coordinator Archive bucket, regardless of whether any role's binding is still live. A nuked role or orchestrator is never counted (the Model excludes both entirely). Each orchestrator's own coordinator role is excluded at every level in the subtree (folded into its own header, or already represented one level up by the bridging worker row that reaches it), so a nested sub-coordinator's agent is counted exactly once. It SHALL render a role row with a status glyph (see status-icon precedence) followed by the role name. Selection is indicated by a `›` marker in the gutter and the selected palette; archived placement dims the row's text style (the glyph itself never lies — only the style dims).
+
+Derived from: `internal/tui/hera/rail.go` (`drawRow`, `drawOrchRow`, `drawRoleRow`), `internal/tui/hera/model.go` (`Model.SubtreeAgentCount`, `Model.BridgeSubtree`).
+
+#### Scenario: Orchestrator header counts its whole subtree, archive included
+
+- **WHEN** an orchestrator has one live worker and two archived (Tier-1 hidden) workers, one of which still holds a live binding (its role was archived without ending its binding)
+- **THEN** its header renders `(3)` right-aligned — all three count, regardless of liveness
+
+#### Scenario: A nested sub-coordinator's own archive rolls up to its parent's badge
+
+- **WHEN** a root orchestrator bridges to a child sub-coordinator via a worker row, and that child has two workers of its own (one archived)
+- **THEN** the root's badge counts the bridging row once plus both of the child's workers, and the child's own badge (viewed on its own) counts just its own two workers — neither count double-counts the bridging row against the child's own coordinator role
+
+#### Scenario: Archived row dims without changing its glyph
+
+- **WHEN** a role is rendered in the archive section
+- **THEN** its text and status glyph render in the dimmed style while the glyph identity is unchanged

--- a/openspec/changes/archive/2026-07-20-fix-hera-rail-subtree-count/tasks.md
+++ b/openspec/changes/archive/2026-07-20-fix-hera-rail-subtree-count/tasks.md
@@ -1,0 +1,32 @@
+## 1. Fix the rail header count
+
+- [x] 1.1 `Model.SubtreeAgentCount(orchID int64) int` (`internal/tui/hera/model.go`,
+  next to `BridgeSubtree`): walks `BridgeSubtree(orchID)` and counts every
+  `Kind == db.HeraKindWorker` role across every orchestrator in the subtree —
+  archived roles included, `Live` ignored. Coordinator roles excluded at
+  every level (folded into their own header / already represented by the
+  parent's bridging worker row).
+- [x] 1.2 `internal/tui/hera/rail.go`'s `drawOrchRow` calls
+  `r.model.SubtreeAgentCount(o.ID)` instead of the old `liveRoleCount(o)`.
+- [x] 1.3 Delete `liveRoleCount` — fully superseded, no remaining callers.
+
+## 2. Tests
+
+- [x] 2.1 `TestModel_SubtreeAgentCount_IncludesArchivedRegardlessOfLiveness`
+  (`internal/tui/hera/model_test.go`): an orchestrator with one live worker
+  and two archived workers (one with `Live: true` — the un-torn-down case,
+  one with `Live: false`) counts all 3, excluding the coordinator.
+- [x] 2.2 `TestModel_SubtreeAgentCount_RecursesIntoNestedSubcoordAndItsArchive`:
+  a root orchestrator bridging to a child sub-coordinator counts the child's
+  own workers (including its archived ones) without double-counting the
+  bridging row against the child's own coordinator role.
+- [x] 2.3 `internal/tui/hera/rail_test.go` and
+  `internal/tui/hera/bug024_test.go`'s existing `liveRoleCount` assertions
+  updated to `Model.SubtreeAgentCount` (same expected values — neither
+  fixture has archived or nested roles, so the numbers are unchanged; only
+  the call site moves).
+
+## 3. Spec
+
+- [x] 3.1 `hera-view` delta: "Orchestrator and role row rendering" requirement
+  text + scenario updated to describe the subtree/archive-inclusive count.

--- a/openspec/specs/hera-view/spec.md
+++ b/openspec/specs/hera-view/spec.md
@@ -127,14 +127,19 @@ Derived from: `internal/tui/hera/rail.go` (`buildRows`), `internal/tui/hera/rail
 
 ### Requirement: Orchestrator and role row rendering (area 3)
 
-The system SHALL render an orchestrator header with a fold chevron (▸ collapsed / ▾ expanded), a coordinator marker glyph, the orchestrator name, and a right-aligned live-role count `(N)` (count of roles with a live binding). It SHALL render a role row with a status glyph (see status-icon precedence) followed by the role name. Selection is indicated by a `›` marker in the gutter and the selected palette; archived placement dims the row's text style (the glyph itself never lies — only the style dims).
+The system SHALL render an orchestrator header with a fold chevron (▸ collapsed / ▾ expanded), a coordinator marker glyph, the orchestrator name, and a right-aligned agent count `(N)`. The count SHALL be the total number of non-coordinator roles (worker rows, including bridged sub-coordinator rows) across the orchestrator's WHOLE bridge subtree — itself plus every orchestrator nested beneath it through the worker→coordinator bridge, at any depth — INCLUDING roles currently hidden in a per-coordinator Archive bucket, regardless of whether any role's binding is still live. A nuked role or orchestrator is never counted (the Model excludes both entirely). Each orchestrator's own coordinator role is excluded at every level in the subtree (folded into its own header, or already represented one level up by the bridging worker row that reaches it), so a nested sub-coordinator's agent is counted exactly once. It SHALL render a role row with a status glyph (see status-icon precedence) followed by the role name. Selection is indicated by a `›` marker in the gutter and the selected palette; archived placement dims the row's text style (the glyph itself never lies — only the style dims).
 
-Derived from: `internal/tui/hera/rail.go:391` (`drawRow`), `internal/tui/hera/rail.go:437` (`drawOrchRow`), `internal/tui/hera/rail.go:470` (`drawRoleRow`), `internal/tui/hera/rail.go:498` (`liveRoleCount`).
+Derived from: `internal/tui/hera/rail.go` (`drawRow`, `drawOrchRow`, `drawRoleRow`), `internal/tui/hera/model.go` (`Model.SubtreeAgentCount`, `Model.BridgeSubtree`).
 
-#### Scenario: Orchestrator header shows live count
+#### Scenario: Orchestrator header counts its whole subtree, archive included
 
-- **WHEN** an orchestrator has three roles, two of which hold live bindings
-- **THEN** its header renders `(2)` right-aligned
+- **WHEN** an orchestrator has one live worker and two archived (Tier-1 hidden) workers, one of which still holds a live binding (its role was archived without ending its binding)
+- **THEN** its header renders `(3)` right-aligned — all three count, regardless of liveness
+
+#### Scenario: A nested sub-coordinator's own archive rolls up to its parent's badge
+
+- **WHEN** a root orchestrator bridges to a child sub-coordinator via a worker row, and that child has two workers of its own (one archived)
+- **THEN** the root's badge counts the bridging row once plus both of the child's workers, and the child's own badge (viewed on its own) counts just its own two workers — neither count double-counts the bridging row against the child's own coordinator role
 
 #### Scenario: Archived row dims without changing its glyph
 


### PR DESCRIPTION
## Summary

- Replace `liveRoleCount` (single-level, live-binding-gated) with `Model.SubtreeAgentCount`: it walks the orchestrator's full `BridgeSubtree` and counts every non-coordinator role (workers, including bridged sub-coordinator rows) across every nesting level — archived (Tier-1 hidden) roles included, liveness ignored entirely.

## Root cause

Two independent miscounts in the old badge:

1. **Archiving a role never ends its binding.** Hiding a worker into a coordinator's greyed-out Archive bucket (the `a` key / `db.ArchiveHeraRole`) only stamps `hera_roles.archived_at` — the role's `hera_binding.ended_at` is untouched (bindings only end via explicit teardown: nuke/delete/reparent/detach). So an archived role keeps `Live == true` forever, and the old `Live`-gated count kept reporting it as current work.
2. **The badge never recursed into nested (bridged) sub-coordinators.** A worker row that bridges to a child orchestrator (a sub-team spawned mid-run) was counted once, but that child's own workers — and its own Archive bucket — were invisible to the parent's badge entirely.

Confirmed against a live repro: `sherlock-land-pr-45`'s header showed `(10)` — 1 live bridging row (`post-wave1-subcoord`) + 9 roles already sitting in its own `Archive (9)` bucket, all still `Live=true` in the DB. The nested sub-coordinator it bridges to had 16 further roles invisible to the count entirely. Correct total: `(26)`.

## Test plan

- `TestModel_SubtreeAgentCount_IncludesArchivedRegardlessOfLiveness` and `TestModel_SubtreeAgentCount_RecursesIntoNestedSubcoordAndItsArchive` (new, `internal/tui/hera/model_test.go`) pin both halves of the fix.
- Existing `liveRoleCount` call sites in `rail_test.go` / `bug024_test.go` updated to `Model.SubtreeAgentCount` (same expected values — no archived/nested roles in those fixtures).
- `make pre-pr` green: build, vet, fmt-check, lint-pr, test-cover-gate @ 88.6%. `make vuln` fails only on pre-existing stdlib CVEs unrelated to this change (CI runs that gate `continue-on-error`).
- Dogfooded onto the live daemon (composed alongside the unmerged `argus/rail-scroll` mouse-scroll feature, neither dropped) — confirmed via `nm` that `SubtreeAgentCount` is compiled in and `liveRoleCount` is gone.

Specs: Updated (`openspec/specs/hera-view/spec.md`, via the archived `fix-hera-rail-subtree-count` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)