### PR TITLE
Tighten ctrl+g/ctrl+b help-overlay wording

### DIFF
--- a/internal/tui/commandpalette_test.go
+++ b/internal/tui/commandpalette_test.go
@@ -84,7 +84,7 @@ func TestPaletteApplicableActions_ClassicAgentViewIsCtxAgentOnly(t *testing.T) {
 	// actions (quit/tab-switch/help) leak into the agent-view palette.
 	testutil.Equal(t, containsLabel(rows, "quit"), false)
 	testutil.Equal(t, containsLabel(rows, "switch to Tasks tab"), false)
-	testutil.Equal(t, containsLabel(rows, "jump to next needs-input (?) / restore when clear"), false)
+	testutil.Equal(t, containsLabel(rows, "jump to next needs-input (?); jumps back once all clear"), false)
 }
 
 func TestPaletteApplicableActions_TaskListIsGlobalPlusTaskList(t *testing.T) {
@@ -98,7 +98,7 @@ func TestPaletteApplicableActions_TaskListIsGlobalPlusTaskList(t *testing.T) {
 	testutil.Equal(t, containsLabel(rows, "new task"), true)
 	// A new CtxGlobal action (add-hera-jump-question) is reachable here too,
 	// like every other global action.
-	testutil.Equal(t, containsLabel(rows, "jump to next needs-input (?) / restore when clear"), true)
+	testutil.Equal(t, containsLabel(rows, "jump to next needs-input (?); jumps back once all clear"), true)
 	// No cross-tab bleed: Hera rail actions absent from the Tasks-tab palette.
 	testutil.Equal(t, containsLabel(rows, "spawn worker under coordinator (new-task modal)"), false)
 }

--- a/internal/tui/keymap/actions.go
+++ b/internal/tui/keymap/actions.go
@@ -177,8 +177,8 @@ var actionLabels = map[Action]string{
 	ActGlobalTabHera: "switch to Projects tab", ActGlobalTabSettings: "switch to Settings tab",
 	ActGlobalRefresh: "refresh screen", ActGlobalDestroy: "destroy task", ActGlobalFork: "fork task",
 	ActGlobalOpenRepo: "open repo", ActGlobalOpenPR: "open PR", ActGlobalPrune: "prune completed",
-	ActGlobalPalette: "command palette", ActGlobalJumpNeedsInput: "jump to next needs-input (?) / restore when clear",
-	ActGlobalRestoreRail: "restore rail (end excursion)",
+	ActGlobalPalette: "command palette", ActGlobalJumpNeedsInput: "jump to next needs-input (?); jumps back once all clear",
+	ActGlobalRestoreRail: "jump back now, even with (?) still open",
 
 	ActTaskNew: "new task", ActTaskStatusAdv: "advance status", ActTaskStatusRev: "revert status",
 	ActTaskArchive: "toggle archive", ActTaskPin: "toggle pin", ActTaskRename: "rename",

--- a/internal/tui/modal/help_test.go
+++ b/internal/tui/modal/help_test.go
@@ -84,10 +84,10 @@ func TestHelpModal_Draw(t *testing.T) {
 	testutil.Contains(t, body, "ctrl+g")
 	testutil.Contains(t, body, "jump to next needs-input (?)")
 	// ctrl+b manual rail restore (add-ctrlg-excursion): the ctrl+g problem-child
-	// excursion's explicit "end excursion" counterpart — fail the build if it's
+	// excursion's explicit manual-restore counterpart — fail the build if it's
 	// ever silently dropped from the generated overlay.
 	testutil.Contains(t, body, "ctrl+b")
-	testutil.Contains(t, body, "restore rail (end excursion)")
+	testutil.Contains(t, body, "jump back now, even with (?) still open")
 	testutil.Contains(t, body, "show/hide hera-managed (workers+coords)")
 	// Task-list `c` opens the copy menu (name / prompt) — fail the build if the
 	// binding text is silently reverted (keybinding-help contract).


### PR DESCRIPTION
Follow-up to #906. Aaron reviewed the shipped `?` help overlay text and flagged that "excursion"/"restore rail" are jargon this feature invented with no in-UI definition — the README table is fine (full sentences), but the terse overlay labels need to read clearly with zero outside context.

- `ActGlobalJumpNeedsInput`: "jump to next needs-input (?); jumps back once all clear"
- `ActGlobalRestoreRail`: "jump back now, even with (?) still open"

Updates the matching `testutil.Contains`/`containsLabel` assertions in `help_test.go` and `commandpalette_test.go`. README.md left as-is (already clear). Pure string tweak, no behavior change.

`make pre-pr` clean (build/vet/fmt-check/lint-pr/test-cover-gate all pass; `make vuln` fails only on pre-existing stdlib CVEs, advisory-only in CI).