### PR TITLE
Add localhost-only pprof debug listener to the TUI process

### DIFF
--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"log/slog"
 	"net"
+	"net/http"
+	_ "net/http/pprof" //nolint:gosec // localhost-only debug listener, see runTUI's startPprofDebugListener
 	"net/rpc/jsonrpc"
 	"os"
 	"path/filepath"
@@ -137,6 +139,34 @@ func parseRemoteFlags(args []string) (remoteURL, token string) {
 	return remoteURL, token
 }
 
+// pprofDebugAddr is the fixed localhost-only address for the diagnostic
+// net/http/pprof listener (add-tui-pprof-debug-listener). Temporary
+// instrumentation for chasing the TUI's unexplained multi-GB RSS growth
+// (context/knowledge/gotchas — see the RSS-leak investigation entry); safe to
+// leave in place afterward as a standing debug aid, same precedent as
+// internal/api's own 127.0.0.1-only binding.
+const pprofDebugAddr = "127.0.0.1:6061"
+
+// startPprofDebugListener starts a localhost-only net/http/pprof listener in
+// the background for live heap/goroutine profiling of a running TUI process
+// (go tool pprof http://127.0.0.1:6061/debug/pprof/heap). Never fatal: a
+// bind failure (e.g. a second concurrent TUI instance) is logged via uxlog
+// and the TUI continues without it — this is diagnostic tooling, not a
+// required capability.
+func startPprofDebugListener() {
+	ln, err := net.Listen("tcp", pprofDebugAddr)
+	if err != nil {
+		uxlog.Log("[tui] pprof debug listener failed to start on %s: %v", pprofDebugAddr, err)
+		return
+	}
+	uxlog.Log("[tui] pprof debug listener on %s (go tool pprof http://%s/debug/pprof/heap)", pprofDebugAddr, pprofDebugAddr)
+	go func() {
+		if err := http.Serve(ln, nil); err != nil { //nolint:gosec // localhost-only, diagnostic use
+			uxlog.Log("[tui] pprof debug listener stopped: %v", err)
+		}
+	}()
+}
+
 func runTUI() {
 	// Initialize UX debug log.
 	if err := uxlog.Init(uxlog.Path(db.DataDir())); err != nil {
@@ -144,6 +174,8 @@ func runTUI() {
 	}
 	defer uxlog.Close()
 	uxlog.Log("=== argus TUI starting ===")
+
+	startPprofDebugListener()
 
 	// Redirect EVERY default logger that could write to the user's terminal
 	// at the program level, NOT by editing the 30+ slog/log call sites that


### PR DESCRIPTION
## Summary

The TUI process has leaked to 60GB+ RSS twice now (both within ~12h of launch), independent of
the per-tick CPU work already fixed in #944/#949. This adds real profiling instead of continuing
to guess:

- `startPprofDebugListener` in `cmd/argus/main.go`, wired into `runTUI()`: starts `net/http/pprof`
  on a fixed `127.0.0.1:6061` listener, background goroutine, never fatal on bind failure (logged
  via uxlog and the TUI continues without it — diagnostic tooling, not a required capability).
- Enables `go tool pprof http://127.0.0.1:6061/debug/pprof/heap` (and `/goroutine`,
  `/allocs`, etc.) against a live TUI instance to actually see what's holding memory, rather than
  theorizing from `ps` numbers.
- Safe to leave in permanently as a standing debug aid — same localhost-only precedent as
  `internal/api`'s own binding.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `golangci-lint run --new-from-rev=origin/master`: 0 issues
- Not a behavioral change to any user-facing surface — diagnostic-only, no OpenSpec change folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)