### PR TITLE
Run CI on pull requests against any base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Drop the `branches: [master]` filter on the `pull_request` trigger in `.github/workflows/ci.yml` so CI runs for a PR regardless of its base branch — previously a PR opened against a feature branch (e.g. a stacked-PR workflow where a task branches off another task's branch) never triggered CI at all.
- `push` stays scoped to `master`.

## Test plan
- N/A (CI workflow config change) — verified by this PR's own CI run triggering successfully.