### PR TITLE
Warn coordinators against recycling while a native sub-agent is in flight

### DIFF
--- a/.claude/skills/hera/SKILL.md
+++ b/.claude/skills/hera/SKILL.md
@@ -235,6 +235,16 @@ or using in-session sub-agents.
      - Units are **independent** (no ordering)? → just `hera_spawn_worker` them in parallel; no DAG.
   3. **Ask the human only** when it's genuinely ambiguous whether the work warrants multi-session
      orchestration at all — never for the routine dependency call above.
+  4. **Prefer a hera worker over a native sub-agent for anything that must survive a coordinator
+     recycle.** Only a hera-tracked session comes back cleanly after a recycle (self-service, or the
+     coord-hook's automatic forced recycle past 1.5x token budget, which has no idle gate at all) — a
+     native sub-agent is just an in-process tool call invisible to the daemon, and gets killed along
+     with the rest of your session with no trace. Don't call `hera_status(request_recycle=true)` while
+     a native sub-agent you dispatched is still running: self-service recycle only defers until you go
+     idle, and a backgrounded sub-agent produces zero output while it works, so you look idle when you
+     aren't — requesting recycle early kills its work mid-flight. If you must hand off or record status
+     while one is still in flight, say so in `handoff_note` so a human reviewing status doesn't
+     force-recycle blindly.
 - **This task holds 2+ bindings?** Pass `orchestrator=` on EVERY tool call.
 - **Got a doorbell?** Call `hera_inbox(cwd=$PWD)` immediately — the content is in the inbox, not the
   doorbell line.

--- a/internal/agent/hera_spawn.go
+++ b/internal/agent/hera_spawn.go
@@ -550,7 +550,15 @@ func HeraCoordinatorOrientation(orchestrator string) string {
 			"for something that just needs an answer back. A single small file or a one-shot grep with a "+
 			"few hits is cheaper read inline than round-tripped through a sub-agent — delegate when the "+
 			"exploration volume clearly dwarfs the answer needed back, not reflexively for every read. "+
-			"Reserve hera_spawn_worker for work that needs its own git worktree, branch, or PR.\n"+
+			"Reserve hera_spawn_worker for work that needs its own git worktree, branch, or PR — and "+
+			"for anything that must outlive this turn: only a hera-tracked session survives a recycle "+
+			"cleanly, while a native sub-agent is just an in-process tool call the daemon can't see. If "+
+			"you do dispatch a native sub-agent and it's still running, do NOT call "+
+			"hera_status(request_recycle=true) until it finishes — self-service recycle only defers "+
+			"until you go idle, and a backgrounded sub-agent produces no output while it runs, so you "+
+			"look idle when you aren't and requesting recycle early kills its work. If you must hand "+
+			"off or record status while one is still in flight, say so in handoff_note so a human "+
+			"reviewing status doesn't force-recycle blindly.\n"+
 			"4. Send pointers, not payloads. Reference path:line, branch names, and task IDs in messages "+
 			"and reports — never paste full file contents or long logs into a hera_send body; that "+
 			"duplicates the content into both your context and the recipient's at once.\n"+


### PR DESCRIPTION
## Summary

- A backgrounded native sub-agent (Agent/Task tool) produces zero PTY output while it runs, so a coordinator looks idle even though real work is still in flight.
- Self-service recycle (`hera_status(request_recycle=true)`) only defers until idle, and the coord-hook's forced recycle at 1.5x token budget has no idle gate at all — either path can silently kill the sub-agent's work mid-flight. There's no code-side fix (no signal exists for "a native sub-agent is currently running"), so this is a documentation-only change.
- Extends coordinator habit #3 ("Delegate with prejudice...") in the `hera_new_orchestrator`/`hera_spawn_worker` orientation text (`internal/agent/hera_spawn.go`) to: prefer hera workers for anything that must outlive the current turn, avoid self-requesting recycle while a native sub-agent is still running, and note it in `handoff_note` if handing off mid-flight.
- Adds the same caveat to `.claude/skills/hera/SKILL.md`'s coordination-decision section (§4) for the standalone-skill-load path.

## Test plan

- [x] Grepped `*_test.go` for orientation-text assertions (`five habits`, `harvest a distillate`) — found `TestHeraCoordinatorOrientation_CarriesFiveDisciplineHabits` in `internal/agent/hera_spawn_test.go`; verified it only asserts substrings that are preserved verbatim, no update needed.
- [x] `make build`
- [x] `make vet`
- [x] `go test ./internal/agent/...` (full package, green — 2 profile-env tests are a known pre-existing local-sandbox flake from `ARGUS_PROFILE` leaking into the test subprocess, unrelated to this change; confirmed green with it unset)
- [x] `make pre-pr` (build/vet/fmt-check/lint-pr green; `test-cover-gate` green at 88.7%; `vuln` flags pre-existing stdlib CVEs against the local Go toolchain, unrelated to this change and `continue-on-error` in CI per the Makefile's own comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>