### PR TITLE
Fix context-pressure indicator to sum cache_read + cache_creation + input tokens

### DIFF
--- a/cmd/argus/coord_hook.go
+++ b/cmd/argus/coord_hook.go
@@ -564,8 +564,17 @@ func budgetReal(_ string) (int, error) {
 }
 
 // readContextSizeReal scans the transcript JSONL for the latest assistant
-// message's usage.cache_read_input_tokens. Reads the file in full rather
-// than seeking from the end: JSONL has no fixed record size, so a true tail
+// message's total input token count: cache_read_input_tokens +
+// cache_creation_input_tokens + input_tokens. cache_read_input_tokens ALONE
+// is not a safe proxy for context size — it only counts tokens actually
+// served from Anthropic's prompt cache this turn, and collapses toward zero
+// on any cache miss (a long idle gap crossing the cache TTL is the common
+// case for an idle hera worker), even though the real context is unchanged
+// or larger: a cache miss rewrites the whole prior context as
+// cache_creation_input_tokens instead of reading it, so summing all three
+// fields is what actually tracks total context regardless of cache hit/miss
+// state (rail-context-size-metric-fix). Reads the file in full rather than
+// seeking from the end: JSONL has no fixed record size, so a true tail
 // would need its own reverse-line-scan; a coordinator's Stop hook already
 // pays one HTTP round trip per turn, so a linear file scan is not the
 // dominant cost. Lines that aren't valid JSON, or aren't an assistant
@@ -594,7 +603,9 @@ func readContextSizeReal(transcriptPath string) (int, error) {
 			Type    string `json:"type"`
 			Message struct {
 				Usage struct {
-					CacheReadInputTokens int `json:"cache_read_input_tokens"`
+					InputTokens              int `json:"input_tokens"`
+					CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+					CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 				} `json:"usage"`
 			} `json:"message"`
 		}
@@ -604,7 +615,8 @@ func readContextSizeReal(transcriptPath string) (int, error) {
 		if entry.Type != "assistant" {
 			continue
 		}
-		size = entry.Message.Usage.CacheReadInputTokens
+		u := entry.Message.Usage
+		size = u.InputTokens + u.CacheCreationInputTokens + u.CacheReadInputTokens
 	}
 	if err := sc.Err(); err != nil {
 		return 0, fmt.Errorf("scan transcript: %w", err)

--- a/cmd/argus/coord_hook_test.go
+++ b/cmd/argus/coord_hook_test.go
@@ -643,7 +643,9 @@ func TestCoordHook_HardStop_ForceRecycleError_LogsToStderr(t *testing.T) {
 
 // TestReadContextSizeReal_TailsLatestAssistantUsage confirms the scan finds
 // the LAST assistant message's usage, tolerating blank and non-JSON lines
-// and non-assistant event types interleaved in a real transcript.
+// and non-assistant event types interleaved in a real transcript, and sums
+// cache_read + cache_creation + input tokens rather than reading
+// cache_read_input_tokens alone.
 func TestReadContextSizeReal_TailsLatestAssistantUsage(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "transcript.jsonl")
 	lines := []string{
@@ -651,13 +653,32 @@ func TestReadContextSizeReal_TailsLatestAssistantUsage(t *testing.T) {
 		`{"type":"assistant","message":{"usage":{"cache_read_input_tokens":100}}}`,
 		"",
 		"not json",
-		`{"type":"assistant","message":{"usage":{"cache_read_input_tokens":42000}}}`,
+		`{"type":"assistant","message":{"usage":{"input_tokens":2,"cache_creation_input_tokens":3000,"cache_read_input_tokens":42000}}}`,
 	}
 	testutil.NoError(t, os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o600))
 
 	size, err := readContextSizeReal(path)
 	testutil.NoError(t, err)
-	testutil.Equal(t, size, 42000)
+	testutil.Equal(t, size, 45002)
+}
+
+// TestReadContextSizeReal_CacheMissStillCountsFullContext pins the exact
+// production bug (rail-context-size-metric-fix): a prompt-cache miss (e.g. an
+// idle gap crossing the cache TTL) rewrites the ENTIRE prior context as
+// cache_creation_input_tokens instead of cache_read_input_tokens, so
+// cache_read_input_tokens alone collapses to 0 even though the real context
+// is unchanged or larger. Summing all three usage fields must still report
+// the true total.
+func TestReadContextSizeReal_CacheMissStillCountsFullContext(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	lines := []string{
+		`{"type":"assistant","message":{"usage":{"input_tokens":2,"cache_creation_input_tokens":399236,"cache_read_input_tokens":0}}}`,
+	}
+	testutil.NoError(t, os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o600))
+
+	size, err := readContextSizeReal(path)
+	testutil.NoError(t, err)
+	testutil.Equal(t, size, 399238)
 }
 
 func TestReadContextSizeReal_MissingFile_Errors(t *testing.T) {

--- a/internal/db/hera.go
+++ b/internal/db/hera.go
@@ -93,9 +93,12 @@ const (
 	// request ("true"). The recycle_coord primitive consumes it and defers the
 	// actual kill-and-restart until the session goes idle.
 	HeraMetaKeyPendingRecycle = "pending_recycle"
-	// HeraMetaKeyContextSize mirrors a hera-bound role's last-observed
-	// cache_read_input_tokens count (add-coordinator-context-management D1;
-	// widened from coordinator-only to any bound role by rail-context-high so
+	// HeraMetaKeyContextSize mirrors a hera-bound role's last-observed total
+	// input token count — cache_read_input_tokens + cache_creation_input_tokens
+	// + input_tokens, NOT cache_read_input_tokens alone, which collapses toward
+	// zero on a prompt-cache miss even though the real context is unchanged or
+	// larger (rail-context-size-metric-fix) — (add-coordinator-context-management
+	// D1; widened from coordinator-only to any bound role by rail-context-high so
 	// the hera-view rail's context-pressure indicator has a live signal for
 	// workers and freelance roles too), overwritten on every Stop-hook
 	// invocation (`argus coord-hook`) — a single scalar, not a time series.

--- a/internal/tui/hera/model.go
+++ b/internal/tui/hera/model.go
@@ -138,8 +138,10 @@ type RoleView struct {
 	AppliedEffort  string
 	ProfileWarning string
 
-	// ContextSize is the bound task's last-observed cache_read_input_tokens
-	// count, mirrored from task_meta(hera, context_size) — the same stamp
+	// ContextSize is the bound task's last-observed total input token count
+	// (cache_read_input_tokens + cache_creation_input_tokens + input_tokens,
+	// NOT cache_read_input_tokens alone — see db.HeraMetaKeyContextSize),
+	// mirrored from task_meta(hera, context_size) — the same stamp
 	// `argus coord-hook` writes on every Stop event for a coordinator, worker,
 	// or freelance role alike (add-worker-context-indicator widened it from
 	// coordinator-only). A pure read off the already-fetched heraMeta map, like


### PR DESCRIPTION
## Summary

- `argus coord-hook`'s `readContextSizeReal` used `cache_read_input_tokens` alone as the hera rail's context-size proxy. That field only counts tokens actually served from Anthropic's prompt cache this turn — on any cache miss (e.g. an idle gap crossing the cache TTL) the whole prior context gets rewritten as `cache_creation_input_tokens` instead, so the stamped `context_size` collapses toward zero (or just freezes) even though the real context is unchanged or larger.
- Confirmed live: a hera worker idle ~29 minutes showed `context_size` frozen across a new turn (389,166 → 389,166) while its in-pane context readout kept climbing, because the cache had expired and the turn's `cache_read_input_tokens` came back `0`.
- Fix: sum `cache_read_input_tokens + cache_creation_input_tokens + input_tokens` from the transcript's latest assistant message, so the metric tracks total context regardless of cache hit/miss state.
- Updated doc comments in `internal/db/hera.go` (`HeraMetaKeyContextSize`) and `internal/tui/hera/model.go` (`RoleView.ContextSize`) to describe the corrected metric.

## Test plan

- [x] `make pre-pr` (build, vet, fmt-check, lint-pr, test-cover-gate all green; `vuln` fails only on 3 stdlib-only Go 1.26.3 CVEs per `context/knowledge/gotchas/ci-gates.md`, confirmed toolchain-only)
- [x] `TestReadContextSizeReal_TailsLatestAssistantUsage` updated to assert the summed value
- [x] `TestReadContextSizeReal_CacheMissStillCountsFullContext` added, pinning the exact production repro (cache_read=0, cache_creation=399236 → size=399238)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
